### PR TITLE
🐛 [Fix] 회원가입 이메일 인증번호 재인증 시 텍스트 필드 미노출 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Auth/Presentation/Components/FormEmailField.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Components/FormEmailField.swift
@@ -289,10 +289,11 @@ extension FormEmailField {
         showError = false
 
         switch verificationState {
-        case .initial:
+        case .initial, .failed:
             // 1단계: 인증번호 요청
             Task {
                 do {
+                    verificationCode = ""
                     verificationState = .verifying
                     try await onVerificationRequested()
                     verificationState = .codeRequested
@@ -318,8 +319,8 @@ extension FormEmailField {
         case .verified:
             // 이미 인증 완료
             break
-        case .verifying, .failed:
-            // 처리 중이거나 실패 상태
+        case .verifying:
+            // 처리 중
             break
         }
     }


### PR DESCRIPTION
## ✨ PR 유형

Fix - 회원가입 이메일 인증 플로우 버그 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->

## 🛠️ 작업내용

- `FormEmailField`에서 `verificationState`가 `.failed`일 때 재인증 요청이 불가능했던 버그 수정
- `.failed` 상태를 `.initial`과 동일하게 인증번호 요청 분기로 처리
- 재인증 시 기존 인증번호 입력값 초기화 (`verificationCode = ""`)
- `.failed` 상태를 `.verifying`의 break 분기에서 제거

## 📋 추후 진행 상황

- 인증 플로우 전반 QA

## 📌 리뷰 포인트

- `Features/Auth/Presentation/Components/FormEmailField.swift` - `.failed` 상태 분기 처리 및 입력값 초기화 타이밍

Closes #378

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)