### PR TITLE
🐛 [Fix] 챌린저 검색 로딩 UX 개선 및 선택 순서 보존

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
@@ -75,7 +75,8 @@ class SearchChallengerViewModel {
     /// 화면 진입 또는 검색어 초기화 시 현재 검색 조건으로 첫 페이지를 로드합니다.
     @MainActor
     func loadInitialChallengers() async {
-        await fetchChallengers(keyword: normalizedSearchText)
+        let requestID = prepareSearch(keyword: normalizedSearchText)
+        await fetchChallengers(keyword: normalizedSearchText, requestID: requestID)
     }
 
     /// 검색어 변경 시 디바운스를 적용해 챌린저 목록을 다시 조회합니다.
@@ -83,6 +84,7 @@ class SearchChallengerViewModel {
     func scheduleSearch() {
         searchTask?.cancel()
         let keyword = normalizedSearchText
+        let requestID = prepareSearch(keyword: keyword)
 
         searchTask = Task { [weak self] in
             do {
@@ -92,7 +94,7 @@ class SearchChallengerViewModel {
             }
 
             guard let self, !Task.isCancelled else { return }
-            await self.fetchChallengers(keyword: keyword)
+            await self.fetchChallengers(keyword: keyword, requestID: requestID)
         }
     }
 
@@ -104,13 +106,7 @@ class SearchChallengerViewModel {
 
     /// 현재 검색 키워드 기준으로 첫 페이지를 조회합니다.
     @MainActor
-    private func fetchChallengers(keyword: String) async {
-        let requestID = UUID()
-        latestRequestID = requestID
-        loadState = .loading
-        currentKeyword = keyword
-        nextCursor = nil
-        hasNext = false
+    private func fetchChallengers(keyword: String, requestID: UUID) async {
         do {
             let query = ChallengerSearchRequestDTO(
                 keyword: keyword.nonEmpty
@@ -151,6 +147,17 @@ class SearchChallengerViewModel {
 
 // MARK: - Helpers
 private extension SearchChallengerViewModel {
+    @MainActor
+    func prepareSearch(keyword: String) -> UUID {
+        let requestID = UUID()
+        latestRequestID = requestID
+        loadState = .loading
+        currentKeyword = keyword
+        nextCursor = nil
+        hasNext = false
+        return requestID
+    }
+
     var normalizedSearchText: String {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines)
     }


### PR DESCRIPTION
## ✨ PR 유형

챌린저 검색 시 로딩뷰 미표시 버그 수정 및 선택 순서 보존 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 검색 시 로딩뷰 즉시 표시 및 챌린저 선택 순서 보존 확인 영상 첨부 필요 -->

## 🛠️ 작업내용

- 챌린저 검색 시 디바운스 대기 전 즉시 로딩 상태로 전환하여 UX 개선
- `prepareSearch` 메서드 분리로 상태 초기화 로직 정리
- 챌린저 선택 시 순서 보존 및 초기화 로직 개선 (#436)
- `requestID` 생성을 호출부에서 관리하도록 변경

## 📋 추후 진행 상황

- 파트장 지정 화면 챌린저 검색에도 동일 패턴 적용 (#427)

## 📌 리뷰 포인트

- `Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift` - `prepareSearch` 분리로 디바운스 대기 전 즉시 로딩 전환 확인
- `Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift` - `loadState` 기반 상태별 UI 분기

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)