### PR TITLE
🐛 [Fix] MyPageRoleDTO organizationId 옵셔널 처리 (#345)

### DIFF
--- a/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
@@ -101,7 +101,7 @@ struct MyPageRoleDTO: Codable {
     let challengerId: String
     let roleType: ManagementTeam
     let organizationType: OrganizationType
-    let organizationId: String
+    let organizationId: String?
     let responsiblePart: String?
     let gisu: String?
     let gisuId: String
@@ -123,7 +123,7 @@ struct MyPageRoleDTO: Codable {
         challengerId = try container.decodeMyPageFlexibleString(forKey: .challengerId)
         roleType = try container.decode(ManagementTeam.self, forKey: .roleType)
         organizationType = try container.decode(OrganizationType.self, forKey: .organizationType)
-        organizationId = try container.decodeMyPageFlexibleString(forKey: .organizationId)
+        organizationId = try container.decodeMyPageFlexibleStringIfPresent(forKey: .organizationId)
         responsiblePart = try container.decodeIfPresent(String.self, forKey: .responsiblePart)
         gisu = try container.decodeMyPageFlexibleStringIfPresent(forKey: .gisu)
         gisuId = try container.decodeMyPageFlexibleString(forKey: .gisuId)


### PR DESCRIPTION
## ✨ PR 유형

MyPage 프로필 DTO 디코딩 버그 수정

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음

## 🛠️ 작업내용

- `MyPageRoleDTO`의 `organizationId` 타입을 `String`에서 `String?`으로 변경
- 커스텀 디코딩에서 `decodeMyPageFlexibleString` → `decodeMyPageFlexibleStringIfPresent`로 변경
- API 응답에서 `organizationId`가 `null`인 경우 디코딩 실패(크래시) 방지

## 📋 추후 진행 상황

- 없음

## 📌 리뷰 포인트

- `Features/MyPage/Data/DTO/MyPageProfileDTO.swift` - organizationId 옵셔널 처리 및 디코딩 로직 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)