### PR TITLE
🐛 [Fix] 사유 출석하기 버튼 활성화 및 시간대별 사유 제출 분기 처리

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Session/Session.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Session/Session.swift
@@ -69,14 +69,11 @@ final class Session: Identifiable, Equatable {
         && !hasSubmitted
     }
 
-    /// 사유 제출 가능 여부 (지각 시간대 전용)
+    /// 사유 제출 가능 여부
     ///
-    /// `.lateWindow` 시간대에만 사유를 제출할 수 있습니다.
-    func canSubmitReason(
-        timeWindow: AttendanceTimeWindow
-    ) -> Bool {
-        timeWindow == .lateWindow
-        && !isLoading
+    /// 아직 제출하지 않은 세션은 시간대와 무관하게 사유를 제출할 수 있습니다.
+    func canSubmitReason() -> Bool {
+        !isLoading
         && !hasSubmitted
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift
@@ -188,24 +188,114 @@ struct ChallengerAttendanceView: View, Equatable {
 #if DEBUG
 // MARK: - Previews
 
-#Preview("출석 전 상태") {
-    ChallengerAttendanceView(
-        container: AttendancePreviewData.container,
-        errorHandler: AttendancePreviewData.errorHandler,
-        mapViewModel: AttendancePreviewData.mapViewModel,
-        attendanceViewModel: AttendancePreviewData.attendanceViewModel,
-        userId: AttendancePreviewData.userId,
-        session: AttendancePreviewData.beforeAttendanceSession
+private struct ChallengerAttendanceScenarioPreview: View {
+    @State private var attendanceViewModel: ChallengerAttendanceViewModel
+    @State private var mapViewModel: BaseMapViewModel
+
+    private let session: Session
+    private let subtitle: String
+
+    init(
+        title: String,
+        subtitle: String,
+        timeWindow: AttendanceTimeWindow,
+        isInsideGeofence: Bool = true,
+        isLocationAuthorized: Bool = true,
+        session: Session? = nil
+    ) {
+        let previewSession = session ?? Self.makeSession(title: title)
+        let mockUseCase = MockChallengerAttendanceUseCase()
+        mockUseCase.mockTimeWindow = timeWindow
+        mockUseCase.mockIsInsideGeofence = isInsideGeofence
+        mockUseCase.mockIsLocationAuthorized = isLocationAuthorized
+        mockUseCase.responseDelay = 0
+
+        _attendanceViewModel = State(initialValue: ChallengerAttendanceViewModel(
+            container: AttendancePreviewData.container,
+            errorHandler: AttendancePreviewData.errorHandler,
+            challengeAttendanceUseCase: mockUseCase
+        ))
+        _mapViewModel = State(initialValue: BaseMapViewModel(
+            container: AttendancePreviewData.container,
+            info: previewSession.info,
+            errorHandler: AttendancePreviewData.errorHandler
+        ))
+
+        self.session = previewSession
+        self.subtitle = subtitle
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text(subtitle)
+                .appFont(.footnote, color: .grey600)
+
+            ChallengerAttendanceView(
+                container: AttendancePreviewData.container,
+                errorHandler: AttendancePreviewData.errorHandler,
+                mapViewModel: mapViewModel,
+                attendanceViewModel: attendanceViewModel,
+                userId: AttendancePreviewData.userId,
+                session: session
+            )
+        }
+        .padding()
+        .background(Color.grey100)
+    }
+
+    private static func makeSession(title: String) -> Session {
+        Session(
+            info: SessionInfo(
+                sessionId: SessionID(value: "preview_\(title)"),
+                icon: .Activity.profile,
+                title: title,
+                week: 8,
+                startTime: .now,
+                endTime: .now.addingTimeInterval(7200),
+                location: AttendancePreviewData.hansungCoordinate
+            ),
+            initialAttendance: nil
+        )
+    }
+}
+
+#Preview("정시 출석 가능") {
+    ChallengerAttendanceScenarioPreview(
+        title: "정시 출석 가능 세션",
+        subtitle: "GPS 출석 버튼 활성화, 사유 제출 버튼도 활성화",
+        timeWindow: .onTime
+    )
+}
+
+#Preview("출석 전 사유 제출") {
+    ChallengerAttendanceScenarioPreview(
+        title: "출석 전 사유 제출 세션",
+        subtitle: "아직 출석 시간 전이어도 사유 제출 버튼은 활성화",
+        timeWindow: .tooEarly
+    )
+}
+
+#Preview("지각 사유 제출") {
+    ChallengerAttendanceScenarioPreview(
+        title: "지각 사유 제출 세션",
+        subtitle: "지각 시간대에서는 사유 제출 시 late reason 경로 사용",
+        timeWindow: .lateWindow
+    )
+}
+
+#Preview("마감 후 불참 사유") {
+    ChallengerAttendanceScenarioPreview(
+        title: "불참 사유 제출 세션",
+        subtitle: "출석 마감 후에도 사유 제출 가능, absent reason 경로 사용",
+        timeWindow: .expired
     )
 }
 
 #Preview("승인 대기 상태") {
-    ChallengerAttendanceView(
-        container: AttendancePreviewData.container,
-        errorHandler: AttendancePreviewData.errorHandler,
-        mapViewModel: AttendancePreviewData.mapViewModel,
-        attendanceViewModel: AttendancePreviewData.attendanceViewModel,
-        userId: AttendancePreviewData.userId,
+    ChallengerAttendanceScenarioPreview(
+        title: "승인 대기 세션",
+        subtitle: "이미 사유 제출 완료된 상태라 버튼 대신 승인 대기 카드 표시",
+        timeWindow: .lateWindow,
         session: AttendancePreviewData.pendingApprovalSession
     )
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
@@ -159,13 +159,17 @@ final class ChallengerAttendanceViewModel {
     ) async {
         let info = session.info
         let timeWindow = currentTimeWindow(for: info)
-        guard timeWindow == .lateWindow || timeWindow == .expired else { return }
 
         session.updateState(.loading)
 
         do {
-            let result = try await challengeAttendanceUseCase.submitLateReason(
-                sessionId: info.sessionId, userId: userId, reason: reason, sheetId: sheetId)
+            let result = try await submitReason(
+                timeWindow: timeWindow,
+                sessionId: info.sessionId,
+                userId: userId,
+                reason: reason,
+                sheetId: sheetId
+            )
             session.updateState(.loaded(result))
 
         } catch let error as DomainError {
@@ -203,10 +207,12 @@ final class ChallengerAttendanceViewModel {
     @MainActor
     func submitAttendanceReason(userId: UserID, session: Session, reason: String, sheetId: Int) async {
         let info = session.info
+        let timeWindow = currentTimeWindow(for: info)
         session.updateState(.loading)
 
         do {
-            let result = try await challengeAttendanceUseCase.submitLateReason(
+            let result = try await submitReason(
+                timeWindow: timeWindow,
                 sessionId: info.sessionId,
                 userId: userId,
                 reason: reason,
@@ -258,9 +264,7 @@ final class ChallengerAttendanceViewModel {
     }
 
     func isReasonSubmittable(for session: Session) -> Bool {
-        session.canSubmitReason(
-            timeWindow: currentTimeWindow(for: session.info)
-        )
+        session.canSubmitReason()
     }
 
     func buttonStyle(for session: Session) -> String {
@@ -275,6 +279,31 @@ final class ChallengerAttendanceViewModel {
 
     private func currentTimeWindow(for info: SessionInfo) -> AttendanceTimeWindow {
         challengeAttendanceUseCase.isWithinAttendanceTime(info: info)
+    }
+
+    private func submitReason(
+        timeWindow: AttendanceTimeWindow,
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        sheetId: Int
+    ) async throws -> Attendance {
+        switch timeWindow {
+        case .tooEarly, .onTime, .lateWindow:
+            return try await challengeAttendanceUseCase.submitLateReason(
+                sessionId: sessionId,
+                userId: userId,
+                reason: reason,
+                sheetId: sheetId
+            )
+        case .expired:
+            return try await challengeAttendanceUseCase.submitAbsentReason(
+                sessionId: sessionId,
+                userId: userId,
+                reason: reason,
+                sheetId: sheetId
+            )
+        }
     }
 
     // MARK: - Cleanup

--- a/AppProduct/AppProductTests/NetworkTest/MoyaNetworkAdapterRequestEncodingTests.swift
+++ b/AppProduct/AppProductTests/NetworkTest/MoyaNetworkAdapterRequestEncodingTests.swift
@@ -2,7 +2,7 @@
 //  MoyaNetworkAdapterRequestEncodingTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/9/26.
+//  Created by euijjang97 on 3/9/26.
 //
 
 import Foundation


### PR DESCRIPTION
## ✨ PR 유형

사유 출석하기 버튼이 탭되지 않는 버그 수정 및 시간대별 사유 제출 API 분기 처리 (Bug Fix)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 각 시간대별 사유 출석 버튼 동작 확인 영상 첨부 필요 -->

## 🛠️ 작업내용

- `Session.canSubmitReason()`에서 `timeWindow == .lateWindow` 제약 제거 → 미제출 상태면 시간대와 무관하게 사유 제출 가능
- `ChallengerAttendanceViewModel`에 `submitReason` 메서드 추가로 시간대별 API 분기 처리
  - `tooEarly` / `onTime` / `lateWindow` → `submitLateReason` API 호출
  - `expired` → `submitAbsentReason` API 호출
- 기존 `submitReasonBtnTapped`, `submitAttendanceReason`에서 `submitReason` 호출로 통합
- `ChallengerAttendanceView` Preview를 시나리오별(정시/사유 제출/지각/마감 후/승인 대기)로 개선

## 📋 추후 진행 상황

- 사유 제출 후 상태 갱신 UX 확인

## 📌 리뷰 포인트

- `Features/Activity/Domain/Models/Session/Session.swift` - `canSubmitReason()` timeWindow 제약 제거가 의도에 맞는지 확인
- `Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift` - `submitReason` 시간대별 분기 로직 (tooEarly/onTime도 lateReason으로 처리)
- `Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift` - 시나리오별 Preview 구성

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)