### PR TITLE
✨ [Feat] 회원가입 후 자동 세션 복구 및 챌린저 검색 디바운스 적용

### DIFF
--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -39,7 +39,8 @@ struct AppProductApp: App {
         case signUp(
             verificationToken: String,
             email: String?,
-            fullName: String?
+            fullName: String?,
+            postRegisterLoginContext: PostRegisterLoginContext?
         )
         /// 승인 대기 화면
         case pendingApproval
@@ -110,16 +111,23 @@ extension AppProductApp {
                 )
                 .transition(rootTransition)
 
-            case .signUp(let verificationToken, let email, let fullName):
+            case .signUp(
+                let verificationToken,
+                let email,
+                let fullName,
+                let postRegisterLoginContext
+            ):
                 SignUpView(
                     oAuthVerificationToken: verificationToken,
                     initialEmail: email,
                     initialName: fullName,
+                    postRegisterLoginContext: postRegisterLoginContext,
                     sendEmailVerificationUseCase: authProvider
                         .sendEmailVerificationUseCase,
                     verifyEmailCodeUseCase: authProvider
                         .verifyEmailCodeUseCase,
                     registerUseCase: authProvider.registerUseCase,
+                    loginUseCase: authProvider.loginUseCase,
                     fetchSignUpDataUseCase: authProvider.fetchSignUpDataUseCase
                 )
                 .transition(rootTransition)
@@ -188,12 +196,17 @@ extension AppProductApp {
         AppFlow(
             showLogin: { transition(to: .login) },
             showMain: { transition(to: .main) },
-            showSignUp: { verificationToken, email, fullName in
+            showSignUp: {
+                verificationToken,
+                email,
+                fullName,
+                postRegisterLoginContext in
                 transition(
                     to: .signUp(
                         verificationToken: verificationToken,
                         email: email,
-                        fullName: fullName
+                        fullName: fullName,
+                        postRegisterLoginContext: postRegisterLoginContext
                     )
                 )
             },

--- a/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
+++ b/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
@@ -74,6 +74,7 @@ private struct PreviewFetchMyProfileUseCase: FetchMyProfileUseCaseProtocol {
             sendEmailVerificationUseCase: PreviewSendEmailUseCase(),
             verifyEmailCodeUseCase: PreviewVerifyCodeUseCase(),
             registerUseCase: PreviewRegisterUseCase(),
+            loginUseCase: PreviewLoginUseCase(),
             fetchSignUpDataUseCase: PreviewFetchSignUpDataUseCase()
         )
     }
@@ -98,6 +99,33 @@ private struct PreviewVerifyCodeUseCase: VerifyEmailCodeUseCaseProtocol {
 private struct PreviewRegisterUseCase: RegisterUseCaseProtocol {
     func execute(request: RegisterRequestDTO) async throws -> Int {
         1
+    }
+}
+
+private struct PreviewLoginUseCase: LoginUseCaseProtocol {
+    func executeKakao(
+        accessToken: String,
+        email: String
+    ) async throws -> OAuthLoginResult {
+        .existingMember(
+            tokenPair: TokenPair(
+                accessToken: "preview_access_token",
+                refreshToken: "preview_refresh_token"
+            )
+        )
+    }
+
+    func executeApple(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    ) async throws -> OAuthLoginResult {
+        .existingMember(
+            tokenPair: TokenPair(
+                accessToken: "preview_access_token",
+                refreshToken: "preview_refresh_token"
+            )
+        )
     }
 }
 

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Models/PostRegisterLoginContext.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Models/PostRegisterLoginContext.swift
@@ -1,0 +1,24 @@
+//
+//  PostRegisterLoginContext.swift
+//  AppProduct
+//
+//  Created by Codex on 3/10/26.
+//
+
+import Foundation
+
+/// 회원가입 직후 세션 복구에 사용할 소셜 로그인 컨텍스트입니다.
+enum PostRegisterLoginContext: Equatable {
+
+    // MARK: - Cases
+
+    /// 카카오 로그인 재시도에 필요한 정보
+    case kakao(accessToken: String, email: String)
+
+    /// Apple 로그인 재시도에 필요한 정보
+    case apple(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    )
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
@@ -66,7 +66,13 @@ final class LoginViewModel {
             print("[Auth] 서버 로그인 결과: \(result)")
             #endif
             loginState = .loaded(result)
-            destination = try await resolveDestination(from: result)
+            destination = try await resolveDestination(
+                from: result,
+                postRegisterLoginContext: .kakao(
+                    accessToken: accessToken,
+                    email: email
+                )
+            )
         } catch {
             loginState = .idle
             errorHandler.handle(error, context: ErrorContext(
@@ -100,7 +106,12 @@ final class LoginViewModel {
                     self.destination = try await self.resolveDestination(
                         from: result,
                         email: email,
-                        fullName: fullName
+                        fullName: fullName,
+                        postRegisterLoginContext: .apple(
+                            authorizationCode: code,
+                            email: email,
+                            fullName: fullName
+                        )
                     )
                 } catch {
                     self.loginState = .idle
@@ -129,7 +140,8 @@ private extension LoginViewModel {
     func resolveDestination(
         from result: OAuthLoginResult,
         email: String? = nil,
-        fullName: String? = nil
+        fullName: String? = nil,
+        postRegisterLoginContext: PostRegisterLoginContext? = nil
     ) async throws -> LoginDestination {
         switch result {
         case .newMember(let verificationToken):
@@ -140,7 +152,8 @@ private extension LoginViewModel {
             return .signUp(
                 verificationToken: verificationToken,
                 email: email,
-                fullName: fullName
+                fullName: fullName,
+                postRegisterLoginContext: postRegisterLoginContext
             )
 
         case .existingMember(let tokenPair):
@@ -204,6 +217,7 @@ enum LoginDestination: Equatable {
     case signUp(
         verificationToken: String,
         email: String?,
-        fullName: String?
+        fullName: String?,
+        postRegisterLoginContext: PostRegisterLoginContext?
     )
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
@@ -21,6 +21,9 @@ final class SignUpViewModel {
     /// OAuth 인증 토큰 (소셜 로그인 시 발급)
     private let oAuthVerificationToken: String
 
+    /// 회원가입 직후 세션 복구에 사용할 소셜 로그인 컨텍스트
+    private let postRegisterLoginContext: PostRegisterLoginContext?
+
     /// 이메일 인증 발송 UseCase
     private let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
 
@@ -29,6 +32,9 @@ final class SignUpViewModel {
 
     /// 회원가입 UseCase
     private let registerUseCase: RegisterUseCaseProtocol
+
+    /// 회원가입 직후 세션 복구용 로그인 UseCase
+    private let loginUseCase: LoginUseCaseProtocol
 
     /// 회원가입 데이터 조회 UseCase
     private let fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
@@ -98,15 +104,19 @@ final class SignUpViewModel {
         oAuthVerificationToken: String,
         initialEmail: String? = nil,
         initialName: String? = nil,
+        postRegisterLoginContext: PostRegisterLoginContext? = nil,
         sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
         verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
         registerUseCase: RegisterUseCaseProtocol,
+        loginUseCase: LoginUseCaseProtocol,
         fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
     ) {
         self.oAuthVerificationToken = oAuthVerificationToken
+        self.postRegisterLoginContext = postRegisterLoginContext
         self.sendEmailVerificationUseCase = sendEmailVerificationUseCase
         self.verifyEmailCodeUseCase = verifyEmailCodeUseCase
         self.registerUseCase = registerUseCase
+        self.loginUseCase = loginUseCase
         self.fetchSignUpDataUseCase = fetchSignUpDataUseCase
         self.email = initialEmail?.trimmingCharacters(
             in: .whitespacesAndNewlines
@@ -253,6 +263,7 @@ final class SignUpViewModel {
         do {
             let memberId = try await registerUseCase
                 .execute(request: request)
+            try await restoreSessionAfterRegisterIfNeeded()
             #if DEBUG
             print("[Auth] register 성공: memberId=\(memberId)")
             #endif
@@ -287,6 +298,34 @@ final class SignUpViewModel {
         }
 
         isLoading = false
+    }
+
+    /// 회원가입 직후 다시 로그인해 액세스 토큰을 저장합니다.
+    private func restoreSessionAfterRegisterIfNeeded() async throws {
+        guard let postRegisterLoginContext else { return }
+
+        let loginResult: OAuthLoginResult
+
+        switch postRegisterLoginContext {
+        case .kakao(let accessToken, let email):
+            loginResult = try await loginUseCase.executeKakao(
+                accessToken: accessToken,
+                email: email
+            )
+        case .apple(let authorizationCode, let email, let fullName):
+            loginResult = try await loginUseCase.executeApple(
+                authorizationCode: authorizationCode,
+                email: email,
+                fullName: fullName
+            )
+        }
+
+        guard case .existingMember = loginResult else {
+            throw AuthError.socialLoginFailed(
+                provider: "Auth",
+                reason: "회원가입 후 세션 복구에 실패했습니다."
+            )
+        }
     }
 
     /// 전체 약관 동의/해제 토글

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -61,8 +61,18 @@ struct LoginView: View {
                 appFlow.showMain()
             case .pendingApproval:
                 appFlow.showPendingApproval()
-            case .signUp(let verificationToken, let email, let fullName):
-                appFlow.showSignUp(verificationToken, email, fullName)
+            case .signUp(
+                let verificationToken,
+                let email,
+                let fullName,
+                let postRegisterLoginContext
+            ):
+                appFlow.showSignUp(
+                    verificationToken,
+                    email,
+                    fullName,
+                    postRegisterLoginContext
+                )
             }
         }
     }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
@@ -49,9 +49,11 @@ struct SignUpView: View {
         oAuthVerificationToken: String,
         initialEmail: String? = nil,
         initialName: String? = nil,
+        postRegisterLoginContext: PostRegisterLoginContext? = nil,
         sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
         verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
         registerUseCase: RegisterUseCaseProtocol,
+        loginUseCase: LoginUseCaseProtocol,
         fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
     ) {
         self._viewModel = .init(
@@ -59,9 +61,11 @@ struct SignUpView: View {
                 oAuthVerificationToken: oAuthVerificationToken,
                 initialEmail: initialEmail,
                 initialName: initialName,
+                postRegisterLoginContext: postRegisterLoginContext,
                 sendEmailVerificationUseCase: sendEmailVerificationUseCase,
                 verifyEmailCodeUseCase: verifyEmailCodeUseCase,
                 registerUseCase: registerUseCase,
+                loginUseCase: loginUseCase,
                 fetchSignUpDataUseCase: fetchSignUpDataUseCase
             )
         )
@@ -532,6 +536,7 @@ private func signUpPreview(shouldFailTerms: Bool = false) -> some View {
             sendEmailVerificationUseCase: SignUpPreviewSendEmailUseCase(),
             verifyEmailCodeUseCase: SignUpPreviewVerifyCodeUseCase(),
             registerUseCase: SignUpPreviewRegisterUseCase(),
+            loginUseCase: SignUpPreviewLoginUseCase(),
             fetchSignUpDataUseCase: SignUpPreviewFetchSignUpDataUseCase(
                 shouldFailTerms: shouldFailTerms
             )
@@ -559,6 +564,33 @@ private struct SignUpPreviewVerifyCodeUseCase: VerifyEmailCodeUseCaseProtocol {
 private struct SignUpPreviewRegisterUseCase: RegisterUseCaseProtocol {
     func execute(request: RegisterRequestDTO) async throws -> Int {
         1
+    }
+}
+
+private struct SignUpPreviewLoginUseCase: LoginUseCaseProtocol {
+    func executeKakao(
+        accessToken: String,
+        email: String
+    ) async throws -> OAuthLoginResult {
+        .existingMember(
+            tokenPair: TokenPair(
+                accessToken: "preview_access_token",
+                refreshToken: "preview_refresh_token"
+            )
+        )
+    }
+
+    func executeApple(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    ) async throws -> OAuthLoginResult {
+        .existingMember(
+            tokenPair: TokenPair(
+                accessToken: "preview_access_token",
+                refreshToken: "preview_refresh_token"
+            )
+        )
     }
 }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
@@ -12,7 +12,7 @@ import UniformTypeIdentifiers
 ///
 /// 챌린저 목록 로드, 검색 필터링, CSV 파일을 통한 일괄 선택 기능을 제공합니다.
 @Observable
-class SearchChallengerViewModel {
+final class SearchChallengerViewModel {
 
     // MARK: - Property
 
@@ -50,6 +50,9 @@ class SearchChallengerViewModel {
     private var currentKeyword: String = ""
 
     /// 디바운스용 검색 태스크
+    private var debounceTask: Task<Void, Never>?
+
+    /// 진행 중인 검색 요청 태스크
     private var searchTask: Task<Void, Never>?
 
     /// 최신 검색 요청 식별자
@@ -58,9 +61,8 @@ class SearchChallengerViewModel {
     /// 다음 페이지 중복 호출 방지 플래그
     private var isFetchingNextPage: Bool = false
 
-    private enum Constants {
-        static let debounceNanoseconds: UInt64 = 400_000_000
-    }
+    private let debounceNanoseconds: UInt64
+    private let sleep: @Sendable (UInt64) async throws -> Void
 
     // MARK: - Init
 
@@ -68,6 +70,22 @@ class SearchChallengerViewModel {
     init(container: DIContainer) {
         let provider = container.resolve(HomeUseCaseProviding.self)
         self.searchChallengersUseCase = provider.searchChallengersUseCase
+        self.debounceNanoseconds = 1_000_000_000
+        self.sleep = { nanoseconds in
+            try await Task.sleep(nanoseconds: nanoseconds)
+        }
+    }
+
+    init(
+        searchChallengersUseCase: SearchChallengersUseCaseProtocol,
+        debounceNanoseconds: UInt64 = 1_000_000_000,
+        sleep: @escaping @Sendable (UInt64) async throws -> Void = { nanoseconds in
+            try await Task.sleep(nanoseconds: nanoseconds)
+        }
+    ) {
+        self.searchChallengersUseCase = searchChallengersUseCase
+        self.debounceNanoseconds = debounceNanoseconds
+        self.sleep = sleep
     }
 
     // MARK: - Function
@@ -82,25 +100,29 @@ class SearchChallengerViewModel {
     /// 검색어 변경 시 디바운스를 적용해 챌린저 목록을 다시 조회합니다.
     @MainActor
     func scheduleSearch() {
-        searchTask?.cancel()
+        debounceTask?.cancel()
         let keyword = normalizedSearchText
         let requestID = prepareSearch(keyword: keyword)
 
-        searchTask = Task { [weak self] in
+        debounceTask = Task { [weak self] in
+            guard let self else { return }
             do {
-                try await Task.sleep(nanoseconds: Constants.debounceNanoseconds)
+                try await sleep(debounceNanoseconds)
             } catch {
                 return
             }
 
-            guard let self, !Task.isCancelled else { return }
-            await self.fetchChallengers(keyword: keyword, requestID: requestID)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                self.startSearchTask(keyword: keyword, requestID: requestID)
+            }
         }
     }
 
     /// 더 이상 필요 없는 검색 태스크를 정리합니다.
     @MainActor
     func cancelSearch() {
+        debounceTask?.cancel()
         searchTask?.cancel()
     }
 
@@ -147,6 +169,14 @@ class SearchChallengerViewModel {
 
 // MARK: - Helpers
 private extension SearchChallengerViewModel {
+    @MainActor
+    func startSearchTask(keyword: String, requestID: UUID) {
+        searchTask = Task { [weak self] in
+            guard let self else { return }
+            await self.fetchChallengers(keyword: keyword, requestID: requestID)
+        }
+    }
+
     @MainActor
     func prepareSearch(keyword: String) -> UUID {
         let requestID = UUID()

--- a/AppProduct/AppProduct/Resource/EnvrionmentKey/AppFlowEnvironmentKey.swift
+++ b/AppProduct/AppProduct/Resource/EnvrionmentKey/AppFlowEnvironmentKey.swift
@@ -9,14 +9,19 @@ import SwiftUI
 struct AppFlow {
     let showLogin: () -> Void
     let showMain: () -> Void
-    let showSignUp: (String, String?, String?) -> Void
+    let showSignUp: (
+        String,
+        String?,
+        String?,
+        PostRegisterLoginContext?
+    ) -> Void
     let showPendingApproval: () -> Void
     let logout: () -> Void
 
     static let noop = AppFlow(
         showLogin: {},
         showMain: {},
-        showSignUp: { _, _, _ in },
+        showSignUp: { _, _, _, _ in },
         showPendingApproval: {},
         logout: {}
     )

--- a/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
+++ b/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
@@ -1,0 +1,192 @@
+//
+//  SignUpViewModelTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/10/26.
+//
+
+@testable import AppProduct
+import Testing
+
+struct SignUpViewModelTests {
+
+    @Test("회원가입 성공 후 카카오 로그인 컨텍스트로 세션을 복구한다")
+    func restoreSessionWithKakaoAfterRegister() async throws {
+        let loginUseCase = MockLoginUseCase()
+        let viewModel = await MainActor.run {
+            makeSUT(
+                postRegisterLoginContext: .kakao(
+                    accessToken: "kakao-access-token",
+                    email: "umc@example.com"
+                ),
+                loginUseCase: loginUseCase
+            )
+        }
+
+        await MainActor.run {
+            viewModel.selectedSchool = School(id: "1", name: "UMC")
+            viewModel.email = "umc@example.com"
+        }
+        try await viewModel.requestEmailVerification()
+        try await viewModel.verifyEmailCode("123456")
+
+        await viewModel.register()
+
+        let snapshot = await loginUseCase.snapshot()
+        let state = await MainActor.run { viewModel.registerState }
+
+        #expect(state == .loaded(1))
+        #expect(snapshot.kakaoCallCount == 1)
+        #expect(snapshot.lastKakaoAccessToken == "kakao-access-token")
+        #expect(snapshot.lastKakaoEmail == "umc@example.com")
+    }
+
+    @Test("회원가입 성공 후 Apple 로그인 컨텍스트로 세션을 복구한다")
+    func restoreSessionWithAppleAfterRegister() async throws {
+        let loginUseCase = MockLoginUseCase()
+        let viewModel = await MainActor.run {
+            makeSUT(
+                postRegisterLoginContext: .apple(
+                    authorizationCode: "apple-code",
+                    email: "apple@example.com",
+                    fullName: "UMC Apple"
+                ),
+                loginUseCase: loginUseCase
+            )
+        }
+
+        await MainActor.run {
+            viewModel.selectedSchool = School(id: "1", name: "UMC")
+            viewModel.email = "apple@example.com"
+        }
+        try await viewModel.requestEmailVerification()
+        try await viewModel.verifyEmailCode("123456")
+
+        await viewModel.register()
+
+        let snapshot = await loginUseCase.snapshot()
+        let state = await MainActor.run { viewModel.registerState }
+
+        #expect(state == .loaded(1))
+        #expect(snapshot.appleCallCount == 1)
+        #expect(snapshot.lastAppleAuthorizationCode == "apple-code")
+        #expect(snapshot.lastAppleEmail == "apple@example.com")
+        #expect(snapshot.lastAppleFullName == "UMC Apple")
+    }
+
+    @MainActor
+    private func makeSUT(
+        postRegisterLoginContext: PostRegisterLoginContext?,
+        loginUseCase: MockLoginUseCase
+    ) -> SignUpViewModel {
+        SignUpViewModel(
+            oAuthVerificationToken: "oauth-verification-token",
+            postRegisterLoginContext: postRegisterLoginContext,
+            sendEmailVerificationUseCase: MockSendEmailVerificationUseCase(),
+            verifyEmailCodeUseCase: MockVerifyEmailCodeUseCase(),
+            registerUseCase: MockRegisterUseCase(),
+            loginUseCase: loginUseCase,
+            fetchSignUpDataUseCase: MockFetchSignUpDataUseCase()
+        )
+    }
+}
+
+private actor MockLoginUseCase: LoginUseCaseProtocol {
+    private var kakaoCallCount: Int = 0
+    private var appleCallCount: Int = 0
+    private var lastKakaoAccessToken: String?
+    private var lastKakaoEmail: String?
+    private var lastAppleAuthorizationCode: String?
+    private var lastAppleEmail: String?
+    private var lastAppleFullName: String?
+
+    func executeKakao(
+        accessToken: String,
+        email: String
+    ) async throws -> OAuthLoginResult {
+        kakaoCallCount += 1
+        lastKakaoAccessToken = accessToken
+        lastKakaoEmail = email
+
+        return .existingMember(
+            tokenPair: TokenPair(
+                accessToken: "saved-access-token",
+                refreshToken: "saved-refresh-token"
+            )
+        )
+    }
+
+    func executeApple(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    ) async throws -> OAuthLoginResult {
+        appleCallCount += 1
+        lastAppleAuthorizationCode = authorizationCode
+        lastAppleEmail = email
+        lastAppleFullName = fullName
+
+        return .existingMember(
+            tokenPair: TokenPair(
+                accessToken: "saved-access-token",
+                refreshToken: "saved-refresh-token"
+            )
+        )
+    }
+
+    func snapshot() -> (
+        kakaoCallCount: Int,
+        appleCallCount: Int,
+        lastKakaoAccessToken: String?,
+        lastKakaoEmail: String?,
+        lastAppleAuthorizationCode: String?,
+        lastAppleEmail: String?,
+        lastAppleFullName: String?
+    ) {
+        (
+            kakaoCallCount,
+            appleCallCount,
+            lastKakaoAccessToken,
+            lastKakaoEmail,
+            lastAppleAuthorizationCode,
+            lastAppleEmail,
+            lastAppleFullName
+        )
+    }
+}
+
+private struct MockRegisterUseCase: RegisterUseCaseProtocol {
+    func execute(request: RegisterRequestDTO) async throws -> Int {
+        1
+    }
+}
+
+private struct MockSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol {
+    func execute(email: String) async throws -> String {
+        "email-verification-id"
+    }
+}
+
+private struct MockVerifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol {
+    func execute(
+        emailVerificationId: String,
+        verificationCode: String
+    ) async throws -> String {
+        "verified-email-token"
+    }
+}
+
+private struct MockFetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol {
+    func fetchSchools() async throws -> [School] {
+        []
+    }
+
+    func fetchTerms(termsType: String) async throws -> Terms {
+        Terms(
+            id: "1",
+            link: "https://example.com",
+            isMandatory: true,
+            termsType: .service
+        )
+    }
+}

--- a/AppProduct/AppProductTests/HomeTest/SearchChallengerViewModelTests.swift
+++ b/AppProduct/AppProductTests/HomeTest/SearchChallengerViewModelTests.swift
@@ -1,0 +1,125 @@
+//
+//  SearchChallengerViewModelTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/10/26.
+//
+
+@testable import AppProduct
+import Testing
+
+struct SearchChallengerViewModelTests {
+
+    @Test("챌린저 검색은 1초 디바운스 후 마지막 입력만 요청한다")
+    func searchUsesOneSecondDebounce() async throws {
+        let useCase = MockSearchChallengersUseCase()
+        let viewModel = await MainActor.run {
+            SearchChallengerViewModel(searchChallengersUseCase: useCase)
+        }
+
+        await MainActor.run {
+            viewModel.searchText = "리"
+            viewModel.scheduleSearch()
+        }
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        await MainActor.run {
+            viewModel.searchText = "리버"
+            viewModel.scheduleSearch()
+        }
+        try await Task.sleep(nanoseconds: 900_000_000)
+
+        let beforeDebounceSnapshot = await useCase.snapshot()
+        #expect(beforeDebounceSnapshot.keywords.isEmpty)
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let afterDebounceSnapshot = await useCase.snapshot()
+        #expect(afterDebounceSnapshot.keywords == ["리버"])
+
+        await MainActor.run {
+            viewModel.cancelSearch()
+        }
+    }
+
+    @Test("새 검색어 입력은 이미 시작된 챌린저 검색 요청을 취소하지 않는다")
+    func newInputDoesNotCancelInFlightSearchRequest() async throws {
+        let useCase = MockSearchChallengersUseCase(
+            responseDelayNanoseconds: 400_000_000
+        )
+        let viewModel = await MainActor.run {
+            SearchChallengerViewModel(searchChallengersUseCase: useCase)
+        }
+
+        await MainActor.run {
+            viewModel.searchText = "리"
+            viewModel.scheduleSearch()
+        }
+        try await Task.sleep(nanoseconds: 1_050_000_000)
+
+        await MainActor.run {
+            viewModel.searchText = "리버"
+            viewModel.scheduleSearch()
+        }
+        try await Task.sleep(nanoseconds: 1_600_000_000)
+
+        let snapshot = await useCase.snapshot()
+        #expect(snapshot.keywords == ["리", "리버"])
+        #expect(snapshot.cancelledCallCount == 0)
+
+        await MainActor.run {
+            viewModel.cancelSearch()
+        }
+    }
+}
+
+private actor MockSearchChallengersUseCase: SearchChallengersUseCaseProtocol {
+    private(set) var keywords: [String] = []
+    private(set) var cancelledCallCount: Int = 0
+
+    private let responseDelayNanoseconds: UInt64
+
+    init(responseDelayNanoseconds: UInt64 = 0) {
+        self.responseDelayNanoseconds = responseDelayNanoseconds
+    }
+
+    func execute(
+        query: ChallengerSearchRequestDTO
+    ) async throws -> ([ChallengerInfo], hasNext: Bool, nextCursor: Int?) {
+        keywords.append(query.keyword ?? "")
+
+        if responseDelayNanoseconds > 0 {
+            do {
+                try await Task.sleep(nanoseconds: responseDelayNanoseconds)
+            } catch {
+                cancelledCallCount += 1
+                throw error
+            }
+        }
+
+        return (
+            [ChallengerInfo.fixture(name: query.keyword ?? "")],
+            false,
+            nil
+        )
+    }
+
+    func snapshot() -> (keywords: [String], cancelledCallCount: Int) {
+        (keywords, cancelledCallCount)
+    }
+}
+
+private extension ChallengerInfo {
+    static func fixture(name: String) -> ChallengerInfo {
+        ChallengerInfo(
+            memberId: 1,
+            challengerId: 1,
+            gen: 11,
+            name: name,
+            nickname: name,
+            schoolName: "UMC",
+            profileImage: nil,
+            part: .front(type: .ios)
+        )
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Feature - 회원가입 직후 Access Token 미전송 문제 해결 (#447) 및 챌린저 검색 디바운스 적용 (#450)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

### 회원가입 후 세션 복구 (#447)
- `PostRegisterLoginContext` 모델 추가 — 소셜 로그인 시 사용한 인증 정보(카카오 accessToken/Apple authorizationCode)를 보존
- `LoginViewModel` → `AppFlow` → `SignUpView` → `SignUpViewModel`까지 `PostRegisterLoginContext` 전달 파이프라인 구성
- `SignUpViewModel.restoreSessionAfterRegisterIfNeeded()` 구현 — 회원가입 완료 직후 보존된 소셜 로그인 컨텍스트로 재로그인하여 Access Token 발급
- `AppFlow.showSignUp` 시그니처에 `PostRegisterLoginContext?` 파라미터 추가

### 챌린저 검색 디바운스 (#450)
- `SearchChallengerViewModel`에 1초(1_000_000_000ns) 디바운스 적용
- `debounceTask`(디바운스 대기)와 `searchTask`(실제 API 호출) 분리하여 취소 로직 명확화
- 테스트 가능한 `sleep` 클로저 주입 이니셜라이저 추가

### 테스트
- `SignUpViewModelTests` 추가
- `SearchChallengerViewModelTests` 추가

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Auth/Presentation/Models/PostRegisterLoginContext.swift` - 소셜 로그인 컨텍스트 모델 설계 확인
- `Features/Auth/Presentation/ViewModels/SignUpViewModel.swift` - `restoreSessionAfterRegisterIfNeeded()` 세션 복구 로직 확인
- `Features/Auth/Presentation/ViewModels/LoginViewModel.swift` - `PostRegisterLoginContext` 생성 및 전달 로직 확인
- `Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift` - 디바운스 Task 분리 및 1초 디바운스 적용 확인
- `Resource/EnvrionmentKey/AppFlowEnvironmentKey.swift` - `showSignUp` 시그니처 변경 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)