### PR TITLE
🐛[Fix] 공지사항 작성 시 파트 미선택으로 전체 파트 대상 공지 허용 (#347)

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
@@ -39,7 +39,6 @@ extension NoticeEditorViewModel {
         let hasBranch = subCategorySelection.selectedBranch != nil
         let hasSchool = subCategorySelection.selectedSchool != nil
         let hasParts = !subCategorySelection.selectedParts.isEmpty
-        let hasPartChipSelected = subCategorySelection.selectedSubCategories.contains(.part)
         let canPickBranch = visibleSubCategories.contains(.branch)
         let canPickSchool = visibleSubCategories.contains(.school)
 
@@ -59,15 +58,6 @@ extension NoticeEditorViewModel {
                 return "전체 기수 대상에서는 지부/파트를 함께 지정할 수 없습니다."
             }
             return nil
-        }
-
-        if memberRole == .centralEducationTeamMember && !hasParts {
-            return "파트를 하나 이상 선택해주세요."
-        }
-
-        // 파트 칩을 활성화했으면 최소 1개는 반드시 선택해야 합니다.
-        if hasPartChipSelected && !hasParts {
-            return "하나 이상의 파트를 선택해주세요."
         }
 
         if hasBranch && hasSchool {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift
@@ -30,7 +30,7 @@ struct TargetSheetView: View {
         
         static let branchGuideMessage: String = "지부를 한 개 선택해주세요."
         static let schoolGuideMessage: String = "학교를 한 개 선택해주세요."
-        static let partGuideMessage: String = "하나 이상의 파트를 선택해주세요."
+        static let partGuideMessage: String = "선택하지 않으면 전체 파트 대상 공지로 발송됩니다."
         static let failedTitle: String = "대상 목록을 불러오지 못했습니다."
         static let failedDescription: String = "일시적인 오류가 발생했습니다. 다시 시도해주세요."
         static let failedIcon: String = "exclamationmark.triangle"


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 공지사항 작성 시 파트 미선택을 허용하여 전체 파트 대상 공지 작성 가능하도록 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 동작 변경이 있으므로, 파트 미선택 상태에서 공지 작성이 정상 동작하는 영상을 첨부해주세요 -->

## 🛠️ 작업내용

- 파트 필수 선택 유효성 검사 제거 (`centralEducationTeamMember` 역할 포함)
- 파트 칩 활성화 시 최소 1개 필수 선택 강제 로직 제거
- 미사용 변수 `hasPartChipSelected` 제거
- 파트 가이드 메시지를 `"선택하지 않으면 전체 파트 대상 공지로 발송됩니다."`로 변경

## 📋 추후 진행 상황

- 서버 응답과 iOS 동작 일치 여부 QA 확인

## 📌 리뷰 포인트

- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift` - 파트 미선택 시 유효성 통과 로직 확인
- `Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift` - 가이드 메시지 변경 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #347