### PR TITLE
🐛 [Fix] 커뮤니티 댓글 정렬 순서 및 시간 표시 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Community/DTO/CommunityCommentResponse.swift
+++ b/AppProduct/AppProduct/Features/Community/DTO/CommunityCommentResponse.swift
@@ -27,7 +27,7 @@ extension CommentDTO {
             profileImage: challengerProfileImage,
             userName: challengerName,
             content: content,
-            createdAt: ISO8601DateFormatter().date(from: createdAt) ?? Date(),
+            createdAt: ServerDateTimeConverter.parseUTCDateTime(createdAt) ?? Date(),
             isAuthor: isAuthor
         )
     }

--- a/AppProduct/AppProduct/Features/Community/Data/Repositories/CommunityDetailRepository.swift
+++ b/AppProduct/AppProduct/Features/Community/Data/Repositories/CommunityDetailRepository.swift
@@ -56,7 +56,14 @@ final class CommunityDetailRepository: CommunityDetailRepositoryProtocol {
             APIResponse<[CommentDTO]>.self,
             from: response.data
         )
-        return try apiResponse.unwrap().map { $0.toCommentModel() }
+        return try apiResponse.unwrap()
+            .map { $0.toCommentModel() }
+            .sorted {
+                if $0.createdAt == $1.createdAt {
+                    return $0.commentId < $1.commentId
+                }
+                return $0.createdAt < $1.createdAt
+            }
     }
     
     func getPostDetail(postId: Int) async throws -> CommunityItemModel {


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 커뮤니티 댓글 정렬 순서 오류 및 시간 표시 "방금 전" 고정 문제 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 (로직 수정) -->

## 🛠️ 작업내용

- `CommunityCommentResponse`: 댓글 시간 파싱을 `ISO8601DateFormatter()` → `ServerDateTimeConverter.parseUTCDateTime`으로 교체하여 다양한 서버 날짜 포맷 대응 및 시간 표시 정확도 개선
- `CommunityDetailRepository`: 댓글 목록을 `createdAt` 오름차순(오래된 순)으로 정렬 추가, 동일 시간일 경우 `commentId`로 정렬

## 📋 추후 진행 상황

- 서버 측 댓글 정렬 순서 확인 (현재 클라이언트 측 정렬로 대응)

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Features/Community/DTO/CommunityCommentResponse.swift` - ServerDateTimeConverter 사용으로 전환
- `AppProduct/AppProduct/Features/Community/Data/Repositories/CommunityDetailRepository.swift` - 댓글 정렬 로직 (createdAt 오름차순 + commentId fallback)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)