### PR TITLE
♻️ [Refactor] 일정 상세 날짜 표시 개선 및 DTO 서버 호환성 강화

### DIFF
--- a/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
@@ -59,8 +59,8 @@ enum NavigationDestination: Hashable {
         case alarmHistory
         /// 일정 등록
         case registrationSchedule
-        /// 일정 상세 (scheduleId: 일정 ID, selectedDate: 선택 날짜)
-        case detailSchedule(scheduleId: Int, selectedDate: Date)
+        /// 일정 상세 (scheduleId: 일정 ID)
+        case detailSchedule(scheduleId: Int)
         /// 홈에서 진입하는 공지 상세
         case detailNotice(detailItem: NoticeDetail)
     }

--- a/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
@@ -70,10 +70,9 @@ private extension NavigationRoutingView {
             NoticeAlarmView()
         case .registrationSchedule:
             ScheduleRegistrationView(container: di, errorHandler: errorHandler)
-        case .detailSchedule(let scheduleId, let selectedDate):
+        case .detailSchedule(let scheduleId):
             ScheduleDetailView(
-                scheduleId: scheduleId,
-                selectedDate: selectedDate
+                scheduleId: scheduleId
             )
         case .detailNotice(let detailItem):
             NoticeDetailView(

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/HomeScheduleDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/HomeScheduleDTO.swift
@@ -29,6 +29,8 @@ struct HomeScheduleResponseDTO: Codable {
         case name
         case startsAt
         case endsAt
+        case startTime
+        case endTime
         case status
         case dDay
     }
@@ -37,10 +39,26 @@ struct HomeScheduleResponseDTO: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         scheduleId = try container.decodeIntFlexibleIfPresent(forKey: .scheduleId) ?? 0
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
-        startsAt = try container.decodeIfPresent(String.self, forKey: .startsAt) ?? ""
-        endsAt = try container.decodeIfPresent(String.self, forKey: .endsAt) ?? ""
+        startsAt = container.decodeDateTimeString(
+            primaryKey: .startsAt,
+            fallbackKey: .startTime
+        )
+        endsAt = container.decodeDateTimeString(
+            primaryKey: .endsAt,
+            fallbackKey: .endTime
+        )
         status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
         dDay = try container.decodeIntFlexibleIfPresent(forKey: .dDay) ?? 0
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(scheduleId, forKey: .scheduleId)
+        try container.encode(name, forKey: .name)
+        try container.encode(startsAt, forKey: .startsAt)
+        try container.encode(endsAt, forKey: .endsAt)
+        try container.encode(status, forKey: .status)
+        try container.encode(dDay, forKey: .dDay)
     }
 }
 
@@ -95,5 +113,11 @@ private extension KeyedDecodingContainer {
             return nil
         }
         return try? decodeIntFlexible(forKey: key)
+    }
+
+    func decodeDateTimeString(primaryKey: Key, fallbackKey: Key) -> String {
+        (try? decodeIfPresent(String.self, forKey: primaryKey))
+        ?? (try? decodeIfPresent(String.self, forKey: fallbackKey))
+        ?? ""
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleDetailDTO.swift
@@ -48,6 +48,8 @@ struct ScheduleDetailDTO: Codable, Sendable, Equatable {
         case tags
         case startsAt
         case endsAt
+        case startTime
+        case endTime
         case isAllDay
         case locationName
         case latitude
@@ -63,8 +65,14 @@ struct ScheduleDetailDTO: Codable, Sendable, Equatable {
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
         tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
-        startsAt = try container.decodeIfPresent(String.self, forKey: .startsAt) ?? ""
-        endsAt = try container.decodeIfPresent(String.self, forKey: .endsAt) ?? ""
+        startsAt = container.decodeDateTimeString(
+            primaryKey: .startsAt,
+            fallbackKey: .startTime
+        )
+        endsAt = container.decodeDateTimeString(
+            primaryKey: .endsAt,
+            fallbackKey: .endTime
+        )
         isAllDay = try container.decodeBoolFlexibleIfPresent(forKey: .isAllDay) ?? false
         locationName = try container.decodeIfPresent(String.self, forKey: .locationName) ?? ""
         latitude = try container.decodeDoubleFlexibleIfPresent(forKey: .latitude) ?? 0
@@ -72,6 +80,23 @@ struct ScheduleDetailDTO: Codable, Sendable, Equatable {
         status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
         dDay = try container.decodeIntFlexibleIfPresent(forKey: .dDay) ?? 0
         requiresAttendanceApproval = try container.decodeBoolFlexibleIfPresent(forKey: .requiresAttendanceApproval) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(scheduleId, forKey: .scheduleId)
+        try container.encode(name, forKey: .name)
+        try container.encode(description, forKey: .description)
+        try container.encode(tags, forKey: .tags)
+        try container.encode(startsAt, forKey: .startsAt)
+        try container.encode(endsAt, forKey: .endsAt)
+        try container.encode(isAllDay, forKey: .isAllDay)
+        try container.encode(locationName, forKey: .locationName)
+        try container.encode(latitude, forKey: .latitude)
+        try container.encode(longitude, forKey: .longitude)
+        try container.encode(status, forKey: .status)
+        try container.encode(dDay, forKey: .dDay)
+        try container.encode(requiresAttendanceApproval, forKey: .requiresAttendanceApproval)
     }
 }
 
@@ -166,5 +191,11 @@ private extension KeyedDecodingContainer {
             }
         }
         return nil
+    }
+
+    func decodeDateTimeString(primaryKey: Key, fallbackKey: Key) -> String {
+        (try? decodeIfPresent(String.self, forKey: primaryKey))
+        ?? (try? decodeIfPresent(String.self, forKey: fallbackKey))
+        ?? ""
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
@@ -23,9 +23,6 @@ class ScheduleDetailViewModel {
     var scheduleId: Int
     private(set) var data: Loadable<ScheduleDetailData> = .idle
 
-    /// 캘린더에서 선택한 날짜 (일시 표시에 사용)
-    var selectedDate: Date
-
     /// 역지오코딩으로 가져온 도로명 주소
     private(set) var roadAddress: String?
     /// 삭제 확인 Alert 데이터
@@ -38,9 +35,8 @@ class ScheduleDetailViewModel {
     var canDeleteSchedule: Bool = false
 
     // MARK: - Init
-    init(scheduleId: Int, selectedDate: Date = .now) {
+    init(scheduleId: Int) {
         self.scheduleId = scheduleId
-        self.selectedDate = selectedDate
     }
 
     // MARK: - Function

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
@@ -218,8 +218,7 @@ struct HomeView: View {
                             pathStore.homePath.append(
                                 .home(
                                     .detailSchedule(
-                                        scheduleId: schedule.scheduleId,
-                                        selectedDate: selectedDate
+                                        scheduleId: schedule.scheduleId
                                     )
                                 )
                             )

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
@@ -31,10 +31,9 @@ struct ScheduleDetailView: View {
 
     // MARK: - Init
 
-    init(scheduleId: Int, selectedDate: Date) {
+    init(scheduleId: Int) {
         self._viewModel = .init(initialValue: .init(
-            scheduleId: scheduleId,
-            selectedDate: selectedDate
+            scheduleId: scheduleId
         ))
     }
 
@@ -220,7 +219,6 @@ struct ScheduleDetailView: View {
 
             SchedulePlaceDateInfo(
                 data: data,
-                selectedDate: viewModel.selectedDate,
                 roadAddress: viewModel.roadAddress,
                 onMapLinkTapped: {
                     viewModel.mapLinkTapped(
@@ -253,7 +251,6 @@ private struct SchedulePlaceDateInfo: View, Equatable {
     // MARK: - Property
 
     let data: ScheduleDetailData
-    let selectedDate: Date
     let roadAddress: String?
     let onMapLinkTapped: () -> Void
 
@@ -265,7 +262,6 @@ private struct SchedulePlaceDateInfo: View, Equatable {
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.data == rhs.data
-        && lhs.selectedDate == rhs.selectedDate
         && lhs.roadAddress == rhs.roadAddress
     }
 
@@ -289,11 +285,11 @@ private struct SchedulePlaceDateInfo: View, Equatable {
     private var dateTimeSection: some View {
         infoSection(iconName: "calendar", tintColor: .orange) {
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
-                Text(selectedDate.toYearMonthDayWithWeekday())
+                Text(dateText)
                     .appFont(.calloutEmphasis)
                     .foregroundStyle(.black)
 
-                Text(data.startsAt.timeRange(to: data.endsAt))
+                Text(timeText)
                     .appFont(.subheadline)
                     .foregroundStyle(.grey600)
             }
@@ -342,5 +338,25 @@ private struct SchedulePlaceDateInfo: View, Equatable {
             .padding()
             .background(tintColor.opacity(0.4), in: .circle)
             .glassEffect(.clear, in: .circle)
+    }
+
+    private var dateText: String {
+        if Calendar.current.isDate(data.startsAt, inSameDayAs: data.endsAt) {
+            return data.startsAt.toYearMonthDayWithWeekday()
+        }
+
+        return "\(data.startsAt.toYearMonthDayWithWeekday()) - \(data.endsAt.toYearMonthDayWithWeekday())"
+    }
+
+    private var timeText: String {
+        if data.isAllDay {
+            return "종일"
+        }
+
+        if Calendar.current.isDate(data.startsAt, inSameDayAs: data.endsAt) {
+            return data.startsAt.timeRange(to: data.endsAt)
+        }
+
+        return "\(data.startsAt.toMonthDayWeekDayWithTime()) - \(data.endsAt.toMonthDayWeekDayWithTime())"
     }
 }

--- a/AppProduct/AppProductTests/HomeScheduleDTOTests.swift
+++ b/AppProduct/AppProductTests/HomeScheduleDTOTests.swift
@@ -1,0 +1,59 @@
+//
+//  HomeScheduleDTOTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/8/26.
+//
+
+import XCTest
+@testable import AppProduct
+
+final class HomeScheduleDTOTests: XCTestCase {
+
+    func test_homeScheduleResponseDTO_startTime_endTime_키도_디코딩한다() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "scheduleId": 395,
+              "name": "운영 회의",
+              "startTime": "2026-03-08T03:44:56.236Z",
+              "endTime": "2026-03-08T05:15:56.236Z",
+              "status": "참여 예정",
+              "dDay": 0
+            }
+            """.data(using: .utf8)
+        )
+
+        let dto = try JSONDecoder().decode(HomeScheduleResponseDTO.self, from: data)
+
+        XCTAssertEqual(dto.startsAt, "2026-03-08T03:44:56.236Z")
+        XCTAssertEqual(dto.endsAt, "2026-03-08T05:15:56.236Z")
+    }
+
+    func test_scheduleDetailDTO_startTime_endTime_키도_디코딩한다() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "scheduleId": 395,
+              "name": "운영 회의",
+              "description": "다음 스프린트 조율",
+              "tags": ["운영"],
+              "startTime": "2026-03-08T03:44:56.236Z",
+              "endTime": "2026-03-08T05:15:56.236Z",
+              "isAllDay": false,
+              "locationName": "UMC 라운지",
+              "latitude": 37.5665,
+              "longitude": 126.9780,
+              "status": "참여 예정",
+              "dDay": 0,
+              "requiresAttendanceApproval": false
+            }
+            """.data(using: .utf8)
+        )
+
+        let dto = try JSONDecoder().decode(ScheduleDetailDTO.self, from: data)
+
+        XCTAssertEqual(dto.startsAt, "2026-03-08T03:44:56.236Z")
+        XCTAssertEqual(dto.endsAt, "2026-03-08T05:15:56.236Z")
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Refactor - 일정 상세 화면 날짜 표시 로직 개선 및 서버 API 필드 호환성 강화

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 스크린샷 추가 필요 - 날짜 범위 표시, 종일 일정 표시 확인 -->

## 🛠️ 작업내용

### 일정 상세 날짜 표시 개선
- `ScheduleDetailView`/`ScheduleDetailViewModel`에서 `selectedDate` 파라미터 제거 (서버 데이터의 `startsAt`/`endsAt` 기반으로 날짜 직접 표시)
- `NavigationDestination.detailSchedule`에서 `selectedDate` 파라미터 제거
- 시작/종료 날짜가 다른 경우 날짜 범위 표시 (`3월 8일(토) - 3월 9일(일)`)
- 종일 일정(`isAllDay`)인 경우 "종일" 텍스트 표시

### 서버 API 호환성
- `HomeScheduleDTO`에 `startTime`/`endTime` fallback 키 추가 (`startsAt` 우선, 없으면 `startTime` 사용)
- `ScheduleDetailDTO`에 동일한 fallback 로직 추가
- `decodeDateTimeString(primaryKey:fallbackKey:)` 헬퍼 메서드 추가

### 테스트
- `HomeScheduleDTOTests` 유닛 테스트 추가

## 📋 추후 진행 상황

- 서버 API 필드명 통일 후 fallback 키 제거 가능

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Features/Home/Data/DTO/HomeScheduleDTO.swift` - `decodeDateTimeString` fallback 로직
- `AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleDetailDTO.swift` - 동일 fallback 로직 적용
- `AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift` - `dateText`/`timeText` computed property로 날짜 범위 및 종일 처리
- `AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift` - `selectedDate` 제거 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)