### PR TITLE
🐛 [Fix] Refresh Token 갱신 요청 방식 수정 (Header → JSON Body)

### DIFF
--- a/AppProduct/AppProduct/Core/NetworkAdapter/TokenRefreshService/TokenRefreshServiceImpl.swift
+++ b/AppProduct/AppProduct/Core/NetworkAdapter/TokenRefreshService/TokenRefreshServiceImpl.swift
@@ -14,7 +14,7 @@ import Foundation
 /// - Important:
 ///   - **NetworkClient와 독립적**: NetworkClient를 사용하지 않음 (무한 루프 방지)
 ///   - **CommonDTO 사용**: 서버의 공통 응답 포맷 사용
-///   - **Bearer 인증**: 리프레시 토큰을 Authorization 헤더에 전송
+///   - **JSON Body 전송**: 서버 문서 스펙에 맞춰 리프레시 토큰을 Request Body에 전송
 ///
 /// - Usage:
 /// ```swift
@@ -85,7 +85,10 @@ struct TokenRefreshServiceImpl: TokenRefreshService {
     /// ```
     /// POST /api/v1/auth/token/renew
     /// Content-Type: application/json
-    /// Authorization: Bearer {refreshToken}
+    ///
+    /// {
+    ///   "refreshToken": "..."
+    /// }
     /// ```
     ///
     /// ## 응답 형식
@@ -109,7 +112,9 @@ struct TokenRefreshServiceImpl: TokenRefreshService {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(refreshToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONEncoder().encode(
+            RefreshTokenRequestBody(refreshToken: refreshToken)
+        )
 
         // 3. 네트워크 요청 실행
         let (data, response) = try await session.data(for: request)
@@ -138,6 +143,12 @@ struct TokenRefreshServiceImpl: TokenRefreshService {
             refreshToken: result.refreshToken
         )
     }
+}
+
+// MARK: - RefreshTokenRequestBody
+
+private struct RefreshTokenRequestBody: Encodable {
+    let refreshToken: String
 }
 
 // MARK: - TokenResult

--- a/AppProduct/AppProductTests/HomeScheduleDTOTests.swift
+++ b/AppProduct/AppProductTests/HomeScheduleDTOTests.swift
@@ -2,7 +2,7 @@
 //  HomeScheduleDTOTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/8/26.
+//  Created by euijjang97 on 3/9/26.
 //
 
 import XCTest

--- a/AppProduct/AppProductTests/ManagementTeamPriorityTests.swift
+++ b/AppProduct/AppProductTests/ManagementTeamPriorityTests.swift
@@ -2,7 +2,7 @@
 //  ManagementTeamPriorityTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/9/26.
+//  Created by euijjang97 on 3/9/26.
 //
 
 import XCTest

--- a/AppProduct/AppProductTests/NetworkTest/TokenRefreshServiceRequestTests.swift
+++ b/AppProduct/AppProductTests/NetworkTest/TokenRefreshServiceRequestTests.swift
@@ -1,0 +1,105 @@
+//
+//  TokenRefreshServiceRequestTests.swift
+//  AppProductTests
+//
+//  Created by euijjang97 on 3/9/26.
+//
+
+import Foundation
+import XCTest
+@testable import AppProduct
+
+final class TokenRefreshServiceRequestTests: XCTestCase {
+
+    private let baseURL = URL(string: "https://example.com")!
+
+    override func tearDown() {
+        RequestCapturingURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func test_refreshToken을_JSON_Body로_전송한다() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RequestCapturingURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+
+        RequestCapturingURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/auth/token/renew")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Content-Type"),
+                "application/json"
+            )
+            XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+
+            let body = try XCTUnwrap(request.httpBody)
+            let payload = try JSONSerialization.jsonObject(with: body) as? [String: String]
+            XCTAssertEqual(payload?["refreshToken"], "refresh-token-value")
+
+            let responseBody = """
+            {
+              "isSuccess": true,
+              "code": "200",
+              "message": "성공",
+              "result": {
+                "accessToken": "new_access_token",
+                "refreshToken": "new_refresh_token"
+              }
+            }
+            """.data(using: .utf8) ?? Data()
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            return (response, responseBody)
+        }
+
+        let sut = TokenRefreshServiceImpl(baseURL: baseURL, session: session)
+
+        let tokenPair = try await sut.refresh("refresh-token-value")
+
+        XCTAssertEqual(tokenPair.accessToken, "new_access_token")
+        XCTAssertEqual(tokenPair.refreshToken, "new_refresh_token")
+    }
+}
+
+private final class RequestCapturingURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(
+                self,
+                didFailWithError: URLError(.badServerResponse)
+            )
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(
+                self,
+                didReceive: response,
+                cacheStoragePolicy: .notAllowed
+            )
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - Refresh Token 갱신 API 요청 방식을 서버 스펙에 맞게 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

- `TokenRefreshServiceImpl`: Refresh Token을 `Authorization: Bearer` 헤더 대신 JSON Request Body로 전송하도록 변경
- `RefreshTokenRequestBody` Encodable 구조체 추가
- 서버 API 스펙(`POST /api/v1/auth/token/renew`)에 맞춰 요청 방식 수정

### 변경 전
```
POST /api/v1/auth/token/renew
Authorization: Bearer {refreshToken}
```

### 변경 후
```
POST /api/v1/auth/token/renew
Content-Type: application/json

{ "refreshToken": "..." }
```

### 테스트
- `TokenRefreshServiceRequestTests` 유닛 테스트 추가

## 📋 추후 진행 상황

- Refresh Token 갱신 실패 케이스 모니터링

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Core/NetworkAdapter/TokenRefreshService/TokenRefreshServiceImpl.swift` - httpBody로 refreshToken 전송 방식 변경
- `AppProduct/AppProductTests/NetworkTest/TokenRefreshServiceRequestTests.swift` - 요청 body 검증 테스트

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)