### PR TITLE
💄 [Design] 챌린저 코드 입력 Alert 문구 변경

### DIFF
--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
@@ -48,18 +48,12 @@ struct MyPageProfileView: View {
                 await viewModel.loadSelectedImage()
             }
         }
-        .alert("기존 챌린저 코드 입력", isPresented: $showAddActivityLogAlert) {
-            TextField("6자리 코드", text: $challengerCode)
-                .keyboardType(.asciiCapable)
-            Button("닫기", role: .cancel) {
-                challengerCode = ""
-            }
-            Button("전송") {
-                submitChallengerCode()
-            }
-        } message: {
-            Text("운영진에게 발급받은 6자리 코드를 입력해주세요.")
-        }
+        .alert(
+            "챌린저 코드 입력",
+            isPresented: $showAddActivityLogAlert,
+            actions: challengerCodeAlertActions,
+            message: challengerCodeAlertMessage
+        )
     }
     
     /// 섹션 구현부
@@ -85,6 +79,25 @@ struct MyPageProfileView: View {
         )
         // 외부 프로필 링크 수정
         ProfileLinkSection(profileLink: profile.profileLink, header: "외부 프로링크")
+    }
+
+    @ViewBuilder
+    private func challengerCodeAlertActions() -> some View {
+        TextField("6자리 코드", text: $challengerCode)
+            .keyboardType(.asciiCapable)
+
+        Button("닫기", role: .cancel) {
+            challengerCode = ""
+        }
+
+        Button("전송") {
+            submitChallengerCode()
+        }
+    }
+
+    @ViewBuilder
+    private func challengerCodeAlertMessage() -> some View {
+        Text("운영진에게 발급받은 6자리 코드를 입력해주세요.")
     }
 
     /// 프로필 이미지 업데이트를 서버에 제출하고 완료 시 화면을 dismiss합니다.


### PR DESCRIPTION
## ✨ PR 유형

Design - 챌린저 코드 입력 Alert 문구 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 스크린샷 추가 필요 - Alert 문구 변경 확인 -->

## 🛠️ 작업내용

- Alert 제목 "기존 챌린저 코드 입력" → "챌린저 코드 입력"으로 변경
- Alert actions/message를 별도 `@ViewBuilder` 메서드로 분리하여 가독성 개선

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift` - Alert 문구 변경 및 코드 구조 정리

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)