### PR TITLE
🐛 [Fix] 회원가입 시 oAuthVerificationToken 만료 에러 Alert 처리

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Error/Handler/ErrorHandler.swift
+++ b/AppProduct/AppProduct/Core/Common/Error/Handler/ErrorHandler.swift
@@ -155,32 +155,37 @@ final class ErrorHandler {
             return .network(networkError)
         }
 
-        // 3. ValidationError
+        // 3. RepositoryError
+        if let repositoryError = error as? RepositoryError {
+            return .repository(repositoryError)
+        }
+
+        // 4. ValidationError
         if let validationError = error as? ValidationError {
             return .validation(validationError)
         }
 
-        // 4. AuthError
+        // 5. AuthError
         if let authError = error as? AuthError {
             return .auth(authError)
         }
 
-        // 5. DomainError
+        // 6. DomainError
         if let domainError = error as? DomainError {
             return .domain(domainError)
         }
 
-        // 6. URLError → NetworkError 변환
+        // 7. URLError → NetworkError 변환
         if let urlError = error as? URLError {
             return .network(convertURLError(urlError))
         }
 
-        // 7. DecodingError → RepositoryError 변환
+        // 8. DecodingError → RepositoryError 변환
         if let decodingError = error as? DecodingError {
             return .repository(.decodingError(detail: describeDecodingError(decodingError)))
         }
 
-        // 8. 알 수 없는 에러
+        // 9. 알 수 없는 에러
         return .unknown(message: error.localizedDescription)
     }
 

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -201,10 +201,11 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
                 print("[Auth] register 에러 응답(\(statusCode)): \(json)")
             }
             #endif
-            throw NetworkError.requestFailed(
+            let networkError = NetworkError.requestFailed(
                 statusCode: statusCode,
                 data: data
             )
+            throw Self.parseServerError(from: networkError) ?? networkError
         }
     }
 

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
@@ -257,6 +257,26 @@ final class SignUpViewModel {
             print("[Auth] register 성공: memberId=\(memberId)")
             #endif
             registerState = .loaded(memberId)
+        } catch let error as AppError {
+            #if DEBUG
+            print("[Auth] register 실패: \(error)")
+            #endif
+            registerState = .failed(error)
+        } catch let error as RepositoryError {
+            #if DEBUG
+            print("[Auth] register 실패: \(error)")
+            #endif
+            registerState = .failed(.repository(error))
+        } catch let error as NetworkError {
+            #if DEBUG
+            print("[Auth] register 실패: \(error)")
+            #endif
+            registerState = .failed(.network(error))
+        } catch let error as AuthError {
+            #if DEBUG
+            print("[Auth] register 실패: \(error)")
+            #endif
+            registerState = .failed(.auth(error))
         } catch {
             #if DEBUG
             print("[Auth] register 실패: \(error)")

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
@@ -21,6 +21,7 @@ struct SignUpView: View {
     /// 현재 포커스된 입력 필드
     @FocusState private var focusedField: SignUpFieldType?
     @State private var lastEmailSnapshot: String = ""
+    @State private var alertPrompt: AlertPrompt?
     @Environment(\.appFlow) private var appFlow
     @Environment(\.di) private var di
     @Environment(\.openURL) private var openURL
@@ -86,6 +87,7 @@ struct SignUpView: View {
                 .navigationSubtitle(Constants.naviSubTitle)
             }
             .keyboardToolbar(focusedField: $focusedField)
+            .alertPrompt(item: $alertPrompt)
             .safeAreaInset(edge: .bottom, content: {
                 mainBtn
             })
@@ -101,6 +103,11 @@ struct SignUpView: View {
                         forKey: AppStorageKey.canAutoLogin
                     )
                     appFlow.showPendingApproval()
+                    return
+                }
+
+                if case .failed(let error) = newState {
+                    handleRegisterFailure(error)
                 }
             }
         }
@@ -456,6 +463,54 @@ extension SignUpView {
 
             // 회원가입 API 호출
             await viewModel.register()
+        }
+    }
+
+    @MainActor
+    private func handleRegisterFailure(_ error: AppError) {
+        if error.isOAuthVerificationExpired {
+            alertPrompt = AlertPrompt(
+                title: "인증이 만료되었어요",
+                message: "회원가입을 계속하려면 다시 로그인해주세요.",
+                positiveBtnTitle: "로그인으로 이동",
+                positiveBtnAction: {
+                    appFlow.showLogin()
+                },
+                negativeBtnTitle: "닫기"
+            )
+            return
+        }
+
+        errorHandler.handle(
+            error,
+            context: .init(
+                feature: "Auth",
+                action: "register",
+                retryAction: {
+                    await viewModel.register()
+                }
+            )
+        )
+    }
+}
+
+// MARK: - Register Error
+
+private extension AppError {
+    var isOAuthVerificationExpired: Bool {
+        switch self {
+        case .repository(let error):
+            guard case .serverError(let code, let message) = error else {
+                return false
+            }
+            if code == "SECURITY-0001" {
+                return true
+            }
+            return message?.contains("만료된 JWT 토큰") == true
+        case .network(.requestFailed(let statusCode, _)):
+            return statusCode == 401
+        default:
+            return false
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

회원가입 중 oAuthVerificationToken 만료 시 에러 무응답 버그 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 토큰 만료 시 Alert 표시 및 로그인 화면 복귀 동선 확인 영상 첨부 필요 -->

## 🛠️ 작업내용

- `AuthRepository`에서 register API 401 응답 시 서버 에러코드(`SECURITY-0001`) 파싱 추가
- `SignUpViewModel`에서 `AppError`, `RepositoryError`, `NetworkError`, `AuthError` 타입별 분기 catch 처리
- `SignUpView`에서 토큰 만료 감지 시 "인증이 만료되었어요" Alert 표시
- Alert "로그인으로 이동" 버튼 탭 시 `appFlow.showLogin()` 호출로 로그인 화면 복귀
- 그 외 에러는 기존 `ErrorHandler`를 통한 Alert 처리
- `ErrorHandler`에 `RepositoryError` 분류 순서 추가

## 📋 추후 진행 상황

- (선택) oAuthVerificationToken 만료 시간 도래 전 자동 복귀 처리 검토

## 📌 리뷰 포인트

- `Features/Auth/Presentation/Views/SignUpView.swift` - `handleRegisterFailure` 에러 분기 로직 및 `isOAuthVerificationExpired` 판별 조건
- `Features/Auth/Data/Repositories/AuthRepository.swift` - 401 응답 시 `parseServerError` 적용 여부
- `Features/Auth/Presentation/ViewModels/SignUpViewModel.swift` - 에러 타입별 catch 분기 처리

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)