### PR TITLE
✨ [Feat] Tuist NetworkCore 모듈 구현 (Config + 외부 패키지)

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Configuration/APIConfig.swift
+++ b/UMCApp/Core/Foundation/Sources/Configuration/APIConfig.swift
@@ -1,0 +1,46 @@
+//
+//  APIConfig.swift
+//  UMCFoundation
+//
+//  Created by euijjang97 on 3/6/26.
+//
+
+import Foundation
+
+public extension Config {
+    /// 네트워크 레이어가 API 요청을 구성할 때 사용하는 설정 모음입니다.
+    ///
+    /// `Config.API`는 plist에 들어 있는 원시 설정 값을 `CoreNetwork`가 바로
+    /// 사용할 수 있는 타입 안전한 값으로 변환해 제공합니다. 호출부에서는
+    /// `BASE_URL` 문자열을 직접 읽기보다 이 네임스페이스를 통해 접근하는 편이 낫습니다.
+    enum API {
+        // MARK: - Property
+
+        /// `Info.plist`에서 읽은 원본 API base URL 문자열입니다.
+        ///
+        /// 일반적으로 빌드 시점에 `Secrets.xcconfig`를 통해 주입되며,
+        /// 잘못된 URL 형식을 분리해 진단할 수 있도록 우선 문자열로 유지합니다.
+        public static var baseURLString: String {
+            Config.stringValue(for: "BASE_URL")
+        }
+
+        /// 외부 API 요청을 만들 때 기준이 되는 정규화된 base URL입니다.
+        ///
+        /// - Returns: `BASE_URL`로부터 생성한 유효한 `URL`입니다.
+        /// - Precondition: `BASE_URL`이 `Info.plist`에 존재하고, 절대 URL로 변환 가능해야 합니다.
+        public static var baseURL: URL {
+            guard let url = URL(string: baseURLString) else {
+                fatalError("Invalid Base_URL: \(baseURLString)")
+            }
+            return url
+        }
+
+        /// feature가 별도로 덮어쓰지 않는 한 모든 API 요청이 공유하는 기본 헤더입니다.
+        ///
+        /// 현재는 JSON 기반 요청을 전제로 한 최소 헤더만 제공하며,
+        /// 공통 헤더 정책이 늘어나면 이 값을 기준으로 확장합니다.
+        public static var defaultHeaders: [String: String] {
+            ["Content-Type": "application/json"]
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Configuration/AuthConfig.swift
+++ b/UMCApp/Core/Foundation/Sources/Configuration/AuthConfig.swift
@@ -1,0 +1,34 @@
+//
+//  AuthConfig.swift
+//  UMCFoundation
+//
+//  Created by euijjang97 on 3/6/26.
+//
+
+import Foundation
+
+public extension Config {
+    /// 인증 공급자 연동에 필요한 설정 모음입니다.
+    ///
+    /// 서드파티 인증 설정을 feature 코드에서 분리하고,
+    /// 빌드 설정을 통해 주입된 값을 한 곳에서 일관되게 참조할 수 있도록 합니다.
+    enum Auth {
+        // MARK: - Property
+
+        /// Kakao SDK 연동에 사용하는 네이티브 앱 키입니다.
+        ///
+        /// - Important: 값은 일반적으로 `Secrets.xcconfig`를 통해 주입되며,
+        ///   `Info.plist`의 `KAKAO_KEY` 항목에서 읽을 수 있어야 합니다.
+        public static var kakaoKey: String {
+            Config.stringValue(for: "KAKAO_KEY")
+        }
+
+        /// Kakao 앱 간 인증에 사용하는 URL Scheme입니다.
+        ///
+        /// `CFBundleURLSchemes`에 등록되는 형식과 동일한 규칙으로 조합해,
+        /// 인증 흐름이 같은 값을 한 소스에서 재사용할 수 있게 합니다.
+        public static var kakaoURLScheme: String {
+            "kakao\(kakaoKey)"
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Configuration/Config.swift
+++ b/UMCApp/Core/Foundation/Sources/Configuration/Config.swift
@@ -1,0 +1,46 @@
+//
+//  Config.swift
+//  UMCFoundation
+//
+//  Created by euijjang97 on 3/6/26.
+//
+
+import Foundation
+
+/// `Info.plist`에 노출된 앱 설정 값을 조회하는 진입점입니다.
+///
+/// 하위 모듈이 `Bundle.main`을 직접 읽지 않도록 런타임 설정 조회를 이
+/// 네임스페이스로 모읍니다. `Config.API`, `Config.Auth` 같은 세부 설정은
+/// 여기서 읽은 원시 plist 값을 모듈별 타입으로 변환해 제공합니다.
+public enum Config {
+    // MARK: - Property
+
+    /// 현재 실행 중인 앱 번들의 `Info.plist` 딕셔너리입니다.
+    ///
+    /// 모든 설정 accessor가 같은 값을 재사용할 수 있도록 한 번만 읽어 캐시합니다.
+    /// 앱 실행에 필요한 설정이 빠진 상태는 복구 가능한 오류가 아니므로,
+    /// plist 자체를 찾지 못하면 즉시 종료합니다.
+    static let infoDictionary: [String: Any] = {
+        guard let dict = Bundle.main.infoDictionary else {
+            fatalError("Info.plist not found")
+        }
+        return dict
+    }()
+
+    // MARK: - Function
+
+    /// 지정한 plist 키에 대응하는 비어 있지 않은 문자열 설정 값을 반환합니다.
+    ///
+    /// - Parameter key: 조회할 `Info.plist` 키입니다.
+    /// - Returns: `key`에 저장된 비어 있지 않은 문자열 값입니다.
+    /// - Important: 이 helper는 값이 이미 build setting 또는 `xcconfig`를 통해
+    ///   앱의 plist에 주입되어 있다고 가정합니다.
+    /// - Precondition: `Info.plist`에 `key`에 해당하는 비어 있지 않은 문자열이 존재해야 합니다.
+    static func stringValue(for key: String) -> String {
+        guard let value = infoDictionary[key] as? String,
+              value.isEmpty == false else {
+            fatalError("\(key) not found in Info.plist")
+        }
+        return value
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Configuration/MapConfig.swift
+++ b/UMCApp/Core/Foundation/Sources/Configuration/MapConfig.swift
@@ -1,0 +1,26 @@
+//
+//  MapConfig.swift
+//  UMCFoundation
+//
+//  Created by euijjang97 on 3/6/26.
+//
+
+import Foundation
+
+public extension Config {
+    /// 지도 및 지오코딩 연동에서 사용하는 설정 모음입니다.
+    ///
+    /// 지도 공급자용 시크릿을 별도 네임스페이스로 분리해,
+    /// 관련 없는 모듈이 인증이나 네트워크 설정에 함께 의존하지 않도록 합니다.
+    enum Map {
+        // MARK: - Property
+
+        /// TMap 기반 서비스를 호출할 때 사용하는 시크릿 키입니다.
+        ///
+        /// - Important: 값은 앱의 빌드 설정을 통해 주입되어야 하며,
+        ///   `Info.plist`의 `TMAP_SECRET_KEY` 항목으로 노출되어 있어야 합니다.
+        public static var tmapSecretKey: String {
+            Config.stringValue(for: "TMAP_SECRET_KEY")
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/CoreFoundationModule.swift
+++ b/UMCApp/Core/Foundation/Sources/CoreFoundationModule.swift
@@ -1,1 +1,0 @@
-public enum UMCFoundationModule {}

--- a/UMCApp/Core/Network/Project.swift
+++ b/UMCApp/Core/Network/Project.swift
@@ -12,6 +12,7 @@ let project = Project(
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+                .external(name: "Moya"),
             ]
         )
     ]

--- a/UMCApp/Core/Network/Sources/Base/BaseTargetType.swift
+++ b/UMCApp/Core/Network/Sources/Base/BaseTargetType.swift
@@ -1,0 +1,9 @@
+//
+//  BaseTargetType.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 3/6/26.
+//
+
+import Foundation
+

--- a/UMCApp/Core/Network/Sources/Base/NetworkConfig.swift
+++ b/UMCApp/Core/Network/Sources/Base/NetworkConfig.swift
@@ -1,0 +1,34 @@
+//
+//  NetworkConfig.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 3/6/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 네트워크 모듈이 사용하는 런타임 설정을 타입 안전하게 노출합니다.
+///
+/// `NetworkConfig`는 원시 plist 접근을 `UMCFoundation`에 위임해
+/// `CoreNetwork`가 앱 설정 키에 직접 의존하지 않도록 만듭니다.
+/// 네트워크 계층의 공통 설정은 이 타입을 통해 읽는 것을 기본으로 합니다.
+public enum NetworkConfig {
+    // MARK: - Property
+
+    /// 공통 네트워크 클라이언트와 target 정의가 사용하는 base URL입니다.
+    ///
+    /// 실제 값은 `Config.API.baseURL`에서 가져오며,
+    /// 그 내부에서는 앱 번들 설정에 주입된 `BASE_URL` 항목을 읽습니다.
+    public static var baseURL: URL {
+        Config.API.baseURL
+    }
+
+    /// target이 별도로 덮어쓰지 않는 한 요청에 적용되는 기본 HTTP 헤더입니다.
+    ///
+    /// 현재 기본값은 JSON 요청을 위한 최소 헤더이며,
+    /// 공통 헤더 정책이 추가되면 이 값을 기준으로 확장합니다.
+    public static var defaultHeaders: [String: String] {
+        Config.API.defaultHeaders
+    }
+}

--- a/UMCApp/Core/Network/Sources/CoreNetworkModule.swift
+++ b/UMCApp/Core/Network/Sources/CoreNetworkModule.swift
@@ -1,1 +1,0 @@
-public enum CoreNetworkModule {}

--- a/UMCApp/Core/UIComponents/Project.swift
+++ b/UMCApp/Core/UIComponents/Project.swift
@@ -12,6 +12,7 @@ let project = Project(
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
+                .external(name: "Kingfisher"),
             ]
         )
     ]

--- a/UMCApp/Tuist/Package.resolved
+++ b/UMCApp/Tuist/Package.resolved
@@ -1,0 +1,51 @@
+{
+  "originHash" : "fac2f052edecc84eb90fe9b129c5c7326d68f3ba3c98fbcbc8ef4c257ec1cd29",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "3f99050e75bbc6fe71fc323adabb039756680016",
+        "version" : "5.11.1"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "c92b84898e34ab46ff0dad86c02a0acbe2d87008",
+        "version" : "8.8.0"
+      }
+    },
+    {
+      "identity" : "moya",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Moya/Moya.git",
+      "state" : {
+        "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
+        "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "132aea4f236ccadc51590b38af0357a331d51fa2",
+        "version" : "6.10.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/UMCApp/Tuist/Package.swift
+++ b/UMCApp/Tuist/Package.swift
@@ -15,8 +15,7 @@ import PackageDescription
 let package = Package(
     name: "UMCApp",
     dependencies: [
-        // Add your own dependencies here:
-        // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
-        // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
+        .package(url: "https://github.com/Moya/Moya.git", from: "15.0.3"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "8.6.1"),
     ]
 )


### PR DESCRIPTION
## ✨ PR 유형

Feature - Tuist 멀티 모듈 환경에서 NetworkCore 및 Foundation Config 구현

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (인프라 레이어)

## 🛠️ 작업내용

**UMCFoundation Config:**
- `Config` 진입점 구현 (Info.plist 기반 설정 조회, `stringValue(for:)`)
- `Config.API`: `baseURL`, `defaultHeaders` 제공
- `Config.Auth`: `kakaoKey`, `kakaoURLScheme` 제공
- `Config.Map`: `tmapSecretKey` 제공
- 플레이스홀더 `CoreFoundationModule.swift` 제거

**CoreNetwork:**
- `NetworkConfig` 구현 (`Config.API`에 위임하는 타입 안전한 네트워크 설정)
- `BaseTargetType` 파일 추가 (스캐폴딩)
- 플레이스홀더 `CoreNetworkModule.swift` 제거

**Tuist 패키지:**
- `Package.swift`에 Moya(15.0.3), Kingfisher(8.6.1) 외부 패키지 추가
- CoreNetwork Project에 Moya 의존성 연결
- CoreUIComponents Project에 Kingfisher 의존성 연결

## 📋 추후 진행 상황

- BaseTargetType 프로토콜 구현
- NetworkAdapter (Moya Provider 래핑) 구현
- 인증 토큰 인터셉터 구현

## 📌 리뷰 포인트

- `UMCApp/Core/Foundation/Sources/Configuration/Config.swift` - Info.plist 설정 조회 구조
- `UMCApp/Core/Foundation/Sources/Configuration/APIConfig.swift` - baseURL/defaultHeaders 제공 로직
- `UMCApp/Core/Network/Sources/Base/NetworkConfig.swift` - Config.API 위임 구조
- `UMCApp/Tuist/Package.swift` - 외부 패키지 버전 확인

Closes #391

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)