### PR TITLE
🐛 [Fix] 번개글 수정 시 기존 장소 프리필 및 직렬화 통일

### DIFF
--- a/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift
@@ -62,7 +62,7 @@ class CommunityPostViewModel {
             category: selectedCategory,
             meetAt: selectedCategory == .lighting ? selectedDate : nil,
             maxParticipants: selectedCategory == .lighting ? maxParticipants : nil,
-            location: selectedCategory == .lighting ? selectedPlace.address : nil,
+            location: selectedCategory == .lighting ? Self.serializePlace(selectedPlace) : nil,
             openChatUrl: selectedCategory == .lighting ? linkText : nil
         )
     }
@@ -87,6 +87,7 @@ class CommunityPostViewModel {
         if let lightningInfo = post.lightningInfo {
             selectedDate = lightningInfo.meetAt
             maxParticipants = lightningInfo.maxParticipants
+            selectedPlace = Self.makePlaceSearchInfo(from: lightningInfo.location)
             linkText = lightningInfo.openChatUrl
         }
 
@@ -108,7 +109,7 @@ class CommunityPostViewModel {
                     title: titleText,
                     content: contentText,
                     meetAt: meetAtString,
-                    location: "\(selectedPlace.address), \(selectedPlace.name)",
+                    location: Self.serializePlace(selectedPlace),
                     maxParticipants: maxParticipants,
                     openChatUrl: linkText
                 )
@@ -165,7 +166,7 @@ class CommunityPostViewModel {
                     title: titleText,
                     content: contentText,
                     meetAt: meetAtString,
-                    location: selectedPlace.address,
+                    location: Self.serializePlace(selectedPlace),
                     maxParticipants: maxParticipants,
                     openChatUrl: linkText
                 )
@@ -228,5 +229,31 @@ class CommunityPostViewModel {
         let maxParticipants: Int?
         let location: String?
         let openChatUrl: String?
+    }
+
+    // MARK: - Place Helpers
+
+    static func makePlaceSearchInfo(from location: String) -> PlaceSearchInfo {
+        let components = location
+            .split(separator: ",", maxSplits: 1, omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+        let address = components.first ?? ""
+        let name = components.count > 1 ? components[1] : address
+
+        return PlaceSearchInfo(
+            name: name,
+            address: address,
+            coordinate: .init(latitude: 0.0, longitude: 0.0)
+        )
+    }
+
+    static func serializePlace(_ place: PlaceSearchInfo) -> String {
+        let trimmedAddress = place.address.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedName = place.name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedAddress.isEmpty else { return trimmedName }
+        guard !trimmedName.isEmpty, trimmedName != trimmedAddress else { return trimmedAddress }
+        return "\(trimmedAddress), \(trimmedName)"
     }
 }

--- a/AppProduct/AppProductTests/CommunityTest/CommunityPostViewModelTests.swift
+++ b/AppProduct/AppProductTests/CommunityTest/CommunityPostViewModelTests.swift
@@ -1,0 +1,45 @@
+//
+//  CommunityPostViewModelTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/10/26.
+//
+
+@testable import AppProduct
+import Testing
+
+struct CommunityPostViewModelTests {
+
+    @Test("번개글 위치 문자열을 수정 폼용 장소 정보로 복원한다")
+    func makePlaceSearchInfoParsesAddressAndName() {
+        let place = CommunityPostViewModel.makePlaceSearchInfo(
+            from: "서울특별시 성동구 왕십리로 83-21, 멋쟁이사자처럼 캠퍼스"
+        )
+
+        #expect(place.address == "서울특별시 성동구 왕십리로 83-21")
+        #expect(place.name == "멋쟁이사자처럼 캠퍼스")
+    }
+
+    @Test("장소명이 없거나 주소와 같으면 수정 요청에 기존 주소만 유지한다")
+    func serializePlaceKeepsRawAddressWhenNameIsMissingOrSame() {
+        let rawAddressOnly = PlaceSearchInfo(
+            name: "서울특별시 성동구 왕십리로 83-21",
+            address: "서울특별시 성동구 왕십리로 83-21",
+            coordinate: .init(latitude: 0.0, longitude: 0.0)
+        )
+        let fullPlace = PlaceSearchInfo(
+            name: "멋쟁이사자처럼 캠퍼스",
+            address: "서울특별시 성동구 왕십리로 83-21",
+            coordinate: .init(latitude: 0.0, longitude: 0.0)
+        )
+
+        #expect(
+            CommunityPostViewModel.serializePlace(rawAddressOnly)
+                == "서울특별시 성동구 왕십리로 83-21"
+        )
+        #expect(
+            CommunityPostViewModel.serializePlace(fullPlace)
+                == "서울특별시 성동구 왕십리로 83-21, 멋쟁이사자처럼 캠퍼스"
+        )
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 번개글 수정 시 기존 번개 위치가 불러와지지 않는 문제 수정 (#446)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 번개글 수정 화면 진입 시 기존 장소가 정상적으로 프리필되는지 확인해주세요 -->

## 🛠️ 작업내용

- 번개글 수정 화면 진입 시 서버 `location` 문자열을 `PlaceSearchInfo`로 역직렬화하여 `selectedPlace`에 프리필
- `makePlaceSearchInfo(from:)` static 헬퍼 추가 — 서버 location 문자열(`"주소, 장소명"`)을 `PlaceSearchInfo`로 변환
- `serializePlace(_:)` static 헬퍼 추가 — `PlaceSearchInfo`를 서버 전송 형식으로 직렬화
- 번개글 생성/수정 시 location 직렬화를 `serializePlace`로 통일 (기존 불일치 해소)
- `CommunityPostViewModelTests` 회귀 테스트 추가

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift` - `makePlaceSearchInfo`, `serializePlace` 헬퍼 로직 및 `setupEditMode`에서 `selectedPlace` 프리필 확인
- `AppProductTests/CommunityTest/CommunityPostViewModelTests.swift` - 직렬화/역직렬화 테스트 커버리지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)