### PR TITLE
🐛 [Fix] 공지 열람 현황 닉네임 표시 및 기수(generation) 매핑 보정

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
@@ -85,10 +85,42 @@ extension NoticeDTO {
 ///
 /// 숫자 필드는 서버 스펙에 맞춰 String으로 처리합니다.
 struct NoticeTargetInfoDTO: Codable {
+    let targetGisu: String?
     let targetGisuId: String
     let targetChapterId: String?
     let targetSchoolId: String?
     let targetParts: [UMCPartType]?
+
+    private enum CodingKeys: String, CodingKey {
+        case targetGisu
+        case targetGisuId
+        case targetChapterId
+        case targetSchoolId
+        case targetParts
+    }
+
+    init(
+        targetGisu: String? = nil,
+        targetGisuId: String,
+        targetChapterId: String?,
+        targetSchoolId: String?,
+        targetParts: [UMCPartType]?
+    ) {
+        self.targetGisu = targetGisu
+        self.targetGisuId = targetGisuId
+        self.targetChapterId = targetChapterId
+        self.targetSchoolId = targetSchoolId
+        self.targetParts = targetParts
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        targetGisu = container.decodeFlexibleOptionalString(forKey: .targetGisu)
+        targetGisuId = container.decodeFlexibleOptionalString(forKey: .targetGisuId) ?? "0"
+        targetChapterId = container.decodeFlexibleOptionalString(forKey: .targetChapterId)
+        targetSchoolId = container.decodeFlexibleOptionalString(forKey: .targetSchoolId)
+        targetParts = try container.decodeIfPresent([UMCPartType].self, forKey: .targetParts)
+    }
 }
 
 // MARK: - Helper
@@ -128,5 +160,18 @@ private extension KeyedDecodingContainer {
                 debugDescription: "Expected String/Int/Double for key '\(key.stringValue)'"
             )
         )
+    }
+
+    func decodeFlexibleOptionalString(forKey key: Key) -> String? {
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(Int(value))
+        }
+        return nil
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeReadStatusDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeReadStatusDTO.swift
@@ -47,6 +47,7 @@ struct NoticeReadStaticsDTO: Codable {
 struct NoticeReadStatusUserDTO: Codable {
     let challengerId: String
     let name: String
+    let nickname: String?
     let profileImageUrl: String?
     let part: String
     let schoolId: String
@@ -57,6 +58,7 @@ struct NoticeReadStatusUserDTO: Codable {
     private enum CodingKeys: String, CodingKey {
         case challengerId
         case name
+        case nickname
         case profileImageUrl
         case part
         case schoolId
@@ -65,16 +67,37 @@ struct NoticeReadStatusUserDTO: Codable {
         case chapterName
     }
 
+    private enum AlternateNicknameCodingKeys: String, CodingKey {
+        case nickName
+        case authorNickname
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.challengerId = container.decodeFlexibleString(forKey: .challengerId)
         self.name = try container.decode(String.self, forKey: .name)
+        self.nickname = try Self.decodeNickname(
+            from: decoder,
+            primaryContainer: container
+        )
         self.profileImageUrl = try? container.decodeIfPresent(String.self, forKey: .profileImageUrl)
         self.part = try container.decode(String.self, forKey: .part)
         self.schoolId = container.decodeFlexibleString(forKey: .schoolId)
         self.schoolName = try container.decode(String.self, forKey: .schoolName)
         self.chapterId = container.decodeFlexibleString(forKey: .chapterId)
         self.chapterName = try container.decode(String.self, forKey: .chapterName)
+    }
+
+    private static func decodeNickname(
+        from decoder: Decoder,
+        primaryContainer: KeyedDecodingContainer<CodingKeys>
+    ) throws -> String? {
+        if let nickname = primaryContainer.decodeFirstNonEmptyString(forKeys: [.nickname]) {
+            return nickname
+        }
+
+        let alternateContainer = try decoder.container(keyedBy: AlternateNicknameCodingKeys.self)
+        return alternateContainer.decodeFirstNonEmptyString(forKeys: [.nickName, .authorNickname])
     }
 }
 
@@ -106,11 +129,14 @@ extension NoticeReadStatusUserDTO {
     func toDomain(isRead: Bool) -> ReadStatusUser {
         // part String → UMCPartType enum 변환
         let userPart = UMCPartType(apiValue: part)
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNickname = nickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let resolvedNickname = trimmedNickname.isEmpty ? trimmedName : trimmedNickname
         
         return ReadStatusUser(
             id: challengerId,
-            name: name,
-            nickName: name, // TODO: 실제 닉네임 필드 추가되면 수정
+            name: trimmedName,
+            nickName: resolvedNickname,
             part: userPart?.name ?? "알 수 없음",
             branch: chapterName,
             campus: schoolName,
@@ -147,6 +173,17 @@ private extension KeyedDecodingContainer {
         }
         if let value = try? decode(Double.self, forKey: key) {
             return String(value)
+        }
+        return nil
+    }
+
+    func decodeFirstNonEmptyString(forKeys keys: [Key]) -> String? {
+        for key in keys {
+            guard let rawValue = decodeFlexibleOptionalString(forKey: key) else { continue }
+            let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
         }
         return nil
     }

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
@@ -13,7 +13,10 @@ extension NoticeTargetInfoDTO {
     // MARK: - Computed Property
     /// 기수 ID를 Int로 변환 (실패 시 0)
     var generationValue: Int {
-        Int(targetGisuId) ?? 0
+        if let targetGisu, let generation = Int(targetGisu), generation > 0 {
+            return generation
+        }
+        return Int(targetGisuId) ?? 0
     }
 
     /// targetInfo 기반으로 공지 출처(scope)를 추론합니다.

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeReadStatusItemModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeReadStatusItemModel.swift
@@ -16,4 +16,14 @@ struct NoticeReadStatusItemModel: Equatable, Identifiable {
     let location: String
     let campus: String
     let isRead: Bool
+
+    var identityText: String {
+        let trimmedNickname = nickName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedName = userName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !trimmedNickname.isEmpty, !trimmedName.isEmpty, trimmedNickname != trimmedName {
+            return "\(trimmedNickname)/\(trimmedName)"
+        }
+        return !trimmedNickname.isEmpty ? trimmedNickname : trimmedName
+    }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeReadStatusItem/NoticeReadStatusItem.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeReadStatusItem/NoticeReadStatusItem.swift
@@ -96,7 +96,7 @@ private struct UserInfoSection: View, Equatable {
         VStack(alignment: .leading, spacing: Constant.userInfoVSpacing) {
             // 이름 + 파트
             HStack(spacing: Constant.userInfoHSpacing) {
-                Text("\(model.userName)/\(model.nickName)")
+                Text(model.identityText)
                     .appFont(.subheadlineEmphasis, color: .grey900)
                 Text(model.part)
                     .appFont(.caption2, color: .gray)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -20,8 +20,9 @@ extension NoticeDetailViewModel {
 
         do {
             let noticeDetail = try await noticeUseCase.getDetailNotice(noticeId: noticeID)
-            noticeState = .loaded(noticeDetail)
-            refreshAuthorDisplayName(for: noticeDetail)
+            let normalizedDetail = normalizeTargetGenerationIfNeeded(in: noticeDetail)
+            noticeState = .loaded(normalizedDetail)
+            refreshAuthorDisplayName(for: normalizedDetail)
             isDetailPreparedForEdit = true
         } catch let error as RepositoryError {
             noticeState = .failed(.repository(error))
@@ -355,8 +356,9 @@ extension NoticeDetailViewModel {
                 title: title,
                 content: content
             )
-            noticeState = .loaded(updatedNotice)
-            refreshAuthorDisplayName(for: updatedNotice)
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: updatedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
 
         } catch let error as DomainError {
             noticeState = .failed(.domain(error))
@@ -393,8 +395,9 @@ extension NoticeDetailViewModel {
                 noticeId: noticeID,
                 links: links
             )
-            noticeState = .loaded(updatedNotice)
-            refreshAuthorDisplayName(for: updatedNotice)
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: updatedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
         } catch let error as RepositoryError {
             noticeState = .failed(.repository(error))
             errorHandler.handle(
@@ -436,8 +439,9 @@ extension NoticeDetailViewModel {
                 noticeId: noticeID,
                 imageIds: imageIds
             )
-            noticeState = .loaded(updatedNotice)
-            refreshAuthorDisplayName(for: updatedNotice)
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: updatedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
         } catch let error as RepositoryError {
             noticeState = .failed(.repository(error))
             errorHandler.handle(
@@ -501,8 +505,9 @@ extension NoticeDetailViewModel {
 
             // 서버 반영 결과(득표수/내 선택 상태)를 최신값으로 반영
             let refreshedNotice = try await noticeUseCase.getDetailNotice(noticeId: noticeID)
-            noticeState = .loaded(refreshedNotice)
-            refreshAuthorDisplayName(for: refreshedNotice)
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: refreshedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
         } catch let error as DomainError {
             isSubmittingVote = false
             errorHandler.handle(

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -32,6 +32,10 @@ final class NoticeDetailViewModel {
         container.resolve(AuthorizationUseCaseProtocol.self)
     }
 
+    var genRepository: ChallengerGenRepositoryProtocol {
+        container.resolve(ChallengerGenRepositoryProtocol.self)
+    }
+
     // MARK: - Core State
 
     /// 공지 상세 상태
@@ -191,9 +195,11 @@ final class NoticeDetailViewModel {
         self.noticeID = Int(model.id) ?? 0
         self.errorHandler = errorHandler
         self.noticeState = .loaded(model)
-        authorDisplayName = model.authorName
+        let normalizedModel = normalizeTargetGenerationIfNeeded(in: model)
+        noticeState = .loaded(normalizedModel)
+        authorDisplayName = normalizedModel.authorName
         Task { [weak self] in
-            self?.refreshAuthorDisplayName(for: model)
+            self?.refreshAuthorDisplayName(for: normalizedModel)
         }
     }
 
@@ -306,6 +312,65 @@ final class NoticeDetailViewModel {
             return "rd"
         default:
             return "th"
+        }
+    }
+
+    // MARK: - Generation Helper
+
+    /// targetAudience.generation 값이 gisu PK인 경우 로컬 매핑으로 실제 기수(gen)로 보정합니다.
+    ///
+    /// 서버가 `targetGisu`를 내려주면 DTO 매퍼에서 우선 적용되고,
+    /// 해당 값이 없거나 `targetGisuId`만 존재할 때만 이 보정 로직이 동작합니다.
+    func normalizeTargetGenerationIfNeeded(in detail: NoticeDetail) -> NoticeDetail {
+        let originalGeneration = detail.targetAudience.generation
+        let resolvedGeneration = resolveGeneration(from: originalGeneration)
+
+        guard resolvedGeneration != originalGeneration else {
+            return detail
+        }
+
+        let normalizedAudience = TargetAudience(
+            generation: resolvedGeneration,
+            scope: detail.targetAudience.scope,
+            parts: detail.targetAudience.parts,
+            branches: detail.targetAudience.branches,
+            schools: detail.targetAudience.schools
+        )
+
+        return NoticeDetail(
+            id: detail.id,
+            generation: resolvedGeneration,
+            scope: detail.scope,
+            category: detail.category,
+            isMustRead: detail.isMustRead,
+            title: detail.title,
+            content: detail.content,
+            authorID: detail.authorID,
+            authorMemberId: detail.authorMemberId,
+            authorName: detail.authorName,
+            authorImageURL: detail.authorImageURL,
+            createdAt: detail.createdAt,
+            updatedAt: detail.updatedAt,
+            targetAudience: normalizedAudience,
+            hasPermission: detail.hasPermission,
+            images: detail.images,
+            imageItems: detail.imageItems,
+            links: detail.links,
+            vote: detail.vote
+        )
+    }
+
+    /// 현재 값이 gisuId인지 판별하여 실제 기수(gen)를 반환합니다.
+    private func resolveGeneration(from value: Int) -> Int {
+        guard value > 0 else { return value }
+        do {
+            let pairs = try genRepository.fetchGenGisuIdPairs()
+            if let matchedGen = pairs.first(where: { $0.gisuId == value })?.gen {
+                return matchedGen
+            }
+            return value
+        } catch {
+            return value
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

공지 열람 현황에서 닉네임이 정상 표시되지 않는 문제와 기수(generation) 값이 gisuId(PK)로 표시되는 문제를 수정합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 열람 현황 리스트에서 닉네임/이름 표시 형태가 변경되었으므로 스크린샷 첨부 권장 -->

## 🛠️ 작업내용

- `NoticeReadStatusDTO`에 `nickname` 필드 추가 및 서버 키 다형성 대응 (`nickName`, `authorNickname` 등 다중 키 디코딩)
- `NoticeReadStatusItemModel`에 `identityText` 계산 프로퍼티 추가 (닉네임과 이름이 다를 때 "닉네임/이름", 같을 때 단일 표시)
- `NoticeReadStatusItem` View에서 하드코딩된 이름 표시 대신 `identityText` 사용
- `NoticeTargetInfoDTO`에 `targetGisu` 필드 추가, `generationValue`에서 실제 기수값 우선 사용하도록 변경
- `NoticeDetailViewModel`에 `normalizeTargetGenerationIfNeeded` 보정 로직 추가 (gisuId → 실제 기수 매핑)
- 공지 상세 조회/수정/링크수정/이미지수정/투표 등 모든 상태 갱신 경로에 기수 보정 적용
- DTO 디코딩 헬퍼 추가: `decodeFlexibleOptionalString`, `decodeFirstNonEmptyString`

## 📋 추후 진행 상황

- 서버에서 닉네임 필드가 통일되면 다중 키 디코딩 로직 제거 가능

## 📌 리뷰 포인트

- `Features/Notice/Data/DTOs/NoticeReadStatusDTO.swift` - nickname 다중 키 디코딩 및 fallback 로직
- `Features/Notice/Data/DTOs/NoticeDTO.swift` - targetGisu 필드 추가 및 flexible 디코딩
- `Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift` - generationValue 우선순위 변경
- `Features/Notice/Domain/Models/NoticeReadStatusItemModel.swift` - identityText 표시 로직
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift` - normalizeTargetGenerationIfNeeded 보정 로직 및 genRepository 사용

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)