### PR TITLE
🐛[Fix] FirebaseApp.configure() 중복 호출로 인한 TestFlight 런치 크래시 해결 (#360)

### DIFF
--- a/AppProduct/AppProduct/App/AppDelegate.swift
+++ b/AppProduct/AppProduct/App/AppDelegate.swift
@@ -40,7 +40,9 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     }
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        FirebaseApp.configure()
+        if FirebaseApp.app() == nil {
+            FirebaseApp.configure()
+        }
         Messaging.messaging().delegate = self
         UNUserNotificationCenter.current().delegate = self
         logDeviceIdentifiers()


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - `FirebaseApp.configure()`가 두 번 이상 호출되어 TestFlight 앱 런치 시 SIGABRT 크래시 발생하는 문제 해결

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

- `AppDelegate.swift:43`의 `FirebaseApp.configure()` 호출에 `FirebaseApp.app() == nil` 방어 코드 추가
- Release/TestFlight 환경에서 앱 생명주기 차이로 인한 중복 초기화 크래시 방지

```swift
// Before
FirebaseApp.configure()

// After
if FirebaseApp.app() == nil {
    FirebaseApp.configure()
}
```

## 📋 추후 진행 상황

- TestFlight 재빌드 후 런치 크래시 해소 확인

## 📌 리뷰 포인트

- `App/AppDelegate.swift` - `FirebaseApp.app() == nil` 방어 조건이 적절한지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #360