### PR TITLE
🐛 [Fix] 활동 탭 출석 지도에 실제 장소 좌표 반영

### DIFF
--- a/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
+++ b/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
@@ -222,7 +222,8 @@ extension DIContainer {
         // MARK: - Activity Feature
         container.register(ActivityRepositoryProviding.self) {
             ActivityRepositoryProvider.real(
-                adapter: container.resolve(MoyaNetworkAdapter.self)
+                adapter: container.resolve(MoyaNetworkAdapter.self),
+                homeRepository: container.resolve(HomeRepositoryProtocol.self)
             )
         }
         container.register(ActivityUseCaseProviding.self) {

--- a/AppProduct/AppProduct/Features/Activity/Data/Provider/ActivityRepositoryProvider.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Provider/ActivityRepositoryProvider.swift
@@ -72,11 +72,13 @@ extension ActivityRepositoryProvider {
     ///
     /// 출석 Repository만 실제 구현체, 나머지는 Mock 유지
     static func real(
-        adapter: MoyaNetworkAdapter
+        adapter: MoyaNetworkAdapter,
+        homeRepository: HomeRepositoryProtocol
     ) -> ActivityRepositoryProvider {
         let attendanceRepo = AttendanceRepository(adapter: adapter)
         let activityRepository = ActivityRepository(
-            attendanceRepository: attendanceRepo
+            attendanceRepository: attendanceRepo,
+            homeRepository: homeRepository
         )
         let studyRepository = StudyRepository(adapter: adapter)
         let memberRepository = MemberRepository(

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/ActivityRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/ActivityRepository.swift
@@ -12,15 +12,24 @@ import SwiftUI
 ///
 /// 출석 가능 일정 API를 통해 세션 목록을 제공합니다.
 final class ActivityRepository: ActivityRepositoryProtocol, @unchecked Sendable {
+    private struct SessionDetailPayload: Sendable {
+        let schedule: AvailableAttendanceSchedule
+        let detail: ScheduleDetailData
+    }
 
     // MARK: - Property
 
     private let attendanceRepository: ChallengerAttendanceRepositoryProtocol
+    private let homeRepository: HomeRepositoryProtocol
 
     // MARK: - Init
 
-    init(attendanceRepository: ChallengerAttendanceRepositoryProtocol) {
+    init(
+        attendanceRepository: ChallengerAttendanceRepositoryProtocol,
+        homeRepository: HomeRepositoryProtocol
+    ) {
         self.attendanceRepository = attendanceRepository
+        self.homeRepository = homeRepository
     }
 
     // MARK: - Function
@@ -29,36 +38,34 @@ final class ActivityRepository: ActivityRepositoryProtocol, @unchecked Sendable 
     func fetchSessions() async throws -> [Session] {
         let schedules = try await attendanceRepository
             .getAvailableSchedules()
-        return schedules.map { schedule in
-            let startTime = Self.parseTime(schedule.startTime)
-            var endTime = Self.parseTime(schedule.endTime)
-            // FIXME: 자정 넘김 휴리스틱 — 서버가 ISO 8601 datetime 반환 시 제거 (#304) - [25.02.18] 이재원
-            if endTime < startTime {
-                endTime = Calendar.current.date(
-                    byAdding: .day, value: 1, to: endTime
-                ) ?? endTime
-            }
-            return Session(
-                info: SessionInfo(
-                    sessionId: SessionID(
-                        value: String(schedule.scheduleId)
-                    ),
-                    // TODO: 서버 API에 icon/week/location 필드 추가 후 하드코딩 제거 예정
-                    icon: .Activity.profile,
-                    title: schedule.scheduleName,
-                    week: 0,
-                    startTime: startTime,
-                    endTime: endTime,
-                    location: Coordinate(
-                        latitude: 37.582967,
-                        longitude: 127.010527
+
+        let payloads = try await withThrowingTaskGroup(
+            of: SessionDetailPayload.self
+        ) { group in
+            for schedule in schedules {
+                group.addTask { [homeRepository] in
+                    let detail = try await homeRepository.getScheduleDetail(
+                        scheduleId: schedule.scheduleId
                     )
-                ),
-                initialAttendance: Self.mapAttendance(
-                    schedule: schedule
-                )
-            )
+                    return SessionDetailPayload(
+                        schedule: schedule,
+                        detail: detail
+                    )
+                }
+            }
+
+            var payloads: [SessionDetailPayload] = []
+            for try await payload in group {
+                payloads.append(payload)
+            }
+            return payloads
         }
+
+        return payloads
+            .map(Self.makeSession(from:))
+            .sorted { lhs, rhs in
+                lhs.info.startTime < rhs.info.startTime
+            }
     }
 
     func fetchCurrentUserId() async throws -> UserID {
@@ -73,13 +80,49 @@ final class ActivityRepository: ActivityRepositoryProtocol, @unchecked Sendable 
     /// 시간 문자열 → 오늘 날짜 기준 Date 변환
     ///
     /// 지원 형식: ISO 8601, "HH:mm:ss", "HH:mm"
-    private static func parseTime(_ timeString: String) -> Date {
+    nonisolated private static func parseTime(_ timeString: String) -> Date {
         // 서버 UTC 시간(ISO 8601 또는 HH:mm:ss/HH:mm) 파싱
         ServerDateTimeConverter.parseUTCDateTimeOrTime(timeString) ?? Date()
     }
 
+    private static func makeSession(
+        from payload: SessionDetailPayload
+    ) -> Session {
+        let schedule = payload.schedule
+        let detail = payload.detail
+        let startTime = parseTime(schedule.startTime)
+        var endTime = parseTime(schedule.endTime)
+
+        // FIXME: 자정 넘김 휴리스틱 — 서버가 ISO 8601 datetime 반환 시 제거 (#304) - [25.02.18] 이재원
+        if endTime < startTime {
+            endTime = Calendar.current.date(
+                byAdding: .day, value: 1, to: endTime
+            ) ?? endTime
+        }
+
+        return Session(
+            info: SessionInfo(
+                sessionId: SessionID(
+                    value: String(schedule.scheduleId)
+                ),
+                icon: .Activity.profile,
+                title: schedule.scheduleName,
+                week: 0,
+                startTime: startTime,
+                endTime: endTime,
+                location: Coordinate(
+                    latitude: detail.latitude,
+                    longitude: detail.longitude
+                )
+            ),
+            initialAttendance: mapAttendance(
+                schedule: schedule
+            )
+        )
+    }
+
     /// AvailableAttendanceSchedule의 status → 초기 Attendance 변환
-    private static func mapAttendance(
+    nonisolated private static func mapAttendance(
         schedule: AvailableAttendanceSchedule
     ) -> Attendance? {
         switch schedule.status {

--- a/AppProduct/AppProduct/Utilities/Extensions/ServerDateTimeConverter.swift
+++ b/AppProduct/AppProduct/Utilities/Extensions/ServerDateTimeConverter.swift
@@ -11,12 +11,12 @@ enum ServerDateTimeConverter {
 
     // MARK: - TimeZone
 
-    static let utcTimeZone: TimeZone = .init(secondsFromGMT: 0) ?? .current
-    static let kstTimeZone: TimeZone = .init(identifier: "Asia/Seoul") ?? .current
+    nonisolated static let utcTimeZone: TimeZone = .init(secondsFromGMT: 0) ?? .current
+    nonisolated static let kstTimeZone: TimeZone = .init(identifier: "Asia/Seoul") ?? .current
 
     // MARK: - Function
 
-    static func parseUTCDateTime(_ value: String) -> Date? {
+    nonisolated static func parseUTCDateTime(_ value: String) -> Date? {
         guard !value.isEmpty else { return nil }
 
         let formatterWithFraction = ISO8601DateFormatter()
@@ -54,7 +54,7 @@ enum ServerDateTimeConverter {
         return nil
     }
 
-    static func toUTCDateTimeString(_ date: Date) -> String {
+    nonisolated static func toUTCDateTimeString(_ date: Date) -> String {
         let formatter = ISO8601DateFormatter()
         formatter.timeZone = utcTimeZone
         formatter.formatOptions = [
@@ -64,7 +64,7 @@ enum ServerDateTimeConverter {
         return formatter.string(from: date)
     }
 
-    static func parseUTCDateTimeOrTime(
+    nonisolated static func parseUTCDateTimeOrTime(
         _ value: String,
         utcDate: String? = nil
     ) -> Date? {
@@ -74,7 +74,7 @@ enum ServerDateTimeConverter {
         return parseUTCTime(value, utcDate: utcDate)
     }
 
-    static func parseUTCTime(
+    nonisolated static func parseUTCTime(
         _ value: String,
         utcDate: String? = nil
     ) -> Date? {
@@ -113,7 +113,7 @@ enum ServerDateTimeConverter {
         return nil
     }
 
-    static func parseUTCDate(_ value: String) -> Date? {
+    nonisolated static func parseUTCDate(_ value: String) -> Date? {
         guard !value.isEmpty else { return nil }
 
         for format in ["yyyy-MM-dd", "yyyy.MM.dd"] {
@@ -129,7 +129,7 @@ enum ServerDateTimeConverter {
         return nil
     }
 
-    static func toKSTDateString(_ date: Date) -> String {
+    nonisolated static func toKSTDateString(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR_POSIX")
         formatter.timeZone = kstTimeZone
@@ -137,7 +137,7 @@ enum ServerDateTimeConverter {
         return formatter.string(from: date)
     }
 
-    static func toKSTTimeString(_ date: Date) -> String {
+    nonisolated static func toKSTTimeString(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR_POSIX")
         formatter.timeZone = kstTimeZone
@@ -147,7 +147,7 @@ enum ServerDateTimeConverter {
 
     // MARK: - Private
 
-    private static func makeUTCCalendar() -> Calendar {
+    nonisolated private static func makeUTCCalendar() -> Calendar {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = utcTimeZone
         return calendar


### PR DESCRIPTION
## ✨ PR 유형

일정 생성 시 지정한 장소와 활동 탭 지도 위치 불일치 버그 수정 (Bug Fix)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 일정 생성 후 활동 탭에서 올바른 장소가 지도에 표시되는지 확인 영상 첨부 필요 -->

## 🛠️ 작업내용

- `ActivityRepository.fetchSessions()`에서 일정 상세 API(`HomeRepository.getScheduleDetail`)를 호출하여 실제 좌표 사용
- 기존 하드코딩된 좌표(`37.582967, 127.010527`) 제거
- `withThrowingTaskGroup`으로 일정 상세 정보를 병렬 조회하여 성능 확보
- 조회 결과를 시작시간 기준 정렬
- `HomeRepositoryProtocol` 의존성을 `DIContainer` 및 `ActivityRepositoryProvider`에 주입
- `ServerDateTimeConverter` 메서드에 `nonisolated` 추가로 Swift 6 Sendable 호환
- 세션 생성 로직을 `makeSession(from:)` 메서드로 분리

## 📋 추후 진행 상황

- 서버에서 일정 목록 API에 좌표 필드가 추가되면 상세 API 호출 제거 가능

## 📌 리뷰 포인트

- `Features/Activity/Data/Repositories/ActivityRepository.swift` - `withThrowingTaskGroup` 병렬 조회 및 `makeSession` 변환 로직
- `Core/DIContainer/DIContainer.swift` - `HomeRepositoryProtocol` 의존성 주입 추가
- `Utilities/Extensions/ServerDateTimeConverter.swift` - `nonisolated` 추가 범위 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)