### PR TITLE
🐛 [Fix] 역할 우선순위 레벨 재조정 및 최고 권한 결정 로직 통합

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
@@ -40,18 +40,21 @@ enum ManagementTeam: String, CaseIterable, Codable, Comparable {
     // MARK: - Level
 
     /// 권한 레벨 (높을수록 상위 권한)
+    ///
+    /// 이슈 #399 기준으로 복수 역할 보유 시 아래 순서를 우선 적용합니다.
+    /// superAdmin은 시스템 역할이므로 별도로 최상위에 둡니다.
     var level: Int {
         switch self {
-        case .superAdmin:                   return 100
-        case .centralPresident:             return 90
-        case .centralVicePresident:         return 85
+        case .superAdmin:                   return 110
+        case .centralPresident:             return 100
+        case .centralVicePresident:         return 90
         case .centralOperatingTeamMember:   return 80
-        case .centralEducationTeamMember:   return 80
-        case .chapterPresident:             return 70
-        case .schoolPresident:              return 60
-        case .schoolVicePresident:          return 55
-        case .schoolPartLeader:             return 40
-        case .schoolEtcAdmin:              return 30
+        case .centralEducationTeamMember:   return 70
+        case .chapterPresident:             return 60
+        case .schoolPresident:              return 50
+        case .schoolVicePresident:          return 40
+        case .schoolPartLeader:             return 30
+        case .schoolEtcAdmin:               return 20
         case .challenger:                   return 0
         }
     }
@@ -65,6 +68,10 @@ enum ManagementTeam: String, CaseIterable, Codable, Comparable {
 
     static func < (lhs: ManagementTeam, rhs: ManagementTeam) -> Bool {
         lhs.level < rhs.level
+    }
+
+    static func highestPriority<S: Sequence>(in roles: S) -> ManagementTeam? where S.Element == ManagementTeam {
+        roles.max()
     }
 
     // MARK: - Display

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -255,7 +255,8 @@ private extension MemberRepository {
                 guard item.memberId > 0 else { continue }
 
                 let part = UMCPartType(apiValue: item.part) ?? .pm
-                let managementTeam = item.roleTypes.max() ?? .challenger
+                let managementTeam = ManagementTeam.highestPriority(in: item.roleTypes)
+                    ?? .challenger
                 let generation = resolvedGeneration(
                     generation: item.generation,
                     gisu: item.gisu
@@ -547,12 +548,13 @@ private extension MemberRepository {
                 .filter { $0.challengerId == nil || $0.challengerId == challengerId }
                 .map(\.roleType)
 
-            if let highestMatchedRole = matchedRoles.max() {
+            if let highestMatchedRole = ManagementTeam.highestPriority(in: matchedRoles) {
                 return highestMatchedRole
             }
         }
 
-        return profile.roles.map(\.roleType).max() ?? fallback
+        return ManagementTeam.highestPriority(in: profile.roles.map(\.roleType))
+            ?? fallback
     }
 
     func resolvedGeneration(

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
@@ -162,7 +162,7 @@ enum MemberStatus: String, Codable {
 extension MyProfileResponseDTO {
     /// DTO → 최고 권한 역할 반환
     func highestRole() -> ManagementTeam {
-        roles.map(\.roleType).max() ?? .challenger
+        ManagementTeam.highestPriority(in: roles.map(\.roleType)) ?? .challenger
     }
 
     /// DTO → HomeProfileResult 변환 (기수 카드 + 역할 정보)

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -97,7 +97,7 @@ final class HomeViewModel {
     /// 다른 Feature에서 `@AppStorage(AppStorageKey.xxx)`로 즉시 접근 가능합니다.
     private func saveProfileToStorage(_ result: HomeProfileResult) {
         let defaults = UserDefaults.standard
-        let latestRole = result.roles.max(by: { $0.gisu < $1.gisu })
+        let latestRole = result.roles.latestHighestPriorityRole
         let resolvedRole = latestRole?.roleType ?? .challenger
         let isApproved = isApprovedProfile(result)
 
@@ -223,6 +223,19 @@ final class HomeViewModel {
         return scheduleByDates[normalizedDate] ?? []
     }
 
+}
+
+extension Array where Element == ChallengerRole {
+    var latestHighestPriorityRole: ChallengerRole? {
+        guard let latestGisu = map(\.gisu).max() else {
+            return nil
+        }
+
+        return filter { $0.gisu == latestGisu }
+            .max { lhs, rhs in
+                lhs.roleType < rhs.roleType
+            }
+    }
 }
 
 extension HomeViewModel {

--- a/AppProduct/AppProductTests/ManagementTeamPriorityTests.swift
+++ b/AppProduct/AppProductTests/ManagementTeamPriorityTests.swift
@@ -1,0 +1,62 @@
+//
+//  ManagementTeamPriorityTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/9/26.
+//
+
+import XCTest
+@testable import AppProduct
+
+final class ManagementTeamPriorityTests: XCTestCase {
+
+    func test_highestPriority_복수_역할_중_가장_높은_직급을_반환한다() {
+        let roles: [ManagementTeam] = [
+            .schoolPresident,
+            .chapterPresident,
+            .schoolPartLeader
+        ]
+
+        let resolvedRole = ManagementTeam.highestPriority(in: roles)
+
+        XCTAssertEqual(resolvedRole, .chapterPresident)
+    }
+
+    func test_latestHighestPriorityRole_같은_기수에서는_직급_우선순위로_선택한다() {
+        let roles = [
+            ChallengerRole(
+                challengerId: 1,
+                gisu: 10,
+                gisuId: 100,
+                roleType: .schoolPresident,
+                responsiblePart: nil,
+                organizationType: .school,
+                organizationId: 10
+            ),
+            ChallengerRole(
+                challengerId: 1,
+                gisu: 10,
+                gisuId: 100,
+                roleType: .chapterPresident,
+                responsiblePart: nil,
+                organizationType: .chapter,
+                organizationId: 20
+            ),
+            ChallengerRole(
+                challengerId: 1,
+                gisu: 9,
+                gisuId: 90,
+                roleType: .centralVicePresident,
+                responsiblePart: nil,
+                organizationType: .central,
+                organizationId: 30
+            )
+        ]
+
+        let resolvedRole = roles.latestHighestPriorityRole
+
+        XCTAssertEqual(resolvedRole?.roleType, .chapterPresident)
+        XCTAssertEqual(resolvedRole?.gisu, 10)
+        XCTAssertEqual(resolvedRole?.organizationType, .chapter)
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 활동 탭에서 복수 역할 보유 시 역할 우선순위가 올바르게 표시되지 않는 문제 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 (로직 수정) -->

## 🛠️ 작업내용

### 역할 우선순위 재조정
- `ManagementTeam` level 값을 10단위 간격으로 재조정하여 각 역할 간 명확한 우선순위 분리
- `centralOperatingTeamMember`(80)와 `centralEducationTeamMember`(70) 간 우선순위 구분 (기존 동일 레벨 80)

### 최고 권한 결정 로직 통합
- `ManagementTeam.highestPriority(in:)` 정적 메서드 추가로 최고 권한 결정 로직 일원화
- `MemberRepository`: 멤버 역할 결정 시 `highestPriority(in:)` 사용
- `MyProfileDTO.highestRole()`: `highestPriority(in:)` 사용

### 홈 역할 저장 로직 개선
- `HomeViewModel.saveProfileToStorage`: 복수 역할 보유 시 최신 기수 내 최고 우선순위 역할 선택 (`latestHighestPriorityRole`)
- 기존: 단순히 가장 높은 기수의 역할 선택 → 개선: 최신 기수 중 최고 우선순위 역할 선택

### 테스트
- `ManagementTeamPriorityTests` 유닛 테스트 추가

## 📋 추후 진행 상황

- 역할 표시 UI 확인

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift` - level 값 재조정 및 `highestPriority(in:)` 메서드
- `AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift` - `latestHighestPriorityRole` computed property
- `AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift` - `highestPriority(in:)` 적용 부분

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)