### PR TITLE
💄 [Design] PenaltyCard 동적 높이 스와이프 UX 개선 및 MyPage 네비게이션 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -28,18 +28,18 @@ class HomeViewModel {
     var generationData: Loadable<[GenerationData]> = .loaded([
         GenerationData(
             gen: 11,
-            penaltyPoint: 3,
+            penaltyPoint: 1,
             penaltyLogs: [
                 .init(reason: "지각", date: "03.26", penaltyPoint: 1),
-                .init(reason: "과제 미제출", date: "03.27", penaltyPoint: 1),
-                .init(reason: "과제 미제출", date: "03.27", penaltyPoint: 2)
             ]
         ),
         GenerationData(
             gen: 12,
-            penaltyPoint: 1,
+            penaltyPoint: 2,
             penaltyLogs: [
                 .init(reason: "지각", date: "03.14", penaltyPoint: 1),
+                .init(reason: "워크북 미제출", date: "03.16", penaltyPoint: 1),
+                .init(reason: "행사 노쇼", date: "04.16", penaltyPoint: 1)
             ]
         )
     ])

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/ProfileCardSection.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/ProfileCardSection.swift
@@ -23,9 +23,9 @@ struct ProfileCardSection: View {
         static let chevron: String = "chevron.right"
     }
 
-    /// DI Container에서 주입받은 NavigationRouter
-    var router: NavigationRouter {
-        di.resolve(NavigationRouter.self)
+    /// DI Container에서 주입받은 PathStore
+    private var pathStore: PathStore {
+        di.resolve(PathStore.self)
     }
 
     // MARK: - Function
@@ -38,7 +38,7 @@ struct ProfileCardSection: View {
 
     var body: some View {
         Button(action: {
-            router.push(to: .myPage(.myInfo(profileData: profileData)))
+            pathStore.mypagePath.append(.myPage(.myInfo(profileData: self.profileData)))
         }, label: {
             HStack(spacing: DefaultSpacing.spacing12, content: {
                 profileImage

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
@@ -24,15 +24,20 @@ class MyPageViewModel {
         challangerInfo: .init(
             challengeId: 0,
             gen: 11,
-            name: "정의찬",
-            nickname: "제옹",
-            schoolName: "중앙대",
+            name: "유엠씨",
+            nickname: "네임",
+            schoolName: "유엠씨대학교",
             profileImage: nil,
             part: .design
         ),
-        socialConnected: [],
+        socialConnected: [
+            .apple,
+            .kakao
+        ],
         activityLogs: [
-            .init(part: .design, generation: 11, role: .campusPartLeader)
+            .init(part: .design, generation: 11, role: .campusPartLeader),
+            .init(part: .pm, generation: 10, role: .challenger),
+            .init(part: .front(type: .ios), generation: 9, role: .campusPresident)
         ],
         profileLink: []
     ))

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
@@ -14,7 +14,7 @@ import PhotosUI
 struct MyPageProfileView: View {
     /// 뷰모델 상태 객체
     @State var viewModel: MyPageProfileViewModel
-    
+
     init(profileData: ProfileData) {
         self._viewModel = .init(initialValue: .init(profileData: profileData))
     }


### PR DESCRIPTION
## ✨ PR 유형

Design - 홈 패널티 카드 UX 개선 및 MyPage 네비게이션 리팩토링

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요
그 외에는 스크린샷으로 올려도 무방합니다.
어떤 작업을 하였는지 시각적으로 바로 확인 가능하게 해주세요! -->

## 🛠️ 작업내용

### Home - PenaltyCard 개선
- 고정 높이(100/240) 제거 → 데이터 양에 따라 동적 높이 조절
- TabView 제거 → 커스텀 DragGesture 기반 스와이프 구현
- 인터랙티브 드래그: 콘텐츠가 손가락을 실시간 추적
- 방향 잠금: 최초 터치 방향으로 수평/수직 판별하여 세로 스크롤과 충돌 방지
- 러버밴드 효과: 첫/마지막 페이지에서 저항감 표현 (translation * 0.3)
- 속도 기반 전환: predictedEndTranslation으로 빠른 플릭 감지
- blurReplace transition으로 페이지 전환 애니메이션 적용

### Home - HomeViewModel
- 목업 패널티 데이터 수정 (동적 높이 테스트용)

### MyPage - ProfileCardSection
- NavigationRouter → PathStore 기반 네비게이션으로 변경
- `router.push(to:)` → `pathStore.mypagePath.append()` 방식 적용

### MyPage - MyPageViewModel
- 목업 프로필 데이터 수정 (소셜 연동, 활동 이력 추가)

## 📋 추후 진행 상황

- PenaltyCard API 연동 시 실데이터 기반 높이 동작 검증
- MyPage 프로필 수정 완료 액션 구현

## 📌 리뷰 포인트

- `Features/Home/Presentation/Components/Card/PenaltyCard.swift` - 커스텀 스와이프 제스처 로직 (방향 잠금, 러버밴드, 속도 감지) 확인
- `Features/MyPage/Presentation/Components/Section/MypageSection/ProfileCardSection.swift` - PathStore 기반 네비게이션 전환 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)