### PR TITLE
🐛[Fix] 마이페이지 바텀 액세서리 '11' 표시 버그 수정 및 문의하기 버튼 구현 (#351)

### DIFF
--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Enum/MyPageSectionType.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Enum/MyPageSectionType.swift
@@ -17,8 +17,6 @@ enum MyPageSectionType: String, CaseIterable {
     case myActiveLogs = "내 활동"
     /// 알림 설정, 위치 설정 등
     case settings = "설정"
-    /// 고객 지원, 문의 등
-    case helpSupport = "지원"
     /// 개인정보처리 방침, 이용약관 등
     case laws = "법률"
     /// 앱 버전 등 앱 정보

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageView.swift
@@ -139,8 +139,6 @@ struct MyPageView: View {
             MyActiveLogSection(sectionType: section)
         case .settings:
             SettingSection(sectionType: section)
-        case .helpSupport:
-            HelpSection(sectionType: section)
         case .laws:
             LawSection(sectionType: section)
         case .info:

--- a/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
+++ b/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
@@ -211,9 +211,25 @@ fileprivate struct CommunityAccessoryView: View {
 }
 // MARK: - MyPage
 
-/// 마이페이지 탭 하단 액세서리 (미구현)
+/// 마이페이지 탭 하단 액세서리 - 문의하기 버튼
 fileprivate struct MyPageAccessoryView: View {
+    private let kakaoPlusManager: KakaoPlusManager = .init()
+
     var body: some View {
-        Text("11")
+        Button(action: {
+            kakaoPlusManager.openKakaoChannel()
+        }) {
+            HStack(spacing: DefaultSpacing.spacing8) {
+                Spacer()
+                Image(systemName: "bubble.left.and.bubble.right.fill")
+                    .foregroundStyle(.indigo500)
+
+                Text("문의하기")
+                    .fontWeight(.semibold)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .foregroundStyle(.grey900)
+        }
     }
 }

--- a/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcTab.swift
+++ b/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcTab.swift
@@ -104,11 +104,6 @@ struct UmcTab: View {
             return false
         }
 
-        // MyPage 탭에서는 항상 Accessory 숨김
-        if tabCase == .mypage {
-            return false
-        }
-
         // 현재 탭의 NavigationStack에 화면이 쌓여있으면 Accessory 숨김
         let currentPath: [NavigationDestination] = {
             switch tabCase {


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 마이페이지 탭 전환 시 바텀 액세서리에 "11" 텍스트가 순간 표시되는 버그 수정 및 문의하기 버튼 구현

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 마이페이지 탭 전환 시 바텀 액세서리에 카카오 문의하기 버튼이 정상 표시되는 영상을 첨부해주세요 -->

## 🛠️ 작업내용

- `MyPageAccessoryView`의 `Text("11")` 플레이스홀더를 카카오 플러스친구 문의하기 버튼으로 교체
- `UmcTab.swift`에서 마이페이지 탭 바텀 액세서리 숨김 로직 제거 (문의하기 버튼 표시를 위해)
- `MyPageSectionType`에서 미사용 `helpSupport` 케이스 제거 (문의하기가 바텀 액세서리로 이동)
- `MyPageView`에서 `HelpSection` 분기 제거

## 📋 추후 진행 상황

- 문의하기 버튼 디자인 피드백 반영

## 📌 리뷰 포인트

- `Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift` - `MyPageAccessoryView` 문의하기 버튼 UI 및 `KakaoPlusManager` 연동 확인
- `Features/Tab/Presentation/Views/UmcTab.swift` - 마이페이지 탭 액세서리 표시 로직 변경 확인
- `Features/MyPage/Presentation/Enum/MyPageSectionType.swift` - `helpSupport` 케이스 제거가 다른 곳에 영향 없는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #351