### PR TITLE
💄 [Design] 챌린저 검색 화면 X 버튼을 Chevron 뒤로가기로 변경

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
@@ -15,6 +15,8 @@ import UniformTypeIdentifiers
 struct SearchChallengerView: View {
     
     // MARK: - Properties
+
+    @Environment(\.dismiss) private var dismiss
     
     /// 상위 뷰와 공유되는 선택된 챌린저 리스트 바인딩
     @Binding var selectedChallengers: [ChallengerInfo]
@@ -47,14 +49,11 @@ struct SearchChallengerView: View {
         .searchable(text: $viewModel.searchText, prompt: "챌린저를 검색해보세요")
         .searchPresentationToolbarBehavior(.avoidHidingContent)
         .navigation(naviTitle: .searchChallenger, displayMode: .inline)
+        .navigationBarBackButtonHidden()
         .toolbar(content: {
-            // FIXME: - 수정 사항
-            /*
-            ToolBarCollection.LeadingButton(image: "doc.text.fill", action: {
-                // CSV 파일 가져오기 모달 표시
-                viewModel.showCSVImporter = true
+            ToolBarCollection.LeadingButton(image: "chevron.left", action: {
+                dismiss()
             })
-             */
             ToolBarCollection.ConfirmBtn(action: {
                 confirmSelection()
             })

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
@@ -49,11 +49,7 @@ struct SearchChallengerView: View {
         .searchable(text: $viewModel.searchText, prompt: "챌린저를 검색해보세요")
         .searchPresentationToolbarBehavior(.avoidHidingContent)
         .navigation(naviTitle: .searchChallenger, displayMode: .inline)
-        .navigationBarBackButtonHidden()
         .toolbar(content: {
-            ToolBarCollection.LeadingButton(image: "chevron.left", action: {
-                dismiss()
-            })
             ToolBarCollection.ConfirmBtn(action: {
                 confirmSelection()
             })

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift
@@ -34,7 +34,7 @@ struct SelectedChallengerView: View {
                 .navigationSubtitle("총 \(challenger.count)명")
                 .toolbar(content: {
                     // 취소 버튼 (현재 기능 없음)
-                    ToolBarCollection.CancelBtn(action: {})
+                    ToolBarCollection.BackBtn(action: {})
                     
                     // 챌린저 추가 버튼 (검색 화면으로 이동)
                     ToolBarCollection.AddBtn(action: {

--- a/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
+++ b/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
@@ -12,6 +12,23 @@ import SwiftUI
 ///
 /// 취소/확인/추가 등 공통 액션 버튼과 필터 메뉴를 제공합니다.
 struct ToolBarCollection {
+    
+    /// 뒤로 가기 버튼
+    struct BackBtn: ToolbarContent {
+        @Environment(\.dismiss) var dismiss
+        var action: () -> Void
+        
+        var body: some ToolbarContent {
+            ToolbarItem(placement: .cancellationAction, content: {
+                Button(role: .cancel, action: {
+                    action()
+                    dismiss()
+                })
+            })
+        }
+    }
+    
+    
     /// 취소 버튼
     struct CancelBtn: ToolbarContent {
         @Environment(\.dismiss) var dismiss


### PR DESCRIPTION
## ✨ PR 유형

Design - 챌린저 검색 화면 네비게이션 버튼 디자인 변경 (#444)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 검색 화면 좌측 상단 버튼이 chevron.left로 변경된 것을 확인해주세요 -->

## 🛠️ 작업내용

- 챌린저 검색 화면(`SearchChallengerView`) 상단 좌측 버튼을 `chevron.left` 아이콘으로 교체
- 기본 네비게이션 백버튼 숨기고(`navigationBarBackButtonHidden`) 커스텀 `dismiss` 동작 연결
- 미사용 CSV 임포트 버튼 주석 코드 제거

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift` - 커스텀 백버튼 동작 및 dismiss 연결 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)