### PR TITLE
🚑 [Hotfix] v1.0.0 재배포 - Release 빌드 오류 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockActivityRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockActivityRepository.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+#if DEBUG
 /// Activity Repository Mock 구현 (개발/테스트용)
 final class MockActivityRepository: ActivityRepositoryProtocol {
 
@@ -21,3 +22,4 @@ final class MockActivityRepository: ActivityRepositoryProtocol {
         return AttendancePreviewData.userId
     }
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockStudyRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockStudyRepository.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+#if DEBUG
 // MARK: - MockStudyRepository
 
 /// Study Repository Mock 구현체
@@ -301,3 +302,4 @@ final class MockStudyRepository: StudyRepositoryProtocol {
         try await Task.sleep(for: .milliseconds(300))
     }
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift
@@ -185,6 +185,7 @@ struct ChallengerAttendanceView: View, Equatable {
     }
 }
 
+#if DEBUG
 // MARK: - Previews
 
 #Preview("출석 전 상태") {
@@ -208,3 +209,4 @@ struct ChallengerAttendanceView: View, Equatable {
         session: AttendancePreviewData.pendingApprovalSession
     )
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
@@ -103,6 +103,7 @@ private struct MyAttendanceItemPresenter: View, Equatable {
     }
 }
 
+#if DEBUG
 // MARK: - Preview
 
 #Preview(traits: .sizeThatFitsLayout) {
@@ -123,3 +124,4 @@ private struct MyAttendanceItemPresenter: View, Equatable {
     .frame(height: 200)
     .background(Color.grey100)
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerSessionCard.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerSessionCard.swift
@@ -94,12 +94,14 @@ struct ChallengerSessionCard: View, Equatable {
     }
 }
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     ZStack {
         Color.grey100.frame(height: 300)
-        
+
         ChallengerSessionCard(
             session: AttendancePreviewData.sessions[1]
         )
     }
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCard.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCard.swift
@@ -125,6 +125,7 @@ fileprivate struct ChallengerMissionCardPresenter: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview("ChallengerMissionCard - All Status") {
     struct PreviewWrapper: View {
         @FocusState private var focusedMissionID: UUID?
@@ -189,3 +190,4 @@ fileprivate struct ChallengerMissionCardPresenter: View, Equatable {
     }
     return PreviewWrapper()
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/ActivityCompactMapView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/ActivityCompactMapView.swift
@@ -122,6 +122,7 @@ fileprivate struct LocationStatusBarView: View {
     }
 }
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     ActivityCompactMapView(
         mapViewModel: BaseMapViewModel(
@@ -136,4 +137,4 @@ fileprivate struct LocationStatusBarView: View {
         LocationManager.shared.requestAuthorization()
     }
 }
-
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/BaseMapComponent.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/BaseMapComponent.swift
@@ -87,9 +87,11 @@ struct BaseMapComponent: View, Equatable {
     }
 }
 
+#if DEBUG
 #Preview {
     BaseMapComponent(viewModel: .init(
         container: AttendancePreviewData.container,
         info: AttendancePreviewData.sessionInfo,
         errorHandler: AttendancePreviewData.errorHandler))
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorAttendanceStatsRow.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorAttendanceStatsRow.swift
@@ -94,6 +94,7 @@ struct OperatorAttendanceStatsRow: View, Equatable {
 
 }
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     ZStack {
         Color.grey100.frame(height: 300)
@@ -111,3 +112,4 @@ struct OperatorAttendanceStatsRow: View, Equatable {
         .padding()
     }
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorPendingSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorPendingSheetView.swift
@@ -157,6 +157,7 @@ struct OperatorPendingSheetView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     NavigationStack {
         Text("Preview")
@@ -177,3 +178,4 @@ struct OperatorPendingSheetView: View {
         )
     }
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -245,6 +245,7 @@ struct ChallengerAttendanceSessionView: View {
     }
 }
 
+#if DEBUG
 #Preview("기본 (필터링 적용)") {
     ZStack {
         Color.grey100.ignoresSafeArea()
@@ -287,3 +288,4 @@ struct ChallengerAttendanceSessionView: View {
         )
     }
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
@@ -129,8 +129,10 @@ struct ChallengerMemberListView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     ChallengerMemberListView(
         container: MissionPreviewData.container,
         errorHandler: MissionPreviewData.errorHandler)
-} 
+}
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerStudyView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerStudyView.swift
@@ -89,8 +89,10 @@ struct ChallengerStudyView: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview {
     ChallengerStudyView(
         container: MissionPreviewData.container,
         errorHandler: MissionPreviewData.errorHandler)
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
@@ -245,6 +245,7 @@ struct OperatorAttendanceSectionView: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview {
     OperatorAttendanceSectionView(
         container: AttendancePreviewData.container,
@@ -252,3 +253,4 @@ struct OperatorAttendanceSectionView: View {
         sessions: AttendancePreviewData.sessions
     )
 }
+#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorMemberManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorMemberManagementView.swift
@@ -139,12 +139,11 @@ struct OperatorMemberManagementView: View {
         }
     }
 }
-
-
-
+#if DEBUG
 #Preview {
     OperatorMemberManagementView(
         container: MissionPreviewData.container,
         errorHandler: MissionPreviewData.errorHandler
     )
 }
+#endif


### PR DESCRIPTION
## ✨ PR 유형

- 🚑 [Hotfix]
- v1.0.0 재배포를 위한 Release 빌드 실패 수정

## 📷 스크린샷 or 영상(UI 변경 시)

- UI 변경 없음

## 🛠️ 작업내용

- Activity 영역 Preview 코드를 `#if DEBUG`로 감싸 Release 컴파일 대상에서 제외
- `MockActivityRepository`, `MockStudyRepository`를 DEBUG 전용으로 제한
- Release에서 발생하던 PreviewData 참조 오류 및 관련 연쇄 컴파일 오류 제거

## 📋 추후 진행 상황

- 동일 패턴의 DEBUG 전용 참조 누락 여부 정적 점검
- 배포 후 develop/main 동기화 상태 점검

## 📌 리뷰 포인트

- Preview 가드 적용 파일들에서 Release 빌드 시 PreviewData 참조가 남지 않는지
- Mock Repository 2개가 DEBUG에서만 컴파일되는지
- 검증 명령 결과
  - `xcodebuild -project AppProduct/AppProduct.xcodeproj -scheme AppProduct -configuration Release -destination 'generic/platform=iOS Simulator' build`

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
