### PR TITLE
🐛[Fix] Xcode Cloud 빌드 시 환경변수 미주입으로 인한 크래시 해결 (#353)

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/project.pbxproj
+++ b/AppProduct/AppProduct.xcodeproj/project.pbxproj
@@ -392,9 +392,12 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = UMC;
+				INFOPLIST_KEY_BASE_URL = "$(BASE_URL)";
+				INFOPLIST_KEY_KAKAO_KEY = "$(KAKAO_KEY)";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "출석체크를 위해 위치 정보를 사용합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "게시글 작성을 위해 앨범에 접근합니다.";
+				INFOPLIST_KEY_TMAP_SECRET_KEY = "$(TMAP_SECRET_KEY)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -445,9 +448,12 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = UMC;
+				INFOPLIST_KEY_BASE_URL = "$(BASE_URL)";
+				INFOPLIST_KEY_KAKAO_KEY = "$(KAKAO_KEY)";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "출석체크를 위해 위치 정보를 사용합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "게시글 작성을 위해 앨범에 접근합니다.";
+				INFOPLIST_KEY_TMAP_SECRET_KEY = "$(TMAP_SECRET_KEY)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - Xcode Cloud 빌드 후 앱 실행 시 환경변수 미주입으로 인한 크래시 해결

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

- `project.pbxproj` Debug/Release 빌드 설정에 환경변수 Info.plist 주입 추가:
  - `INFOPLIST_KEY_BASE_URL = "$(BASE_URL)"` - 서버 Base URL
  - `INFOPLIST_KEY_KAKAO_KEY = "$(KAKAO_KEY)"` - 카카오 SDK 키
  - `INFOPLIST_KEY_TMAP_SECRET_KEY = "$(TMAP_SECRET_KEY)"` - TMap SDK 키
- Xcode Cloud 환경에서 설정한 환경변수가 Info.plist를 통해 런타임에 접근 가능하도록 처리

## 📋 추후 진행 상황

- Xcode Cloud 빌드 후 앱 정상 실행 확인

## 📌 리뷰 포인트

- `AppProduct.xcodeproj/project.pbxproj` - Debug/Release 양쪽 빌드 설정에 동일한 환경변수가 추가되었는지 확인
- Xcode Cloud 워크플로우에 `BASE_URL`, `KAKAO_KEY`, `TMAP_SECRET_KEY` 환경변수가 설정되어 있는지 확인 필요

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #353