### PR TITLE
👷 [CI/CD] iOS CI 빌드 결과 디스코드 웹훅 알림 추가

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -76,3 +76,70 @@ jobs:
           if [ "`ls -A | grep -i \\.xcworkspace`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
           xcodebuild build -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+
+  notify:
+    name: Notify Discord
+    needs: build
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip notification when webhook secret is missing
+        if: ${{ secrets.DISCORD_WEBHOOK_URL == '' }}
+        run: echo "DISCORD_WEBHOOK_URL is not configured. Skipping Discord notification."
+
+      - name: Send build result to Discord
+        if: ${{ secrets.DISCORD_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_MENTION_ROLE_ID: ${{ secrets.DISCORD_MENTION_ROLE_ID }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          COMMIT_SHA: ${{ github.sha }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          python3 - << 'PY' > payload.json
+          import json
+          import os
+
+          build_result = os.environ["BUILD_RESULT"]
+          short_sha = os.environ["COMMIT_SHA"][:7]
+          pr_url = os.environ.get("PR_URL") or "N/A"
+          mention_role_id = os.environ.get("DISCORD_MENTION_ROLE_ID", "").strip()
+
+          if build_result == "success":
+              status_text = "SUCCESS ✅"
+              color = 5763719  # green
+              mention = ""
+          else:
+              status_text = "FAILED ❌"
+              color = 15548997  # red
+              mention = f"<@&{mention_role_id}>" if mention_role_id else "@here"
+
+          payload = {
+              "content": mention,
+              "embeds": [
+                  {
+                      "title": "iOS CI Build Result",
+                      "url": os.environ["WORKFLOW_URL"],
+                      "color": color,
+                      "fields": [
+                          {"name": "Build Status", "value": status_text, "inline": True},
+                          {"name": "Branch", "value": os.environ["REF_NAME"], "inline": True},
+                          {"name": "Commit", "value": f"`{short_sha}` by {os.environ['ACTOR']}", "inline": True},
+                          {"name": "PR", "value": pr_url, "inline": False},
+                      ],
+                      "footer": {"text": os.environ["REPOSITORY"]},
+                  }
+              ],
+          }
+
+          print(json.dumps(payload))
+          PY
+
+          curl -sS -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data @payload.json


### PR DESCRIPTION
## ✨ PR 유형

CI/CD - GitHub Actions 워크플로우에 디스코드 웹훅 알림 기능 추가

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음

## 🛠️ 작업내용

- `.github/workflows/ios.yml`에 `notify` job 추가 (build job 완료 후 항상 실행)
- 빌드 성공 시 녹색 임베드 메시지 전송
- 빌드 실패 시 적색 임베드 메시지 + 역할 멘션 전송
- `DISCORD_WEBHOOK_URL` Secret 미설정 시 graceful skip 처리
- `DISCORD_MENTION_ROLE_ID`로 실패 시 특정 역할 멘션 지원
- PR URL, 커밋 SHA, 브랜치명, 액터 정보를 임베드 필드에 포함

## 📋 추후 진행 상황

- GitHub Repository Secrets에 `DISCORD_WEBHOOK_URL` 등록 필요
- (선택) `DISCORD_MENTION_ROLE_ID` 등록하여 실패 시 특정 역할 멘션

## 📌 리뷰 포인트

- `.github/workflows/ios.yml` - notify job의 `if: always()` 조건 및 Secret 미설정 시 skip 로직 확인
- Python 스크립트로 Discord 임베드 payload 생성하는 부분 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #363