### PR TITLE
🐛 [Fix] 챌린저 선택 순서 보존 및 초기화 로직 개선 (#426)

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
@@ -149,17 +149,40 @@ struct SearchChallengerView: View {
     ///
     /// `selectedChallengersMap`에서 최종 선택된 챌린저 목록을 추출합니다.
     private func confirmSelection() {
-        selectedChallengers = Array(viewModel.selectedChallengersMap.values)
+        var orderedSelection: [ChallengerInfo] = []
+        var handledKeys: Set<String> = []
+
+        for challenger in selectedChallengers {
+            let key = challenger.selectionKey
+            guard let updatedChallenger = viewModel.selectedChallengersMap[key] else {
+                continue
+            }
+            guard handledKeys.insert(key).inserted else {
+                continue
+            }
+            orderedSelection.append(updatedChallenger)
+        }
+
+        let appendedSelection = viewModel.selectedChallengersMap
+            .values
+            .sorted { $0.selectionKey < $1.selectionKey }
+            .filter { handledKeys.insert($0.selectionKey).inserted }
+
+        selectedChallengers = orderedSelection + appendedSelection
     }
 
     /// 기존에 선택되어 있던 챌린저들을 memberId 기반으로 초기화
     ///
     /// 상위 뷰에서 전달받은 `selectedChallengers`를 ViewModel의 선택 상태에 반영합니다.
     private func initializeSelectedIds() {
-        viewModel.selectedKeys = Set(selectedChallengers.map(\.selectionKey))
-        for challenger in selectedChallengers {
-            viewModel.selectedChallengersMap[challenger.selectionKey] = challenger
-        }
+        let selectionMap = Dictionary(
+            uniqueKeysWithValues: selectedChallengers.map { challenger in
+                (challenger.selectionKey, challenger)
+            }
+        )
+
+        viewModel.selectedKeys = Set(selectionMap.keys)
+        viewModel.selectedChallengersMap = selectionMap
     }
     
     /// CSV 파일 가져오기 완료 후 처리 액션


### PR DESCRIPTION
## ✨ PR 유형

챌린저 검색에서 선택한 챌린저의 순서가 유지되지 않는 버그 수정

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음

## 🛠️ 작업내용

- `confirmSelection()`에서 기존 선택 순서를 유지하면서 새로 추가된 챌린저만 append하도록 로직 변경
- 선택 해제된 챌린저가 결과에서 올바르게 필터링되도록 guard 조건 추가
- `initializeSelectedIds()`에서 `Dictionary(uniqueKeysWithValues:)`를 사용하여 중복 키 방지 및 일괄 초기화로 개선

## 📋 추후 진행 상황

- 없음

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift` - `confirmSelection()` 순서 보존 로직 및 `initializeSelectedIds()` 초기화 방식 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)