### PR TITLE
🐛 [Fix] AccessToken 재발급 API URI 불일치 수정 (#343)

### DIFF
--- a/AppProduct/AppProduct/Core/NetworkAdapter/TokenRefreshService/TokenRefreshServiceImpl.swift
+++ b/AppProduct/AppProduct/Core/NetworkAdapter/TokenRefreshService/TokenRefreshServiceImpl.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// TokenRefreshService 프로토콜의 실제 구현체입니다.
 ///
-/// 서버의 `/auth/reissue` 엔드포인트를 호출하여 리프레시 토큰으로 새로운 토큰 쌍을 발급받습니다.
+/// 서버의 `/api/v1/auth/token/renew` 엔드포인트를 호출하여 리프레시 토큰으로 새로운 토큰 쌍을 발급받습니다.
 ///
 /// - Important:
 ///   - **NetworkClient와 독립적**: NetworkClient를 사용하지 않음 (무한 루프 방지)
@@ -34,7 +34,7 @@ struct TokenRefreshServiceImpl: TokenRefreshService {
 
     /// API 서버 기본 URL
     ///
-    /// - Note: `/auth/reissue` 경로가 추가됩니다.
+    /// - Note: `/api/v1/auth/token/renew` 경로가 추가됩니다.
     private let baseURL: URL
 
     /// URLSession 인스턴스 (네트워크 요청 실행)
@@ -83,7 +83,7 @@ struct TokenRefreshServiceImpl: TokenRefreshService {
     /// ## 요청 형식
     ///
     /// ```
-    /// POST /auth/reissue
+    /// POST /api/v1/auth/token/renew
     /// Content-Type: application/json
     /// Authorization: Bearer {refreshToken}
     /// ```
@@ -103,7 +103,7 @@ struct TokenRefreshServiceImpl: TokenRefreshService {
     /// ```
     func refresh(_ refreshToken: String) async throws -> TokenPair {
         // 1. URL 생성
-        let url = baseURL.appending(path: "auth/reissue")
+        let url = baseURL.appending(path: "api/v1/auth/token/renew")
 
         // 2. URLRequest 구성
         var request = URLRequest(url: url)


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - AccessToken 재발급 API URI 불일치 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

- `TokenRefreshServiceImpl.swift`의 토큰 재발급 엔드포인트를 `auth/reissue` → `api/v1/auth/token/renew`로 변경
- 관련 주석/문서 내 URI 참조 일괄 수정 (L12, L37, L86)

### 배경
서버 팀(박경운/하늘) 로그 확인 결과, AT 자동 재발급 요청이 구 URI(`/auth/reissue`)로 전송되고 있었음.
`AuthRouter.renewToken`에는 이미 올바른 `/api/v1/auth/token/renew`가 정의되어 있었으나, `NetworkClient`의 토큰 자동 갱신에서 사용하는 `TokenRefreshServiceImpl`은 하드코딩된 구 URI를 사용 중이었음.

## 📋 추후 진행 상황

- `TokenRefreshServiceImpl`이 `AuthRouter`를 재사용하도록 리팩토링 검토 (URI 이중 관리 방지)

## 📌 리뷰 포인트

- `Core/NetworkAdapter/TokenRefreshService/TokenRefreshServiceImpl.swift` - 엔드포인트 경로 변경 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)