### PR TITLE
✨[Feat] 승인 대기 뷰에서 계정 삭제 기능 추가 (#365)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -82,25 +82,25 @@ jobs:
     needs: build
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      DISCORD_MENTION_ROLE_ID: ${{ secrets.DISCORD_MENTION_ROLE_ID }}
+      BUILD_RESULT: ${{ needs.build.result }}
+      REPOSITORY: ${{ github.repository }}
+      REF_NAME: ${{ github.ref_name }}
+      ACTOR: ${{ github.actor }}
+      COMMIT_SHA: ${{ github.sha }}
+      WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
 
     steps:
-      - name: Skip notification when webhook secret is missing
-        if: ${{ secrets.DISCORD_WEBHOOK_URL == '' }}
-        run: echo "DISCORD_WEBHOOK_URL is not configured. Skipping Discord notification."
-
       - name: Send build result to Discord
-        if: ${{ secrets.DISCORD_WEBHOOK_URL != '' }}
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          DISCORD_MENTION_ROLE_ID: ${{ secrets.DISCORD_MENTION_ROLE_ID }}
-          BUILD_RESULT: ${{ needs.build.result }}
-          REPOSITORY: ${{ github.repository }}
-          REF_NAME: ${{ github.ref_name }}
-          ACTOR: ${{ github.actor }}
-          COMMIT_SHA: ${{ github.sha }}
-          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
+          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+            echo "DISCORD_WEBHOOK_URL is not configured. Skipping Discord notification."
+            exit 0
+          fi
+
           python3 - << 'PY' > payload.json
           import json
           import os

--- a/AppProduct/AppProduct.xcodeproj/project.pbxproj
+++ b/AppProduct/AppProduct.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		0EEC14D52F0B92FA00345AD8 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0EEC14D42F0B92FA00345AD8 /* Kingfisher */; };
 		1F3173D62F127A5000601344 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 1F3173D52F127A5000601344 /* FirebaseCore */; };
 		1F3173D82F127A5000601344 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 1F3173D72F127A5000601344 /* FirebaseMessaging */; };
-		1FA0A1B12F40000100A1B2C3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1FA0A1B22F40000100A1B2C3 /* GoogleService-Info.plist */; };
 		1F953CD92F31D2BB0067FE73 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 1F953CD82F31D2BB0067FE73 /* AppIcon.icon */; };
 		1FEF7EC82F2C9D3200AB3DBB /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = 1FEF7EC72F2C9D3200AB3DBB /* Documentation.docc */; };
 /* End PBXBuildFile section */
@@ -36,7 +35,6 @@
 /* Begin PBXFileReference section */
 		0E6380A92F02F1020060E4D9 /* AppProduct.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppProduct.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F75B9912F123E6500B97089 /* AppProductTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppProductTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		1FA0A1B22F40000100A1B2C3 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "AppProduct/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		1F953CD82F31D2BB0067FE73 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		1FEF7EC72F2C9D3200AB3DBB /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -88,7 +86,6 @@
 			isa = PBXGroup;
 			children = (
 				1F953CD82F31D2BB0067FE73 /* AppIcon.icon */,
-				1FA0A1B22F40000100A1B2C3 /* GoogleService-Info.plist */,
 				1FEF7EC72F2C9D3200AB3DBB /* Documentation.docc */,
 				1FE63EEA2F20BDEF00D92F6A /* AppleCreateML */,
 				0E6380AB2F02F1020060E4D9 /* AppProduct */,
@@ -212,7 +209,6 @@
 		0E6380A72F02F1020060E4D9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			files = (
-				1FA0A1B12F40000100A1B2C3 /* GoogleService-Info.plist in Resources */,
 				1F953CD92F31D2BB0067FE73 /* AppIcon.icon in Resources */,
 			);
 		};

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
@@ -22,6 +22,7 @@ struct FailedVerificationUMC: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.appFlow) private var appFlow
     @Environment(\.di) private var di
+    @Environment(ErrorHandler.self) private var errorHandler
 
     /// 카카오톡 채널 연동 매니저
     let kakaoPlusManager: KakaoPlusManager = .init()
@@ -32,6 +33,8 @@ struct FailedVerificationUMC: View {
     @State private var alertPrompt: AlertPrompt?
     /// 전송 중 상태
     @State private var isSubmitting: Bool = false
+    /// 계정 삭제 진행 상태
+    @State private var isDeletingAccount: Bool = false
     /// 입력된 챌린저 코드
     @State private var challengerCode: String = ""
     
@@ -61,7 +64,8 @@ struct FailedVerificationUMC: View {
         static let mainBtnText: String = "UMC 공식 홈페이지 방문"
         /// 기존 챌린저 인증 버튼 텍스트
         static let verifyBtnText: String = "기존 챌린저 코드 입력"
-
+        /// 상단 텍스트 버튼용 기존 챌린저 인증 문구
+        static let verifyTextButtonTitle: String = "기존 챌린저 인증하기"
         /// UMC 공식 홈페이지 URL
         static let homePageURL: String = "https://umc.it.kr"
     }
@@ -73,22 +77,24 @@ struct FailedVerificationUMC: View {
                 topWarningImage
                 Spacer().frame(maxHeight: Constants.mianVspacing)
                 warningTitle
+                existingChallengerTextButton
                 Spacer()
             }
             .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
             .toolbar {
                 ToolBarCollection.FailedVerificationBottomToolbar(
                     isSubmitting: isSubmitting,
+                    isDeletingAccount: isDeletingAccount,
                     onHome: {
                         if let url = URL(string: Constants.homePageURL) {
                             openURL(url)
                         }
                     },
-                    onCode: {
-                        showCodeAlert = true
-                    },
                     onInquiry: {
                         kakaoPlusManager.openKakaoChannel()
+                    },
+                    onDeleteAccount: {
+                        presentDeleteAccountPrompt()
                     }
                 )
             }
@@ -140,6 +146,19 @@ struct FailedVerificationUMC: View {
                 .appFont(.callout, weight: .medium, color: .grey600)
                 .multilineTextAlignment(.center)
         }
+    }
+
+    /// 제목/부제목 하단의 기존 챌린저 인증 텍스트 버튼
+    private var existingChallengerTextButton: some View {
+        Button {
+            showCodeAlert = true
+        } label: {
+            Text(Constants.verifyTextButtonTitle)
+                .underline()
+                .appFont(.callout, weight: .semibold, color: .indigo500)
+        }
+        .padding(.top, DefaultSpacing.spacing16)
+        .disabled(isSubmitting || isDeletingAccount)
     }
 
     // MARK: - Private Function
@@ -198,8 +217,86 @@ struct FailedVerificationUMC: View {
             positiveBtnTitle: "확인"
         )
     }
+
+    /// 계정 삭제 확인 프롬프트를 표시합니다.
+    private func presentDeleteAccountPrompt() {
+        alertPrompt = AlertPrompt(
+            title: "계정 삭제",
+            message: "계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다. 정말 삭제하시겠습니까?",
+            positiveBtnTitle: "삭제",
+            positiveBtnAction: {
+                Task {
+                    await deleteAccount()
+                }
+            },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    /// 승인 대기 화면에서 계정 삭제를 수행합니다.
+    @MainActor
+    private func deleteAccount() async {
+        guard !isDeletingAccount else { return }
+        isDeletingAccount = true
+        defer { isDeletingAccount = false }
+
+        do {
+            let provider = di.resolve(MyPageUseCaseProviding.self)
+            try await provider.deleteMemberUseCase.execute()
+            try await di.resolve(NetworkClient.self).logout()
+            di.resetCache()
+            appFlow.showLogin()
+        } catch {
+            errorHandler.handle(
+                error,
+                context: .init(
+                    feature: "Auth",
+                    action: "deleteMemberFromPendingApproval"
+                )
+            )
+        }
+    }
 }
 
 #Preview {
     FailedVerificationUMC()
+        .environment(\.di, failedVerificationPreviewContainer)
+        .environment(\.appFlow, .noop)
+        .environment(ErrorHandler())
 }
+
+#if DEBUG
+private var failedVerificationPreviewContainer: DIContainer {
+    let container = DIContainer()
+    container.register(AuthUseCaseProviding.self) {
+        AuthUseCaseProvider(
+            repositoryProvider: AuthRepositoryProvider.mock(),
+            tokenStore: KeychainTokenStore()
+        )
+    }
+    container.register(MyPageUseCaseProviding.self) {
+        MyPageUseCaseProvider(repository: MockMyPageRepository())
+    }
+    container.register(NetworkClient.self) {
+        AuthSystemFactory.makeTestNetworkClient(
+            tokenStore: FailedVerificationPreviewTokenStore(),
+            refreshService: FailedVerificationPreviewTokenRefreshService()
+        )
+    }
+    return container
+}
+
+private actor FailedVerificationPreviewTokenStore: TokenStore {
+    func getAccessToken() async -> String? { nil }
+    func getRefreshToken() async -> String? { nil }
+    func save(accessToken: String, refreshToken: String) async throws { }
+    func clear() async throws { }
+}
+
+private struct FailedVerificationPreviewTokenRefreshService: TokenRefreshService {
+    func refresh(_ refreshToken: String) async throws -> TokenPair {
+        TokenPair(accessToken: "preview_access", refreshToken: "preview_refresh")
+    }
+}
+#endif

--- a/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
+++ b/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
@@ -611,9 +611,10 @@ struct ToolBarCollection {
     /// 챌린저 인증 실패 화면 하단 툴바
     struct FailedVerificationBottomToolbar: ToolbarContent {
         let isSubmitting: Bool
+        let isDeletingAccount: Bool
         let onHome: () -> Void
-        let onCode: () -> Void
         let onInquiry: () -> Void
+        let onDeleteAccount: () -> Void
 
         private enum Constants {
             static let iconSize: CGFloat = 18
@@ -625,18 +626,8 @@ struct ToolBarCollection {
                     icon: "house.fill",
                     title: "홈페이지",
                     color: .indigo,
-                    disabled: false,
+                    disabled: isDeletingAccount,
                     action: onHome
-                )
-            }
-
-            ToolbarItem(placement: .bottomBar) {
-                actionButton(
-                    icon: "number.square.fill",
-                    title: "기존 챌린저",
-                    color: .orange,
-                    disabled: isSubmitting,
-                    action: onCode
                 )
             }
 
@@ -645,8 +636,18 @@ struct ToolBarCollection {
                     icon: "message.fill",
                     title: "문의하기",
                     color: .yellow,
-                    disabled: false,
+                    disabled: isDeletingAccount,
                     action: onInquiry
+                )
+            }
+
+            ToolbarItem(placement: .bottomBar) {
+                actionButton(
+                    icon: "person.crop.circle.badge.xmark",
+                    title: "계정 삭제",
+                    color: .red,
+                    disabled: isSubmitting || isDeletingAccount,
+                    action: onDeleteAccount
                 )
             }
         }


### PR DESCRIPTION
## ✨ PR 유형

App Store 심사 가이드라인 준수를 위해, 승인 대기 상태(`FailedVerificationUMC`)에서도 계정 삭제가 가능하도록 기능을 추가합니다.

Closes #365

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경이 포함되어 있으므로 스크린샷/영상을 추가해주세요 -->

## 🛠️ 작업내용

- `FailedVerificationUMC`에 계정 삭제 확인 다이얼로그(`AlertPrompt`) 및 삭제 로직 추가
- 기존 `DeleteMemberUseCase` 재사용하여 API 호출 → 로그아웃 → 로그인 화면 이동 처리
- 기존 챌린저 코드 입력 버튼을 하단 툴바에서 본문 내 텍스트 버튼으로 이동
- 하단 툴바 재구성: **홈페이지 / 문의하기 / 계정 삭제** 3개 버튼 배치
- `ToolBarCollection.FailedVerificationBottomToolbar` 파라미터 변경 (`onCode` → `onDeleteAccount`)
- Preview용 Mock 객체 추가 (`MockMyPageRepository`, `FailedVerificationPreviewTokenStore` 등)
- CI/CD 디스코드 웹훅 `env` 블록을 job 레벨로 이동하여 구조 개선

## 📋 추후 진행 상황

- App Store 심사 재제출 및 리뷰 대응

## 📌 리뷰 포인트

- `Features/Auth/Presentation/Views/FailedVerificationUMC.swift` - 계정 삭제 로직 (`deleteAccount()`) 및 DIContainer를 통한 UseCase 주입 방식
- `Utilities/ToolBar/ToolBarCollection.swift` - 하단 툴바 버튼 구성 변경 및 disabled 상태 처리
- `.github/workflows/ios.yml` - env 블록 구조 변경이 기존 동작에 영향 없는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)