### PR TITLE
👷 [CI/CD] Xcode Cloud Firebase plist 복원 처리 추가

### DIFF
--- a/AppProduct/Documentation.docc/Resources/SECRET_CIDCD_GUIDE.md
+++ b/AppProduct/Documentation.docc/Resources/SECRET_CIDCD_GUIDE.md
@@ -41,8 +41,28 @@ BASE_URL[config=Release]=https:/$()/api.your-service.com
 | `BASE_URL_DEBUG` | Debug API 서버 주소 | `https://dev.api.umc-product.com` |
 | `BASE_URL_RELEASE` | Release API 서버 주소 | `https://api.umc-product.com` |
 | `BASE_URL` | 레거시 단일 API 주소(선택) | `https://api.umc-product.com` |
+| `TMAP_SECRET_KEY` | TMap Geocoding Secret Key | `your_tmap_secret_key` |
+| `GOOGLE_SERVICE_INFO_PLIST_BASE64` | `GoogleService-Info.plist`의 Base64 문자열 | `PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4...` |
 
 4. 환경 변수는 `ci_scripts/ci_post_clone.sh`에서 자동으로 `Secrets.xcconfig`에 주입됩니다
+
+5. Firebase 설정 파일(`GoogleService-Info.plist`)은 `GOOGLE_SERVICE_INFO_PLIST_BASE64`로 복원됩니다
+
+### GoogleService-Info.plist Base64 생성 방법
+
+로컬에서 아래 명령으로 Base64 문자열을 만든 뒤, App Store Connect의 Xcode Cloud 환경 변수에
+`GOOGLE_SERVICE_INFO_PLIST_BASE64`로 등록하세요.
+
+```bash
+# macOS
+base64 -i AppProduct/AppProduct/GoogleService-Info.plist | tr -d '\n'
+
+# Linux
+base64 -w 0 AppProduct/AppProduct/GoogleService-Info.plist
+```
+
+> 보안상 `GoogleService-Info.plist` 원본 파일은 저장소에 커밋하지 않고,
+> Xcode Cloud 환경 변수로만 주입하는 방식을 권장합니다.
 
 ### GitHub Actions (선택 사항)
 
@@ -55,6 +75,8 @@ GitHub Actions를 사용하는 경우:
    - `BASE_URL_DEBUG`
    - `BASE_URL_RELEASE`
    - `BASE_URL` (선택, 하위 호환)
+   - `TMAP_SECRET_KEY`
+   - `GOOGLE_SERVICE_INFO_PLIST_BASE64`
 
 ## 보안 주의사항
 


### PR DESCRIPTION
## ✨ PR 유형

- [x] CI/CD
- [x] Docs

## 📷 스크린샷 or 영상(UI 변경 시)
- UI 변경 없음

## 🛠️ 작업내용
- `ci_scripts/ci_post_clone.sh`에 `GOOGLE_SERVICE_INFO_PLIST_BASE64` 환경변수를 디코드해 `AppProduct/AppProduct/GoogleService-Info.plist`를 생성하는 로직 추가
- `GOOGLE_SERVICE_INFO_PLIST_CONTENT`(raw xml) fallback 경로 추가
- 복원된 plist 형식 검증(`<plist` 포함 여부) 및 실패 시 명확한 에러 메시지 추가
- 민감정보 노출 방지를 위해 `Secrets.xcconfig` 전체 출력 제거
- `AppProduct/Documentation.docc/Resources/SECRET_CIDCD_GUIDE.md`에 Xcode Cloud 환경변수/설정 절차 및 Base64 생성 방법 문서화

## 📋 추후 진행 상황
- App Store Connect > Xcode Cloud 환경변수에 `GOOGLE_SERVICE_INFO_PLIST_BASE64` 실제 값 등록
- 워크플로우 1회 실행해 post-clone 단계에서 plist 복원 로그 확인

## 📌 리뷰 포인트
- `ci_scripts/ci_post_clone.sh`의 base64 디코드 분기(macOS/GNU) 동작
- `ci_scripts/ci_post_clone.sh`의 필수 env 누락 시 실패 처리 및 로그 메시지
- `AppProduct/Documentation.docc/Resources/SECRET_CIDCD_GUIDE.md`의 운영 절차가 실제 설정 화면과 일치하는지

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
