### PR TITLE
♻️ [Refactor] ActivityView sectionMenu를 ToolBarCollection으로 컴포넌트화

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/ActivityView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/ActivityView.swift
@@ -46,9 +46,15 @@ struct ActivityView: View {
         )
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                sectionMenu
-            }
+            ToolBarCollection.ToolBarCenterMenu(
+                items: availableSections,
+                selection: Binding(
+                    get: { currentSection },
+                    set: { selectedSection = $0 }
+                ),
+                itemLabel: { $0.rawValue },
+                itemIcon: { $0.icon }
+            ) 
         }
         .task {
             // ViewModel 초기화 및 데이터 로드(Computed Property를 위해 init 대신 task에서 초기화)
@@ -64,31 +70,6 @@ struct ActivityView: View {
     }
 
     // MARK: - View Component
-
-    /// 섹션 선택 Menu
-    private var sectionMenu: some View {
-        Menu {
-            ForEach(availableSections) { section in
-                Button {
-                    withAnimation(.snappy) {
-                        selectedSection = section
-                    }
-                } label: {
-                    Label(section.rawValue, systemImage: section.icon)
-                }
-            }
-        } label: {
-            HStack(spacing: DefaultSpacing.spacing4) {
-                Text(currentSection.rawValue)
-                    .appFont(.subheadline, weight: .medium)
-                Image(systemName: "chevron.down.circle.fill")
-                    .foregroundStyle(.gray.opacity(0.5))
-                    .font(.caption)
-            }
-            .padding(DefaultConstant.defaultToolBarTitlePadding)
-            .glassEffect(.regular)
-        }
-    }
 
     /// 섹션에 해당하는 뷰 반환
     @ViewBuilder

--- a/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
+++ b/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
@@ -144,7 +144,9 @@ struct ToolBarCollection {
         }
     }
     
-    /// 상단 중앙 메뉴 툴바 (아이콘O)
+    /// 상단 중앙 메뉴 툴바
+    ///
+    /// TODO: 레거시 코드 제거 필요 - 담당자: 소피
     struct TopBarCenterMenu<Item: Identifiable & Hashable>: ToolbarContent {
         let icon: String
         let title: String
@@ -226,6 +228,60 @@ struct ToolBarCollection {
                     Toggle("모집중", isOn: isRecruiting)
                 }
             })
+        }
+    }
+
+    /// 상단 중앙 섹션 메뉴 툴바 (Button 기반, 애니메이션 지원)
+    struct ToolBarCenterMenu<Item: Identifiable & Hashable>: ToolbarContent {
+        let items: [Item]
+        @Binding var selection: Item
+        let itemLabel: (Item) -> String
+        let itemIcon: ((Item) -> String)?
+
+        init(
+            items: [Item],
+            selection: Binding<Item>,
+            itemLabel: @escaping (Item) -> String,
+            itemIcon: ((Item) -> String)? = nil
+        ) {
+            self.items = items
+            self._selection = selection
+            self.itemLabel = itemLabel
+            self.itemIcon = itemIcon
+        }
+
+        var body: some ToolbarContent {
+            ToolbarItem(placement: .principal) {
+                Menu {
+                    ForEach(items) { item in
+                        Button {
+                            withAnimation(.snappy) {
+                                selection = item
+                            }
+                        } label: {
+                            if let itemIcon = itemIcon {
+                                Label(itemLabel(item), systemImage: itemIcon(item))
+                            } else {
+                                Text(itemLabel(item))
+                            }
+                        }
+                    }
+                } label: {
+                    menuLabel
+                }
+            }
+        }
+
+        private var menuLabel: some View {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Text(itemLabel(selection))
+                    .appFont(.subheadline, weight: .medium)
+                Image(systemName: "chevron.down.circle.fill")
+                    .foregroundStyle(.gray.opacity(0.5))
+                    .font(.caption)
+            }
+            .padding(DefaultConstant.defaultToolBarTitlePadding)
+            .glassEffect(.regular)
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor - 코드 재구조화 및 컴포넌트 추출

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (동작 동일)

## 🛠️ 작업내용

- `ActivityView`의 `sectionMenu`를 `ToolBarCollection.ToolBarCenterMenu`로 이동
- Generic 타입(`Identifiable & Hashable`)으로 설계하여 모든 뷰에서 재사용 가능
- Button 기반 선택으로 `withAnimation(.snappy)` 애니메이션 지원
- Liquid Glass 디자인 시스템 적용 (`.glassEffect(.regular)`)
- 기존 `TopBarCenterMenu`에 레거시 표시 TODO 추가

### 변경 파일
- `ToolBarCollection.swift` - `ToolBarCenterMenu` 컴포넌트 추가
- `ActivityView.swift` - 새 컴포넌트 사용으로 변경, 기존 `sectionMenu` 제거 (-25줄)

## 📋 추후 진행 상황

- 기존 `TopBarCenterMenu` 사용처 확인 후 `ToolBarCenterMenu`로 마이그레이션 검토

## 📌 리뷰 포인트

- `Utilities/ToolBar/` - 새 `ToolBarCenterMenu` 컴포넌트 설계 확인
- `Features/Activity/Presentation/Views/` - 컴포넌트 적용 방식 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)