### PR TITLE
🔧 [Chore] 스킴 토큰 등록 및 MyProfileDTO 기수 매핑 안정화

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
@@ -169,9 +169,16 @@ extension MyProfileResponseDTO {
             )
         }
 
-        let gisuIdByGisu = Dictionary(
-            uniqueKeysWithValues: roles.map { ($0.gisu, $0.gisuId) }
-        )
+        let gisuIdByGisu = roles.reduce(into: [Int: Int]()) { partialResult, role in
+            // 동일 기수 역할이 여러 개일 수 있어 안전하게 병합한다.
+            if let existing = partialResult[role.gisu] {
+                if existing == 0, role.gisuId != 0 {
+                    partialResult[role.gisu] = role.gisuId
+                }
+            } else {
+                partialResult[role.gisu] = role.gisuId
+            }
+        }
         let generations: [GenerationData] = (challengerRecords ?? []).compactMap { record in
             let gisuId = gisuIdByGisu[record.gisu] ?? record.gisuId
             return record.toGenerationData(gisuId: gisuId)


### PR DESCRIPTION
## ✨ PR 유형

Chore / Fix - 디버그 스킴 API 테스트 토큰 자동 등록 및 프로필 DTO 기수-gisuId 매핑 안정화

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요
그 외에는 스크린샷으로 올려도 무방합니다.
어떤 작업을 하였는지 시각적으로 바로 확인 가능하게 해주세요! -->

## 🛠️ 작업내용

### 디버그 토큰 자동 등록
- `AppDelegate`에 `seedAPITestTokenIfNeeded()` 메서드 추가
- 스킴 환경변수 `UMC_API_TEST_ACCESS_TOKEN`으로 전달된 토큰을 Keychain에 자동 저장
- 디버그 빌드 시 인증 우회 편의성 향상

### MyProfileDTO 기수 매핑 안정화
- `MyProfileResponseDTO`의 gisuIdByGisu 딕셔너리 생성 로직을 `reduce(into:)`로 변경
- 동일 기수에 여러 역할이 존재할 때 `Dictionary(uniqueKeysWithValues:)` 크래시 방지
- gisuId가 0인 값보다 유효한 값을 우선 사용하도록 병합 로직 추가

## 📋 추후 진행 상황

- Home API 리팩토링 후속 작업

## 📌 리뷰 포인트

- `App/AppDelegate.swift` - `seedAPITestTokenIfNeeded()` 호출 순서 확인 (`seedAppStorageProfileIfNeeded` 전에 호출)
- `Features/Home/Data/DTO/MyProfileDTO.swift` - 동일 기수 다중 역할 시 gisuId 병합 로직 (0 값 우선순위 처리)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)