### PR TITLE
🐛 [Fix] AnyEncodable 캡처 문제로 인한 출석 장소 변경 크래시 수정

### DIFF
--- a/AppProduct/AppProduct/Core/NetworkAdapter/TokenRefreshService/MoyaNetworkAdapter.swift
+++ b/AppProduct/AppProduct/Core/NetworkAdapter/TokenRefreshService/MoyaNetworkAdapter.swift
@@ -373,7 +373,10 @@ fileprivate struct AnyEncodable: Encodable {
     ///
     /// - Parameter wrapped: 원본 Encodable 객체
     init<T: Encodable>(_ wrapped: T) {
-        _encode = wrapped.encode(to:)
+        let wrappedValue = wrapped
+        _encode = { encoder in
+            try wrappedValue.encode(to: encoder)
+        }
     }
 
     /// Encodable 프로토콜 구현

--- a/AppProduct/AppProductTests/NetworkTest/MoyaNetworkAdapterRequestEncodingTests.swift
+++ b/AppProduct/AppProductTests/NetworkTest/MoyaNetworkAdapterRequestEncodingTests.swift
@@ -1,0 +1,188 @@
+//
+//  MoyaNetworkAdapterRequestEncodingTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/9/26.
+//
+
+import Foundation
+internal import Alamofire
+import Moya
+import XCTest
+@testable import AppProduct
+
+@MainActor
+final class MoyaNetworkAdapterRequestEncodingTests: XCTestCase {
+
+    private let baseURL = URL(string: "https://example.com")!
+
+    override func tearDown() {
+        RequestCapturingURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func test_requestJSONEncodable가_JSON_Body를_안전하게_인코딩한다() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RequestCapturingURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+
+        let networkClient = NetworkClient(
+            session: session,
+            tokenStore: StubTokenStore(),
+            refreshService: StubTokenRefreshService(),
+            authPolicy: NonAuthenticatedPolicy()
+        )
+        let sut = MoyaNetworkAdapter(networkClient: networkClient, baseURL: baseURL)
+
+        RequestCapturingURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/schedules/12/location")
+            XCTAssertEqual(request.httpMethod, "PATCH")
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Content-Type"),
+                "application/json"
+            )
+
+            let body = try XCTUnwrap(request.httpBody)
+            let payload = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: body) as? [String: Any]
+            )
+
+            XCTAssertEqual(payload["locationName"] as? String, "UMC Lounge")
+            XCTAssertEqual(payload["latitude"] as? Double, 37.1234)
+            XCTAssertEqual(payload["longitude"] as? Double, 127.5678)
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            let responseBody = """
+            {
+              "isSuccess": true,
+              "code": "200",
+              "message": "성공",
+              "result": null
+            }
+            """.data(using: .utf8) ?? Data()
+
+            return (response, responseBody)
+        }
+
+        _ = try await sut.request(
+            TestTarget.patchScheduleLocation(
+                scheduleId: 12,
+                body: TestScheduleLocationUpdateRequestDTO(
+                    locationName: "UMC Lounge",
+                    latitude: 37.1234,
+                    longitude: 127.5678
+                )
+            )
+        )
+    }
+}
+
+private enum TestTarget: TargetType {
+    case patchScheduleLocation(scheduleId: Int, body: TestScheduleLocationUpdateRequestDTO)
+
+    var baseURL: URL {
+        URL(string: "https://example.com")!
+    }
+
+    var path: String {
+        switch self {
+        case .patchScheduleLocation(let scheduleId, _):
+            return "/api/v1/schedules/\(scheduleId)/location"
+        }
+    }
+
+    var method: Moya.Method {
+        .patch
+    }
+
+    var sampleData: Data {
+        Data()
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .patchScheduleLocation(_, let body):
+            return .requestJSONEncodable(body)
+        }
+    }
+
+    var validationType: ValidationType {
+        .none
+    }
+
+    var headers: [String: String]? {
+        ["Content-Type": "application/json"]
+    }
+}
+
+private struct TestScheduleLocationUpdateRequestDTO: Encodable, Sendable, Equatable {
+    let locationName: String
+    let latitude: Double
+    let longitude: Double
+}
+
+private actor StubTokenStore: TokenStore {
+    func getAccessToken() async -> String? { nil }
+    func getRefreshToken() async -> String? { nil }
+    func save(accessToken: String, refreshToken: String) async throws {}
+    func clear() async throws {}
+}
+
+private struct StubTokenRefreshService: TokenRefreshService {
+    func refresh(_ refreshToken: String) async throws -> TokenPair {
+        throw NetworkError.tokenRefreshFailed(reason: nil)
+    }
+}
+
+private struct NonAuthenticatedPolicy: AuthenticationPolicy {
+    nonisolated func requireAuthentication(_ request: URLRequest) -> Bool {
+        false
+    }
+
+    nonisolated func isUnauthorizedResponse(_ response: HTTPURLResponse) -> Bool {
+        false
+    }
+}
+
+private final class RequestCapturingURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(
+                self,
+                didFailWithError: URLError(.badServerResponse)
+            )
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(
+                self,
+                didReceive: response,
+                cacheStoragePolicy: .notAllowed
+            )
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## ✨ PR 유형

출석 장소 변경 시 `requestJSONEncodable` 인코딩 크래시 수정 (Bug Fix)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 출석 장소 변경 정상 동작 확인 영상 첨부 필요 -->

## 🛠️ 작업내용

- `AnyEncodable` init에서 `wrapped` 값을 로컬 변수로 캡처하여 메모리 안전성 확보
- 기존 `wrapped.encode(to:)` 직접 참조 방식에서 클로저 내 명시적 캡처로 변경
- `MoyaNetworkAdapterRequestEncodingTests` 추가하여 `requestJSONEncodable` JSON Body 인코딩 검증

## 📋 추후 진행 상황

- 일정 생성 시 장소 좌표 불일치 문제 별도 확인 (#430)

## 📌 리뷰 포인트

- `Core/NetworkAdapter/TokenRefreshService/MoyaNetworkAdapter.swift` - `AnyEncodable.init` 클로저 캡처 방식 변경
- `AppProductTests/NetworkTest/MoyaNetworkAdapterRequestEncodingTests.swift` - `RequestCapturingURLProtocol`을 활용한 JSON Body 인코딩 테스트

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)