### PR TITLE
✨ [Feat] 챌린저 코드 입력 시 에러코드별 팝업 분기 및 권한 즉시 반영

### DIFF
--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -212,9 +212,18 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
     func registerExistingChallenger(
         code: String
     ) async throws {
-        _ = try await adapter.request(
-            AuthRouter.registerExistingChallenger(code: code)
-        )
+        do {
+            let response = try await adapter.request(
+                AuthRouter.registerExistingChallenger(code: code)
+            )
+            let apiResponse = try decoder.decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let error as NetworkError {
+            throw Self.parseServerError(from: error) ?? error
+        }
     }
 
     /// 학교 목록을 조회합니다.
@@ -271,6 +280,24 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
 // MARK: - Private Helpers
 
 private extension AuthRepository {
+    static func parseServerError(from error: NetworkError) -> Error? {
+        guard case .requestFailed(_, let data) = error,
+              let data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        let code = json["code"] as? String
+        let message = (json["message"] as? String) ?? (json["result"] as? String)
+
+        guard code != nil || message != nil else {
+            return nil
+        }
+
+        return RepositoryError.serverError(code: code, message: message)
+    }
+
     func describeDecodingError(_ error: DecodingError) -> String {
         switch error {
         case .keyNotFound(let key, let context):

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
@@ -175,13 +175,23 @@ struct FailedVerificationUMC: View {
         isSubmitting = true
         Task {
             do {
-                let useCase = di.resolve(AuthUseCaseProviding.self)
+                try await di.resolve(AuthUseCaseProviding.self)
                     .registerExistingChallengerUseCase
-                try await useCase.execute(code: trimmedCode)
+                    .execute(code: trimmedCode)
+                let profile = try await di.resolve(HomeUseCaseProviding.self)
+                    .fetchMyProfileUseCase
+                    .execute()
                 await MainActor.run {
+                    syncProfileToStorage(profile)
                     isSubmitting = false
                     challengerCode = ""
                     presentSuccessPrompt()
+                }
+            } catch let error as RepositoryError {
+                await MainActor.run {
+                    isSubmitting = false
+                    challengerCode = ""
+                    presentCodeFailurePrompt(for: error)
                 }
             } catch {
                 await MainActor.run {
@@ -214,6 +224,32 @@ struct FailedVerificationUMC: View {
         alertPrompt = AlertPrompt(
             title: "인증 실패",
             message: "입력 코드가 존재하지 않습니다.",
+            positiveBtnTitle: "확인"
+        )
+    }
+
+    /// 서버 에러 코드에 맞는 인증 실패 안내 프롬프트를 표시합니다.
+    private func presentCodeFailurePrompt(for error: RepositoryError) {
+        let message: String
+
+        switch error.code {
+        case "CHALLENGER-0002":
+            message = "이미 등록된 사용자입니다."
+        case "CHALLENGER-0012":
+            message = "이미 사용된 챌린저 기록 추가용 코드입니다."
+        case "CHALLENGER-0013":
+            message = "코드에 등록된 사용자 이름이 요청자와 일치하지 않습니다."
+        case "CHALLENGER-0014":
+            message = "코드에 등록된 학교가 요청자 소속과 일치하지 않습니다."
+        case "CHALLENGER-0016":
+            message = "챌린저 기록 코드를 먼저 입력해주세요."
+        default:
+            message = sanitizedErrorMessage(from: error.userMessage)
+        }
+
+        alertPrompt = AlertPrompt(
+            title: "인증 실패",
+            message: message,
             positiveBtnTitle: "확인"
         )
     }
@@ -256,6 +292,79 @@ struct FailedVerificationUMC: View {
                 )
             )
         }
+    }
+
+    private func syncProfileToStorage(_ profile: HomeProfileResult) {
+        let defaults = UserDefaults.standard
+        let latestRole = latestHighestPriorityRole(in: profile.roles)
+        let resolvedRole = ManagementTeam.highestPriority(
+            in: profile.roles.map(\.roleType)
+        ) ?? latestRole?.roleType ?? .challenger
+
+        defaults.set(profile.memberId, forKey: AppStorageKey.memberId)
+        defaults.set(profile.schoolId, forKey: AppStorageKey.schoolId)
+        defaults.set(profile.schoolName, forKey: AppStorageKey.schoolName)
+        defaults.set(profile.latestGisuId ?? 0, forKey: AppStorageKey.gisuId)
+        defaults.set(profile.latestChallengerId ?? 0, forKey: AppStorageKey.challengerId)
+        defaults.set(profile.chapterId ?? 0, forKey: AppStorageKey.chapterId)
+        defaults.set(profile.chapterName, forKey: AppStorageKey.chapterName)
+        defaults.set(profile.part?.apiValue ?? "", forKey: AppStorageKey.responsiblePart)
+        defaults.set(
+            latestRole?.organizationType.rawValue ?? OrganizationType.chapter.rawValue,
+            forKey: AppStorageKey.organizationType
+        )
+        defaults.set(
+            latestRole?.organizationId ?? (profile.chapterId ?? 0),
+            forKey: AppStorageKey.organizationId
+        )
+        defaults.set(resolvedRole.rawValue, forKey: AppStorageKey.memberRole)
+        defaults.set(
+            profile.roles.map(\.roleType.rawValue),
+            forKey: AppStorageKey.memberRoles
+        )
+        defaults.set(isApprovedProfile(profile), forKey: AppStorageKey.canAutoLogin)
+
+        di.resolve(UserSessionManager.self).updateRole(resolvedRole)
+        NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
+    }
+
+    private func isApprovedProfile(_ profile: HomeProfileResult) -> Bool {
+        if !profile.generations.isEmpty {
+            return true
+        }
+
+        for seasonType in profile.seasonTypes {
+            if case .gens(let generations) = seasonType, !generations.isEmpty {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func latestHighestPriorityRole(
+        in roles: [ChallengerRole]
+    ) -> ChallengerRole? {
+        guard let latestGisu = roles.map(\.gisu).max() else {
+            return nil
+        }
+
+        return roles
+            .filter { $0.gisu == latestGisu }
+            .max { lhs, rhs in
+                lhs.roleType < rhs.roleType
+            }
+    }
+
+    private func sanitizedErrorMessage(from message: String) -> String {
+        let pattern = #"^[A-Z]+-\d{4}\s*[:\-]?\s*"#
+        let sanitized = message.replacingOccurrences(
+            of: pattern,
+            with: "",
+            options: .regularExpression
+        )
+        let trimmed = sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "인증에 실패했습니다. 다시 시도해주세요." : trimmed
     }
 }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -93,12 +93,14 @@ final class HomeViewModel {
 
     /// 프로필 정보를 AppStorage(UserDefaults)에 저장
     ///
-    /// 최신 기수(max gisu) 기준으로 역할 정보를 저장합니다.
+    /// 최신 기수 정보는 유지하되, 대표 역할은 최고 권한 기준으로 저장합니다.
     /// 다른 Feature에서 `@AppStorage(AppStorageKey.xxx)`로 즉시 접근 가능합니다.
     private func saveProfileToStorage(_ result: HomeProfileResult) {
         let defaults = UserDefaults.standard
         let latestRole = result.roles.latestHighestPriorityRole
-        let resolvedRole = latestRole?.roleType ?? .challenger
+        let resolvedRole = ManagementTeam.highestPriority(
+            in: result.roles.map(\.roleType)
+        ) ?? latestRole?.roleType ?? .challenger
         let isApproved = isApprovedProfile(result)
 
         defaults.set(result.memberId, forKey: AppStorageKey.memberId)

--- a/AppProduct/AppProduct/Features/MyPage/Data/Repository/MyPageRepository.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Repository/MyPageRepository.swift
@@ -55,9 +55,18 @@ final class MyPageRepository: MyPageRepositoryProtocol, @unchecked Sendable {
 
     /// 운영진 발급 코드로 기존 챌린저 기록을 추가합니다.
     func addChallengerRecord(code: String) async throws {
-        _ = try await adapter.request(
-            MyPageRouter.addChallengerRecord(code: code)
-        )
+        do {
+            let response = try await adapter.request(
+                MyPageRouter.addChallengerRecord(code: code)
+            )
+            let apiResponse = try decoder.decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let error as NetworkError {
+            throw Self.parseServerError(from: error) ?? error
+        }
     }
 
     /// 프로필 이미지 업로드 3단계 플로우: prepare → upload → confirm → patch
@@ -162,6 +171,28 @@ final class MyPageRepository: MyPageRepositoryProtocol, @unchecked Sendable {
             from: response.data
         )
         return try apiResponse.unwrap().toDomain()
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension MyPageRepository {
+    static func parseServerError(from error: NetworkError) -> Error? {
+        guard case .requestFailed(_, let data) = error,
+              let data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        let code = json["code"] as? String
+        let message = (json["message"] as? String) ?? (json["result"] as? String)
+
+        guard code != nil || message != nil else {
+            return nil
+        }
+
+        return RepositoryError.serverError(code: code, message: message)
     }
 }
 

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
@@ -14,10 +14,12 @@ import PhotosUI
 struct MyPageProfileView: View {
     /// 뷰모델 상태 객체
     @State var viewModel: MyPageProfileViewModel
+    @Environment(\.di) private var di
     @Environment(ErrorHandler.self) private var errorHandler
     @Environment(\.dismiss) private var dismiss
     @State private var showAddActivityLogAlert: Bool = false
     @State private var challengerCode: String = ""
+    @State private var alertPrompt: AlertPrompt?
 
     init(container: DIContainer, profileData: ProfileData) {
         let provider = container.resolve(MyPageUseCaseProviding.self)
@@ -54,6 +56,7 @@ struct MyPageProfileView: View {
             actions: challengerCodeAlertActions,
             message: challengerCodeAlertMessage
         )
+        .alertPrompt(item: $alertPrompt)
     }
     
     /// 섹션 구현부
@@ -138,6 +141,17 @@ struct MyPageProfileView: View {
                 await MainActor.run {
                     challengerCode = ""
                 }
+                let profile = try await di.resolve(HomeUseCaseProviding.self)
+                    .fetchMyProfileUseCase
+                    .execute()
+                await MainActor.run {
+                    syncProfileToStorage(profile)
+                }
+            } catch let error as RepositoryError {
+                await MainActor.run {
+                    challengerCode = ""
+                    presentCodeFailurePrompt(for: error)
+                }
             } catch {
                 await MainActor.run {
                     challengerCode = ""
@@ -148,6 +162,104 @@ struct MyPageProfileView: View {
                 )
             }
         }
+    }
+
+    private func presentCodeFailurePrompt(for error: RepositoryError) {
+        let message: String
+
+        switch error.code {
+        case "CHALLENGER-0002":
+            message = "이미 등록된 사용자입니다."
+        case "CHALLENGER-0012":
+            message = "이미 사용된 챌린저 기록 추가용 코드입니다."
+        case "CHALLENGER-0013":
+            message = "코드에 등록된 사용자 이름이 요청자와 일치하지 않습니다."
+        case "CHALLENGER-0014":
+            message = "코드에 등록된 학교가 요청자 소속과 일치하지 않습니다."
+        case "CHALLENGER-0016":
+            message = "챌린저 기록 코드를 먼저 입력해주세요."
+        default:
+            message = sanitizedErrorMessage(from: error.userMessage)
+        }
+
+        alertPrompt = AlertPrompt(
+            title: "인증 실패",
+            message: message,
+            positiveBtnTitle: "확인"
+        )
+    }
+
+    private func syncProfileToStorage(_ profile: HomeProfileResult) {
+        let defaults = UserDefaults.standard
+        let latestRole = latestHighestPriorityRole(in: profile.roles)
+        let resolvedRole = ManagementTeam.highestPriority(
+            in: profile.roles.map(\.roleType)
+        ) ?? latestRole?.roleType ?? .challenger
+
+        defaults.set(profile.memberId, forKey: AppStorageKey.memberId)
+        defaults.set(profile.schoolId, forKey: AppStorageKey.schoolId)
+        defaults.set(profile.schoolName, forKey: AppStorageKey.schoolName)
+        defaults.set(profile.latestGisuId ?? 0, forKey: AppStorageKey.gisuId)
+        defaults.set(profile.latestChallengerId ?? 0, forKey: AppStorageKey.challengerId)
+        defaults.set(profile.chapterId ?? 0, forKey: AppStorageKey.chapterId)
+        defaults.set(profile.chapterName, forKey: AppStorageKey.chapterName)
+        defaults.set(profile.part?.apiValue ?? "", forKey: AppStorageKey.responsiblePart)
+        defaults.set(
+            latestRole?.organizationType.rawValue ?? OrganizationType.chapter.rawValue,
+            forKey: AppStorageKey.organizationType
+        )
+        defaults.set(
+            latestRole?.organizationId ?? (profile.chapterId ?? 0),
+            forKey: AppStorageKey.organizationId
+        )
+        defaults.set(resolvedRole.rawValue, forKey: AppStorageKey.memberRole)
+        defaults.set(
+            profile.roles.map(\.roleType.rawValue),
+            forKey: AppStorageKey.memberRoles
+        )
+        defaults.set(isApprovedProfile(profile), forKey: AppStorageKey.canAutoLogin)
+
+        di.resolve(UserSessionManager.self).updateRole(resolvedRole)
+        NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
+    }
+
+    private func isApprovedProfile(_ profile: HomeProfileResult) -> Bool {
+        if !profile.generations.isEmpty {
+            return true
+        }
+
+        for seasonType in profile.seasonTypes {
+            if case .gens(let generations) = seasonType, !generations.isEmpty {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func latestHighestPriorityRole(
+        in roles: [ChallengerRole]
+    ) -> ChallengerRole? {
+        guard let latestGisu = roles.map(\.gisu).max() else {
+            return nil
+        }
+
+        return roles
+            .filter { $0.gisu == latestGisu }
+            .max { lhs, rhs in
+                lhs.roleType < rhs.roleType
+            }
+    }
+
+    private func sanitizedErrorMessage(from message: String) -> String {
+        let pattern = #"^[A-Z]+-\d{4}\s*[:\-]?\s*"#
+        let sanitized = message.replacingOccurrences(
+            of: pattern,
+            with: "",
+            options: .regularExpression
+        )
+        let trimmed = sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "인증에 실패했습니다. 다시 시도해주세요." : trimmed
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

Feature - 챌린저 코드 입력 시 서버 에러코드별 팝업 분기 및 AppStorage 즉시 반영

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 에러코드별 팝업 동작 확인 필요 -->

## 🛠️ 작업내용

- `AuthRepository`, `MyPageRepository`에 `parseServerError(from:)` 추가하여 서버 에러코드/메시지 추출
- `FailedVerificationUMC`에 에러코드별 팝업 메시지 분기 처리
  - CHALLENGER-0002: 이미 등록된 챌린저
  - CHALLENGER-0012: 유효하지 않은 코드
  - CHALLENGER-0013: 만료된 코드
  - CHALLENGER-0014: 이미 사용된 코드
  - CHALLENGER-0016: 기타 등록 실패
- 챌린저 코드 등록 성공 시 `syncProfileToStorage`로 AppStorage 즉시 갱신 (홈 새로고침 불필요)
- `MyPageProfileView`에 동일한 에러코드별 팝업 및 프로필 동기화 적용
- `HomeViewModel`의 역할 결정 로직을 `ManagementTeam.highestPriority(in:)`로 변경

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Auth/Data/Repositories/AuthRepository.swift` - parseServerError 에러코드 추출 로직
- `Features/Auth/Presentation/Views/FailedVerificationUMC.swift` - 에러코드별 팝업 분기 및 syncProfileToStorage
- `Features/Home/Presentation/ViewModels/HomeViewModel.swift` - highestPriority 기반 역할 결정
- `Features/MyPage/Data/Repository/MyPageRepository.swift` - parseServerError 패턴 동일 적용
- `Features/MyPage/Presentation/Views/MyPageProfileView.swift` - 에러코드별 팝업 및 프로필 동기화

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)