### PR TITLE
🎉 [Chore] xcodeproj 파일 Git 추적 제외

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ playground.xcworkspace
 # Packages/
 # Package.pins
 # Package.resolved
-# *.xcodeproj
+*.xcodeproj
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
 # .swiftpm


### PR DESCRIPTION
## ✨ PR 유형

- 🎉 Chore: 프로젝트 설정 변경

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음

## 🛠️ 작업내용

- chore: Environment Variables Key 보안을 위한 xcodeproj 파일 깃 공유 제외

### 변경 내용
`.gitignore`에 `*.xcodeproj` 추가하여 Xcode 프로젝트 파일을 Git 추적에서 제외

**이유:**
- Environment Variables Key가 xcodeproj 파일 내에 포함됨
- API Key, Secret 등 민감 정보 유출 방지
- 팀원 간 로컬 환경 설정 충돌 방지

## 📋 추후 진행 상황

- [x] 팀원들에게 xcodeproj 제외 안내
- [x] 프로젝트 초기 설정 가이드 문서화

## 📌 리뷰 포인트

- `.gitignore` 변경이 기존 추적 파일에 영향 없는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)