### PR TITLE
♻️ [Refactor] 공지·마이페이지 리팩토링 및 프로필 링크 수정 기능 (#310)

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/xcshareddata/xcschemes/NoticeDebug.xcscheme
+++ b/AppProduct/AppProduct.xcodeproj/xcshareddata/xcschemes/NoticeDebug.xcscheme
@@ -142,7 +142,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-noticeDebugState loaded"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-noticeDebugState failed"
@@ -154,7 +154,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--notice-force-permission"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>

--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -24,7 +24,7 @@ struct AppProductApp: App {
     @State private var container: DIContainer
     @State private var didConfigureAppDelegate: Bool = false
     @State private var errorHandler: ErrorHandler = .init()
-    @State private var appState: AppState = .splash
+    @State private var appState: AppState = .main
     private let sharedModelContainer: ModelContainer
     
     // MARK: - AppState

--- a/AppProduct/AppProduct/Core/Common/Authorization/Models/ResourcePermission.swift
+++ b/AppProduct/AppProduct/Core/Common/Authorization/Models/ResourcePermission.swift
@@ -21,6 +21,7 @@ enum AuthorizationResourceType: String, CaseIterable, Hashable {
 /// 리소스 권한 타입
 enum AuthorizationPermissionType: String, CaseIterable, Hashable {
     case read = "READ"
+    case edit = "EDIT"
     case write = "WRITE"
     case delete = "DELETE"
     case approve = "APPROVE"
@@ -44,4 +45,3 @@ struct ResourcePermission: Hashable {
         permissions.contains { grantedPermissions.contains($0) }
     }
 }
-

--- a/AppProduct/AppProduct/Core/Common/Error/Handler/ErrorHandler.swift
+++ b/AppProduct/AppProduct/Core/Common/Error/Handler/ErrorHandler.swift
@@ -197,13 +197,16 @@ final class ErrorHandler {
 
     private func describeDecodingError(_ error: DecodingError) -> String {
         switch error {
-        case .keyNotFound(let key, _):
-            return "Missing key: \(key.stringValue)"
+        case .keyNotFound(let key, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            let location = path.isEmpty ? key.stringValue : "\(path).\(key.stringValue)"
+            return "Missing key: \(location)"
         case .typeMismatch(let type, let context):
             let path = context.codingPath.map(\.stringValue).joined(separator: ".")
             return "Type mismatch: expected \(type) at \(path)"
-        case .valueNotFound(let type, _):
-            return "Value not found: \(type)"
+        case .valueNotFound(let type, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "Value not found: \(type) at \(path)"
         case .dataCorrupted(let context):
             return "Data corrupted: \(context.debugDescription)"
         @unknown default:
@@ -284,4 +287,3 @@ final class ErrorHandler {
         }
     }
 }
-

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
@@ -30,6 +30,8 @@ struct MyProfileResponseDTO: Codable {
     let schoolName: String
     /// 프로필 이미지 URL
     let profileImageLink: String?
+    /// 외부 프로필 링크
+    let profile: MyProfileExternalLinksDTO?
     /// 멤버 상태 (ACTIVE / INACTIVE / WITHDRAWN)
     let status: MemberStatus
     /// 기수별 역할 목록
@@ -45,6 +47,7 @@ struct MyProfileResponseDTO: Codable {
         case schoolId
         case schoolName
         case profileImageLink
+        case profile
         case status
         case roles
         case challengerRecords
@@ -59,9 +62,41 @@ struct MyProfileResponseDTO: Codable {
         schoolId = try container.decodeIntFlexibleIfPresent(forKey: .schoolId) ?? 0
         schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
         profileImageLink = try container.decodeIfPresent(String.self, forKey: .profileImageLink)
+        profile = try container.decodeIfPresent(MyProfileExternalLinksDTO.self, forKey: .profile)
         status = try container.decodeIfPresent(MemberStatus.self, forKey: .status) ?? .inactive
         roles = try container.decodeIfPresent([RoleDTO].self, forKey: .roles) ?? []
         challengerRecords = try container.decodeIfPresent([ChallengerMemberDTO].self, forKey: .challengerRecords) ?? []
+    }
+}
+
+// MARK: - External Links DTO
+
+/// 내 프로필 응답 내 `profile` 하위 객체
+struct MyProfileExternalLinksDTO: Codable {
+    let id: Int?
+    let linkedIn: String?
+    let instagram: String?
+    let github: String?
+    let blog: String?
+    let personal: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case linkedIn
+        case instagram
+        case github
+        case blog
+        case personal
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIntFlexibleIfPresent(forKey: .id)
+        linkedIn = try container.decodeIfPresent(String.self, forKey: .linkedIn)
+        instagram = try container.decodeIfPresent(String.self, forKey: .instagram)
+        github = try container.decodeIfPresent(String.self, forKey: .github)
+        blog = try container.decodeIfPresent(String.self, forKey: .blog)
+        personal = try container.decodeIfPresent(String.self, forKey: .personal)
     }
 }
 

--- a/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageUploadDTO.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageUploadDTO.swift
@@ -7,7 +7,27 @@
 
 import Foundation
 
+// MARK: - Profile Image
+
 /// 회원 정보 수정 요청 DTO (프로필 이미지 ID)
 struct UpdateMemberProfileImageRequestDTO: Codable {
     let profileImageId: String
+}
+
+// MARK: - Profile Links
+
+/// 회원 정보 수정 요청 DTO (소셜/포트폴리오 링크)
+///
+/// `PATCH /api/v1/member/profile/links` 요청 바디로 사용됩니다.
+struct UpdateMemberProfileLinksRequestDTO: Codable {
+    /// 수정할 링크 항목 배열
+    let links: [UpdateMemberProfileLinkRequestDTO]
+}
+
+/// 링크 수정 요청 항목 DTO
+struct UpdateMemberProfileLinkRequestDTO: Codable {
+    /// 링크 타입 (예: "GITHUB", "LINKEDIN", "BLOG")
+    let type: String
+    /// 링크 URL 문자열
+    let link: String
 }

--- a/AppProduct/AppProduct/Features/MyPage/Data/Repository/Mock/MockMyPageRepository.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Repository/Mock/MockMyPageRepository.swift
@@ -13,12 +13,36 @@ final class MockMyPageRepository: MyPageRepositoryProtocol {
         MyPageMockData.profile
     }
 
+    func fetchMemberProfile(memberId: Int) async throws -> MemberProfileSummary {
+        let profile = MyPageMockData.profile
+        let latestRole = profile.activityLogs
+            .sorted { $0.role > $1.role }
+            .first
+        return MemberProfileSummary(
+            memberId: "\(memberId)",
+            name: profile.challangerInfo.name,
+            nickname: profile.challangerInfo.nickname,
+            generation: profile.challangerInfo.gen,
+            roleName: latestRole?.role.korean ?? "챌린저",
+            profileImageURL: profile.challangerInfo.profileImage
+        )
+    }
+
     func updateProfileImage(
         imageData: Data,
         fileName: String,
         contentType: String
     ) async throws -> ProfileData {
         MyPageMockData.profile
+    }
+
+    func updateProfileLinks(
+        _ links: [ProfileLink]
+    ) async throws -> ProfileData {
+        let target = MyPageMockData.profile
+        var profile = target
+        profile.profileLink = links
+        return profile
     }
 
     func deleteMember() async throws {}

--- a/AppProduct/AppProduct/Features/MyPage/Data/Router/MyPageRouter.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Router/MyPageRouter.swift
@@ -15,8 +15,12 @@ import Moya
 enum MyPageRouter {
     /// 내 프로필 조회
     case getMyProfile
+    /// 특정 멤버 프로필 조회
+    case getMemberProfile(memberId: Int)
     /// 회원 정보 수정 (프로필 이미지 ID 반영)
     case patchMember(request: UpdateMemberProfileImageRequestDTO)
+    /// 회원 정보 수정 (외부 링크 반영)
+    case patchMemberProfileLinks(request: UpdateMemberProfileLinksRequestDTO)
     /// 회원 탈퇴
     case deleteMember
     /// 내가 쓴 글 목록
@@ -37,8 +41,12 @@ extension MyPageRouter: BaseTargetType {
         switch self {
         case .getMyProfile:
             return "/api/v1/member/me"
+        case .getMemberProfile(let memberId):
+            return "/api/v1/member/profile/\(memberId)"
         case .patchMember:
             return "/api/v1/member"
+        case .patchMemberProfileLinks:
+            return "/api/v1/member/profile/links"
         case .deleteMember:
             return "/api/v1/member"
         case .getMyPosts:
@@ -56,7 +64,11 @@ extension MyPageRouter: BaseTargetType {
         switch self {
         case .getMyProfile:
             return .get
+        case .getMemberProfile:
+            return .get
         case .patchMember:
+            return .patch
+        case .patchMemberProfileLinks:
             return .patch
         case .deleteMember:
             return .delete
@@ -71,7 +83,11 @@ extension MyPageRouter: BaseTargetType {
         switch self {
         case .getMyProfile, .deleteMember:
             return .requestPlain
+        case .getMemberProfile:
+            return .requestPlain
         case .patchMember(let request):
+            return .requestJSONEncodable(request)
+        case .patchMemberProfileLinks(let request):
             return .requestJSONEncodable(request)
         case .getMyPosts(let query),
              .getCommentedPosts(let query),

--- a/AppProduct/AppProduct/Features/MyPage/Domain/Interface/MyPageRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Domain/Interface/MyPageRepositoryProtocol.swift
@@ -12,6 +12,9 @@ protocol MyPageRepositoryProtocol: Sendable {
 
     /// 내 프로필 조회
     func fetchMyProfile() async throws -> ProfileData
+    
+    /// 특정 멤버 프로필 조회
+    func fetchMemberProfile(memberId: Int) async throws -> MemberProfileSummary
 
     /// 프로필 이미지를 업로드하고 회원 프로필에 반영합니다.
     ///
@@ -21,6 +24,11 @@ protocol MyPageRepositoryProtocol: Sendable {
         imageData: Data,
         fileName: String,
         contentType: String
+    ) async throws -> ProfileData
+
+    /// 외부 프로필 링크(GitHub, LinkedIn, Blog) 정보를 서버에 반영합니다.
+    func updateProfileLinks(
+        _ links: [ProfileLink]
     ) async throws -> ProfileData
 
     /// 회원 탈퇴를 수행합니다.

--- a/AppProduct/AppProduct/Features/MyPage/Domain/UseCases/Implementations/UpdateMyPageProfileLinksUseCase.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Domain/UseCases/Implementations/UpdateMyPageProfileLinksUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  UpdateMyPageProfileLinksUseCase.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 2/18/26.
+//
+
+import Foundation
+
+/// 프로필 외부 링크(GitHub, LinkedIn, Blog) 수정 UseCase 구현체
+///
+/// Repository를 통해 링크 수정 API를 호출하고 갱신된 프로필 데이터를 반환합니다.
+final class UpdateMyPageProfileLinksUseCase: UpdateMyPageProfileLinksUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: MyPageRepositoryProtocol
+
+    // MARK: - Init
+
+    init(repository: MyPageRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    func execute(profileLinks: [ProfileLink]) async throws -> ProfileData {
+        try await repository.updateProfileLinks(profileLinks)
+    }
+}

--- a/AppProduct/AppProduct/Features/MyPage/Domain/UseCases/UpdateMyPageProfileLinksUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Domain/UseCases/UpdateMyPageProfileLinksUseCaseProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  UpdateMyPageProfileLinksUseCaseProtocol.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 2/18/26.
+//
+
+import Foundation
+
+/// 프로필 외부 링크 수정 UseCase Protocol
+///
+/// 소셜/포트폴리오 링크 배열을 서버에 반영하고 갱신된 프로필을 반환합니다.
+protocol UpdateMyPageProfileLinksUseCaseProtocol {
+    /// 프로필 링크를 서버에 반영합니다.
+    ///
+    /// - Parameter profileLinks: 수정할 프로필 링크 배열
+    /// - Returns: 서버 반영 후 갱신된 `ProfileData`
+    func execute(
+        profileLinks: [ProfileLink]
+    ) async throws -> ProfileData
+}

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/LinkSection.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/LinkSection.swift
@@ -56,7 +56,7 @@ struct LinkSection: View {
 
             Button(action: {
                 // 유효한 URL이 있으면 열고, 없으면 Alert 표시
-                if let validURL = URL(string: linkRow.url), !linkRow.url.isEmpty {
+                if let validURL = Self.normalizedURL(linkRow.url) {
                     openURL(validURL)
                 } else {
                     alertInsert(linkRow.type.rawValue)
@@ -82,6 +82,25 @@ struct LinkSection: View {
     /// - Parameter profileLink: 표시할 프로필 링크 데이터
     /// - Returns: MyPageSectionRow 뷰
     private func row(_ profileLink: ProfileLink) -> some View {
-        MyPageSectionRow(icon: profileLink.type.icon, title: profileLink.type.title, rightImage: "arrow.up.right")
+            MyPageSectionRow(icon: profileLink.type.icon, title: profileLink.type.title, rightImage: "arrow.up.right")
+    }
+
+    /// URL 문자열을 정규화하여 유효한 URL을 반환합니다.
+    ///
+    /// 스킴이 없는 경우 `https://`를 자동 보완합니다.
+    /// 빈 문자열이거나 유효하지 않으면 `nil`을 반환합니다.
+    private static func normalizedURL(_ rawURL: String) -> URL? {
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let directURL = URL(string: trimmed), directURL.scheme != nil {
+            return directURL
+        }
+
+        if let withHTTPS = URL(string: "https://\(trimmed)") {
+            return withHTTPS
+        }
+
+        return nil
     }
 }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Enum/ScocialLinkType.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Enum/ScocialLinkType.swift
@@ -49,4 +49,30 @@ enum SocialLinkType: String, CaseIterable {
         case .blog: return "https://yourblog.com"
         }
     }
+
+    /// API 요청/응답에서 사용하는 type 문자열
+    var apiType: String {
+        switch self {
+        case .github:
+            return "GITHUB"
+        case .linkedin:
+            return "LINKEDIN"
+        case .blog:
+            return "BLOG"
+        }
+    }
+
+    /// API 문자열에서 SocialLinkType을 유추합니다.
+    init?(apiType: String) {
+        switch apiType.uppercased() {
+        case "GITHUB":
+            self = .github
+        case "LINKEDIN":
+            self = .linkedin
+        case "BLOG":
+            self = .blog
+        default:
+            return nil
+        }
+    }
 }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Provider/MyPageUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Provider/MyPageUseCaseProvider.swift
@@ -14,6 +14,8 @@ import Foundation
 protocol MyPageUseCaseProviding {
     var fetchMyPageProfileUseCase: FetchMyPageProfileUseCaseProtocol { get }
     var updateMyPageProfileImageUseCase: UpdateMyPageProfileImageUseCaseProtocol { get }
+    /// 프로필 외부 링크 수정 UseCase
+    var updateMyPageProfileLinksUseCase: UpdateMyPageProfileLinksUseCaseProtocol { get }
     var deleteMemberUseCase: DeleteMemberUseCaseProtocol { get }
     var fetchMyPostsUseCase: FetchMyPostsUseCaseProtocol { get }
     var fetchMyCommentedPostsUseCase: FetchMyCommentedPostsUseCaseProtocol { get }
@@ -30,6 +32,7 @@ final class MyPageUseCaseProvider: MyPageUseCaseProviding {
 
     let fetchMyPageProfileUseCase: FetchMyPageProfileUseCaseProtocol
     let updateMyPageProfileImageUseCase: UpdateMyPageProfileImageUseCaseProtocol
+    let updateMyPageProfileLinksUseCase: UpdateMyPageProfileLinksUseCaseProtocol
     let deleteMemberUseCase: DeleteMemberUseCaseProtocol
     let fetchMyPostsUseCase: FetchMyPostsUseCaseProtocol
     let fetchMyCommentedPostsUseCase: FetchMyCommentedPostsUseCaseProtocol
@@ -44,6 +47,9 @@ final class MyPageUseCaseProvider: MyPageUseCaseProviding {
             repository: repository
         )
         self.updateMyPageProfileImageUseCase = UpdateMyPageProfileImageUseCase(
+            repository: repository
+        )
+        self.updateMyPageProfileLinksUseCase = UpdateMyPageProfileLinksUseCase(
             repository: repository
         )
         self.deleteMemberUseCase = DeleteMemberUseCase(

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageProfileViewModel.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageProfileViewModel.swift
@@ -33,6 +33,9 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
 
     /// 프로필 이미지 수정 API 진행 상태
     var isUpdatingProfileImage: Bool = false
+
+    /// 최초 조회/수정 화면 진입 시 링크 스냅샷
+    private var initialProfileLinkState: [SocialLinkType: String]
     
     init(
         profileData: ProfileData,
@@ -40,6 +43,7 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
     ) {
         self.profileData = profileData
         self.useCaseProvider = useCaseProvider
+        self.initialProfileLinkState = Self.makeProfileLinkState(from: profileData.profileLink)
     }
     
     // MARK: - Function
@@ -52,7 +56,17 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
 
     /// 저장 버튼 활성화 여부
     var canSubmit: Bool {
-        selectedImageData != nil && !isUpdatingProfileImage
+        !isUpdatingProfileImage && (hasPendingImageUpdate || hasPendingLinkUpdate)
+    }
+
+    /// 갤러리에서 새 이미지를 선택하여 업로드 대기 중인지 여부
+    private var hasPendingImageUpdate: Bool {
+        selectedImageData != nil
+    }
+
+    /// 현재 링크 상태가 최초 스냅샷과 달라져 서버 반영이 필요한지 여부
+    private var hasPendingLinkUpdate: Bool {
+        Self.makeProfileLinkState(from: normalizedProfileLinksForSubmit) != initialProfileLinkState
     }
 
     /// 프로필 이미지를 서버에 업로드 후 회원 정보에 반영합니다.
@@ -63,26 +77,75 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
     /// - Throws: 네트워크 오류 또는 서버 에러
     /// - Important: 호출 전 `canSubmit`이 true인지 확인해야 합니다.
     @MainActor
-    func submitProfileImageUpdate() async throws {
-        guard let imageData = selectedImageData else {
+    func submitProfileUpdate() async throws {
+        guard !isUpdatingProfileImage else {
+            return
+        }
+
+        let hasImageUpdate = selectedImageData != nil
+        let hasLinkUpdate = hasPendingLinkUpdate
+        guard hasImageUpdate || hasLinkUpdate else {
             return
         }
 
         isUpdatingProfileImage = true
         defer { isUpdatingProfileImage = false }
 
-        // 타임스탬프 기반 고유 파일명 생성
-        let fileName = "profile_\(Int(Date().timeIntervalSince1970)).jpg"
-        let updatedProfile = try await useCaseProvider
-            .updateMyPageProfileImageUseCase
-            .execute(
-                imageData: imageData,
-                fileName: fileName,
-                contentType: "image/jpeg"
-            )
+        var updatedProfile = profileData
+
+        if hasImageUpdate, let imageData = selectedImageData {
+            let fileName = "profile_\(Int(Date().timeIntervalSince1970)).jpg"
+            updatedProfile = try await useCaseProvider
+                .updateMyPageProfileImageUseCase
+                .execute(
+                    imageData: imageData,
+                    fileName: fileName,
+                    contentType: "image/jpeg"
+                )
+        }
+
+        if hasLinkUpdate {
+            updatedProfile = try await useCaseProvider
+                .updateMyPageProfileLinksUseCase
+                .execute(profileLinks: normalizedProfileLinksForSubmit)
+        }
 
         profileData = updatedProfile
+        initialProfileLinkState = Self.makeProfileLinkState(from: updatedProfile.profileLink)
         selectedImageData = nil
         selectedPhotoItem = nil
+    }
+
+    // MARK: - Private Method
+
+    /// 현재 프로필 링크를 정규화하여 서버 제출용 배열로 반환합니다.
+    private var normalizedProfileLinksForSubmit: [ProfileLink] {
+        let currentLinks = Self.makeProfileLinkState(from: profileData.profileLink)
+
+        return SocialLinkType.allCases.map {
+            ProfileLink(
+                type: $0,
+                url: currentLinks[$0] ?? ""
+            )
+        }
+    }
+
+    /// 프로필 링크 배열을 `[SocialLinkType: String]` 스냅샷으로 변환합니다.
+    ///
+    /// 변경 감지(diff) 비교에 사용되며, URL 공백을 제거하고
+    /// 모든 `SocialLinkType` 케이스에 대해 키를 보장합니다.
+    private static func makeProfileLinkState(
+        from profileLinks: [ProfileLink]
+    ) -> [SocialLinkType: String] {
+        var mapped: [SocialLinkType: String] = [:]
+        profileLinks.forEach {
+            mapped[$0.type] = $0.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return Dictionary(
+            uniqueKeysWithValues: SocialLinkType.allCases.map { type in
+                (type, mapped[type] ?? "")
+            }
+        )
     }
 }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyActivePostsView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyActivePostsView.swift
@@ -199,6 +199,7 @@ private func myActivePostsPreview(
 private struct MyPageUseCaseProviderPreviewMock: MyPageUseCaseProviding {
     let fetchMyPageProfileUseCase: FetchMyPageProfileUseCaseProtocol = FetchMyPageProfilePreviewUseCase()
     let updateMyPageProfileImageUseCase: UpdateMyPageProfileImageUseCaseProtocol = UpdateMyPageProfileImagePreviewUseCase()
+    let updateMyPageProfileLinksUseCase: UpdateMyPageProfileLinksUseCaseProtocol = UpdateMyPageProfileLinksPreviewUseCase()
     let deleteMemberUseCase: DeleteMemberUseCaseProtocol = DeleteMemberPreviewUseCase()
     let fetchMyPostsUseCase: FetchMyPostsUseCaseProtocol = FetchMyPostsPreviewUseCase()
     let fetchMyCommentedPostsUseCase: FetchMyCommentedPostsUseCaseProtocol = FetchMyCommentedPostsPreviewUseCase()
@@ -233,6 +234,16 @@ private struct UpdateMyPageProfileImagePreviewUseCase: UpdateMyPageProfileImageU
         contentType: String
     ) async throws -> ProfileData {
         try await FetchMyPageProfilePreviewUseCase().execute()
+    }
+}
+
+private struct UpdateMyPageProfileLinksPreviewUseCase: UpdateMyPageProfileLinksUseCaseProtocol {
+    func execute(
+        profileLinks: [ProfileLink]
+    ) async throws -> ProfileData {
+        var profile = try await FetchMyPageProfilePreviewUseCase().execute()
+        profile.profileLink = profileLinks
+        return profile
     }
 }
 

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
@@ -74,14 +74,14 @@ struct MyPageProfileView: View {
     private func submitProfileUpdate() {
         Task {
             do {
-                try await viewModel.submitProfileImageUpdate()
+                try await viewModel.submitProfileUpdate()
                 dismiss()
             } catch {
                 errorHandler.handle(
                     error,
                     context: .init(
                         feature: "MyPage",
-                        action: "submitProfileImageUpdate"
+                        action: "submitProfileUpdate"
                     )
                 )
             }

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailDTO.swift
@@ -22,9 +22,10 @@ struct NoticeDetailDTO: Codable {
     let createdAt: String
     let updatedAt: String?
     let targetInfo: NoticeTargetInfoDTO
-    let authorChallengerId: String
+    let authorChallengerId: String?
+    let authorMemberId: String?
     let authorNickname: String?
-    let authorName: String
+    let authorName: String?
     let authorProfileImageUrl: String?
 
     // 상세 추가 필드
@@ -35,6 +36,61 @@ struct NoticeDetailDTO: Codable {
     let category: String?
     let isMustRead: Bool?
     let hasPermission: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case content
+        case shouldSendNotification
+        case viewCount
+        case createdAt
+        case updatedAt
+        case targetInfo
+        case authorChallengerId
+        case authorMemberId
+        case authorNickname
+        case authorName
+        case authorProfileImageUrl
+        case vote
+        case images
+        case links
+        case scope
+        case category
+        case isMustRead
+        case hasPermission
+    }
+
+    /// 커스텀 디코더: 필드 누락·타입 불일치를 방어적으로 처리합니다.
+    ///
+    /// 서버 응답이 불완전할 경우에도 앱 크래시를 방지하기 위해
+    /// 각 필드에 대해 개별적으로 디코딩을 시도하고 기본값으로 폴백합니다.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decodeStringFlexible(forKey: .id)
+        title = try container.decodeStringOrEmpty(forKey: .title)
+        content = try container.decodeStringOrEmpty(forKey: .content)
+        shouldSendNotification = try? container.decode(Bool.self, forKey: .shouldSendNotification)
+        viewCount = try container.decodeStringFlexible(forKey: .viewCount)
+        createdAt = try container.decodeStringOrEmpty(forKey: .createdAt)
+        updatedAt = try? container.decodeIfPresent(String.self, forKey: .updatedAt)
+        targetInfo = (try? container.decode(NoticeTargetInfoDTO.self, forKey: .targetInfo))
+            ?? NoticeTargetInfoDTO(targetGisuId: "0", targetChapterId: nil, targetSchoolId: nil, targetParts: nil)
+        authorChallengerId = try? container.decodeStringOrNil(forKey: .authorChallengerId)
+        authorMemberId = try? container.decodeStringOrNil(forKey: .authorMemberId)
+        authorNickname = try? container.decodeStringOrNil(forKey: .authorNickname)
+        authorName = try? container.decodeStringOrNil(forKey: .authorName)
+        authorProfileImageUrl = try? container.decodeStringOrNil(forKey: .authorProfileImageUrl)
+
+        vote = try? container.decodeIfPresent(NoticeDetailVoteDTO.self, forKey: .vote)
+        images = (try? container.decode([NoticeDetailImageDTO].self, forKey: .images)) ?? []
+        links = (try? container.decode([NoticeDetailLinkDTO].self, forKey: .links)) ?? []
+
+        scope = try? container.decodeStringOrNil(forKey: .scope)
+        category = try? container.decodeStringOrNil(forKey: .category)
+        isMustRead = try? container.decodeIfPresent(Bool.self, forKey: .isMustRead)
+        hasPermission = try? container.decodeIfPresent(Bool.self, forKey: .hasPermission)
+    }
 }
 
 // MARK: - toDomain 변환
@@ -90,8 +146,9 @@ extension NoticeDetailDTO {
             isMustRead: isMustRead ?? false,
             title: title,
             content: content,
-            authorID: authorChallengerId,
-            authorName: authorName,
+            authorID: authorChallengerId ?? "0",
+            authorMemberId: authorMemberId,
+            authorName: authorName ?? "알 수 없음",
             authorImageURL: authorProfileImageUrl,
             createdAt: createdAt.toISO8601Date(),
             updatedAt: updatedAt?.toISO8601Date(),
@@ -119,5 +176,42 @@ private extension String {
         }
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: self) ?? Date()
+    }
+}
+
+// MARK: - Flexible Decoding Helpers
+
+private extension KeyedDecodingContainer {
+    /// String/Int/Double 타입을 모두 String으로 디코딩합니다.
+    func decodeStringFlexible(forKey key: Key) throws -> String {
+        if let value = try? decode(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(value)
+        }
+        throw DecodingError.valueNotFound(
+            String.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected String value for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    /// 디코딩 실패 시 빈 문자열을 반환합니다.
+    func decodeStringOrEmpty(forKey key: Key) throws -> String {
+        return (try? decodeStringFlexible(forKey: key)) ?? ""
+    }
+
+    /// 명시적 null 또는 디코딩 실패 시 nil을 반환합니다.
+    func decodeStringOrNil(forKey key: Key) throws -> String? {
+        if try decodeNil(forKey: key) {
+            return nil
+        }
+        return try? decodeStringFlexible(forKey: key)
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticePageDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticePageDTO.swift
@@ -18,5 +18,46 @@ struct NoticePageDTO<T: Codable>: Codable {
     let totalElements: String
     let totalPages: String
     let hasNext: Bool
-    let hasPrevious: Bool
+    let hasPrevious: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case content
+        case page
+        case size
+        case totalElements
+        case totalPages
+        case hasNext
+        case hasPrevious
+    }
+
+    /// 테스트/프리뷰용 멤버와이즈 이니셜라이저
+    init(
+        content: [T],
+        page: String,
+        size: String,
+        totalElements: String,
+        totalPages: String,
+        hasNext: Bool,
+        hasPrevious: Bool?
+    ) {
+        self.content = content
+        self.page = page
+        self.size = size
+        self.totalElements = totalElements
+        self.totalPages = totalPages
+        self.hasNext = hasNext
+        self.hasPrevious = hasPrevious
+    }
+
+    /// 커스텀 디코더: 서버 응답의 페이징 메타데이터를 안전하게 파싱합니다.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.content = try container.decode([T].self, forKey: .content)
+        self.page = try container.decode(String.self, forKey: .page)
+        self.size = try container.decode(String.self, forKey: .size)
+        self.totalElements = try container.decode(String.self, forKey: .totalElements)
+        self.totalPages = try container.decode(String.self, forKey: .totalPages)
+        self.hasNext = try container.decode(Bool.self, forKey: .hasNext)
+        self.hasPrevious = try container.decodeIfPresent(Bool.self, forKey: .hasPrevious)
+    }
 }

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeReadStatusDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeReadStatusDTO.swift
@@ -16,6 +16,14 @@ struct NoticeReadStaticsDTO: Codable {
     let unreadCount: String
     let readRate: String
 
+    /// 테스트/프리뷰 및 낙관적 UI 갱신용 멤버와이즈 이니셜라이저
+    init(totalCount: String, readCount: String, unreadCount: String, readRate: String) {
+        self.totalCount = totalCount
+        self.readCount = readCount
+        self.unreadCount = unreadCount
+        self.readRate = readRate
+    }
+
     private enum CodingKeys: String, CodingKey {
         case totalCount
         case readCount
@@ -23,6 +31,7 @@ struct NoticeReadStaticsDTO: Codable {
         case readRate
     }
 
+    /// 커스텀 디코더: 서버 응답의 숫자/문자열 타입 불일치를 유연하게 처리합니다.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.totalCount = container.decodeFlexibleString(forKey: .totalCount)

--- a/AppProduct/AppProduct/Features/Notice/Domain/Enums/NoticeRequestFactory.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Enums/NoticeRequestFactory.swift
@@ -65,11 +65,11 @@ enum NoticeRequestFactory {
             requestSchoolId = nil
             requestPart = selectedPart?.umcPartType
         case .school:
-            requestChapterId = myChapterId
+            requestChapterId = nil
             requestSchoolId = mySchoolId
             requestPart = selectedPart?.umcPartType
         case .part(let filterPart):
-            requestChapterId = myChapterId
+            requestChapterId = nil
             requestSchoolId = mySchoolId
             requestPart = filterPart.umcPartType
         }

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
@@ -31,6 +31,8 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
 
     /// 작성자 ID
     let authorID: String
+    /// 작성자 멤버 ID (authorMemberId)
+    let authorMemberId: String?
     /// 작성자 이름
     let authorName: String
     /// 작성자 프로필 이미지 URL
@@ -56,7 +58,9 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
     /// 첨부 투표
     let vote: NoticeVote?
 
-    
+    /// 작성자 표기 기본값 (닉네임/이름-기수TH UMC 직책)
+    var defaultAuthorDisplayName: String { authorName }
+
     /// NoticeChip에 표시할 공지 타입
     var noticeType: NoticeType {
         // 파트 공지인 경우
@@ -73,6 +77,48 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
         case .campus:
             return .campus
         }
+    }
+
+    init(
+        id: String,
+        generation: Int,
+        scope: NoticeScope,
+        category: NoticeCategory,
+        isMustRead: Bool,
+        title: String,
+        content: String,
+        authorID: String,
+        authorMemberId: String? = nil,
+        authorName: String,
+        authorImageURL: String?,
+        createdAt: Date,
+        updatedAt: Date?,
+        targetAudience: TargetAudience,
+        hasPermission: Bool,
+        images: [String],
+        imageItems: [NoticeAttachmentImage] = [],
+        links: [String],
+        vote: NoticeVote?
+    ) {
+        self.id = id
+        self.generation = generation
+        self.scope = scope
+        self.category = category
+        self.isMustRead = isMustRead
+        self.title = title
+        self.content = content
+        self.authorID = authorID
+        self.authorMemberId = authorMemberId
+        self.authorName = authorName
+        self.authorImageURL = authorImageURL
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.targetAudience = targetAudience
+        self.hasPermission = hasPermission
+        self.images = images
+        self.imageItems = imageItems
+        self.links = links
+        self.vote = vote
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeModel.swift
@@ -188,3 +188,30 @@ struct GenerationFilterState: Equatable {
         mainFilterStates[key] = state
     }
 }
+
+// MARK: - NoticeListSubFilterChip
+/// 공지 리스트 하단 칩 구성 타입
+enum NoticeListSubFilterChip: Identifiable, Equatable {
+    case all
+    case branch
+    case school
+    case part
+
+    var id: String {
+        switch self {
+        case .all: return "all"
+        case .branch: return "branch"
+        case .school: return "school"
+        case .part: return "part"
+        }
+    }
+
+    var labelText: String {
+        switch self {
+        case .all: return "전체"
+        case .branch: return "지부"
+        case .school: return "학교"
+        case .part: return "파트"
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/Attachment/ImageAttachmentCard.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/Attachment/ImageAttachmentCard.swift
@@ -62,7 +62,7 @@ struct ImageAttachmentCard: View, Equatable {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFill()
-            } else if let imageURL, let url = URL(string: imageURL) {
+            } else if let imageURL, let url = resolveImageURL(from: imageURL) {
                 KFImage(url)
                     .placeholder {
                         RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius)
@@ -87,6 +87,20 @@ struct ImageAttachmentCard: View, Equatable {
                 .glassEffect()
                 .padding(Constants.xmarkPadding)
         }
+    }
+
+    /// 이미지 문자열을 앱에서 사용할 수 있는 URL 문자열로 정규화합니다.
+    /// 상대 식별값(예: 업로드 파일 ID)도 서버 파일 조회 API 경로로 변환합니다.
+    private func resolveImageURL(from rawURL: String) -> URL? {
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let absoluteURL = URL(string: trimmed), absoluteURL.scheme != nil {
+            return absoluteURL
+        }
+
+        guard let baseURL = URL(string: Config.baseURL) else { return nil }
+        return baseURL.appendingPathComponent("api/v1/storage/\(trimmed)")
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeLinkCard.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeLinkCard.swift
@@ -23,7 +23,14 @@ struct NoticeLinkCard: View {
     // MARK: - Body
     var body: some View {
         Button(action: {
-            openURL(URL(string: url)!)
+            let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard
+                let linkURL = URL(string: trimmed),
+                linkURL.scheme != nil
+            else {
+                return
+            }
+            openURL(linkURL)
         }) {
             HStack {
                 LinkIconPresenter()

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeReadStatusButton.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeReadStatusButton.swift
@@ -16,17 +16,20 @@ struct NoticeReadStatusButton: View {
     let confirmedCount: Int
     let totalCount: Int
     let readRate: Double?
+    let isLoading: Bool
     let action: () -> Void
 
     init(
         confirmedCount: Int,
         totalCount: Int,
         readRate: Double? = nil,
+        isLoading: Bool = false,
         action: @escaping () -> Void
     ) {
         self.confirmedCount = confirmedCount
         self.totalCount = totalCount
         self.readRate = readRate
+        self.isLoading = isLoading
         self.action = action
     }
     
@@ -47,6 +50,9 @@ struct NoticeReadStatusButton: View {
     }
     
     private var progressText: String {
+        if isLoading {
+            return "불러오는 중..."
+        }
         let percentage = Int(progress * 100)
         return "\(confirmedCount)/\(totalCount)명 (\(percentage)%)"
     }
@@ -88,9 +94,15 @@ struct NoticeReadStatusButton: View {
                 .foregroundStyle(.grey000)
                 
                 // 중간: Gauge
-                Gauge(value: progress, in: 0...1) {}
-                    .gaugeStyle(.linearCapacity)
-                    .tint(progressGradient)
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(.linear)
+                        .tint(.grey400)
+                } else {
+                    Gauge(value: progress, in: 0...1) {}
+                        .gaugeStyle(.linearCapacity)
+                        .tint(progressGradient)
+                }
                 
                 // 하단: 안내 텍스트
                 Text("터치하여 미확인 인원 관리하기")
@@ -105,6 +117,7 @@ struct NoticeReadStatusButton: View {
                     .glassEffect(.regular.interactive(), in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius))
             }
         }
+        .disabled(isLoading)
     }
 }
 
@@ -122,6 +135,14 @@ struct NoticeReadStatusButton: View {
         
         NoticeReadStatusButton(confirmedCount: 0, totalCount: 10) {
             print("Tapped")
+        }
+
+        NoticeReadStatusButton(
+            confirmedCount: 0,
+            totalCount: 0,
+            isLoading: true
+        ) {
+            print("Loading")
         }
     }
     .padding()

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift
@@ -20,6 +20,66 @@ extension NoticeDetailViewModel {
         }
     }
 
+    /// 공지 상세 진입 시 통계(read-statics)만 선조회합니다.
+    ///
+    /// 하단 수신 확인 카드의 숫자/비율을 먼저 안정적으로 노출하고,
+    /// 상세 목록(read-status)은 시트 진입 시점에만 로드합니다.
+    @MainActor
+    func prefetchReadStaticsIfNeeded(forceReload: Bool = false) async {
+        guard forceReload || !hasPrefetchedReadStatics else { return }
+        guard noticeID > 0 else { return }
+        if forceReload == false, readStatics != nil { return }
+
+        isReadStaticsLoading = true
+        defer { isReadStaticsLoading = false }
+        do {
+            readStatics = try await noticeUseCase.getReadStatics(noticeId: noticeID)
+            hasPrefetchedReadStatics = true
+        } catch let error as RepositoryError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "prefetchReadStaticsIfNeeded"
+                )
+            )
+            // 통계 선조회 실패는 상세 진입을 막지 않으며, 시트 진입 시 재시도할 수 있습니다.
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "prefetchReadStaticsIfNeeded"
+                )
+            )
+            // 통계 선조회 실패는 상세 진입을 막지 않으며, 시트 진입 시 재시도할 수 있습니다.
+        }
+    }
+
+    /// 읽음 처리 직후 UI를 즉시 반영하기 위해 통계를 낙관적으로 갱신합니다.
+    func applyOptimisticReadStatics() {
+        guard let current = readStatics else { return }
+
+        let readCount = Int(current.readCount) ?? 0
+        let unreadCount = Int(current.unreadCount) ?? 0
+        let totalCount = Int(current.totalCount) ?? max(readCount + unreadCount, 0)
+
+        guard totalCount > 0 else { return }
+        guard unreadCount > 0 else { return }
+        guard readCount < totalCount else { return }
+
+        let nextReadCount = readCount + 1
+        let nextUnreadCount = max(unreadCount - 1, 0)
+        let nextReadRate = Double(nextReadCount) / Double(totalCount)
+
+        readStatics = NoticeReadStaticsDTO(
+            totalCount: String(totalCount),
+            readCount: String(nextReadCount),
+            unreadCount: String(nextUnreadCount),
+            readRate: String(nextReadRate)
+        )
+    }
+
     /// 공지 열람 현황 데이터 로드 (통계 + 상세)
     @MainActor
     func fetchReadStatus(showLoadingState: Bool = true) async {
@@ -41,9 +101,12 @@ extension NoticeDetailViewModel {
 
         do {
             resetReadStatusPagination()
-
-            let statics = try await noticeUseCase.getReadStatics(noticeId: noticeID)
-            readStatics = statics
+            if readStatics == nil {
+                isReadStaticsLoading = true
+                readStatics = try await noticeUseCase.getReadStatics(noticeId: noticeID)
+                hasPrefetchedReadStatics = true
+                isReadStaticsLoading = false
+            }
 
             let confirmedResponse = try await fetchReadStatusPage(cursorId: 0, status: .confirmed)
             let unconfirmedResponse = try await fetchReadStatusPage(cursorId: 0, status: .unconfirmed)
@@ -64,15 +127,38 @@ extension NoticeDetailViewModel {
                 )
             )
 
+        } catch let error as RepositoryError {
+            isReadStaticsLoading = false
+            readStatics = nil
+            readStatusState = .failed(.repository(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchReadStatus")
+            )
         } catch let error as DomainError {
+            isReadStaticsLoading = false
             readStatics = nil
             readStatusState = .failed(.domain(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchReadStatus")
+            )
         } catch let error as NetworkError {
+            isReadStaticsLoading = false
             readStatics = nil
             readStatusState = .failed(.network(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchReadStatus")
+            )
         } catch {
+            isReadStaticsLoading = false
             readStatics = nil
             readStatusState = .failed(.unknown(message: error.localizedDescription))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchReadStatus")
+            )
         }
     }
 
@@ -143,7 +229,17 @@ extension NoticeDetailViewModel {
             }
 
             readStatusState = .loaded(current)
+        } catch let error as RepositoryError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "loadMoreReadStatusIfNeeded")
+            )
+            // 페이징 실패는 기존 데이터를 유지합니다.
         } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "loadMoreReadStatusIfNeeded")
+            )
             // 페이징 실패는 기존 데이터를 유지합니다.
         }
     }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
@@ -99,6 +99,9 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
     /// 학교 선택 시트 목록
     var schoolOptions: [NoticeTargetOption] = []
 
+    /// 타겟(지부/학교/파트) 시트 데이터 로딩 상태
+    var targetOptionsState: Loadable<Bool> = .idle
+
     /// 공지사항 제목
     var title: String = ""
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
@@ -20,13 +20,15 @@ extension NoticeViewModel {
     ///   - organizationTypeRawValue: 사용자 조직 타입 raw value
     ///   - chapterId: 사용자 지부 ID
     ///   - schoolId: 사용자 학교 ID
+    ///   - memberRoleRawValue: 사용자 역할 raw value
     func applyUserContext(
         schoolName: String,
         chapterName: String,
         responsiblePart: String,
         organizationTypeRawValue: String,
         chapterId: Int,
-        schoolId: Int
+        schoolId: Int,
+        memberRoleRawValue: String
     ) {
         self.userContext = NoticeUserContext(
             schoolName: schoolName,
@@ -34,12 +36,14 @@ extension NoticeViewModel {
             responsiblePart: responsiblePart
         )
         self.organizationType = OrganizationType(rawValue: organizationTypeRawValue)
+        self.memberRole = ManagementTeam(rawValue: memberRoleRawValue)
         self.chapterId = chapterId
         self.schoolId = schoolId
 
-        if organizationType != .central, case .central = selectedMainFilter {
+        let validMainFilters = mainFilterItems
+        if !validMainFilters.contains(selectedMainFilter) {
             var state = currentState
-            state.mainFilter = .all
+            state.mainFilter = validMainFilters.first ?? .all
             currentState = state
         }
     }
@@ -63,11 +67,25 @@ extension NoticeViewModel {
                 }
             } else {
                 noticeItems = .failed(.domain(.custom(message: "기수 정보를 불러오지 못했습니다.")))
+                errorHandler?.handle(
+                    DomainError.custom(message: "기수 정보를 불러오지 못했습니다."),
+                    context: .init(
+                        feature: "Notice",
+                        action: "fetchGisuList"
+                    )
+                )
             }
         } catch {
             gisuPairs = []
             generations = []
             noticeItems = .failed(.domain(.custom(message: "기수 정보를 불러오지 못했습니다.")))
+            errorHandler?.handle(
+                error,
+                context: .init(
+                    feature: "Notice",
+                    action: "fetchGisuList"
+                )
+            )
         }
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -153,7 +153,7 @@ struct NoticeDetailView: View {
                     Image(data.authorImageURL ?? Constants.defaultProfileImageName)
                         .resizable()
                         .frame(width: Constants.profileSize.width, height: Constants.profileSize.height)
-                    Text(data.authorName)
+                    Text(viewModel.authorDisplayName.isEmpty ? data.authorName : viewModel.authorDisplayName)
                 }
                 Spacer()
                 Text(data.createdAt.toYearMonthDay())
@@ -168,7 +168,7 @@ struct NoticeDetailView: View {
 
     /// 공지 본문/투표/이미지/링크를 순서대로 구성합니다.
     private func bottomSection(_ data: NoticeDetail) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
             Text(data.content)
                 .appFont(.body)
                 .multilineTextAlignment(.leading)
@@ -254,7 +254,8 @@ struct NoticeDetailView: View {
             NoticeReadStatusButton(
                 confirmedCount: viewModel.confirmedCount,
                 totalCount: viewModel.totalCount,
-                readRate: viewModel.readRate
+                readRate: viewModel.readRate,
+                isLoading: viewModel.isReadStaticsLoading && viewModel.readStatics == nil
             ) {
                 viewModel.openReadStatusSheet()
             }
@@ -309,23 +310,34 @@ struct NoticeDetailView: View {
 
     // MARK: - Task
 
-    /// 화면 진입 시 읽음 처리, 열람 현황, 권한, 상세 데이터를 순차 로드합니다.
+    /// 화면 진입 시 읽음 처리, 열람 현황, 권한, 상세 데이터를 로드합니다.
     @MainActor
     private func onTask() async {
         viewModel.updateErrorHandler(errorHandler)
-        await viewModel.markAsReadIfNeeded()
-        await viewModel.fetchReadStatus()
-        await viewModel.fetchNoticePermission()
+
         guard !shouldForceDetailFailedInDebug else {
             viewModel.noticeState = .failed(.unknown(message: "공지 상세 데이터를 불러오지 못했습니다."))
             return
         }
-        guard !shouldSkipDetailFetchInDebug else {
+
+        if shouldSkipDetailFetchInDebug {
             viewModel.isDetailPreparedForEdit = true
-            return
+            Task { await viewModel.prefetchReadStaticsIfNeeded(forceReload: true) }
+        } else {
+            async let detailTask: Void = viewModel.fetchNoticeDetail()
+            async let staticsTask: Void = viewModel.prefetchReadStaticsIfNeeded()
+            async let permissionTask: Void = viewModel.fetchNoticePermission()
+            async let markAsReadTask = viewModel.markAsReadIfNeeded()
+
+            let didMarkAsRead = await markAsReadTask
+            await detailTask
+            await staticsTask
+            await permissionTask
+            if didMarkAsRead {
+                viewModel.applyOptimisticReadStatics()
+                Task { await viewModel.prefetchReadStaticsIfNeeded(forceReload: true) }
+            }
         }
-        await viewModel.fetchNoticeDetail()
-        await viewModel.fetchNoticePermission()
     }
 
     // MARK: - Private Methods

--- a/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
+++ b/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
@@ -78,9 +78,16 @@ fileprivate struct HomeBottonAccessoryView: View {
 fileprivate struct NoticeAccessoryView: View {
     @Environment(\.di) private var di
     @AppStorage(AppStorageKey.noticeSelectedGisuId) private var noticeSelectedGisuId: Int = 0
+    @AppStorage(AppStorageKey.memberRole) private var memberRoleRaw: String = ""
 
     private var pathStore: PathStore {
         di.resolve(PathStore.self)
+    }
+
+    /// 중앙 운영 사무국원은 공지 작성 권한이 없어 작성 버튼을 노출하지 않습니다.
+    private var canShowCreateButton: Bool {
+        let role = ManagementTeam(rawValue: memberRoleRaw)
+        return role != .centralOperatingTeamMember && role != .challenger
     }
 
     /// 에디터에 전달할 기수 ID (0이면 nil로 변환)
@@ -90,7 +97,7 @@ fileprivate struct NoticeAccessoryView: View {
 
     var body: some View {
         Group {
-            if pathStore.noticePath.isEmpty {
+            if pathStore.noticePath.isEmpty && canShowCreateButton {
                 Button(action: {
                     pathStore.noticePath.append(
                         .notice(.editor(mode: .create, selectedGisuId: selectedGisuId))

--- a/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcTab.swift
+++ b/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcTab.swift
@@ -99,8 +99,12 @@ struct UmcTab: View {
     ///
     /// Activity 탭에서는 Admin 권한이 있는 경우에만 Accessory를 표시합니다.
     private func shouldShowAccessory() -> Bool {
-        // 챌린저는 공지 탭에서만 Bottom Accessory를 노출하지 않음
-        if tabCase == .notice && isGeneralChallenger {
+        // 공지 작성 권한이 없는 역할은 공지 탭 Accessory를 숨깁니다.
+        if tabCase == .notice && (effectiveMemberRole == .challenger || isGeneralChallenger) {
+            return false
+        }
+        // 중앙 운영 사무국원은 공지 작성 권한이 없어 공지 탭 Accessory를 숨깁니다.
+        if tabCase == .notice && effectiveMemberRole == .centralOperatingTeamMember {
             return false
         }
 


### PR DESCRIPTION
## ✨ PR 유형

공지사항 에디터/상세/열람 현황 리팩토링 + 마이페이지 프로필 링크 수정 기능 추가

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->

## 🛠️ 작업내용

### 마이페이지 프로필 링크 수정
- `UpdateMyPageProfileLinksUseCase` / `Protocol` 신규 추가
- `MyPageRepository`에 링크 정규화(`normalizedProfileLinks`) 및 PATCH API 연결
- `MyPageProfileViewModel`에 링크 변경 감지(diff 기반) 및 제출 로직 추가
- `MyPageRouter`에 `patchMemberProfileLinks` 라우트 추가
- `MyPageUploadDTO`에 링크 수정 요청 DTO 추가
- `SocialLinkType`에 `apiType`, `placeholder` 프로퍼티 추가
- `LinkSection`에 URL 정규화(`normalizedURL`) 로직 추가

### 공지 에디터 역할 기반 타겟 정책 정교화
- 중앙 총괄/부총괄, 교육국원, 지부장, 학교 회장단별 카테고리/서브카테고리 정책 분리
- `allowedSubCategories(for:memberRole:)` 역할별 서브카테고리 노출 제어
- `normalizeSelectionForCurrentCategory`로 선택 상태 일관성 보장
- 기수 미선택 시 금지 조합(학교+파트) 방지 로직 추가

### 공지 상세 작성자 프로필 표시 개선
- `authorMemberId` 기반 멤버 프로필 API 조회
- "닉네임/이름-기수TH UMC 직책" 형식으로 작성자 표시명 갱신
- `NoticeDetailModel`에 `authorMemberId`, `defaultAuthorDisplayName` 추가

### 공지 열람 통계 선조회 및 낙관적 UI 갱신
- `prefetchReadStaticsIfNeeded`로 상세 진입 시 통계 먼저 로드
- `applyOptimisticReadStatics`로 읽음 처리 직후 UI 즉시 반영
- `NoticeReadStatusButton`에 `isLoading`, `readRate` 프로퍼티 추가

### 공지 DTO 방어적 디코딩 강화
- `NoticeDTO`, `NoticeDetailDTO`, `NoticePageDTO`, `NoticeReadStatusDTO`에 String/Int/Double 유연 디코딩 적용
- 커스텀 디코더로 서버 응답 타입 불일치 방어

### 기타
- `ResourcePermission` 모델 및 리소스별 권한 조회 기능 추가
- `ErrorHandler`에 `RepositoryError` 분기 추가
- 디버그 스킴 기본 비활성화 (NoticeDebug loaded/force-permission → NO)
- 전체 변경 파일에 Swift 문서화 주석(`///`) 및 MARK 섹션 보강

## 📋 추후 진행 상황

- 공지 에디터 필독(isMustRead) 기능 연결
- 열람 현황 필터(지부별/학교별) UI 연동
- 프로필 링크 수정 후 마이페이지 갱신 플로우 검증

## 📌 리뷰 포인트

- `Features/MyPage/Domain/UseCases/` - 프로필 링크 수정 UseCase 설계 확인
- `Features/MyPage/Data/Repository/MyPageRepository.swift` - `normalizedProfileLinks` 정규화 로직
- `Features/MyPage/Presentation/ViewModels/MyPageProfileViewModel.swift` - 링크 변경 감지 diff 로직 (`makeProfileLinkState`)
- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift` - 역할별 타겟 정책 (`allowedSubCategories`, `normalizeSelectionForCurrentCategory`)
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift` - 작성자 프로필 조회 및 표시명 조합 로직
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift` - 통계 선조회 및 낙관적 갱신

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)