### PR TITLE
🐛 [Fix] 마이페이지 활동 이력에 운영진 기록 표시 및 ADMIN 파트 추가

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/UMCPartType.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/UMCPartType.swift
@@ -25,6 +25,9 @@ import SwiftUI
 enum UMCPartType: Codable, Equatable, Hashable {
     // MARK: - Cases
 
+    /// 운영진 파트
+    case admin
+
     /// 기획 파트 (Project Manager)
     case pm
 
@@ -52,6 +55,8 @@ enum UMCPartType: Codable, Equatable, Hashable {
     ///   - Front: "Web", "Android", "iOS"
     var name: String {
         switch self {
+        case .admin:
+            return "Admin"
         case .pm:
             return "PM"
         case .design:
@@ -68,6 +73,8 @@ enum UMCPartType: Codable, Equatable, Hashable {
     /// 정렬 순서: PM(0) > Design(1) > Web(2) > iOS(3) > Android(4) > Spring(5) > NodeJS(6)
     var sortOrder: Int {
         switch self {
+        case .admin:
+            return -1
         case .pm:
             return 0
         case .design:
@@ -94,6 +101,8 @@ enum UMCPartType: Codable, Equatable, Hashable {
     /// 파트별 고유 색상
     var color: Color {
         switch self {
+        case .admin:
+            return .indigo
         case .pm:
             return .purple
         case .design:
@@ -115,6 +124,7 @@ enum UMCPartType: Codable, Equatable, Hashable {
     /// 파트별 아이콘
     var icon: String {
         switch self {
+        case .admin: return "person.badge.key.fill"
         case .pm: return "doc.text.fill"
         case .design: return "paintpalette.fill"
         case .server(type: .spring): return "leaf.fill"
@@ -161,6 +171,7 @@ enum UMCPartType: Codable, Equatable, Hashable {
     /// 서버 API 쿼리 파라미터용 문자열
     var apiValue: String {
         switch self {
+        case .admin:                    return "ADMIN"
         case .pm:                       return "PLAN"
         case .design:                   return "DESIGN"
         case .server(let type):
@@ -180,6 +191,7 @@ enum UMCPartType: Codable, Equatable, Hashable {
     /// 서버 API 문자열로부터 생성
     init?(apiValue: String) {
         switch apiValue {
+        case "ADMIN":       self = .admin
         case "PLAN":        self = .pm
         case "DESIGN":      self = .design
         case "SPRINGBOOT":  self = .server(type: .spring)

--- a/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
@@ -237,12 +237,14 @@ struct MyPageChallengerPointDTO: Codable {
 extension MyPageProfileResponseDTO {
     func toProfileData() -> ProfileData {
         let records = challengerRecords ?? []
-        let latestRecord = records.max { $0.gisu.intValue < $1.gisu.intValue }
+        let visibleRecords = records.filter { UMCPartType(apiValue: $0.part) != .admin }
+        let latestRecord = visibleRecords.max { $0.gisu.intValue < $1.gisu.intValue }
+            ?? records.max { $0.gisu.intValue < $1.gisu.intValue }
         let latestRole = roles.max { ($0.gisu?.intValue ?? 0) < ($1.gisu?.intValue ?? 0) }
         let profileLinks = profileLinks()
 
         let fallbackPart = latestRole?.responsiblePart
-            .flatMap { UMCPartType(apiValue: $0) } ?? .pm
+            .flatMap { UMCPartType(apiValue: $0) } ?? .admin
 
         let challengerInfo = ChallengerInfo(
             memberId: id.intValue,
@@ -254,13 +256,7 @@ extension MyPageProfileResponseDTO {
             part: UMCPartType(apiValue: latestRecord?.part ?? "") ?? fallbackPart
         )
 
-        let logs = records.map { record in
-            ActivityLog(
-                part: UMCPartType(apiValue: record.part) ?? .pm,
-                generation: record.gisu.intValue,
-                role: .challenger
-            )
-        }
+        let logs = activityLogs(records: records)
 
         return ProfileData(
             challengeId: latestRecord?.challengerId.intValue ?? latestRole?.challengerId.intValue ?? 0,
@@ -269,6 +265,35 @@ extension MyPageProfileResponseDTO {
             activityLogs: logs,
             profileLink: profileLinks
         )
+    }
+
+    private func activityLogs(records: [MyPageChallengerRecordDTO]) -> [ActivityLog] {
+        let roleLogs = roles.map { role in
+            ActivityLog(
+                part: role.responsiblePart.flatMap { UMCPartType(apiValue: $0) } ?? .admin,
+                generation: role.gisu?.intValue ?? 0,
+                role: role.roleType
+            )
+        }
+
+        let challengerLogs = records.compactMap { record -> ActivityLog? in
+            guard let part = UMCPartType(apiValue: record.part), part != .admin else {
+                return nil
+            }
+
+            return ActivityLog(
+                part: part,
+                generation: record.gisu.intValue,
+                role: .challenger
+            )
+        }
+
+        return (roleLogs + challengerLogs).sorted { lhs, rhs in
+            if lhs.generation == rhs.generation {
+                return lhs.role > rhs.role
+            }
+            return lhs.generation > rhs.generation
+        }
     }
 
     /// 서버 응답의 외부 링크 필드를 `SocialLinkType` 기반 `[ProfileLink]` 배열로 변환합니다.

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticePart.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticePart.swift
@@ -84,6 +84,8 @@ enum NoticePart: String, CaseIterable, Identifiable, Equatable, Hashable {
 
     init?(umcPartType: UMCPartType) {
         switch umcPartType {
+        case .admin:
+            return nil
         case .front(let type):
             switch type {
             case .web:

--- a/AppProduct/AppProductTests/MyPageProfileDTOTests.swift
+++ b/AppProduct/AppProductTests/MyPageProfileDTOTests.swift
@@ -1,0 +1,151 @@
+//
+//  MyPageProfileDTOTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/9/26.
+//
+
+import XCTest
+@testable import AppProduct
+
+final class MyPageProfileDTOTests: XCTestCase {
+
+    func test_toProfileData_운영진_역할을_활동이력에_포함하고_ADMIN_챌린저기록은_제외한다() throws {
+        let sut = try makeProfileDTO(from: """
+        {
+          "id": "10",
+          "name": "홍길동",
+          "nickname": "길동",
+          "email": "test@example.com",
+          "schoolId": "1",
+          "schoolName": "UMC University",
+          "profileImageLink": null,
+          "profile": null,
+          "status": "ACTIVE",
+          "roles": [
+            {
+              "id": "101",
+              "challengerId": "1001",
+              "roleType": "SCHOOL_PART_LEADER",
+              "organizationType": "SCHOOL",
+              "organizationId": "10",
+              "responsiblePart": "IOS",
+              "gisu": "6",
+              "gisuId": "600"
+            },
+            {
+              "id": "102",
+              "challengerId": "1002",
+              "roleType": "SCHOOL_ETC_ADMIN",
+              "organizationType": "SCHOOL",
+              "organizationId": "10",
+              "responsiblePart": null,
+              "gisu": "5",
+              "gisuId": "500"
+            }
+          ],
+          "challengerRecords": [
+            {
+              "challengerId": "2001",
+              "memberId": "10",
+              "gisu": "6",
+              "part": "ADMIN",
+              "challengerPoints": [],
+              "name": "홍길동",
+              "nickname": "길동",
+              "email": "test@example.com",
+              "schoolId": "1",
+              "schoolName": "UMC University",
+              "profileImageLink": null,
+              "status": "ACTIVE"
+            },
+            {
+              "challengerId": "2002",
+              "memberId": "10",
+              "gisu": "5",
+              "part": "IOS",
+              "challengerPoints": [],
+              "name": "홍길동",
+              "nickname": "길동",
+              "email": "test@example.com",
+              "schoolId": "1",
+              "schoolName": "UMC University",
+              "profileImageLink": null,
+              "status": "ACTIVE"
+            }
+          ]
+        }
+        """)
+
+        let profile = sut.toProfileData()
+
+        XCTAssertEqual(profile.activityLogs.count, 3)
+        XCTAssertEqual(
+            profile.activityLogs.map(\.role),
+            [.schoolPartLeader, .schoolEtcAdmin, .challenger]
+        )
+        XCTAssertEqual(
+            profile.activityLogs.map(\.part),
+            [.front(type: .ios), .admin, .front(type: .ios)]
+        )
+        XCTAssertEqual(profile.activityLogs.map(\.generation), [6, 5, 5])
+    }
+
+    func test_toProfileData_최신_ADMIN_기록이_있어도_프로필_대표파트는_일반_챌린저기록을_우선한다() throws {
+        let sut = try makeProfileDTO(from: """
+        {
+          "id": "10",
+          "name": "홍길동",
+          "nickname": "길동",
+          "email": "test@example.com",
+          "schoolId": "1",
+          "schoolName": "UMC University",
+          "profileImageLink": null,
+          "profile": null,
+          "status": "ACTIVE",
+          "roles": [],
+          "challengerRecords": [
+            {
+              "challengerId": "2001",
+              "memberId": "10",
+              "gisu": "7",
+              "part": "ADMIN",
+              "challengerPoints": [],
+              "name": "홍길동",
+              "nickname": "길동",
+              "email": "test@example.com",
+              "schoolId": "1",
+              "schoolName": "UMC University",
+              "profileImageLink": null,
+              "status": "ACTIVE"
+            },
+            {
+              "challengerId": "2002",
+              "memberId": "10",
+              "gisu": "6",
+              "part": "ANDROID",
+              "challengerPoints": [],
+              "name": "홍길동",
+              "nickname": "길동",
+              "email": "test@example.com",
+              "schoolId": "1",
+              "schoolName": "UMC University",
+              "profileImageLink": null,
+              "status": "ACTIVE"
+            }
+          ]
+        }
+        """)
+
+        let profile = sut.toProfileData()
+
+        XCTAssertEqual(profile.challangerInfo.gen, 6)
+        XCTAssertEqual(profile.challangerInfo.part, .front(type: .android))
+        XCTAssertEqual(profile.challengeId, 2002)
+    }
+
+    private func makeProfileDTO(from json: String) throws -> MyPageProfileResponseDTO {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder().decode(MyPageProfileResponseDTO.self, from: data)
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 마이페이지 활동 이력에서 운영진 활동 기록이 표시되지 않는 문제 수정 및 ChallengerPart ADMIN 값 대응

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 스크린샷 추가 필요 - 운영진 활동 이력 표시 확인 -->

## 🛠️ 작업내용

### ADMIN 파트 추가
- `UMCPartType`에 `.admin` 케이스 추가 (서버 ChallengerPart ENUM의 `ADMIN` 대응)
- `apiValue`: `"ADMIN"` 매핑
- `NoticePart`: `.admin` 파트는 공지 파트 필터에서 제외 (`nil` 반환)

### 활동 이력 로직 개선
- `MyPageProfileDTO.toProfileData()`: 운영진(roles) 활동 기록을 활동 이력에 포함
- `challengerRecord` 중 파트가 `ADMIN`인 기록은 챌린저 이력에서 제외 (운영진만 하는 사람의 시스템 기록)
- 활동 이력을 기수 내림차순 + 역할 우선순위순으로 정렬
- 프로필 대표 파트 선택 시 ADMIN 기록 제외하고 실제 챌린저 기록 우선

### 테스트
- `MyPageProfileDTOTests` 유닛 테스트 추가

## 📋 추후 진행 상황

- Android와 활동 이력 표시 동작 일치 확인

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Core/Common/Enum/UMCPartType.swift` - `.admin` 케이스 추가 및 속성 정의
- `AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift` - `activityLogs()` 메서드: 운영진 + 챌린저 기록 통합 및 ADMIN 필터링
- `AppProduct/AppProduct/Features/Notice/Domain/Models/NoticePart.swift` - `.admin` → `nil` 처리

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)