### PR TITLE
🐛[Fix] 공지 전체 조회 시 gisuId null 전송 방지 (#349)

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
@@ -50,8 +50,14 @@ extension NoticeViewModel {
 
     /// 기수 목록 조회
     func fetchGisuList() {
+        guard !isFetchingGisuList else { return }
+        isFetchingGisuList = true
+        defer { isFetchingGisuList = false }
+
         do {
-            gisuPairs = try genRepository.fetchGenGisuIdPairs()
+            let fetchedPairs = try genRepository.fetchGenGisuIdPairs()
+            gisuPairs = fetchedPairs.filter { $0.gisuId > 0 }
+            isGisuListLoaded = !gisuPairs.isEmpty
 
             generations = gisuPairs.map { Generation(value: $0.gen) }
 
@@ -66,6 +72,7 @@ extension NoticeViewModel {
                     await fetchNotices()
                 }
             } else {
+                isGisuListLoaded = false
                 noticeItems = .failed(.domain(.custom(message: "기수 정보를 불러오지 못했습니다.")))
                 errorHandler?.handle(
                     DomainError.custom(message: "기수 정보를 불러오지 못했습니다."),
@@ -77,6 +84,7 @@ extension NoticeViewModel {
             }
         } catch {
             gisuPairs = []
+            isGisuListLoaded = false
             generations = []
             noticeItems = .failed(.domain(.custom(message: "기수 정보를 불러오지 못했습니다.")))
             errorHandler?.handle(
@@ -92,6 +100,7 @@ extension NoticeViewModel {
     /// 기수 선택
     /// - Parameter generation: 선택된 기수
     func selectGeneration(_ generation: Generation) {
+        guard gisuPairs.contains(where: { $0.gen == generation.value && $0.gisuId > 0 }) else { return }
         selectedGeneration = generation
         if generationStates[generation.value] == nil {
             generationStates[generation.value] = GenerationFilterState()
@@ -148,6 +157,7 @@ extension NoticeViewModel {
 
     /// 현재 선택된 gen에 매핑된 gisuId를 반환
     func currentSelectedGisuId() -> Int? {
-        gisuPairs.first(where: { $0.gen == selectedGeneration.value })?.gisuId
+        guard isGisuListLoaded else { return nil }
+        return gisuPairs.first(where: { $0.gen == selectedGeneration.value && $0.gisuId > 0 })?.gisuId
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -122,9 +122,17 @@ extension NoticeViewModel {
         if page == 0 {
             noticeItems = .loading
         }
+
+        guard isGisuListLoaded, !gisuPairs.isEmpty else {
+            if !isFetchingGisuList {
+                fetchGisuList()
+            }
+            return nil
+        }
+
         guard pagingState.begin(page: page) else { return nil }
 
-        guard let gisuId = currentSelectedGisuId() else {
+        guard let gisuId = resolveCurrentGisuIdWithFallback() else {
             handleFetchError(
                 .domain(.custom(message: "기수 정보를 불러오지 못했습니다.")),
                 page: page,
@@ -134,6 +142,26 @@ extension NoticeViewModel {
             return nil
         }
         return gisuId
+    }
+
+    /// 현재 선택 기수의 gisuId를 우선 사용하고, 없으면 최신 기수로 보정합니다.
+    @MainActor
+    private func resolveCurrentGisuIdWithFallback() -> Int? {
+        if let gisuId = currentSelectedGisuId(), gisuId > 0 {
+            return gisuId
+        }
+
+        guard let fallback = gisuPairs
+            .filter({ $0.gisuId > 0 })
+            .max(by: { $0.gen < $1.gen }) else {
+            return nil
+        }
+
+        selectedGeneration = Generation(value: fallback.gen)
+        if generationStates[fallback.gen] == nil {
+            generationStates[fallback.gen] = GenerationFilterState()
+        }
+        return fallback.gisuId
     }
 
     /// 페이지 응답을 목록 상태에 반영합니다.

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
@@ -37,6 +37,10 @@ final class NoticeViewModel {
 
     /// 기수-기수ID 쌍 목록
     var gisuPairs: [(gen: Int, gisuId: Int)] = []
+    /// 기수 매핑 로딩 완료 여부
+    var isGisuListLoaded: Bool = false
+    /// 기수 매핑 로딩 진행 여부
+    var isFetchingGisuList: Bool = false
 
     var pagingState = NoticePagingState()
     var userContext: NoticeUserContext = .empty


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 공지 전체 조회 API 요청 시 gisuId가 null로 전송되어 서버 에러가 발생하는 문제 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 - 로직 수정만 포함 -->

## 🛠️ 작업내용

- `NoticeViewModel`에 `isGisuListLoaded` / `isFetchingGisuList` 상태 플래그 추가
- `fetchGisuList()`에서 중복 호출 방지 및 gisuId <= 0인 항목 필터링
- `performPagedFetch()`에서 기수 목록 로딩 완료 전 API 호출 차단
- `resolveCurrentGisuIdWithFallback()` 메서드 추가 - 선택 기수의 gisuId가 없을 시 최신 기수로 자동 보정
- `selectGeneration()`에서 유효한 gisuId가 있는 기수만 선택 허용
- `currentSelectedGisuId()`에 `isGisuListLoaded` guard 및 gisuId > 0 검증 추가

## 📋 추후 진행 상황

- 서버 validation 추가 후 연동 테스트

## 📌 리뷰 포인트

- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift` - `resolveCurrentGisuIdWithFallback()` 보정 로직이 적절한지 확인
- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift` - 기수 목록 로딩 순서 보장 및 `selectGeneration()` guard 조건 확인
- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift` - 새 상태 플래그 추가

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #349