### PR TITLE
🎨 [Design] 공지사항 칩 명칭 개선 (학교→교내, 지부→정식명칭)

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/project.pbxproj
+++ b/AppProduct/AppProduct.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8B8B4462NV;
 				ENABLE_PREVIEWS = YES;
@@ -439,7 +439,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8B8B4462NV;
 				ENABLE_PREVIEWS = YES;

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
@@ -56,10 +56,11 @@ struct NoticeDTO: Codable {
 // MARK: - Mapping
 extension NoticeDTO {
     /// NoticeDTO → NoticeItemModel 변환 (공지 목록용)
-    func toItemModel() -> NoticeItemModel {
+    func toItemModel(scopeDisplayNameOverride: String? = nil) -> NoticeItemModel {
         let generation = targetInfo.generationValue
         let scope = targetInfo.resolvedScope
         let category = targetInfo.resolvedCategory
+        let scopeDisplayName = scopeDisplayNameOverride ?? targetInfo.resolvedScopeDisplayName
         
         return NoticeItemModel(
             noticeId: id,
@@ -75,7 +76,8 @@ extension NoticeDTO {
             links: [],  // 기본 조회에는 없음
             images: [],  // 기본 조회에는 없음
             vote: nil,
-            viewCount: Int(viewCount) ?? 0
+            viewCount: Int(viewCount) ?? 0,
+            scopeDisplayName: scopeDisplayName
         )
     }
 }
@@ -89,6 +91,10 @@ struct NoticeTargetInfoDTO: Codable {
     let targetGisuId: String
     let targetChapterId: String?
     let targetSchoolId: String?
+    let targetChapterName: String?
+    let targetSchoolName: String?
+    let chapterName: String?
+    let schoolName: String?
     let targetParts: [UMCPartType]?
 
     private enum CodingKeys: String, CodingKey {
@@ -96,6 +102,10 @@ struct NoticeTargetInfoDTO: Codable {
         case targetGisuId
         case targetChapterId
         case targetSchoolId
+        case targetChapterName
+        case targetSchoolName
+        case chapterName
+        case schoolName
         case targetParts
     }
 
@@ -104,12 +114,20 @@ struct NoticeTargetInfoDTO: Codable {
         targetGisuId: String,
         targetChapterId: String?,
         targetSchoolId: String?,
+        targetChapterName: String? = nil,
+        targetSchoolName: String? = nil,
+        chapterName: String? = nil,
+        schoolName: String? = nil,
         targetParts: [UMCPartType]?
     ) {
         self.targetGisu = targetGisu
         self.targetGisuId = targetGisuId
         self.targetChapterId = targetChapterId
         self.targetSchoolId = targetSchoolId
+        self.targetChapterName = targetChapterName
+        self.targetSchoolName = targetSchoolName
+        self.chapterName = chapterName
+        self.schoolName = schoolName
         self.targetParts = targetParts
     }
 
@@ -119,7 +137,23 @@ struct NoticeTargetInfoDTO: Codable {
         targetGisuId = container.decodeFlexibleOptionalString(forKey: .targetGisuId) ?? "0"
         targetChapterId = container.decodeFlexibleOptionalString(forKey: .targetChapterId)
         targetSchoolId = container.decodeFlexibleOptionalString(forKey: .targetSchoolId)
+        targetChapterName = container.decodeFlexibleOptionalString(forKey: .targetChapterName)
+        targetSchoolName = container.decodeFlexibleOptionalString(forKey: .targetSchoolName)
+        chapterName = container.decodeFlexibleOptionalString(forKey: .chapterName)
+        schoolName = container.decodeFlexibleOptionalString(forKey: .schoolName)
         targetParts = try container.decodeIfPresent([UMCPartType].self, forKey: .targetParts)
+    }
+
+    var resolvedChapterName: String? {
+        let candidates = [targetChapterName, chapterName]
+        return candidates
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { !$0.isEmpty })
+    }
+
+    var targetChapterIdValue: Int? {
+        guard let targetChapterId else { return nil }
+        return Int(targetChapterId)
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
@@ -38,6 +38,16 @@ extension NoticeTargetInfoDTO {
         return .general
     }
 
+    /// 일반 공지(scope=branch) 칩 표기용 이름을 제공합니다.
+    var resolvedScopeDisplayName: String? {
+        switch resolvedScope {
+        case .branch:
+            return resolvedChapterName
+        case .central, .campus:
+            return nil
+        }
+    }
+
     var resolvedParts: [UMCPartType] {
         targetParts ?? []
     }

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeEditorTargetRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeEditorTargetRepository.swift
@@ -41,6 +41,16 @@ struct NoticeEditorTargetRepository: NoticeEditorTargetRepositoryProtocol {
         }
     }
 
+    /// 지부 ID로 지부명을 조회합니다.
+    func fetchBranchName(chapterId: Int) async throws -> String {
+        let response = try await adapter.request(NoticeEditorTargetRouter.getChapter(chapterId: chapterId))
+        let apiResponse = try decoder.decode(
+            APIResponse<ChapterDTO>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap().name
+    }
+
     /// 전체 학교 목록 조회 API를 호출하고 학교명 배열을 반환합니다.
     func fetchAllSchools() async throws -> [NoticeTargetOption] {
         let response = try await adapter.requestWithoutAuth(NoticeEditorTargetRouter.getAllSchools)

--- a/AppProduct/AppProduct/Features/Notice/Data/Router/NoticeEditorTargetRouter.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Router/NoticeEditorTargetRouter.swift
@@ -20,6 +20,8 @@ enum NoticeEditorTargetRouter: BaseTargetType {
     case getAllSchools
     /// 기수별 지부 및 소속 학교 목록 조회
     case getChaptersWithSchools(gisuId: Int)
+    /// 지부 단건 조회
+    case getChapter(chapterId: Int)
 
     // MARK: - BaseTargetType
 
@@ -32,13 +34,15 @@ enum NoticeEditorTargetRouter: BaseTargetType {
             return "/api/v1/schools/all"
         case .getChaptersWithSchools:
             return "/api/v1/chapters/with-schools"
+        case .getChapter(let chapterId):
+            return "/api/v1/chapters/\(chapterId)"
         }
     }
 
     /// HTTP 메서드
     var method: Moya.Method {
         switch self {
-        case .getAllChapters, .getAllSchools, .getChaptersWithSchools:
+        case .getAllChapters, .getAllSchools, .getChaptersWithSchools, .getChapter:
             return .get
         }
     }
@@ -53,6 +57,8 @@ enum NoticeEditorTargetRouter: BaseTargetType {
                 parameters: ["gisuId": gisuId],
                 encoding: URLEncoding.queryString
             )
+        case .getChapter:
+            return .requestPlain
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Domain/Enums/NoticeItemTag.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Enums/NoticeItemTag.swift
@@ -14,6 +14,7 @@ struct NoticeItemTag: Equatable {
 
     let scope: NoticeScope
     let category: NoticeCategory
+    let scopeDisplayName: String?
 
     // MARK: - Computed Property
 
@@ -23,8 +24,10 @@ struct NoticeItemTag: Equatable {
         case .general:
             switch scope {
             case .central: return "중앙"
-            case .branch: return "지부"
-            case .campus: return "학교"
+            case .branch:
+                let displayName = scopeDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                return displayName.isEmpty ? "지부" : displayName
+            case .campus: return "교내"
             }
         case .part(let part):
             return NoticePart(umcPartType: part)?.displayName ?? "파트"

--- a/AppProduct/AppProduct/Features/Notice/Domain/Interfaces/NoticeEditorTargetRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Interfaces/NoticeEditorTargetRepositoryProtocol.swift
@@ -11,6 +11,8 @@ import Foundation
 protocol NoticeEditorTargetRepositoryProtocol {
     /// 전체 지부 목록을 조회합니다.
     func fetchAllBranches() async throws -> [NoticeTargetOption]
+    /// 지부 ID로 지부명을 조회합니다.
+    func fetchBranchName(chapterId: Int) async throws -> String
     /// 전체 학교 목록을 조회합니다.
     func fetchAllSchools() async throws -> [NoticeTargetOption]
     /// 특정 지부(챕터)에 속한 학교 목록을 조회합니다.

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
@@ -28,6 +28,7 @@ struct NoticeItemModel: Equatable, Identifiable {
     let images: [String]
     let vote: NoticeVote?
     let viewCount: Int
+    let scopeDisplayName: String?
 
     init(
         noticeId: String = UUID().uuidString,
@@ -43,7 +44,8 @@ struct NoticeItemModel: Equatable, Identifiable {
         links: [String],
         images: [String],
         vote: NoticeVote?,
-        viewCount: Int
+        viewCount: Int,
+        scopeDisplayName: String? = nil
     ) {
         self.noticeId = noticeId
         self.generation = generation
@@ -59,11 +61,12 @@ struct NoticeItemModel: Equatable, Identifiable {
         self.images = images
         self.vote = vote
         self.viewCount = viewCount
+        self.scopeDisplayName = scopeDisplayName
     }
     
     /// UI 표시용 태그 (scope + category 조합)
     var tag: NoticeItemTag {
-        NoticeItemTag(scope: scope, category: category)
+        NoticeItemTag(scope: scope, category: category, scopeDisplayName: scopeDisplayName)
     }
     
     var hasLink: Bool { !links.isEmpty }

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeEditorTargetUseCase.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeEditorTargetUseCase.swift
@@ -26,6 +26,10 @@ final class NoticeEditorTargetUseCase: NoticeEditorTargetUseCaseProtocol {
         try await repository.fetchAllBranches()
     }
 
+    func fetchBranchName(chapterId: Int) async throws -> String {
+        try await repository.fetchBranchName(chapterId: chapterId)
+    }
+
     func fetchAllSchools() async throws -> [NoticeTargetOption] {
         try await repository.fetchAllSchools()
     }

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeEditorTargetUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeEditorTargetUseCaseProtocol.swift
@@ -11,6 +11,8 @@ import Foundation
 protocol NoticeEditorTargetUseCaseProtocol {
     /// 전체 지부 목록을 조회합니다.
     func fetchAllBranches() async throws -> [NoticeTargetOption]
+    /// 지부 ID로 지부명을 조회합니다.
+    func fetchBranchName(chapterId: Int) async throws -> String
     /// 전체 학교 목록을 조회합니다.
     func fetchAllSchools() async throws -> [NoticeTargetOption]
     /// 특정 지부(챕터)에 속한 학교 목록을 조회합니다.

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -97,7 +97,7 @@ extension NoticeViewModel {
         do {
             let request = buildNoticeListRequest(gisuId: gisuId, page: page)
             let response = try await requestAction(request)
-            applyPagedResponse(response, page: page)
+            await applyPagedResponse(response, page: page)
         } catch let error as RepositoryError {
             handleFetchError(.repository(error), page: page, action: "fetchNotices", failure: error)
         } catch let error as DomainError {
@@ -169,7 +169,7 @@ extension NoticeViewModel {
     ///   - response: 공지 페이징 응답 DTO
     ///   - page: 조회한 페이지 인덱스
     @MainActor
-    private func applyPagedResponse(_ response: NoticePageDTO<NoticeDTO>, page: Int) {
+    private func applyPagedResponse(_ response: NoticePageDTO<NoticeDTO>, page: Int) async {
         #if DEBUG
         print(
             "[NoticeViewModel] applyPagedResponse " +
@@ -196,7 +196,12 @@ extension NoticeViewModel {
             return
         }
 
-        let items = response.content.map { $0.toItemModel() }
+        let branchNameOverrides = await resolveBranchNameOverrides(from: response.content)
+        let items = response.content.map { dto in
+            let chapterId = dto.targetInfo.targetChapterIdValue
+            let scopeDisplayName = chapterId.flatMap { branchNameOverrides[$0] }
+            return dto.toItemModel(scopeDisplayNameOverride: scopeDisplayName)
+        }
         pagingState.applySuccess(page: page, hasNextPage: response.hasNext)
 
         if page == 0 {
@@ -205,6 +210,36 @@ extension NoticeViewModel {
             let mergedItems = (noticeItems.value ?? []) + items
             noticeItems = .loaded(mergedItems)
         }
+    }
+
+    @MainActor
+    private func resolveBranchNameOverrides(from notices: [NoticeDTO]) async -> [Int: String] {
+        let missingBranchIds = Set(
+            notices.compactMap { dto -> Int? in
+                guard dto.targetInfo.resolvedScope == .branch else { return nil }
+                guard dto.targetInfo.resolvedScopeDisplayName == nil else { return nil }
+                return dto.targetInfo.targetChapterIdValue
+            }
+        )
+
+        guard !missingBranchIds.isEmpty else { return [:] }
+
+        var resolved: [Int: String] = [:]
+        for chapterId in missingBranchIds {
+            if let cached = chapterNameCache[chapterId] {
+                resolved[chapterId] = cached
+                continue
+            }
+            do {
+                let chapterName = try await noticeEditorTargetUseCase.fetchBranchName(chapterId: chapterId)
+                chapterNameCache[chapterId] = chapterName
+                resolved[chapterId] = chapterName
+            } catch {
+                // 조회 실패 시 기본 칩 라벨(지부)로 fallback
+                continue
+            }
+        }
+        return resolved
     }
 
     /// 조회 실패 상태를 반영합니다.

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
@@ -27,6 +27,11 @@ final class NoticeViewModel {
         container.resolve(ChallengerGenRepositoryProtocol.self)
     }
 
+    /// 공지 타겟(지부/학교) 조회 UseCase
+    var noticeEditorTargetUseCase: NoticeEditorTargetUseCaseProtocol {
+        container.resolve(NoticeEditorTargetUseCaseProtocol.self)
+    }
+
     /// ViewModel 기능을 extension 파일로 분리해 관리하므로,
     /// 동일 타입 extension에서도 상태 변경이 가능하도록 내부 공개합니다.
     var organizationType: OrganizationType?
@@ -37,6 +42,8 @@ final class NoticeViewModel {
 
     /// 기수-기수ID 쌍 목록
     var gisuPairs: [(gen: Int, gisuId: Int)] = []
+    /// 지부명 캐시 (chapterId -> chapterName)
+    var chapterNameCache: [Int: String] = [:]
     /// 기수 매핑 로딩 완료 여부
     var isGisuListLoaded: Bool = false
     /// 기수 매핑 로딩 진행 여부


### PR DESCRIPTION
## ✨ PR 유형

Design - 공지사항 아이템 칩 명칭을 실제 조직 명칭으로 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->

## 🛠️ 작업내용

**칩 명칭 변경:**
- 학교 칩: 학교명 → **"교내"** 로 표시
- 지부 칩: "지부" → **정식 명칭** (Ain, Leo 등)으로 표시
- 파트 칩: 기존 정식 명칭 유지 (Plan, Design, Web, iOS 등)

**데이터 레이어:**
- `NoticeTargetInfoDTO`에 `targetChapterName`/`targetSchoolName`/`chapterName`/`schoolName` 필드 추가
- `resolvedScopeDisplayName` 계산 프로퍼티 추가 (지부 scope일 때 지부명 반환)
- `NoticeDTO.toItemModel`에 `scopeDisplayNameOverride` 파라미터 추가

**지부명 폴백 조회:**
- 서버 응답에 지부명이 누락된 경우 `chapterId`로 지부 단건 조회 API 호출
- `NoticeEditorTargetRouter.getChapter` 엔드포인트 추가
- `NoticeViewModel`에 `chapterNameCache` 추가하여 지부명 캐싱
- `resolveBranchNameOverrides`로 페이지 응답 시 누락된 지부명 일괄 조회

**도메인:**
- `NoticeItemModel`에 `scopeDisplayName` 필드 추가
- `NoticeItemTag`에서 `scopeDisplayName` 기반으로 칩 텍스트 생성

## 📋 추후 진행 상황

- 서버에서 지부명 필드가 안정적으로 내려오면 폴백 조회 로직 제거 가능

## 📌 리뷰 포인트

- `Features/Notice/Domain/Enums/NoticeItemTag.swift` - 칩 텍스트 변환 로직 (학교→교내, 지부→정식명칭)
- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift` - `resolveBranchNameOverrides` 지부명 폴백 조회 및 캐싱
- `Features/Notice/Data/DTOs/NoticeDTO.swift` - `toItemModel`에 scopeDisplayNameOverride 전달 구조

Closes #384

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)