### PR TITLE
🚀 [Release] develop → main 릴리즈 반영

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/project.pbxproj
+++ b/AppProduct/AppProduct.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8B8B4462NV;
 				ENABLE_PREVIEWS = YES;
@@ -437,6 +438,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8B8B4462NV;
 				ENABLE_PREVIEWS = YES;

--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -36,7 +36,11 @@ struct AppProductApp: App {
         /// 로그인 화면
         case login
         /// 회원가입 화면
-        case signUp(verificationToken: String)
+        case signUp(
+            verificationToken: String,
+            email: String?,
+            fullName: String?
+        )
         /// 승인 대기 화면
         case pendingApproval
         /// 메인 화면 (탭)
@@ -106,9 +110,11 @@ extension AppProductApp {
                 )
                 .transition(rootTransition)
 
-            case .signUp(let verificationToken):
+            case .signUp(let verificationToken, let email, let fullName):
                 SignUpView(
                     oAuthVerificationToken: verificationToken,
+                    initialEmail: email,
+                    initialName: fullName,
                     sendEmailVerificationUseCase: authProvider
                         .sendEmailVerificationUseCase,
                     verifyEmailCodeUseCase: authProvider
@@ -182,8 +188,14 @@ extension AppProductApp {
         AppFlow(
             showLogin: { transition(to: .login) },
             showMain: { transition(to: .main) },
-            showSignUp: { verificationToken in
-                transition(to: .signUp(verificationToken: verificationToken))
+            showSignUp: { verificationToken, email, fullName in
+                transition(
+                    to: .signUp(
+                        verificationToken: verificationToken,
+                        email: email,
+                        fullName: fullName
+                    )
+                )
             },
             showPendingApproval: { transition(to: .pendingApproval) },
             logout: { handleAuthSessionExpired() }

--- a/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
+++ b/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
@@ -32,7 +32,9 @@ private struct PreviewLoginUseCase: LoginUseCaseProtocol {
     }
 
     func executeApple(
-        authorizationCode: String
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
     ) async throws -> OAuthLoginResult {
         .existingMember(
             tokenPair: TokenPair(

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -58,13 +58,22 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
 
     /// Apple 소셜 로그인을 수행합니다.
     ///
-    /// - Parameter authorizationCode: Apple Sign In에서 발급받은 인증 코드
+    /// - Parameters:
+    ///   - authorizationCode: Apple Sign In에서 발급받은 인증 코드
+    ///   - email: Apple에서 제공한 이메일(최초 로그인 시)
+    ///   - fullName: Apple에서 제공한 이름(최초 로그인 시)
     /// - Returns: 기존 회원/신규 회원 분기 결과
     func loginApple(
-        authorizationCode: String
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
     ) async throws -> OAuthLoginResult {
         let response = try await adapter.requestWithoutAuth(
-            AuthRouter.loginApple(authorizationCode: authorizationCode)
+            AuthRouter.loginApple(
+                authorizationCode: authorizationCode,
+                email: email,
+                fullName: fullName
+            )
         )
         #if DEBUG
         if let json = String(data: response.data, encoding: .utf8) {

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
@@ -29,7 +29,9 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
     }
 
     func loginApple(
-        authorizationCode: String
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
     ) async throws -> OAuthLoginResult {
         try await Task.sleep(for: .milliseconds(500))
 

--- a/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
@@ -17,7 +17,11 @@ enum AuthRouter: BaseTargetType {
     /// 카카오 소셜 로그인
     case loginKakao(accessToken: String, email: String)
     /// Apple 소셜 로그인
-    case loginApple(authorizationCode: String)
+    case loginApple(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    )
     /// 액세스 토큰 재발급
     case renewToken(refreshToken: String)
     /// 내 OAuth 연동 정보 조회
@@ -96,11 +100,18 @@ enum AuthRouter: BaseTargetType {
                 ],
                 encoding: JSONEncoding.default
             )
-        case .loginApple(let authorizationCode):
+        case .loginApple(let authorizationCode, let email, let fullName):
+            var parameters: [String: String] = [
+                "authorizationCode": authorizationCode
+            ]
+            if let email, !email.isEmpty {
+                parameters["email"] = email
+            }
+            if let fullName, !fullName.isEmpty {
+                parameters["fullName"] = fullName
+            }
             return .requestParameters(
-                parameters: [
-                    "authorizationCode": authorizationCode
-                ],
+                parameters: parameters,
                 encoding: JSONEncoding.default
             )
         case .renewToken(let refreshToken):

--- a/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
@@ -21,10 +21,15 @@ protocol AuthRepositoryProtocol: Sendable {
     ) async throws -> OAuthLoginResult
 
     /// Apple 소셜 로그인
-    /// - Parameter authorizationCode: Apple 인증 코드
+    /// - Parameters:
+    ///   - authorizationCode: Apple 인증 코드
+    ///   - email: Apple에서 제공한 이메일(최초 로그인 시)
+    ///   - fullName: Apple에서 제공한 사용자 이름(최초 로그인 시)
     /// - Returns: 로그인 결과
     func loginApple(
-        authorizationCode: String
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
     ) async throws -> OAuthLoginResult
 
     /// 토큰 재발급

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/LoginUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/LoginUseCase.swift
@@ -41,10 +41,14 @@ final class LoginUseCase: LoginUseCaseProtocol {
     }
 
     func executeApple(
-        authorizationCode: String
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
     ) async throws -> OAuthLoginResult {
         let result = try await repository.loginApple(
-            authorizationCode: authorizationCode
+            authorizationCode: authorizationCode,
+            email: email,
+            fullName: fullName
         )
         try await saveTokenIfNeeded(result)
         return result

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/LoginUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/LoginUseCaseProtocol.swift
@@ -22,9 +22,14 @@ protocol LoginUseCaseProtocol {
     ) async throws -> OAuthLoginResult
 
     /// Apple 로그인 실행
-    /// - Parameter authorizationCode: Apple 인증 코드
+    /// - Parameters:
+    ///   - authorizationCode: Apple 인증 코드
+    ///   - email: Apple에서 제공한 이메일(최초 로그인 시)
+    ///   - fullName: Apple에서 제공한 이름(최초 로그인 시)
     /// - Returns: 로그인 결과
     func executeApple(
-        authorizationCode: String
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
     ) async throws -> OAuthLoginResult
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
@@ -96,6 +96,8 @@ final class SignUpViewModel {
 
     init(
         oAuthVerificationToken: String,
+        initialEmail: String? = nil,
+        initialName: String? = nil,
         sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
         verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
         registerUseCase: RegisterUseCaseProtocol,
@@ -106,6 +108,12 @@ final class SignUpViewModel {
         self.verifyEmailCodeUseCase = verifyEmailCodeUseCase
         self.registerUseCase = registerUseCase
         self.fetchSignUpDataUseCase = fetchSignUpDataUseCase
+        self.email = initialEmail?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ) ?? ""
+        self.name = initialName?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ) ?? ""
     }
 
     // MARK: - Function

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -61,8 +61,8 @@ struct LoginView: View {
                 appFlow.showMain()
             case .pendingApproval:
                 appFlow.showPendingApproval()
-            case .signUp(let verificationToken):
-                appFlow.showSignUp(verificationToken)
+            case .signUp(let verificationToken, let email, let fullName):
+                appFlow.showSignUp(verificationToken, email, fullName)
             }
         }
     }
@@ -160,7 +160,11 @@ private struct LoginViewPreviewLoginUseCase: LoginUseCaseProtocol {
         )
     }
 
-    func executeApple(authorizationCode: String) async throws -> OAuthLoginResult {
+    func executeApple(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    ) async throws -> OAuthLoginResult {
         .existingMember(
             tokenPair: TokenPair(
                 accessToken: "preview_access_token",

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
@@ -46,6 +46,8 @@ struct SignUpView: View {
 
     init(
         oAuthVerificationToken: String,
+        initialEmail: String? = nil,
+        initialName: String? = nil,
         sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
         verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
         registerUseCase: RegisterUseCaseProtocol,
@@ -54,6 +56,8 @@ struct SignUpView: View {
         self._viewModel = .init(
             wrappedValue: SignUpViewModel(
                 oAuthVerificationToken: oAuthVerificationToken,
+                initialEmail: initialEmail,
+                initialName: initialName,
                 sendEmailVerificationUseCase: sendEmailVerificationUseCase,
                 verifyEmailCodeUseCase: verifyEmailCodeUseCase,
                 registerUseCase: registerUseCase,

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -225,7 +225,6 @@ final class HomeViewModel {
 
 }
 
-#if DEBUG
 extension HomeViewModel {
     static func emptyPreview(container: DIContainer) -> HomeViewModel {
         let viewModel = HomeViewModel(container: container)
@@ -270,4 +269,3 @@ extension HomeViewModel {
         return viewModel
     }
 }
-#endif

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -225,6 +225,7 @@ final class HomeViewModel {
 
 }
 
+#if DEBUG
 extension HomeViewModel {
     static func emptyPreview(container: DIContainer) -> HomeViewModel {
         let viewModel = HomeViewModel(container: container)
@@ -269,3 +270,4 @@ extension HomeViewModel {
         return viewModel
     }
 }
+#endif

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
@@ -154,7 +154,9 @@ class MyPageViewModel {
         case .apple:
             let authorizationCode = try await fetchAppleAuthorizationCode()
             result = try await authProvider.loginUseCase.executeApple(
-                authorizationCode: authorizationCode
+                authorizationCode: authorizationCode,
+                email: nil,
+                fullName: nil
             )
         }
 

--- a/AppProduct/AppProduct/Features/Splash/Presentation/Views/SplashView.swift
+++ b/AppProduct/AppProduct/Features/Splash/Presentation/Views/SplashView.swift
@@ -37,19 +37,7 @@ struct SplashView: View {
     // MARK: - Body
     
     var body: some View {
-        VStack(spacing: 12) {
-            Logo()
-            #if DEBUG
-            VStack(alignment: .leading, spacing: 4) {
-                Text("accessToken: \(viewModel.debugAccessToken)")
-                Text("refreshToken: \(viewModel.debugRefreshToken)")
-            }
-            .appFont(.caption2, weight: .regular, color: .grey500)
-            .lineLimit(2)
-            .multilineTextAlignment(.center)
-            .padding(.horizontal, 20)
-            #endif
-        }
+        Logo()
             .task {
                 await viewModel
                     .checkAuthStatus()

--- a/AppProduct/AppProduct/Resource/EnvrionmentKey/AppFlowEnvironmentKey.swift
+++ b/AppProduct/AppProduct/Resource/EnvrionmentKey/AppFlowEnvironmentKey.swift
@@ -9,14 +9,14 @@ import SwiftUI
 struct AppFlow {
     let showLogin: () -> Void
     let showMain: () -> Void
-    let showSignUp: (String) -> Void
+    let showSignUp: (String, String?, String?) -> Void
     let showPendingApproval: () -> Void
     let logout: () -> Void
 
     static let noop = AppFlow(
         showLogin: {},
         showMain: {},
-        showSignUp: { _ in },
+        showSignUp: { _, _, _ in },
         showPendingApproval: {},
         logout: {}
     )


### PR DESCRIPTION
## ✨ PR 유형

- Release

## 📷 스크린샷 or 영상(UI 변경 시)

- UI 구조 변경 없음 (동작 안정화 및 로그인 플로우 개선 중심)

## 🛠️ 작업내용

- `main` 이후 `develop`에 반영된 안정화/리팩토링/인증 관련 변경사항을 릴리즈합니다.
- Sign in with Apple에서 `ASAuthorizationAppleIDCredential`의 `email/fullName`을 로그인 요청에 전달하고, 신규 회원가입 화면 초기값으로 반영했습니다.
- Xcode Cloud 아카이브 환경에서 발생하던 Preview 관련 컴파일 이슈를 수정했습니다.
- 자동 로그인 판정 로직 및 커리큘럼/스플래시 관련 안정화 커밋을 포함합니다.

## 📋 추후 진행 상황

- TestFlight에서 Apple/Kakao 로그인, 자동 로그인, 회원가입 진입 회귀 확인
- App Store Review 코멘트 대응사항 재확인 후 제출

## 📌 리뷰 포인트

- Apple 로그인 정보 전달/주입 경로 확인
  - `AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginViewModel.swift`
  - `AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift`
  - `AppProduct/AppProduct/App/AppProductApp.swift`
  - `AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift`
- `develop..main` 커밋 전체 릴리즈 범위 검토
  - `a4954f7d`, `661727f9`, `5ac01834`, `15391226`, `3e401d76`, `e3767480`, `e6849e36`

## ✅ Checklist

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
