### PR TITLE
✨ [Feat] 홈 실패 상태 UX 개선 및 에러 카드 공용화

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/xcshareddata/xcschemes/AppProduct.xcscheme
+++ b/AppProduct/AppProduct.xcodeproj/xcshareddata/xcschemes/AppProduct.xcscheme
@@ -63,6 +63,20 @@
             ReferencedContainer = "container:AppProduct.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-homeDebugState failed"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-homeDebugState loaded"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-homeDebugState loading"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "KAKAO_APP_KEY"

--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -24,7 +24,7 @@ struct AppProductApp: App {
     @State private var container: DIContainer
     @State private var didConfigureAppDelegate: Bool = false
     @State private var errorHandler: ErrorHandler = .init()
-    @State private var appState: AppState = .splash
+    @State private var appState: AppState = .main
     private let sharedModelContainer: ModelContainer
     
     // MARK: - AppState

--- a/AppProduct/AppProduct/Core/Common/UIComponents/SectionErrorCard/SectionErrorCard.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/SectionErrorCard/SectionErrorCard.swift
@@ -1,0 +1,99 @@
+//
+//  SectionErrorCard.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 2/16/26.
+//
+
+import SwiftUI
+
+/// 섹션 오류 카드에서 사용하는 컨텐츠 타입
+///
+/// 외부에서는 case를 선택해 제목/설명 조합을 재사용합니다.
+enum SectionErrorCardContent: Equatable {
+    case seasonInfo
+    case penaltyInfo
+    case recentNotice
+    case custom(title: String, description: String)
+
+    var title: String {
+        switch self {
+        case .seasonInfo:
+            return "기수 정보를 불러오지 못했어요"
+        case .penaltyInfo:
+            return "패널티 정보를 불러오지 못했어요"
+        case .recentNotice:
+            return "최근 공지를 불러오지 못했어요"
+        case .custom(let title, _):
+            return title
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .seasonInfo, .penaltyInfo, .recentNotice:
+            return "일시적인 오류가 발생했습니다. 다시 시도해주세요."
+        case .custom(_, let description):
+            return description
+        }
+    }
+}
+
+/// 어느 섹션에서든 재사용 가능한 에러 카드 컴포넌트
+struct SectionErrorCard: View {
+    private enum Constants {
+        static let retryText: String = "다시 시도"
+    }
+
+    let content: SectionErrorCardContent
+    let isLoading: Bool
+    let retryAction: () -> Void
+
+    init(
+        content: SectionErrorCardContent,
+        isLoading: Bool = false,
+        retryAction: @escaping () -> Void
+    ) {
+        self.content = content
+        self.isLoading = isLoading
+        self.retryAction = retryAction
+    }
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.title2)
+                .foregroundStyle(.orange)
+
+            VStack(spacing: DefaultSpacing.spacing4) {
+                Text(content.title)
+                    .font(.headline)
+                Text(content.description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            Button(action: {
+                guard !isLoading else { return }
+                retryAction()
+            }) {
+                ZStack {
+                    Text(Constants.retryText)
+                        .opacity(isLoading ? 0 : 1)
+                    if isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                            .tint(.white)
+                    }
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .allowsHitTesting(!isLoading)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, DefaultSpacing.spacing24)
+        .padding(.horizontal, DefaultSpacing.spacing16)
+        .glassEffect(.regular, in: .containerRelative)
+    }
+}

--- a/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
+++ b/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
@@ -104,10 +104,24 @@ private struct PreviewFetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol {
 }
 
 #Preview("홈") {
-    @Previewable @Environment(\.di) var di
-    NavigationStack {
-        HomeView(container: di)
+    LoginHomePreviewView()
+}
+
+/// 홈 화면 Preview용 래퍼 뷰 (PathStore 포함 DIContainer 구성)
+private struct LoginHomePreviewView: View {
+    private let di: DIContainer
+
+    init() {
+        let container = DIContainer()
+        container.register(PathStore.self) { PathStore() }
+        self.di = container
     }
-    .environment(DIContainer())
-    .environment(ErrorHandler())
+
+    var body: some View {
+        NavigationStack {
+            HomeView(container: di, shouldFetchOnTask: false)
+        }
+        .environment(di)
+        .environment(ErrorHandler())
+    }
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -17,8 +17,12 @@ final class HomeViewModel {
     // MARK: - Property
 
     private let container: DIContainer
-    private let useCaseProvider: HomeUseCaseProviding
-    private let genRepository: ChallengerGenRepositoryProtocol
+    private var useCaseProvider: HomeUseCaseProviding {
+        container.resolve(HomeUseCaseProviding.self)
+    }
+    private var genRepository: ChallengerGenRepositoryProtocol {
+        container.resolve(ChallengerGenRepositoryProtocol.self)
+    }
 
     /// 프로필에서 받은 역할 정보 (공지 API 호출 시 사용)
     private(set) var roles: [ChallengerRole] = []
@@ -46,8 +50,6 @@ final class HomeViewModel {
 
     init(container: DIContainer) {
         self.container = container
-        self.useCaseProvider = container.resolve(HomeUseCaseProviding.self)
-        self.genRepository = container.resolve(ChallengerGenRepositoryProtocol.self)
     }
 
     // MARK: - Function
@@ -189,4 +191,21 @@ final class HomeViewModel {
         let normalizedDate = calendar.startOfDay(for: date)
         return scheduleByDates[normalizedDate] ?? []
     }
+
+#if DEBUG
+    /// Preview/테스트 환경에서 ViewModel 상태를 직접 주입합니다.
+    func seedForDebugState(
+        seasonData: Loadable<[SeasonType]>,
+        generationData: Loadable<[GenerationData]>,
+        recentNoticeData: Loadable<[RecentNoticeData]>,
+        scheduleByDates: [Date: [ScheduleData]],
+        roles: [ChallengerRole] = []
+    ) {
+        self.seasonData = seasonData
+        self.generationData = generationData
+        self.recentNoticeData = recentNoticeData
+        self.scheduleByDates = scheduleByDates
+        self.roles = roles
+    }
+#endif
 }

--- a/AppProduct/AppProduct/Scheme/HomeDebugScheme.swift
+++ b/AppProduct/AppProduct/Scheme/HomeDebugScheme.swift
@@ -1,0 +1,120 @@
+//
+//  HomeDebugScheme.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 2/16/26.
+//
+
+import Foundation
+
+#if DEBUG
+enum HomeDebugState: String {
+    case loading
+    case loaded
+    case failed
+
+    static func fromLaunchArgument() -> HomeDebugState? {
+        let arguments = ProcessInfo.processInfo.arguments
+        if let index = arguments.firstIndex(of: "-homeDebugState"),
+           arguments.indices.contains(index + 1) {
+            return HomeDebugState(rawValue: arguments[index + 1])
+        }
+
+        if let environmentValue = ProcessInfo.processInfo.environment["HOME_DEBUG_STATE"] {
+            return HomeDebugState(rawValue: environmentValue)
+        }
+
+        return nil
+    }
+
+    func apply(to viewModel: HomeViewModel, selectedDate: Date) {
+        viewModel.seedForDebugState(
+            seasonData: seasonLoadable,
+            generationData: generationLoadable,
+            recentNoticeData: noticeLoadable,
+            scheduleByDates: schedules(selectedDate: selectedDate)
+        )
+    }
+
+    private var seasonLoadable: Loadable<[SeasonType]> {
+        switch self {
+        case .loading:
+            return .loading
+        case .loaded:
+            return .loaded([.days(42), .gens([1, 2])])
+        case .failed:
+            return .failed(.unknown(message: "기수 데이터를 불러오지 못했습니다."))
+        }
+    }
+
+    private var generationLoadable: Loadable<[GenerationData]> {
+        switch self {
+        case .loading:
+            return .loading
+        case .loaded:
+            return .loaded([
+                GenerationData(
+                    gisuId: 101,
+                    gen: 1,
+                    penaltyPoint: 1,
+                    penaltyLogs: [
+                        PenaltyInfoItem(
+                            reason: "지각",
+                            date: "2026.01.10",
+                            penaltyPoint: 1
+                        )
+                    ]
+                ),
+                GenerationData(
+                    gisuId: 102,
+                    gen: 2,
+                    penaltyPoint: 0,
+                    penaltyLogs: []
+                )
+            ])
+        case .failed:
+            return .failed(.unknown(message: "패널티 데이터를 불러오지 못했습니다."))
+        }
+    }
+
+    private var noticeLoadable: Loadable<[RecentNoticeData]> {
+        switch self {
+        case .loading:
+            return .loading
+        case .loaded:
+            return .loaded([
+                RecentNoticeData(
+                    category: .operationsTeam,
+                    title: "2기 OT 공지",
+                    createdAt: .now
+                ),
+                RecentNoticeData(
+                    category: .univ,
+                    title: "학교별 스터디 모집 안내",
+                    createdAt: .now.addingTimeInterval(-86_400)
+                )
+            ])
+        case .failed:
+            return .failed(.unknown(message: "최근 공지를 불러오지 못했습니다."))
+        }
+    }
+
+    private func schedules(selectedDate: Date) -> [Date: [ScheduleData]] {
+        guard self == .loaded else { return [:] }
+        let normalizedDate = Calendar.current.startOfDay(for: selectedDate)
+        return [
+            normalizedDate: [
+                ScheduleData(
+                    scheduleId: 1,
+                    title: "UMC 정기 세션",
+                    startsAt: selectedDate,
+                    endsAt: selectedDate.addingTimeInterval(3_600),
+                    status: "참여 예정",
+                    dDay: 0
+                )
+            ]
+        ]
+    }
+}
+
+#endif


### PR DESCRIPTION
## ✨ PR 유형

- Feat
- Design
- Refactor

## 📷 스크린샷 or 영상(UI 변경 시)
- 홈 실패 상태 UI 및 재시도 로딩 UX 반영 (시뮬레이터 캡처 기반)
- 필요 시 PR 코멘트로 추가 캡처 업로드하겠습니다.

## 🛠️ 작업내용
- 홈 실패 상태에서 빈 화면(`Color.clear`) 대신 섹션별 에러 카드가 보이도록 변경했습니다.
- `다시 시도` 동작 시 버튼 내부 로딩 인디케이터를 표시하고, 재시도 중 카드가 사라지지 않도록 상태 분기를 조정했습니다.
- `SectionErrorCard` 공용 컴포넌트와 `SectionErrorCardContent` enum을 추가해 다른 뷰에서도 재사용 가능하게 구성했습니다.
- 시뮬레이터 목업/디버그 상태 주입 코드를 `Scheme/HomeDebugScheme.swift`로 분리해 관리하도록 정리했습니다.

## 📋 추후 진행 상황
- 홈 이외 Feature에도 `SectionErrorCard`를 적용해 실패 UX를 통일할 예정입니다.
- 공용 에러 카드 디자인 토큰(색/간격/버튼 스타일) 정규화 여부를 검토할 예정입니다.

## 📌 리뷰 포인트
- `/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift`
  - `.failed`/`.loading` 분기에서 재시도 중 카드 유지 로직이 의도대로 동작하는지
- `/AppProduct/AppProduct/Core/Common/UIComponents/SectionErrorCard/SectionErrorCard.swift`
  - enum 기반 콘텐츠 선택 방식과 버튼 내부 로딩 표시 UX가 재사용 가능한지
- `/AppProduct/AppProduct/Scheme/HomeDebugScheme.swift`
  - 시뮬레이터 디버그 상태 주입이 기존 런타임 로직에 영향을 주지 않는지
- `/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift`
  - DEBUG 전용 시드 메서드 접근 범위 및 프로덕션 영향 여부

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
