### PR TITLE
🐛 [Fix] 활동 기수 날짜 계산 로직 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Data/Repository/HomeRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/HomeRepository.swift
@@ -114,36 +114,46 @@ private extension HomeRepository {
         let generations = Set(profile.roles.map(\.gisu) + records.map(\.gisu))
             .filter { $0 > 0 }
             .sorted()
-        let gisuIds = Set(profile.roles.map(\.gisuId) + records.map(\.gisuId))
+        let recordGisuIds = Set(records.map(\.gisuId))
             .filter { $0 > 0 }
+        let roleGisuIds = Set(profile.roles.map(\.gisuId))
+            .filter { $0 > 0 }
+        let targetGisuIds = recordGisuIds.isEmpty ? roleGisuIds : recordGisuIds
 
-        guard !gisuIds.isEmpty else {
+        guard !targetGisuIds.isEmpty else {
             return [
                 .days(0),
                 .gens(generations)
             ]
         }
 
-        var totalDays = 0
-        try await withThrowingTaskGroup(of: Int.self) { group in
-            for gisuId in gisuIds {
+        var earliestStartDate: Date?
+        try await withThrowingTaskGroup(of: Date?.self) { group in
+            for gisuId in targetGisuIds {
                 group.addTask {
-                    try await self.fetchActivityDays(gisuId: gisuId)
+                    try await self.fetchSeasonStartDate(gisuId: gisuId)
                 }
             }
 
-            for try await days in group {
-                totalDays += days
+            for try await startDate in group {
+                guard let startDate else { continue }
+                if let currentEarliest = earliestStartDate {
+                    earliestStartDate = min(currentEarliest, startDate)
+                } else {
+                    earliestStartDate = startDate
+                }
             }
         }
 
+        let activityDays = earliestStartDate.map { calculateActivityDays(from: $0) } ?? 0
+
         return [
-            .days(max(totalDays, 0)),
+            .days(activityDays),
             .gens(generations)
         ]
     }
 
-    func fetchActivityDays(gisuId: Int) async throws -> Int {
+    func fetchSeasonStartDate(gisuId: Int) async throws -> Date? {
         let response = try await adapter.request(
             HomeRouter.getGisuDetail(gisuId: gisuId)
         )
@@ -153,11 +163,25 @@ private extension HomeRepository {
         )
         let gisuDetail = try apiResponse.unwrap()
 
-        let calendar = Calendar.current
-        let start = calendar.startOfDay(for: gisuDetail.startAt)
-        let endSource = gisuDetail.isActive ? Date() : gisuDetail.endAt
-        let end = calendar.startOfDay(for: endSource)
+        guard gisuDetail.startAt != .distantPast else {
+            return nil
+        }
 
-        return max(calendar.dateComponents([.day], from: start, to: end).day ?? 0, 0)
+        return gisuDetail.startAt
+    }
+
+    func calculateActivityDays(from startDate: Date, to endDate: Date = Date()) -> Int {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = ServerDateTimeConverter.kstTimeZone
+
+        let start = calendar.startOfDay(for: startDate)
+        let end = calendar.startOfDay(for: endDate)
+
+        guard start <= end else {
+            return 0
+        }
+
+        let elapsedDays = calendar.dateComponents([.day], from: start, to: end).day ?? 0
+        return max(elapsedDays + 1, 0)
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Fix - 활동 기수 날짜 계산 로직 버그 수정

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (데이터 계산 로직 수정)

## 🛠️ 작업내용

- 기수별 개별 활동일수 합산 방식 → 가장 빠른 기수 시작일 기준 계산으로 변경
- 챌린저 레코드 기수 ID 우선 사용, 없을 경우 role 기수 ID로 폴백
- `fetchActivityDays` → `fetchSeasonStartDate`로 리팩토링 (활동일수 대신 시작일 반환)
- `calculateActivityDays` 메서드 추가 (시작일~오늘 날짜 계산, KST 기준)
- `startAt`이 `distantPast`인 경우 nil 반환하여 무효 데이터 필터링
- 활동일수 계산 시 당일 포함 (+1일)

## 📋 추후 진행 상황

- 서버 아이콘 문자열 종류 확정 후 매핑 확장

## 📌 리뷰 포인트

- `Features/Home/Data/Repository/HomeRepository.swift` - `recordGisuIds` / `roleGisuIds` 폴백 로직 및 `calculateActivityDays` 날짜 계산 로직

Closes #377

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)