### PR TITLE
🐛[Fix] GoogleService-Info.plist 번들 미포함으로 TestFlight 런치 크래시 해결 (#357)

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/project.pbxproj
+++ b/AppProduct/AppProduct.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0EEC14D52F0B92FA00345AD8 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0EEC14D42F0B92FA00345AD8 /* Kingfisher */; };
 		1F3173D62F127A5000601344 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 1F3173D52F127A5000601344 /* FirebaseCore */; };
 		1F3173D82F127A5000601344 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 1F3173D72F127A5000601344 /* FirebaseMessaging */; };
+		1FA0A1B12F40000100A1B2C3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1FA0A1B22F40000100A1B2C3 /* GoogleService-Info.plist */; };
 		1F953CD92F31D2BB0067FE73 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 1F953CD82F31D2BB0067FE73 /* AppIcon.icon */; };
 		1FEF7EC82F2C9D3200AB3DBB /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = 1FEF7EC72F2C9D3200AB3DBB /* Documentation.docc */; };
 /* End PBXBuildFile section */
@@ -35,6 +36,7 @@
 /* Begin PBXFileReference section */
 		0E6380A92F02F1020060E4D9 /* AppProduct.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppProduct.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F75B9912F123E6500B97089 /* AppProductTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppProductTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1FA0A1B22F40000100A1B2C3 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "AppProduct/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		1F953CD82F31D2BB0067FE73 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		1FEF7EC72F2C9D3200AB3DBB /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -86,6 +88,7 @@
 			isa = PBXGroup;
 			children = (
 				1F953CD82F31D2BB0067FE73 /* AppIcon.icon */,
+				1FA0A1B22F40000100A1B2C3 /* GoogleService-Info.plist */,
 				1FEF7EC72F2C9D3200AB3DBB /* Documentation.docc */,
 				1FE63EEA2F20BDEF00D92F6A /* AppleCreateML */,
 				0E6380AB2F02F1020060E4D9 /* AppProduct */,
@@ -209,6 +212,7 @@
 		0E6380A72F02F1020060E4D9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			files = (
+				1FA0A1B12F40000100A1B2C3 /* GoogleService-Info.plist in Resources */,
 				1F953CD92F31D2BB0067FE73 /* AppIcon.icon in Resources */,
 			);
 		};

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -42,6 +42,16 @@ if [ -z "$BASE_URL_DEBUG_VALUE" ] || [ -z "$BASE_URL_RELEASE_VALUE" ]; then
   exit 1
 fi
 
+if [ -z "$KAKAO_KEY" ]; then
+  echo "ERROR: KAKAO_KEY environment variable is required."
+  exit 1
+fi
+
+if [ -z "$TMAP_SECRET_KEY" ]; then
+  echo "ERROR: TMAP_SECRET_KEY environment variable is required."
+  exit 1
+fi
+
 # xcconfig에서는 '//'가 주석이므로 URL을 https:/$()/... 형식으로 변환
 to_xcconfig_url() {
   printf "%s" "$1" | sed 's#://#:/$()/#'
@@ -61,6 +71,11 @@ EOF
 
 echo "Secrets.xcconfig created successfully"
 echo "Secrets.xcconfig created successfully at: $CONFIG_PATH"
+
+if ! grep -q '^KAKAO_KEY=' "$CONFIG_PATH" || ! grep -q '^TMAP_SECRET_KEY=' "$CONFIG_PATH"; then
+  echo "ERROR: Secrets.xcconfig validation failed (missing required keys)"
+  exit 1
+fi
 
 # Firebase GoogleService-Info.plist 복원
 # - 권장: GOOGLE_SERVICE_INFO_PLIST_BASE64


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - `GoogleService-Info.plist`가 앱 번들에 미포함되어 `FirebaseApp.configure()` 호출 시 SIGABRT 크래시 발생하는 문제 해결

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

- `project.pbxproj`에 `GoogleService-Info.plist`를 AppProduct 타깃의 `Copy Bundle Resources`에 등록
- `ci_post_clone.sh`에 `KAKAO_KEY`, `TMAP_SECRET_KEY` 환경변수 필수 검증 추가
- `Secrets.xcconfig` 생성 후 필수 키(`KAKAO_KEY`, `TMAP_SECRET_KEY`) 포함 여부 검증 로직 추가

## 📋 추후 진행 상황

- Xcode Cloud 재빌드 후 TestFlight 앱 정상 실행 확인

## 📌 리뷰 포인트

- `AppProduct.xcodeproj/project.pbxproj` - `GoogleService-Info.plist`가 `PBXResourcesBuildPhase`에 정상 등록되었는지 확인
- `ci_scripts/ci_post_clone.sh` - 환경변수 검증 및 xcconfig 검증 로직 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #357