### PR TITLE
🐛 [Fix] 자동 로그인 판정 로직 개선 및 인증 플로우 안정화

### DIFF
--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -90,7 +90,8 @@ extension AppProductApp {
                     networkClient: container.resolve(NetworkClient.self),
                     fetchMyProfileUseCase: container.resolve(
                         HomeUseCaseProviding.self
-                    ).fetchMyProfileUseCase
+                    ).fetchMyProfileUseCase,
+                    tokenStore: container.resolve(TokenStore.self)
                 )
                 .transition(rootTransition)
 
@@ -100,6 +101,7 @@ extension AppProductApp {
                     fetchMyProfileUseCase: container.resolve(
                         HomeUseCaseProviding.self
                     ).fetchMyProfileUseCase,
+                    tokenStore: container.resolve(TokenStore.self),
                     errorHandler: errorHandler
                 )
                 .transition(rootTransition)
@@ -167,6 +169,7 @@ extension AppProductApp {
     
     /// 세션 만료 시 캐시 초기화 후 로그인 화면으로 전환합니다.
     private func handleAuthSessionExpired() {
+        UserDefaults.standard.set(false, forKey: AppStorageKey.canAutoLogin)
         Task {
             try? await container.resolve(NetworkClient.self).logout()
         }

--- a/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
@@ -25,6 +25,8 @@ enum AppStorageKey {
     static let recentSearchPlaces: String = "recentSearchPlaces"
     /// OAuth 연동된 소셜 provider 목록(JSON 문자열 배열)
     static let connectedSocialProviders: String = "connectedSocialProviders"
+    /// 자동 로그인 허용 여부 (승인/등록 완료 사용자만 true)
+    static let canAutoLogin: String = "canAutoLogin"
 
     // MARK: - Profile (최신 기수 기준)
 

--- a/AppProduct/AppProduct/Core/Manager/User/UserSessionManager.swift
+++ b/AppProduct/AppProduct/Core/Manager/User/UserSessionManager.swift
@@ -22,8 +22,7 @@ final class UserSessionManager {
     // MARK: - Property
 
     /// 현재 사용자의 역할 (서버에서 받아온 실제 권한)
-    // TODO: 바텀 엑세서리 확인 위해 기본 권환 바꿨으므로 추후 배포 시에는 challenger로 수정 필요 - [25.1.23] 이재원
-    private(set) var currentRole: ManagementTeam = .centralOperatingTeamMember
+    private(set) var currentRole: ManagementTeam = .challenger
 
     /// Admin 모드 활성화 여부
     private(set) var isAdminModeEnabled: Bool = false

--- a/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
+++ b/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
@@ -12,6 +12,7 @@ import SwiftUI
     LoginView(
         loginUseCase: PreviewLoginUseCase(),
         fetchMyProfileUseCase: PreviewFetchMyProfileUseCase(),
+        tokenStore: KeychainTokenStore(),
         errorHandler: ErrorHandler()
     )
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
@@ -94,7 +94,7 @@ struct FailedVerificationUMC: View {
             }
             .alert("기존 챌린저 코드 입력", isPresented: $showCodeAlert) {
                 TextField("6자리 코드", text: $challengerCode)
-                    .keyboardType(.numberPad)
+                    .keyboardType(.asciiCapable)
                 Button("닫기", role: .cancel) {
                     challengerCode = ""
                 }
@@ -147,8 +147,8 @@ struct FailedVerificationUMC: View {
     /// 기존 챌린저 인증 코드를 서버에 전송합니다.
     private func submitChallengerCode() {
         let trimmedCode = challengerCode.trimmingCharacters(in: .whitespacesAndNewlines)
-        let isDigitsOnly = trimmedCode.allSatisfy(\.isNumber)
-        guard trimmedCode.count == 6, isDigitsOnly else {
+        let isAlphanumeric = trimmedCode.unicodeScalars.allSatisfy(CharacterSet.alphanumerics.contains)
+        guard trimmedCode.count == 6, isAlphanumeric else {
             presentInvalidCodePrompt()
             return
         }
@@ -181,6 +181,10 @@ struct FailedVerificationUMC: View {
             message: "기존 챌린저로 인증되었습니다.",
             positiveBtnTitle: "확인",
             positiveBtnAction: {
+                UserDefaults.standard.set(
+                    true,
+                    forKey: AppStorageKey.canAutoLogin
+                )
                 appFlow.showMain()
             }
         )
@@ -190,7 +194,7 @@ struct FailedVerificationUMC: View {
     private func presentInvalidCodePrompt() {
         alertPrompt = AlertPrompt(
             title: "인증 실패",
-            message: "입력 코드 번호가 존재하지 않습니다.",
+            message: "입력 코드가 존재하지 않습니다.",
             positiveBtnTitle: "확인"
         )
     }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -24,12 +24,14 @@ struct LoginView: View {
     init(
         loginUseCase: LoginUseCaseProtocol,
         fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol,
+        tokenStore: TokenStore,
         errorHandler: ErrorHandler
     ) {
         self._viewModel = .init(
             wrappedValue: LoginViewModel(
                 loginUseCase: loginUseCase,
                 fetchMyProfileUseCase: fetchMyProfileUseCase,
+                tokenStore: tokenStore,
                 errorHandler: errorHandler
             )
         )
@@ -126,10 +128,68 @@ fileprivate struct BottomSocialBtns: View {
                     }
                 }, label: {
                     btn.image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
                 })
                 .glassEffect(.regular.interactive())
                 .disabled(isLoading)
             }
         }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .padding(.bottom, DefaultConstant.defaultSafeBottom)
     }
 }
+
+#if DEBUG
+#Preview("로그인 화면") {
+    LoginView(
+        loginUseCase: LoginViewPreviewLoginUseCase(),
+        fetchMyProfileUseCase: LoginViewPreviewFetchMyProfileUseCase(),
+        tokenStore: KeychainTokenStore(),
+        errorHandler: ErrorHandler()
+    )
+}
+
+private struct LoginViewPreviewLoginUseCase: LoginUseCaseProtocol {
+    func executeKakao(accessToken: String, email: String) async throws -> OAuthLoginResult {
+        .existingMember(
+            tokenPair: TokenPair(
+                accessToken: "preview_access_token",
+                refreshToken: "preview_refresh_token"
+            )
+        )
+    }
+
+    func executeApple(authorizationCode: String) async throws -> OAuthLoginResult {
+        .existingMember(
+            tokenPair: TokenPair(
+                accessToken: "preview_access_token",
+                refreshToken: "preview_refresh_token"
+            )
+        )
+    }
+}
+
+private struct LoginViewPreviewFetchMyProfileUseCase: FetchMyProfileUseCaseProtocol {
+    func execute() async throws -> HomeProfileResult {
+        HomeProfileResult(
+            memberId: 1,
+            schoolId: 1,
+            schoolName: "UMC University",
+            latestChallengerId: 1,
+            latestGisuId: 1,
+            chapterId: 1,
+            chapterName: "Preview",
+            part: .front(type: .ios),
+            seasonTypes: [
+                .days(1),
+                .gens([1])
+            ],
+            roles: [],
+            generations: [
+                GenerationData(gisuId: 1, gen: 1, penaltyPoint: 0, penaltyLogs: [])
+            ]
+        )
+    }
+}
+#endif

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
@@ -92,6 +92,10 @@ struct SignUpView: View {
             }
             .onChange(of: viewModel.registerState) { _, newState in
                 if case .loaded = newState {
+                    UserDefaults.standard.set(
+                        false,
+                        forKey: AppStorageKey.canAutoLogin
+                    )
                     appFlow.showPendingApproval()
                 }
             }

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
@@ -167,6 +167,7 @@ extension MyProfileResponseDTO {
 
     /// DTO → HomeProfileResult 변환 (기수 카드 + 역할 정보)
     func toHomeProfileResult(seasonTypes: [SeasonType]? = nil) -> HomeProfileResult {
+        let records = challengerRecords ?? []
         let challengerRoles = roles.map {
             ChallengerRole(
                 challengerId: $0.challengerId,
@@ -195,12 +196,16 @@ extension MyProfileResponseDTO {
             return record.toGenerationData(gisuId: gisuId)
         }
 
-        let latestRecord = (challengerRecords ?? [])
+        let latestRecord = records
             .max(by: { $0.gisu < $1.gisu })
+
+        let mergedGens = Set(roles.map(\.gisu) + records.map(\.gisu))
+            .filter { $0 > 0 }
+            .sorted()
 
         let resolvedSeasonTypes = seasonTypes ?? [
             .days(0),
-            .gens(Set(roles.map(\.gisu)).sorted())
+            .gens(mergedGens)
         ]
 
         return HomeProfileResult(

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/HomeRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/HomeRepository.swift
@@ -110,8 +110,12 @@ final class HomeRepository: HomeRepositoryProtocol, @unchecked Sendable {
 
 private extension HomeRepository {
     func makeSeasonTypes(profile: MyProfileResponseDTO) async throws -> [SeasonType] {
-        let generations = Set(profile.roles.map(\.gisu)).sorted()
-        let gisuIds = Set(profile.roles.map(\.gisuId)).filter { $0 > 0 }
+        let records = profile.challengerRecords ?? []
+        let generations = Set(profile.roles.map(\.gisu) + records.map(\.gisu))
+            .filter { $0 > 0 }
+            .sorted()
+        let gisuIds = Set(profile.roles.map(\.gisuId) + records.map(\.gisuId))
+            .filter { $0 > 0 }
 
         guard !gisuIds.isEmpty else {
             return [

--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
@@ -276,17 +276,25 @@ fileprivate struct CardInfo: View {
     @ViewBuilder
     private func descripContent(items: [PenaltyInfoItem]) -> some View {
         if items.isEmpty {
-            ContentUnavailableView(
-                "등록된 패널티가 없습니다.",
-                systemImage: "exclamationmark.circle",
-                description: Text("현재 부과된 패널티 사유가 없습니다.")
-            )
+            emptyPenaltyState
         } else {
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
                 ForEach(items.indices, id: \.self) { index in
                     descripCard(item: items[index])
                 }
             }
+        }
+    }
+
+    private var emptyPenaltyState: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            Image(systemName: "checkmark.shield.fill")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(.green500)
+
+            Text("등록된 패널티가 없습니다.")
+                .appFont(.bodyEmphasis, color: .grey900)
+                .multilineTextAlignment(.leading)
         }
     }
     

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
@@ -246,7 +246,7 @@ struct HomeView: View {
                                systemImage: "calendar.badge.exclamationmark",
                                description: Text("선택한 날짜에 등록된 일정이 없습니다.")
         )
-        .glassEffect(.regular, in: .containerRelative)
+        .glassEffect(.regular, in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true))
     }
 
     @MainActor
@@ -353,7 +353,12 @@ struct HomeView: View {
     @ViewBuilder
     private func recentView(_ recentNoticeData: [RecentNoticeData]) -> some View {
         if recentNoticeData.isEmpty {
-            LoadingView(.home(.recentNoticeLoading))
+            ContentUnavailableView(
+                "최근 공지가 없습니다.",
+                systemImage: "megaphone",
+                description: Text("아직 등록된 최근 공지 항목이 없습니다.")
+            )
+            .glassEffect(.regular, in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true))
         } else {
             LazyVStack(spacing: DefaultSpacing.spacing8) {
                 ForEach(recentNoticeData.prefix(Constants.recentCardCount), id: \.id) { data in
@@ -417,4 +422,30 @@ private struct ScheduleCardPressStyle: ButtonStyle {
             .opacity(configuration.isPressed ? 0.92 : 1.0)
             .animation(.spring(response: 0.22, dampingFraction: 0.8), value: configuration.isPressed)
     }
+}
+
+#Preview("홈 - Empty Data") {
+    let container = DIContainer()
+    container.register(PathStore.self) { PathStore() }
+
+    return HomeView(
+        container: container,
+        viewModel: HomeViewModel.emptyPreview(container: container),
+        shouldFetchOnTask: false
+    )
+    .environment(\.di, container)
+    .environment(ErrorHandler())
+}
+
+#Preview("홈 - 패널티 0점") {
+    let container = DIContainer()
+    container.register(PathStore.self) { PathStore() }
+
+    return HomeView(
+        container: container,
+        viewModel: HomeViewModel.zeroPenaltyPreview(container: container),
+        shouldFetchOnTask: false
+    )
+    .environment(\.di, container)
+    .environment(ErrorHandler())
 }

--- a/AppProduct/AppProduct/Features/Splash/Presentation/ViewModels/SplashViewModel.swift
+++ b/AppProduct/AppProduct/Features/Splash/Presentation/ViewModels/SplashViewModel.swift
@@ -17,21 +17,28 @@ final class SplashViewModel {
 
     private let networkClient: NetworkClient
     private let fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol
+    private let tokenStore: TokenStore
 
     /// 인증 상태 검사 완료 여부
     private(set) var isCheckComplete = false
 
     /// 스플래시 인증 판정 결과
     private(set) var authStatus: SplashAuthStatus = .notLoggedIn
+    /// 디버그 표시용 액세스 토큰 문자열
+    private(set) var debugAccessToken: String = "(nil)"
+    /// 디버그 표시용 리프레시 토큰 문자열
+    private(set) var debugRefreshToken: String = "(nil)"
 
     // MARK: - Init
 
     init(
         networkClient: NetworkClient,
-        fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol
+        fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol,
+        tokenStore: TokenStore
     ) {
         self.networkClient = networkClient
         self.fetchMyProfileUseCase = fetchMyProfileUseCase
+        self.tokenStore = tokenStore
     }
 
     // MARK: - Function
@@ -41,11 +48,13 @@ final class SplashViewModel {
     /// 2초 대기와 토큰 검사를 동시에 실행합니다.
     @MainActor
     func checkAuthStatus() async {
+        await updateDebugTokens()
         async let delay: Void = Task.sleep(for: .seconds(2))
         async let resolvedStatus = resolveAuthStatus()
 
         _ = try? await delay
         authStatus = await resolvedStatus
+        await updateDebugTokens()
         isCheckComplete = true
     }
 
@@ -53,7 +62,13 @@ final class SplashViewModel {
 
     /// 토큰/프로필 기반으로 스플래시 인증 상태를 판정합니다.
     private func resolveAuthStatus() async -> SplashAuthStatus {
-        guard await networkClient.isLoggedIn() else {
+        let defaults = UserDefaults.standard
+        let canAutoLogin = defaults.bool(
+            forKey: AppStorageKey.canAutoLogin
+        )
+        let hasAccessToken = await networkClient.isLoggedIn()
+
+        guard hasAccessToken else {
             return .notLoggedIn
         }
 
@@ -66,19 +81,47 @@ final class SplashViewModel {
             do {
                 _ = try await networkClient.forceRefreshToken()
             } catch {
-                // 리프레시 만료/실패 시 인증 상태를 정리하고 로그인 화면으로 보냅니다.
-                try? await networkClient.logout()
-                return .notLoggedIn
+                // 리프레시 실패 시에도 액세스 토큰으로 프로필 조회를 한 번 더 시도합니다.
             }
         }
 
         do {
             let profile = try await fetchMyProfileUseCase.execute()
-            return profile.generations.isEmpty ? .pendingApproval : .approved
+            let isApproved = isApprovedProfile(profile)
+            if isApproved {
+                if !canAutoLogin {
+                    defaults.set(true, forKey: AppStorageKey.canAutoLogin)
+                }
+                return .approved
+            }
+            return canAutoLogin ? .pendingApproval : .notLoggedIn
         } catch {
             // 토큰은 있으나 프로필 조회 실패 시 로그인 화면으로 안전하게 폴백
+            if canAutoLogin {
+                try? await networkClient.logout()
+            }
             return .notLoggedIn
         }
+    }
+
+    func isApprovedProfile(_ profile: HomeProfileResult) -> Bool {
+        if !profile.generations.isEmpty {
+            return true
+        }
+
+        for seasonType in profile.seasonTypes {
+            if case .gens(let generations) = seasonType, !generations.isEmpty {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    @MainActor
+    func updateDebugTokens() async {
+        debugAccessToken = await tokenStore.getAccessToken() ?? "(nil)"
+        debugRefreshToken = await tokenStore.getRefreshToken() ?? "(nil)"
     }
 }
 

--- a/AppProduct/AppProduct/Features/Splash/Presentation/Views/SplashView.swift
+++ b/AppProduct/AppProduct/Features/Splash/Presentation/Views/SplashView.swift
@@ -22,12 +22,14 @@ struct SplashView: View {
 
     init(
         networkClient: NetworkClient,
-        fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol
+        fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol,
+        tokenStore: TokenStore
     ) {
         self._viewModel = .init(
             wrappedValue: SplashViewModel(
                 networkClient: networkClient,
-                fetchMyProfileUseCase: fetchMyProfileUseCase
+                fetchMyProfileUseCase: fetchMyProfileUseCase,
+                tokenStore: tokenStore
             )
         )
     }
@@ -35,7 +37,19 @@ struct SplashView: View {
     // MARK: - Body
 
     var body: some View {
-        Logo()
+        VStack(spacing: 12) {
+            Logo()
+            #if DEBUG
+            VStack(alignment: .leading, spacing: 4) {
+                Text("accessToken: \(viewModel.debugAccessToken)")
+                Text("refreshToken: \(viewModel.debugRefreshToken)")
+            }
+            .appFont(.caption2, weight: .regular, color: .grey500)
+            .lineLimit(2)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 20)
+            #endif
+        }
             .task {
                 await viewModel.checkAuthStatus()
             }


### PR DESCRIPTION
## ✨ PR 유형

Fix - 자동 로그인 판정 로직 개선 및 인증 플로우 전반 안정화

## 📷 스크린샷 or 영상(UI 변경 시)

- 패널티 0점 빈 상태 UI 변경 (체크마크 아이콘)
- 빈 공지/일정 상태 ContentUnavailableView 적용

## 🛠️ 작업내용

### 자동 로그인 판정 (canAutoLogin)
- `AppStorageKey.canAutoLogin` 키 추가하여 승인 완료 사용자만 자동 로그인 허용
- Splash → 토큰 존재 + 프로필 승인 완료 시에만 자동 로그인
- 로그인/회원가입/세션 만료 시 canAutoLogin 상태 동기화

### 인증 플로우 안정화
- `SplashViewModel`: 토큰 리프레시 실패 시 즉시 로그아웃 대신 프로필 조회 한 번 더 시도
- `LoginViewModel`: `ensureTokensStored()` 추가하여 토큰 저장 누락 방지
- `LoginViewModel`/`SplashViewModel`/`HomeViewModel`: `isApprovedProfile()` 통일 (generations + seasonTypes 모두 확인)
- `FailedVerificationUMC`: 챌린저 코드 입력을 숫자 전용 → 영숫자 6자리로 변경

### TokenStore 주입 확대
- `SplashView`, `LoginView`에 `TokenStore` 의존성 주입 추가
- `SplashView`에 디버그 모드 토큰 표시 기능 추가

### Home 데이터 개선
- `HomeRepository`/`MyProfileDTO`: 기수 목록 생성 시 `challengerRecords`도 병합하여 누락 방지
- `HomeViewModel`: 프로필 저장 시 `UserSessionManager` 역할 업데이트 연동
- `fetchRecentNotices()`: 역할 정보 없을 때 AppStorage fallback 처리

### UI 개선
- `PenaltyCard`: 패널티 0점 빈 상태를 체크마크 아이콘 UI로 교체
- `HomeView`: 빈 일정/공지에 `ContentUnavailableView` 적용 및 glassEffect 통일
- `LoginView`: 소셜 버튼 이미지 resizable 적용 및 패딩 추가

### 기타
- `UserSessionManager`: 기본 역할을 `.challenger`로 복원 (디버그용 임시 값 제거)
- Preview 코드 추가 (LoginView, HomeView)

## 📋 추후 진행 상황

- isApprovedProfile 로직 공통 유틸로 추출 검토

## 📌 리뷰 포인트

- `Features/Splash/Presentation/ViewModels/SplashViewModel.swift` - 토큰 리프레시 실패 시 프로필 조회 재시도 로직
- `Features/Auth/Presentation/ViewModels/LoginViewModel.swift` - ensureTokensStored 토큰 저장 로직 및 승인 판정 분기
- `Features/Home/Presentation/ViewModels/HomeViewModel.swift` - canAutoLogin 동기화 및 fetchRecentNotices fallback 처리
- `Features/Home/Data/Repository/HomeRepository.swift` - challengerRecords 병합 로직
- `Core/Common/Enum/AppStorageKey.swift` - canAutoLogin 키 추가

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)