### PR TITLE
♻️ [Refactor] 챌린저 검색 API cursor 마이그레이션 및 디바운싱 적용

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerSearchDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerSearchDTO.swift
@@ -9,29 +9,25 @@ import Foundation
 
 // MARK: - Request
 
-/// 챌린저 전역 검색 요청 DTO
+/// 챌린저 커서 검색 요청 DTO
 ///
-/// `GET /api/v1/challenger/search/global` 엔드포인트의 Query Parameter
+/// `GET /api/v1/challenger/search/cursor` 엔드포인트의 Query Parameter
 struct ChallengerSearchRequestDTO {
     /// 이전 페이지의 마지막 챌린저 ID (첫 페이지 조회 시 nil)
     let cursor: Int?
     /// 한 페이지에 조회할 항목 수 (기본값 50, 최대 50)
     let size: Int
-    /// 이름으로 부분 검색
-    let name: String?
-    /// 닉네임으로 부분 검색
-    let nickname: String?
+    /// 이름 또는 닉네임 통합 검색 키워드
+    let keyword: String?
 
     init(
         cursor: Int? = nil,
         size: Int = 50,
-        name: String? = nil,
-        nickname: String? = nil
+        keyword: String? = nil
     ) {
         self.cursor = cursor
         self.size = size
-        self.name = name
-        self.nickname = nickname
+        self.keyword = keyword
     }
 
     /// Query Parameter Dictionary 변환
@@ -40,8 +36,7 @@ struct ChallengerSearchRequestDTO {
             "size": size
         ]
         if let cursor { params["cursor"] = cursor }
-        if let name { params["name"] = name }
-        if let nickname { params["nickname"] = nickname }
+        if let keyword { params["keyword"] = keyword }
         return params
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/ChallengerSearchRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/ChallengerSearchRepository.swift
@@ -41,7 +41,7 @@ final class ChallengerSearchRepository: ChallengerSearchRepositoryProtocol, @unc
         query: ChallengerSearchRequestDTO
     ) async throws -> ChallengerSearchResponseDTO {
         let response = try await adapter.request(
-            ChallengerSearchRouter.searchGlobal(query: query)
+            ChallengerSearchRouter.searchCursor(query: query)
         )
         let apiResponse = try decoder.decode(
             APIResponse<ChallengerSearchResponseDTO>.self,

--- a/AppProduct/AppProduct/Features/Home/Data/Router/ChallengerSearchRouter.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Router/ChallengerSearchRouter.swift
@@ -15,8 +15,8 @@ import Moya
 ///
 /// - SeeAlso: ``ChallengerSearchRepository``, ``ChallengerSearchRequestDTO``
 enum ChallengerSearchRouter {
-    /// 챌린저 전역 검색 (Cursor 기반 페이지네이션)
-    case searchGlobal(query: ChallengerSearchRequestDTO)
+    /// 챌린저 커서 검색 (Cursor 기반 페이지네이션)
+    case searchCursor(query: ChallengerSearchRequestDTO)
 }
 
 extension ChallengerSearchRouter: BaseTargetType {
@@ -25,8 +25,8 @@ extension ChallengerSearchRouter: BaseTargetType {
 
     var path: String {
         switch self {
-        case .searchGlobal:
-            return "/api/v1/challenger/search/global"
+        case .searchCursor:
+            return "/api/v1/challenger/search/cursor"
         }
     }
 
@@ -34,7 +34,7 @@ extension ChallengerSearchRouter: BaseTargetType {
 
     var method: Moya.Method {
         switch self {
-        case .searchGlobal:
+        case .searchCursor:
             return .get
         }
     }
@@ -43,7 +43,7 @@ extension ChallengerSearchRouter: BaseTargetType {
 
     var task: Moya.Task {
         switch self {
-        case .searchGlobal(let query):
+        case .searchCursor(let query):
             return .requestParameters(
                 parameters: query.queryItems,
                 encoding: URLEncoding.queryString

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
@@ -46,6 +46,22 @@ class SearchChallengerViewModel {
     /// 다음 페이지 존재 여부
     private(set) var hasNext: Bool = false
 
+    /// 현재 검색 컨텍스트의 키워드
+    private var currentKeyword: String = ""
+
+    /// 디바운스용 검색 태스크
+    private var searchTask: Task<Void, Never>?
+
+    /// 최신 검색 요청 식별자
+    private var latestRequestID: UUID = UUID()
+
+    /// 다음 페이지 중복 호출 방지 플래그
+    private var isFetchingNextPage: Bool = false
+
+    private enum Constants {
+        static let debounceNanoseconds: UInt64 = 400_000_000
+    }
+
     // MARK: - Init
 
     /// - Parameter container: 의존성 주입 컨테이너 (HomeUseCaseProviding에서 UseCase 해소)
@@ -56,21 +72,60 @@ class SearchChallengerViewModel {
 
     // MARK: - Function
 
-    /// searchText 기반으로 챌린저 목록을 서버에서 가져옵니다.
+    /// 화면 진입 또는 검색어 초기화 시 현재 검색 조건으로 첫 페이지를 로드합니다.
     @MainActor
-    func fetchChallengers() async {
+    func loadInitialChallengers() async {
+        await fetchChallengers(keyword: normalizedSearchText)
+    }
+
+    /// 검색어 변경 시 디바운스를 적용해 챌린저 목록을 다시 조회합니다.
+    @MainActor
+    func scheduleSearch() {
+        searchTask?.cancel()
+        let keyword = normalizedSearchText
+
+        searchTask = Task { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: Constants.debounceNanoseconds)
+            } catch {
+                return
+            }
+
+            guard let self, !Task.isCancelled else { return }
+            await self.fetchChallengers(keyword: keyword)
+        }
+    }
+
+    /// 더 이상 필요 없는 검색 태스크를 정리합니다.
+    @MainActor
+    func cancelSearch() {
+        searchTask?.cancel()
+    }
+
+    /// 현재 검색 키워드 기준으로 첫 페이지를 조회합니다.
+    @MainActor
+    private func fetchChallengers(keyword: String) async {
+        let requestID = UUID()
+        latestRequestID = requestID
         loadState = .loading
+        currentKeyword = keyword
+        nextCursor = nil
+        hasNext = false
         do {
-            let trimmed = searchText.trimmingCharacters(in: .whitespaces)
             let query = ChallengerSearchRequestDTO(
-                name: trimmed.isEmpty ? nil : trimmed
+                keyword: keyword.nonEmpty
             )
             let (challengers, hasNext, nextCursor) = try await searchChallengersUseCase.execute(query: query)
+            guard latestRequestID == requestID else { return }
             self.allChallengers = challengers
             self.hasNext = hasNext
             self.nextCursor = nextCursor
             loadState = .loaded(true)
         } catch {
+            guard latestRequestID == requestID else { return }
+            allChallengers = []
+            nextCursor = nil
+            hasNext = false
             loadState = .failed(.unknown(message: "챌린저 검색 에러"))
         }
     }
@@ -78,14 +133,32 @@ class SearchChallengerViewModel {
     /// 다음 페이지 챌린저를 추가 로드합니다.
     @MainActor
     func fetchNextPage() async {
-        guard hasNext, let cursor = nextCursor else { return }
+        guard hasNext, let cursor = nextCursor, !isFetchingNextPage else { return }
+        isFetchingNextPage = true
+        defer { isFetchingNextPage = false }
         do {
-            let query = ChallengerSearchRequestDTO(cursor: cursor)
+            let query = ChallengerSearchRequestDTO(
+                cursor: cursor,
+                keyword: currentKeyword.nonEmpty
+            )
             let (challengers, hasNext, nextCursor) = try await searchChallengersUseCase.execute(query: query)
             self.allChallengers.append(contentsOf: challengers)
             self.hasNext = hasNext
             self.nextCursor = nextCursor
         } catch {}
+    }
+}
+
+// MARK: - Helpers
+private extension SearchChallengerViewModel {
+    var normalizedSearchText: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private extension String {
+    var nonEmpty: String? {
+        isEmpty ? nil : self
     }
 }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
@@ -21,6 +21,13 @@ struct SearchChallengerView: View {
     
     /// 검색 화면의 상태 및 로직을 관리하는 뷰 모델
     @State var viewModel: SearchChallengerViewModel
+
+    private enum Constants {
+        static let loadingMessage: String = "챌린저 목록을 불러오는 중입니다."
+        static let failedTitle: String = "챌린저 검색에 실패했어요"
+        static let failedSystemImage: String = "exclamationmark.triangle"
+        static let failedRetryTitle: String = "다시 시도"
+    }
     
     // MARK: - Init
     
@@ -36,22 +43,7 @@ struct SearchChallengerView: View {
     // MARK: - Body
     
     var body: some View {
-        Group {
-            // 검색 결과 유무에 따른 분기 처리
-            if viewModel.allChallengers.isEmpty {
-                emptyResultView
-            } else {
-                ChallengerFormView(
-                    challenger: .constant(viewModel.allChallengers),
-                    showCheckBox: true,
-                    selectedIds: $viewModel.selectedKeys,
-                    tap: toggleSelection,
-                    onBottomReached: {
-                        Task { await viewModel.fetchNextPage() }
-                    }
-                )
-            }
-        }
+        stateContent
         .searchable(text: $viewModel.searchText, prompt: "챌린저를 검색해보세요")
         .searchPresentationToolbarBehavior(.avoidHidingContent)
         .navigation(naviTitle: .searchChallenger, displayMode: .inline)
@@ -82,14 +74,51 @@ struct SearchChallengerView: View {
         .alertPrompt(item: $viewModel.alertPrompt)
         .task {
             initializeSelectedIds()
-            await viewModel.fetchChallengers()
+            await viewModel.loadInitialChallengers()
         }
         .onChange(of: viewModel.searchText) {
-            Task { await viewModel.fetchChallengers() }
+            viewModel.scheduleSearch()
+        }
+        .onDisappear {
+            viewModel.cancelSearch()
         }
     }
     
     // MARK: - Computed Properties
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch viewModel.loadState {
+        case .idle, .loading:
+            Progress(message: Constants.loadingMessage, size: .regular)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .loaded:
+            if viewModel.allChallengers.isEmpty {
+                emptyResultView
+            } else {
+                ChallengerFormView(
+                    challenger: .constant(viewModel.allChallengers),
+                    showCheckBox: true,
+                    selectedIds: $viewModel.selectedKeys,
+                    tap: toggleSelection,
+                    onBottomReached: {
+                        Task { await viewModel.fetchNextPage() }
+                    }
+                )
+            }
+        case .failed(let error):
+            RetryContentUnavailableView(
+                title: Constants.failedTitle,
+                systemImage: Constants.failedSystemImage,
+                description: error.userMessage,
+                retryTitle: Constants.failedRetryTitle,
+                isRetrying: viewModel.loadState.isLoading
+            ) {
+                await viewModel.loadInitialChallengers()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
 
     /// 검색 결과가 없을 때 표시되는 뷰
     private var emptyResultView: some View {


### PR DESCRIPTION
## ✨ PR 유형

챌린저 검색 API를 deprecated된 `search/global`에서 `search/cursor`로 마이그레이션하고, 검색 디바운싱 및 로딩 UX를 개선하는 리팩토링

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 검색 시 로딩뷰 표시 및 디바운싱 동작 확인 영상 첨부 필요 -->

## 🛠️ 작업내용

- 챌린저 검색 API를 `/api/v1/challenger/search/global` → `/api/v1/challenger/search/cursor`로 변경
- 기존 `name`/`nickname` 파라미터를 `keyword` 단일 필드로 통합
- 검색 입력에 400ms 디바운싱 적용하여 불필요한 API 호출 방지
- `latestRequestID` 기반 Race Condition 방지 (최신 요청 결과만 반영)
- 검색 중 로딩뷰(`Progress`) 표시 및 에러 시 `RetryContentUnavailableView` 적용
- 다음 페이지 중복 호출 방지 `isFetchingNextPage` 플래그 추가

## 📋 추후 진행 상황

- 파트장 지정 화면 챌린저 검색에도 동일한 디바운싱/로딩뷰 패턴 적용 (#427)

## 📌 리뷰 포인트

- `Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift` - 디바운싱 로직(`scheduleSearch`) 및 Race Condition 방지(`latestRequestID`) 구현
- `Features/Home/Data/Router/ChallengerSearchRouter.swift` - API 엔드포인트 변경 (`searchGlobal` → `searchCursor`)
- `Features/Home/Data/DTO/ChallengerSearchDTO.swift` - `keyword` 단일 필드로 파라미터 통합
- `Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift` - `loadState` 기반 상태별 UI 분기 처리

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)