### PR TITLE
♻️ [Refactor] 공지사항 필터링 로직 개선 (2계층 구조 + 파트 Nested Menu)

### DIFF
--- a/AppProduct/AppProduct/Features/MyPage/Data/DTO/AddChallengerRecordRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/DTO/AddChallengerRecordRequestDTO.swift
@@ -2,7 +2,7 @@
 //  AddChallengerRecordRequestDTO.swift
 //  AppProduct
 //
-//  Created by Codex on 3/6/26.
+//  Created by euijjang97 on 3/6/26.
 //
 
 import Foundation

--- a/AppProduct/AppProduct/Features/MyPage/Domain/UseCases/AddChallengerRecordUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Domain/UseCases/AddChallengerRecordUseCaseProtocol.swift
@@ -2,7 +2,7 @@
 //  AddChallengerRecordUseCaseProtocol.swift
 //  AppProduct
 //
-//  Created by Codex on 3/6/26.
+//  Created by euijjang97 on 3/6/26.
 //
 
 import Foundation

--- a/AppProduct/AppProduct/Features/MyPage/Domain/UseCases/Implementations/AddChallengerRecordUseCase.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Domain/UseCases/Implementations/AddChallengerRecordUseCase.swift
@@ -2,7 +2,7 @@
 //  AddChallengerRecordUseCase.swift
 //  AppProduct
 //
-//  Created by Codex on 3/6/26.
+//  Created by euijjang97 on 3/6/26.
 //
 
 import Foundation

--- a/AppProduct/AppProduct/Features/Notice/Domain/Enums/NoticeRequestFactory.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Enums/NoticeRequestFactory.swift
@@ -10,14 +10,12 @@ import Foundation
 // MARK: - NoticeRequestFactory
 /// 공지 목록/검색 요청 DTO를 생성합니다.
 enum NoticeRequestFactory {
-    /// 메인필터/조직 타입에 따라 적절한 NoticeListRequestDTO를 생성합니다.
+    /// 메인필터에 따라 적절한 NoticeListRequestDTO를 생성합니다.
     ///
     /// - Parameters:
     ///   - gisuId: 조회할 기수 ID
     ///   - page: 페이지 번호
     ///   - selectedMainFilter: 현재 선택된 메인필터
-    ///   - selectedPart: 선택된 파트 (파트 필터 시)
-    ///   - organizationType: 사용자 소속 조직 타입
     ///   - chapterId: 사용자 지부 ID
     ///   - schoolId: 사용자 학교 ID
     /// - Returns: API 요청용 DTO
@@ -25,8 +23,6 @@ enum NoticeRequestFactory {
         gisuId: Int,
         page: Int,
         selectedMainFilter: NoticeMainFilterType,
-        selectedPart: NoticePart?,
-        organizationType: OrganizationType?,
         chapterId: Int,
         schoolId: Int,
         pageSize: Int,
@@ -40,37 +36,25 @@ enum NoticeRequestFactory {
         let requestPart: UMCPartType?
 
         switch selectedMainFilter {
-        case .all:
-            switch organizationType {
-            case .central:
-                requestChapterId = nil
-                requestSchoolId = nil
-            case .chapter:
-                requestChapterId = myChapterId
-                requestSchoolId = nil
-            case .school:
-                requestChapterId = myChapterId
-                requestSchoolId = mySchoolId
-            default:
-                requestChapterId = myChapterId
-                requestSchoolId = mySchoolId
-            }
-            requestPart = nil
-        case .central:
+        case .all, .central:
+            // iOS-01 (UMC 공지): gisuId only
             requestChapterId = nil
             requestSchoolId = nil
             requestPart = nil
         case .branch:
+            // iOS-03 (지부 필터): gisuId + chapterId
             requestChapterId = myChapterId
             requestSchoolId = nil
-            requestPart = selectedPart?.umcPartType
+            requestPart = nil
         case .school:
+            // iOS-02 (학교 필터): gisuId + schoolId
             requestChapterId = nil
             requestSchoolId = mySchoolId
-            requestPart = selectedPart?.umcPartType
+            requestPart = nil
         case .part(let filterPart):
+            // iOS-04 (파트 필터): gisuId + part
             requestChapterId = nil
-            requestSchoolId = mySchoolId
+            requestSchoolId = nil
             requestPart = filterPart.umcPartType
         }
 

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeModel.swift
@@ -92,7 +92,7 @@ enum NoticeMainFilterType: Identifiable, Equatable, Hashable {
     var labelText: String {
         switch self {
         case .all: return "전체"
-        case .central: return "중앙운영사무국"
+        case .central: return "UMC 공지"
         case .branch(let name): return name
         case .school(let name): return name
         case .part(let part): return part.displayName

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
@@ -41,7 +41,14 @@ extension NoticeViewModel {
         self.schoolId = schoolId
 
         let validMainFilters = mainFilterItems
-        if !validMainFilters.contains(selectedMainFilter) {
+        let isCurrentPartSelectionValid: Bool = {
+            if case .part = selectedMainFilter {
+                return canSelectPartFilter
+            }
+            return validMainFilters.contains(selectedMainFilter)
+        }()
+
+        if !isCurrentPartSelectionValid {
             var state = currentState
             state.mainFilter = validMainFilters.first ?? .all
             currentState = state

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -232,8 +232,6 @@ extension NoticeViewModel {
             gisuId: gisuId,
             page: page,
             selectedMainFilter: selectedMainFilter,
-            selectedPart: selectedPart,
-            organizationType: organizationType,
             chapterId: chapterId,
             schoolId: schoolId,
             pageSize: pageSize,

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
@@ -123,37 +123,10 @@ final class NoticeViewModel {
 
     /// 역할(memberRole) 기반으로 노출할 메인필터 항목 목록을 반환합니다.
     ///
-    /// 중앙 운영진은 전체/중앙/지부/학교/파트, 지부장은 지부 이하,
-    /// 학교 운영진/챌린저는 학교 이하만 노출됩니다.
+    /// 권한과 무관하게 상위 조직 필터는 UMC 공지/본인 지부/본인 학교를 노출합니다.
+    /// 파트 필터는 별도 Nested Menu에서 제공합니다.
     var mainFilterItems: [NoticeMainFilterType] {
-        let partItem: [NoticeMainFilterType] = {
-            guard let userPart = userContext.part else { return [] }
-            return [.part(userPart)]
-        }()
-
-        switch memberRole {
-        case .superAdmin:
-            return []
-        case .centralPresident, .centralVicePresident, .centralOperatingTeamMember, .centralEducationTeamMember:
-            return [.all, .central, .branch(userContext.branchName), .school(userContext.schoolName)] + partItem
-        case .chapterPresident:
-            return [.all, .branch(userContext.branchName), .school(userContext.schoolName)] + partItem
-        case .schoolPresident, .schoolVicePresident:
-            return [.all, .branch(userContext.branchName), .school(userContext.schoolName)] + partItem
-        case .schoolPartLeader, .schoolEtcAdmin, .challenger:
-            return [.all, .school(userContext.schoolName)] + partItem
-        case .none:
-            var items: [NoticeMainFilterType] = [.all]
-            if organizationType == .central {
-                items.append(.central)
-            }
-            items.append(.branch(userContext.branchName))
-            items.append(.school(userContext.schoolName))
-            if let userPart = userContext.part {
-                items.append(.part(userPart))
-            }
-            return items
-        }
+        [.central, .branch(userContext.branchName), .school(userContext.schoolName)]
     }
 
     /// 상단 메인 메뉴에 표시할 기본 조직 필터 목록(파트 제외)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
@@ -156,27 +156,37 @@ final class NoticeViewModel {
         }
     }
 
+    /// 상단 메인 메뉴에 표시할 기본 조직 필터 목록(파트 제외)
+    var baseMainFilterItems: [NoticeMainFilterType] {
+        mainFilterItems.filter {
+            if case .part = $0 { return false }
+            return true
+        }
+    }
+
+    /// 파트 Nested Menu 노출 여부
+    var canSelectPartFilter: Bool {
+        memberRole != .superAdmin
+    }
+
+    /// 파트 Nested Menu 항목
+    var partFilterItems: [NoticePart] {
+        canSelectPartFilter ? NoticePart.allCases : []
+    }
+
     /// 현재 메인필터에 따라 노출할 하단 서브필터 칩 목록을 반환합니다.
     ///
     /// - 전체/파트: 칩 없음
     /// - 중앙/지부: 전체 + 파트
     /// - 학교: 학교 + 파트
     var subFilterChips: [NoticeListSubFilterChip] {
-        switch selectedMainFilter {
-        case .all, .part:
-            return []
-        case .central:
-            return [.all, .part]
-        case .branch:
-            return [.all, .part]
-        case .school:
-            return [.school, .part]
-        }
+        // iOS 공지 필터는 2계층(기수 + 조직/파트)만 사용합니다.
+        []
     }
 
     /// 서브필터 표시 여부 (중앙/지부/학교만)
     var showSubFilter: Bool {
-        !subFilterChips.isEmpty
+        false
     }
 
     var pageSize: Int {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeView.swift
@@ -276,18 +276,41 @@ struct NoticeView: View {
     /// 상단 툴바(기수 + 메인 필터)를 구성합니다.
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
-        if !viewModel.mainFilterItems.isEmpty {
-            ToolBarCollection.ToolBarCenterMenu(
-                items: viewModel.mainFilterItems,
-                selection: mainFilterBinding,
-                itemLabel: { $0.labelText },
-                itemIcon: { $0.labelIcon },
-                onSelect: { selected in
-                    #if DEBUG
-                    print("[Notice][MainFilter] tapped: \(selected.labelText)")
-                    #endif
+        if !viewModel.baseMainFilterItems.isEmpty {
+            ToolbarTitleMenu {
+                ForEach(viewModel.baseMainFilterItems) { item in
+                    Button {
+                        viewModel.selectMainFilter(item)
+                        #if DEBUG
+                        print("[Notice][MainFilter] tapped: \(item.labelText)")
+                        #endif
+                    } label: {
+                        Label(item.labelText, systemImage: item.labelIcon)
+                            .imageScale(.small)
+                            .font(.subheadline)
+                    }
                 }
-            )
+
+                if viewModel.canSelectPartFilter {
+                    Menu {
+                        ForEach(viewModel.partFilterItems) { part in
+                            Button {
+                                viewModel.selectMainFilter(.part(part))
+                                #if DEBUG
+                                print("[Notice][MainFilter] part tapped: \(part.displayName)")
+                                #endif
+                            } label: {
+                                Label(part.displayName, systemImage: part.iconName)
+                                    .font(.subheadline)
+                            }
+                        }
+                    } label: {
+                        Label("파트", systemImage: "person.3.fill")
+                            .imageScale(.small)
+                            .font(.subheadline)
+                    }
+                }
+            }
         }
 
         ToolBarCollection.GenerationFilter(
@@ -296,15 +319,6 @@ struct NoticeView: View {
             selection: generationBinding
         )
     }
-
-    /// 메인필터 선택 바인딩
-    private var mainFilterBinding: Binding<NoticeMainFilterType> {
-        Binding(
-            get: { viewModel.selectedMainFilter },
-            set: { viewModel.selectMainFilter($0) }
-        )
-    }
-
     /// 메인 필터 타입에 따라 노출되는 서브필터 영역입니다.
     @ViewBuilder
     private var topSafeAreaContent: some View {

--- a/AppProduct/AppProductTests/NoticeRequestFactoryTests.swift
+++ b/AppProduct/AppProductTests/NoticeRequestFactoryTests.swift
@@ -1,0 +1,84 @@
+//
+//  NoticeRequestFactoryTests.swift
+//  AppProductTests
+//
+//  Created by euijjang97 on 3/6/26.
+//
+
+import XCTest
+@testable import AppProduct
+
+final class NoticeRequestFactoryTests: XCTestCase {
+
+    func test_iOS01_UMC공지_요청은_gisuId만_포함한다() {
+        let request = NoticeRequestFactory.make(
+            gisuId: 9,
+            page: 0,
+            selectedMainFilter: .central,
+            chapterId: 11,
+            schoolId: 22,
+            pageSize: 20,
+            sort: ["createdAt,DESC"]
+        )
+
+        let query = request.queryItems
+        XCTAssertEqual(query["gisuId"] as? Int, 9)
+        XCTAssertNil(query["chapterId"])
+        XCTAssertNil(query["schoolId"])
+        XCTAssertNil(query["part"])
+    }
+
+    func test_iOS02_학교필터_요청은_schoolId를_포함한다() {
+        let request = NoticeRequestFactory.make(
+            gisuId: 9,
+            page: 0,
+            selectedMainFilter: .school("중앙대학교"),
+            chapterId: 11,
+            schoolId: 22,
+            pageSize: 20,
+            sort: ["createdAt,DESC"]
+        )
+
+        let query = request.queryItems
+        XCTAssertEqual(query["gisuId"] as? Int, 9)
+        XCTAssertNil(query["chapterId"])
+        XCTAssertEqual(query["schoolId"] as? Int, 22)
+        XCTAssertNil(query["part"])
+    }
+
+    func test_iOS03_지부필터_요청은_chapterId를_포함한다() {
+        let request = NoticeRequestFactory.make(
+            gisuId: 9,
+            page: 0,
+            selectedMainFilter: .branch("Product"),
+            chapterId: 11,
+            schoolId: 22,
+            pageSize: 20,
+            sort: ["createdAt,DESC"]
+        )
+
+        let query = request.queryItems
+        XCTAssertEqual(query["gisuId"] as? Int, 9)
+        XCTAssertEqual(query["chapterId"] as? Int, 11)
+        XCTAssertNil(query["schoolId"])
+        XCTAssertNil(query["part"])
+    }
+
+    func test_iOS04_파트필터_요청은_part만_포함한다() {
+        let request = NoticeRequestFactory.make(
+            gisuId: 9,
+            page: 0,
+            selectedMainFilter: .part(.ios),
+            chapterId: 11,
+            schoolId: 22,
+            pageSize: 20,
+            sort: ["createdAt,DESC"]
+        )
+
+        let query = request.queryItems
+        XCTAssertEqual(query["gisuId"] as? Int, 9)
+        XCTAssertNil(query["chapterId"])
+        XCTAssertNil(query["schoolId"])
+        XCTAssertEqual(query["part"] as? String, UMCPartType.front(type: .ios).apiValue)
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Refactor - 공지사항 필터링 로직을 iOS 2계층 구조로 개선 및 파트 Nested Menu 전환

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->

## 🛠️ 작업내용

**필터링 로직 개선:**
- `NoticeRequestFactory`에서 `organizationType`/`selectedPart` 파라미터 제거, 2계층 필터 구조로 단순화
- iOS-01 (UMC 공지): `gisuId`만 전송
- iOS-02 (학교 필터): `gisuId` + `schoolId`
- iOS-03 (지부 필터): `gisuId` + `chapterId`
- iOS-04 (파트 필터): `gisuId` + `part`
- 서브필터(3계층) 완전 제거 (`subFilterChips`/`showSubFilter` 비활성화)

**UI 변경:**
- 메인필터에서 파트를 Nested Menu로 분리 (`baseMainFilterItems` + `partFilterItems`)
- `ToolBarCenterMenu` → `ToolbarTitleMenu` + `Menu` 조합으로 전환
- "중앙운영사무국" 라벨 → "UMC 공지"로 변경

**기타:**
- 파트 필터 선택 유효성 검증 로직 추가 (`canSelectPartFilter`)
- `NoticeRequestFactory` 단위 테스트 추가
- MyPage UseCase 파일 작성자 정보 수정

## 📋 추후 진행 상황

- 공지사항 칩 명칭 개선 (#384)

## 📌 리뷰 포인트

- `Features/Notice/Domain/Enums/NoticeRequestFactory.swift` - 2계층 필터별 Query 파라미터 매핑 로직
- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift` - `baseMainFilterItems`/`partFilterItems` 분리 및 서브필터 제거
- `Features/Notice/Presentation/Views/NoticeView.swift` - ToolbarTitleMenu + 파트 Nested Menu UI 구조
- `AppProductTests/NoticeRequestFactoryTests.swift` - 필터별 DTO 생성 테스트 케이스

Closes #382

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)