### PR TITLE
✨ [Feat] 홈 최근 공지 상세 진입 및 UX 개선 (#314)

### DIFF
--- a/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
@@ -61,6 +61,8 @@ enum NavigationDestination: Hashable {
         case registrationSchedule
         /// 일정 상세 (scheduleId: 일정 ID, selectedDate: 선택 날짜)
         case detailSchedule(scheduleId: Int, selectedDate: Date)
+        /// 홈에서 진입하는 공지 상세
+        case detailNotice(detailItem: NoticeDetail)
     }
 
     /// 공지사항(Notice) 관련 화면 목적지

--- a/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
@@ -75,6 +75,12 @@ private extension NavigationRoutingView {
                 scheduleId: scheduleId,
                 selectedDate: selectedDate
             )
+        case .detailNotice(let detailItem):
+            NoticeDetailView(
+                container: di,
+                errorHandler: errorHandler,
+                model: detailItem
+            )
         }
     }
     

--- a/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityDetailView.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityDetailView.swift
@@ -29,12 +29,12 @@ struct CommunityDetailView: View {
         static let commentInputActionRowSpacing: CGFloat = DefaultSpacing.spacing8
         static let textFieldMinHeight: CGFloat = 36
         static let textFieldPadding: EdgeInsets = .init(top: 0, leading: 16, bottom: 0, trailing: 16)
-        static let sendButtonSize: CGSize = .init(width: 48, height: 48)
+        static let sendButtonSize: CGSize = .init(width: 42, height: 42)
         static let commentLoadingMessage: String = "댓글을 불러오는 중입니다..."
         static let commentsCountTitle: String = "댓글 %d개"
         static let commentLoadFailedTitle: String = "댓글을 불러오지 못했어요"
         static let commentLoadFailedDescription: String = "댓글을 불러오지 못했습니다.\n잠시 후 다시 시도해주세요."
-        static let collapsedButtonSize: CGFloat = 56
+        static let collapsedButtonSize: CGFloat = 64
         static let inputHorizontalPadding: CGFloat = 20
         static let inputBottomOffset: CGFloat = 10
         static let commentInputAnimation: Animation = .easeInOut(duration: 0.2)

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
@@ -62,6 +62,7 @@ struct NoticeListRequestDTO {
 /// 홈 화면 최근 공지 Response DTO
 struct NoticeListResponseDTO: Codable {
     let id: String
+    let noticeId: Int
     let title: String
     let content: String
     let shouldSendNotification: Bool
@@ -75,6 +76,7 @@ struct NoticeListResponseDTO: Codable {
 
     private enum CodingKeys: String, CodingKey {
         case id
+        case noticeId
         case title
         case content
         case shouldSendNotification
@@ -89,7 +91,11 @@ struct NoticeListResponseDTO: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        self.id = try container.decodeStringFlexibleIfPresent(forKey: .id) ?? "0"
+        let decodedId = try container.decodeStringFlexibleIfPresent(forKey: .id) ?? "0"
+        let decodedNoticeId = try container.decodeIntFlexibleIfPresent(forKey: .noticeId)
+
+        self.id = decodedId
+        self.noticeId = decodedNoticeId ?? Int(decodedId) ?? 0
         self.title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
         self.content = try container.decodeIfPresent(String.self, forKey: .content) ?? ""
         self.shouldSendNotification = try container.decodeBoolFlexibleIfPresent(forKey: .shouldSendNotification) ?? false
@@ -120,6 +126,7 @@ extension NoticeListResponseDTO {
         let date = createdAt.toISO8601Date()
 
         return RecentNoticeData(
+            noticeId: noticeId,
             category: category,
             title: title,
             createdAt: date

--- a/AppProduct/AppProduct/Features/Home/Domain/Models/Home/RecentNoticeData.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/Home/RecentNoticeData.swift
@@ -15,6 +15,9 @@ struct RecentNoticeData: Equatable, Identifiable {
     
     /// 고유 식별자
     let id: UUID = .init()
+
+    /// 공지 ID (상세 조회용)
+    let noticeId: Int
     
     /// 공지 카테고리 (학교, 운영진, 지부 등)
     let category: RecentCategory
@@ -24,4 +27,16 @@ struct RecentNoticeData: Equatable, Identifiable {
     
     /// 공지사항 작성 일시
     let createdAt: Date
+
+    init(
+        noticeId: Int = 0,
+        category: RecentCategory,
+        title: String,
+        createdAt: Date
+    ) {
+        self.noticeId = noticeId
+        self.category = category
+        self.title = title
+        self.createdAt = createdAt
+    }
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
@@ -362,10 +362,55 @@ struct HomeView: View {
         } else {
             LazyVStack(spacing: DefaultSpacing.spacing8) {
                 ForEach(recentNoticeData.prefix(Constants.recentCardCount), id: \.id) { data in
-                    RecentNoticeCard(data: data)
+                    Button {
+                        openRecentNoticeDetail(data)
+                    } label: {
+                        RecentNoticeCard(data: data)
+                    }
+                    .buttonStyle(.plain)
                 }
             }
         }
+    }
+
+    private func openRecentNoticeDetail(_ data: RecentNoticeData) {
+        let detail = makeNoticeDetail(from: data)
+        pathStore.homePath.append(.home(.detailNotice(detailItem: detail)))
+    }
+
+    private func makeNoticeDetail(from data: RecentNoticeData) -> NoticeDetail {
+        let scope: NoticeScope
+        switch data.category {
+        case .operationsTeam:
+            scope = .central
+        case .univ:
+            scope = .campus
+        case .oranization:
+            scope = .branch
+        }
+
+        let generation = viewModel.roles.max(by: { $0.gisu < $1.gisu })?.gisu ?? 0
+        let targetAudience = TargetAudience.all(generation: generation, scope: scope)
+
+        return NoticeDetail(
+            id: String(data.noticeId),
+            generation: generation,
+            scope: scope,
+            category: .general,
+            isMustRead: false,
+            title: data.title,
+            content: "",
+            authorID: "",
+            authorName: "",
+            authorImageURL: nil,
+            createdAt: data.createdAt,
+            updatedAt: nil,
+            targetAudience: targetAudience,
+            hasPermission: false,
+            images: [],
+            links: [],
+            vote: nil
+        )
     }
 }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
@@ -22,6 +22,11 @@ struct ScheduleDetailView: View {
         static let editLoadingMessage: String = "일정 정보를 불러오는 중입니다."
         static let detailTitle: String = "상세 안내"
         static let mapButtonTitle: String = "지도 보기"
+        static let failedTitle: String = "일정을 불러오지 못했어요"
+        static let failedSystemImage: String = "exclamationmark.triangle"
+        static let retryTitle: String = "다시 시도"
+        static let retryMinButtonWidth: CGFloat = 72
+        static let retryMinButtonHeight: CGFloat = 20
     }
 
     // MARK: - Init
@@ -81,8 +86,22 @@ struct ScheduleDetailView: View {
                         longitude: data.longitude
                     )
                 }
-        case .failed:
-            Color.clear
+        case .failed(let error):
+            RetryContentUnavailableView(
+                title: Constants.failedTitle,
+                systemImage: Constants.failedSystemImage,
+                description: error.userMessage,
+                retryTitle: Constants.retryTitle,
+                isRetrying: viewModel.data.isLoading,
+                minRetryButtonWidth: Constants.retryMinButtonWidth,
+                minRetryButtonHeight: Constants.retryMinButtonHeight
+            ) {
+                let provider = di.resolve(HomeUseCaseProviding.self)
+                await viewModel.fetchScheduleDetail(
+                    fetchScheduleDetailUseCase: provider.fetchScheduleDetailUseCase
+                )
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -250,7 +250,7 @@ struct NoticeDetailView: View {
     /// 펼침 상태 수신 확인 카드 inset
     @ViewBuilder
     private func expandedReadStatusInset() -> some View {
-        if !isReadStatusBarCollapsed {
+        if shouldShowReadStatusInset && !isReadStatusBarCollapsed {
             NoticeReadStatusButton(
                 confirmedCount: viewModel.confirmedCount,
                 totalCount: viewModel.totalCount,
@@ -269,7 +269,7 @@ struct NoticeDetailView: View {
     /// 압축 상태 원형 버튼 inset
     @ViewBuilder
     private func collapsedReadStatusInset() -> some View {
-        if isReadStatusBarCollapsed {
+        if shouldShowReadStatusInset && isReadStatusBarCollapsed {
             Button(action: expandReadStatusBar) {
                 Image(systemName: Constants.collapsedButtonIcon)
                     .font(.system(size: Constants.collapsedButtonIconSize, weight: .semibold))
@@ -317,6 +317,10 @@ struct NoticeDetailView: View {
 
         guard !shouldForceDetailFailedInDebug else {
             viewModel.noticeState = .failed(.unknown(message: "공지 상세 데이터를 불러오지 못했습니다."))
+            return
+        }
+        guard viewModel.noticeID > 0 else {
+            viewModel.noticeState = .failed(.unknown(message: "유효하지 않은 공지입니다."))
             return
         }
 
@@ -454,5 +458,13 @@ struct NoticeDetailView: View {
     /// 현재 로드된 공지 상세 데이터 (loaded 상태일 때만 존재)
     private var currentNotice: NoticeDetail? {
         viewModel.noticeState.value
+    }
+
+    /// 상세 로드 실패/로딩 상태에서는 하단 수신 확인 inset을 숨깁니다.
+    private var shouldShowReadStatusInset: Bool {
+        if case .loaded = viewModel.noticeState {
+            return true
+        }
+        return false
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Feature - 홈 최근 공지 카드 탭 시 공지 상세 진입, 이미지 뷰어 드래그 dismiss, 일정 상세 에러 UI 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이므로 스크린샷/영상 첨부 필요 -->

## 🛠️ 작업내용

### 홈 최근 공지 상세 진입
- `NavigationDestination.home`에 `detailNotice` 케이스 추가
- `NavigationRoutingView`에 `NoticeDetailView` 라우팅 연결
- `RecentNoticeData`에 `noticeId` 필드 추가 및 memberwise init 구현
- `NoticeListResponseDTO`에 `noticeId` 디코딩 추가
- `HomeView`에 `makeNoticeDetail(from:)` 변환 로직 및 카드 탭 액션 구현

### 공지 상세 개선
- `NoticeDetailView` 수신 확인 inset을 `loaded` 상태에서만 표시 (`shouldShowReadStatusInset`)
- `noticeID`가 0 이하일 때 유효하지 않은 공지 에러 처리

### 이미지 뷰어 UX
- `ImageViewerScreen`에 아래로 드래그하여 닫기 제스처 추가 (120pt 임계값)
- 스프링 애니메이션으로 원위치 복귀

### 기타 개선
- `ScheduleDetailView` 실패 상태에 `RetryContentUnavailableView` 적용
- `CommunityDetailView` 댓글 입력 버튼/필드 사이즈 미세 조정

## 📋 추후 진행 상황

- 홈 공지 상세에서 전체 content 로딩 (현재 빈 문자열로 전달 후 상세 API에서 로드)
- 이미지 뷰어 드래그 시 배경 투명도 연동

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/HomeView.swift` - `makeNoticeDetail(from:)` 변환 로직 (카테고리→scope 매핑)
- `Core/Navigation/NavigationDestination.swift` - `detailNotice` 네비게이션 케이스 추가
- `Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift` - `shouldShowReadStatusInset` 및 noticeID 유효성 검사
- `Features/Notice/Presentation/Components/DetailCard/NoticeImageCard.swift` - 드래그 dismiss 제스처 로직
- `Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift` - 실패 상태 RetryContentUnavailableView 적용

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)