### PR TITLE
🐛 [Fix] 커뮤니티 날짜/시간 UTC 변환 로직 통합 및 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Community/DTO/CommunityPostResponseDTO.swift
+++ b/AppProduct/AppProduct/Features/Community/DTO/CommunityPostResponseDTO.swift
@@ -78,40 +78,11 @@ struct LightningInfoDTO: Codable {
     
     func toModel() -> CommunityLightningInfo {
         return CommunityLightningInfo(
-            meetAt: DateParser.parse(meetAt),
+            meetAt: ServerDateTimeConverter.parseUTCDateTime(meetAt) ?? Date(),
             location: location,
             maxParticipants: Int(maxParticipants) ?? 0,
             openChatUrl: openChatUrl
         )
-    }
-}
-
-private enum DateParser {
-    static let iso8601WithFractional: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter
-    }()
-
-    static let iso8601: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter
-    }()
-
-    static let iso8601WithoutTimezone: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone.current
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-        return formatter
-    }()
-
-    static func parse(_ string: String) -> Date {
-        iso8601WithFractional.date(from: string)
-            ?? iso8601.date(from: string)
-            ?? iso8601WithoutTimezone.date(from: string)
-            ?? Date()
     }
 }
 
@@ -127,7 +98,7 @@ extension PostListItemDTO {
             profileImage: authorProfileImage,
             userName: authorName,
             part: UMCPartType(apiValue: authorPart ?? "PM") ?? .pm,
-            createdAt: DateParser.parse(createdAt),
+            createdAt: ServerDateTimeConverter.parseUTCDateTime(createdAt) ?? Date(),
             likeCount: Int(likeCount) ?? 0,
             commentCount: Int(commentCount) ?? 0,
             scrapCount: 0,
@@ -150,7 +121,7 @@ extension PostDetailDTO {
             profileImage: authorProfileImage,
             userName: authorName,
             part: UMCPartType(apiValue: authorPart ?? "PM") ?? .pm,
-            createdAt: DateParser.parse(writeTime),
+            createdAt: ServerDateTimeConverter.parseUTCDateTime(writeTime) ?? Date(),
             likeCount: Int(likeCount) ?? 0,
             commentCount: Int(commentCount) ?? 0,
             scrapCount: Int(scrapCount) ?? 0,

--- a/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift
@@ -102,7 +102,7 @@ class CommunityPostViewModel {
         do {
             if selectedCategory == .lighting {
                 // 번개 모임 생성
-                let meetAtString = DateFormatter.serverLocalDateTime.string(from: selectedDate)
+                let meetAtString = ServerDateTimeConverter.toUTCDateTimeString(selectedDate)
 
                 let request = CreateLightningPostRequestDTO(
                     title: titleText,
@@ -159,7 +159,7 @@ class CommunityPostViewModel {
         do {
             if selectedCategory == .lighting {
                 // 번개 모임 수정
-                let meetAtString = DateFormatter.serverLocalDateTime.string(from: selectedDate)
+                let meetAtString = ServerDateTimeConverter.toUTCDateTimeString(selectedDate)
 
                 let request = CreateLightningPostRequestDTO(
                     title: titleText,
@@ -229,14 +229,4 @@ class CommunityPostViewModel {
         let location: String?
         let openChatUrl: String?
     }
-}
-
-private extension DateFormatter {
-    static let serverLocalDateTime: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone.current
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-        return formatter
-    }()
 }

--- a/AppProduct/AppProduct/Utilities/Extensions/ServerDateTimeConverter.swift
+++ b/AppProduct/AppProduct/Utilities/Extensions/ServerDateTimeConverter.swift
@@ -35,6 +35,9 @@ enum ServerDateTimeConverter {
         }
 
         for format in [
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ",
+            "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+            "yyyy-MM-dd'T'HH:mm:ssZ",
             "yyyy-MM-dd'T'HH:mm:ss.SSSSSS",
             "yyyy-MM-dd'T'HH:mm:ss.SSS",
             "yyyy-MM-dd'T'HH:mm:ss"
@@ -49,6 +52,16 @@ enum ServerDateTimeConverter {
         }
 
         return nil
+    }
+
+    static func toUTCDateTimeString(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = utcTimeZone
+        formatter.formatOptions = [
+            .withInternetDateTime,
+            .withFractionalSeconds
+        ]
+        return formatter.string(from: date)
     }
 
     static func parseUTCDateTimeOrTime(

--- a/AppProduct/AppProductTests/ServerDateTimeConverterTests.swift
+++ b/AppProduct/AppProductTests/ServerDateTimeConverterTests.swift
@@ -1,0 +1,46 @@
+//
+//  ServerDateTimeConverterTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/8/26.
+//
+
+import XCTest
+@testable import AppProduct
+
+final class ServerDateTimeConverterTests: XCTestCase {
+
+    func test_toUTCDateTimeString_서울시간을_Z_포함_UTC로_변환한다() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul") ?? .current
+
+        let components = DateComponents(
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 3,
+            day: 8,
+            hour: 12,
+            minute: 44,
+            second: 56,
+            nanosecond: 236_000_000
+        )
+
+        let date = try XCTUnwrap(calendar.date(from: components))
+
+        XCTAssertEqual(
+            ServerDateTimeConverter.toUTCDateTimeString(date),
+            "2026-03-08T03:44:56.236Z"
+        )
+    }
+
+    func test_parseUTCDateTime_오프셋_포함_ISO8601을_정상_파싱한다() throws {
+        let date = try XCTUnwrap(
+            ServerDateTimeConverter.parseUTCDateTime("2026-03-08T12:44:56.236+0900")
+        )
+
+        XCTAssertEqual(
+            ServerDateTimeConverter.toUTCDateTimeString(date),
+            "2026-03-08T03:44:56.236Z"
+        )
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

커뮤니티 댓글/게시글 시간 표시 버그 수정 - UTC 변환 로직 통합

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

- `CommunityPostResponseDTO`의 로컬 `DateParser` enum을 제거하고 `ServerDateTimeConverter`로 통합
- `CommunityPostViewModel`의 로컬 `DateFormatter.serverLocalDateTime`을 제거하고 `ServerDateTimeConverter.toUTCDateTimeString()`으로 교체
- `ServerDateTimeConverter`에 UTC 타임존 포함 포맷 3종 추가 (`Z` 접미사 대응)
- `ServerDateTimeConverter.toUTCDateTimeString()` 메서드 추가 (Date → UTC ISO8601 문자열 변환)
- `ServerDateTimeConverterTests` 유닛 테스트 추가

## 📋 추후 진행 상황

- 댓글 정렬 순서 확인 (서버 측 정렬 이슈 여부 파악)

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Utilities/Extensions/ServerDateTimeConverter.swift` - UTC 타임존 포맷 추가 및 toUTCDateTimeString 메서드 확인
- `AppProduct/AppProduct/Features/Community/DTO/CommunityPostResponseDTO.swift` - 로컬 DateParser 제거 후 ServerDateTimeConverter 사용 전환
- `AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift` - 번개 모임 날짜 UTC 변환 로직

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)