### PR TITLE
♻️ [Refactor] 날짜 인코딩 로직 ServerDateTimeConverter로 통합

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/StudyGroupScheduleCreateRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/StudyGroupScheduleCreateRequestDTO.swift
@@ -52,15 +52,12 @@ struct StudyGroupScheduleCreateRequestDTO: Encodable {
         try container.encode(gisuId, forKey: .gisuId)
         try container.encode(requiresApproval, forKey: .requiresApproval)
 
-        // Date → ISO 8601 문자열로 직접 인코딩 (서버가 밀리초 포함 포맷을 요구)
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         try container.encode(
-            formatter.string(from: startsAt),
+            ServerDateTimeConverter.toUTCDateTimeString(startsAt),
             forKey: .startsAt
         )
         try container.encode(
-            formatter.string(from: endsAt),
+            ServerDateTimeConverter.toUTCDateTimeString(endsAt),
             forKey: .endsAt
         )
     }

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/GenerateScheduleRequetDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/GenerateScheduleRequetDTO.swift
@@ -67,10 +67,8 @@ struct GenerateScheduleRequetDTO: Encodable {
         try container.encode(gisuId, forKey: .gisuId)
         try container.encode(requiresApproval, forKey: .requiresApproval)
 
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let startsAtString = formatter.string(from: startsAt)
-        let endsAtString = formatter.string(from: endsAt)
+        let startsAtString = ServerDateTimeConverter.toUTCDateTimeString(startsAt)
+        let endsAtString = ServerDateTimeConverter.toUTCDateTimeString(endsAt)
         try container.encode(startsAtString, forKey: .startsAt)
         try container.encode(endsAtString, forKey: .endsAt)
     }

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/UpdateScheduleRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/UpdateScheduleRequestDTO.swift
@@ -46,13 +46,17 @@ struct UpdateScheduleRequestDTO: Encodable {
         try container.encodeIfPresent(tags, forKey: .tags)
         try container.encodeIfPresent(participantMemberIds, forKey: .participantMemberIds)
 
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         if let startsAt {
-            try container.encode(formatter.string(from: startsAt), forKey: .startsAt)
+            try container.encode(
+                ServerDateTimeConverter.toUTCDateTimeString(startsAt),
+                forKey: .startsAt
+            )
         }
         if let endsAt {
-            try container.encode(formatter.string(from: endsAt), forKey: .endsAt)
+            try container.encode(
+                ServerDateTimeConverter.toUTCDateTimeString(endsAt),
+                forKey: .endsAt
+            )
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift
@@ -126,12 +126,9 @@ final class NoticeUseCase: NoticeUseCaseProtocol {
             throw DomainError.custom(message: "종료 시간은 시작 시간보다 늦어야 합니다")
         }
 
-        // 2. Date → ISO8601 String 변환 (서버 API가 fractionalSeconds 포함 형식을 요구)
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-        let startsAtString = dateFormatter.string(from: startsAt)
-        let endsAtString = dateFormatter.string(from: endsAtExclusive)
+        // 2. Date → ISO8601 UTC String 변환
+        let startsAtString = ServerDateTimeConverter.toUTCDateTimeString(startsAt)
+        let endsAtString = ServerDateTimeConverter.toUTCDateTimeString(endsAtExclusive)
 
         // 3. DTO 생성
         let requestDTO = AddVoteRequestDTO(

--- a/AppProduct/AppProductTests/RequestDateEncodingTests.swift
+++ b/AppProduct/AppProductTests/RequestDateEncodingTests.swift
@@ -1,0 +1,100 @@
+//
+//  RequestDateEncodingTests.swift
+//  AppProductTests
+//
+//  Created by euijjang on 3/8/26.
+//
+
+import XCTest
+@testable import AppProduct
+
+final class RequestDateEncodingTests: XCTestCase {
+
+    func test_일정생성DTO는_UTC_Z형식으로_인코딩한다() throws {
+        let dto = GenerateScheduleRequetDTO(
+            name: "정기 모임",
+            startsAt: makeSeoulDate(hour: 12, minute: 44),
+            endsAt: makeSeoulDate(hour: 14, minute: 15),
+            isAllDay: false,
+            locationName: "UMC",
+            latitude: 37.5,
+            longitude: 127.0,
+            description: "설명",
+            participantMemberIds: [1, 2],
+            tags: [.general],
+            gisuId: 9,
+            requiresApproval: false
+        )
+
+        let json = try encodedJSON(from: dto)
+
+        XCTAssertEqual(json["startsAt"] as? String, "2026-03-08T03:44:56.236Z")
+        XCTAssertEqual(json["endsAt"] as? String, "2026-03-08T05:15:56.236Z")
+    }
+
+    func test_일정수정DTO는_UTC_Z형식으로_인코딩한다() throws {
+        let dto = UpdateScheduleRequestDTO(
+            name: nil,
+            startsAt: makeSeoulDate(hour: 12, minute: 44),
+            endsAt: makeSeoulDate(hour: 14, minute: 15),
+            isAllDay: nil,
+            locationName: nil,
+            latitude: nil,
+            longitude: nil,
+            description: nil,
+            tags: nil,
+            participantMemberIds: nil
+        )
+
+        let json = try encodedJSON(from: dto)
+
+        XCTAssertEqual(json["startsAt"] as? String, "2026-03-08T03:44:56.236Z")
+        XCTAssertEqual(json["endsAt"] as? String, "2026-03-08T05:15:56.236Z")
+    }
+
+    func test_스터디일정생성DTO는_UTC_Z형식으로_인코딩한다() throws {
+        let dto = StudyGroupScheduleCreateRequestDTO(
+            name: "스터디",
+            startsAt: makeSeoulDate(hour: 12, minute: 44),
+            endsAt: makeSeoulDate(hour: 14, minute: 15),
+            isAllDay: false,
+            locationName: "강의실",
+            latitude: 37.5,
+            longitude: 127.0,
+            description: "자료 준비",
+            tags: ["STUDY"],
+            studyGroupId: 1,
+            gisuId: 9,
+            requiresApproval: true
+        )
+
+        let json = try encodedJSON(from: dto)
+
+        XCTAssertEqual(json["startsAt"] as? String, "2026-03-08T03:44:56.236Z")
+        XCTAssertEqual(json["endsAt"] as? String, "2026-03-08T05:15:56.236Z")
+    }
+
+    private func encodedJSON<T: Encodable>(from value: T) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return object
+    }
+
+    private func makeSeoulDate(hour: Int, minute: Int) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul") ?? .current
+
+        let components = DateComponents(
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 3,
+            day: 8,
+            hour: hour,
+            minute: minute,
+            second: 56,
+            nanosecond: 236_000_000
+        )
+
+        return calendar.date(from: components) ?? Date()
+    }
+}

--- a/AppProduct/AppProductTests/ServerDateTimeConverterTests.swift
+++ b/AppProduct/AppProductTests/ServerDateTimeConverterTests.swift
@@ -2,7 +2,7 @@
 //  ServerDateTimeConverterTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/8/26.
+//  Created by euijjang on 3/8/26.
 //
 
 import XCTest


### PR DESCRIPTION
## ✨ PR 유형

Refactor - 프로젝트 전반의 날짜 변환 로직을 ServerDateTimeConverter로 통합

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

### 날짜 변환 통합 (ServerDateTimeConverter)
- `ServerDateTimeConverter`에 UTC 타임존 포함 포맷 3종 추가 (`Z` 접미사 대응)
- `ServerDateTimeConverter.toUTCDateTimeString()` 메서드 추가 (Date → UTC ISO8601 문자열)

### 커뮤니티 (fix/394 포함)
- `CommunityPostResponseDTO`의 로컬 `DateParser` enum 제거 → `ServerDateTimeConverter` 사용
- `CommunityPostViewModel`의 로컬 `DateFormatter.serverLocalDateTime` 제거 → `ServerDateTimeConverter` 사용

### Request DTO 통합
- `StudyGroupScheduleCreateRequestDTO`: 로컬 `ISO8601DateFormatter` → `ServerDateTimeConverter.toUTCDateTimeString` 교체
- `GenerateScheduleRequetDTO`: 로컬 `ISO8601DateFormatter` → `ServerDateTimeConverter.toUTCDateTimeString` 교체
- `UpdateScheduleRequestDTO`: 로컬 `ISO8601DateFormatter` → `ServerDateTimeConverter.toUTCDateTimeString` 교체
- `NoticeUseCase` 투표 생성: 로컬 `ISO8601DateFormatter` → `ServerDateTimeConverter.toUTCDateTimeString` 교체

### 테스트
- `ServerDateTimeConverterTests` 유닛 테스트 추가
- `RequestDateEncodingTests` 유닛 테스트 추가

## 📋 추후 진행 상황

- 추가 날짜 변환 로직 발견 시 ServerDateTimeConverter로 통합

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Utilities/Extensions/ServerDateTimeConverter.swift` - toUTCDateTimeString 메서드 및 UTC 포맷 추가
- `AppProduct/AppProduct/Features/Activity/Data/DTOs/StudyGroupScheduleCreateRequestDTO.swift` - encode 메서드 내 날짜 변환
- `AppProduct/AppProduct/Features/Home/Data/DTO/GenerateScheduleRequetDTO.swift` - encode 메서드 내 날짜 변환
- `AppProduct/AppProduct/Features/Home/Data/DTO/UpdateScheduleRequestDTO.swift` - Optional Date 인코딩 처리
- `AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift` - 투표 생성 시 날짜 변환

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)