### PR TITLE
✨ [Feat] 대기 승인 뷰에 로그아웃 및 회원 탈퇴 기능 추가

### DIFF
--- a/AppProduct/AppProduct/Features/Auth/Presentation/Models/PostRegisterLoginContext.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Models/PostRegisterLoginContext.swift
@@ -2,7 +2,7 @@
 //  PostRegisterLoginContext.swift
 //  AppProduct
 //
-//  Created by Codex on 3/10/26.
+//  Created by euijjang97 on 3/10/26.
 //
 
 import Foundation

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/FailedVerificationUMCViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/FailedVerificationUMCViewModel.swift
@@ -1,0 +1,316 @@
+//
+//  FailedVerificationUMCViewModel.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 3/10/26.
+//
+
+import Foundation
+
+/// UMC 챌린저 인증 실패 화면의 상태와 액션을 관리하는 ViewModel
+@Observable
+final class FailedVerificationUMCViewModel {
+
+    // MARK: - Property
+
+    /// 경고 아이콘 애니메이션 활성화 상태
+    var showWarning: Bool = false
+
+    /// 코드 입력 얼럿 표시 상태
+    var showCodeAlert: Bool = false
+
+    /// 공통 알럿 프롬프트 상태
+    var alertPrompt: AlertPrompt?
+
+    /// 전송 중 상태
+    var isSubmitting: Bool = false
+
+    /// 계정 삭제 진행 상태
+    var isDeletingAccount: Bool = false
+
+    /// 로그아웃 진행 상태
+    var isLoggingOut: Bool = false
+
+    /// 입력된 챌린저 코드
+    var challengerCode: String = ""
+
+    // MARK: - Function
+
+    func presentCodeAlert() {
+        showCodeAlert = true
+    }
+
+    func dismissCodeAlert() {
+        challengerCode = ""
+    }
+
+    @MainActor
+    func submitChallengerCode(
+        container: DIContainer,
+        appFlow: AppFlow
+    ) async {
+        let trimmedCode = challengerCode.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        let isAlphanumeric = trimmedCode.unicodeScalars.allSatisfy(
+            CharacterSet.alphanumerics.contains
+        )
+
+        guard trimmedCode.count == 6, isAlphanumeric else {
+            presentInvalidCodePrompt()
+            return
+        }
+
+        isSubmitting = true
+
+        do {
+            try await container.resolve(AuthUseCaseProviding.self)
+                .registerExistingChallengerUseCase
+                .execute(code: trimmedCode)
+            let profile = try await container.resolve(HomeUseCaseProviding.self)
+                .fetchMyProfileUseCase
+                .execute()
+
+            syncProfileToStorage(profile, container: container)
+            isSubmitting = false
+            challengerCode = ""
+            presentSuccessPrompt(appFlow: appFlow)
+        } catch let error as RepositoryError {
+            isSubmitting = false
+            challengerCode = ""
+            presentCodeFailurePrompt(for: error)
+        } catch {
+            isSubmitting = false
+            challengerCode = ""
+            presentInvalidCodePrompt()
+        }
+    }
+
+    func presentDeleteAccountPrompt(
+        container: DIContainer,
+        appFlow: AppFlow,
+        errorHandler: ErrorHandler
+    ) {
+        alertPrompt = AlertPrompt(
+            title: "계정 삭제",
+            message: "계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다. 정말 삭제하시겠습니까?",
+            positiveBtnTitle: "삭제",
+            positiveBtnAction: { [weak self] in
+                guard let self else { return }
+                Task { @MainActor in
+                    await self.deleteAccount(
+                        container: container,
+                        appFlow: appFlow,
+                        errorHandler: errorHandler
+                    )
+                }
+            },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    func presentLogoutPrompt(
+        container: DIContainer,
+        appFlow: AppFlow,
+        errorHandler: ErrorHandler
+    ) {
+        alertPrompt = AlertPrompt(
+            title: "로그아웃",
+            message: "로그아웃하시겠습니까?",
+            positiveBtnTitle: "로그아웃",
+            positiveBtnAction: { [weak self] in
+                guard let self else { return }
+                Task { @MainActor in
+                    await self.logout(
+                        container: container,
+                        appFlow: appFlow,
+                        errorHandler: errorHandler
+                    )
+                }
+            },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    // MARK: - Private Function
+
+    private func presentSuccessPrompt(appFlow: AppFlow) {
+        alertPrompt = AlertPrompt(
+            title: "인증 완료",
+            message: "기존 챌린저로 인증되었습니다.",
+            positiveBtnTitle: "확인",
+            positiveBtnAction: {
+                UserDefaults.standard.set(
+                    true,
+                    forKey: AppStorageKey.canAutoLogin
+                )
+                appFlow.showMain()
+            }
+        )
+    }
+
+    private func presentInvalidCodePrompt() {
+        alertPrompt = AlertPrompt(
+            title: "인증 실패",
+            message: "입력 코드가 존재하지 않습니다.",
+            positiveBtnTitle: "확인"
+        )
+    }
+
+    private func presentCodeFailurePrompt(for error: RepositoryError) {
+        let message: String
+
+        switch error.code {
+        case "CHALLENGER-0002":
+            message = "이미 등록된 사용자입니다."
+        case "CHALLENGER-0012":
+            message = "이미 사용된 챌린저 기록 추가용 코드입니다."
+        case "CHALLENGER-0013":
+            message = "코드에 등록된 사용자 이름이 요청자와 일치하지 않습니다."
+        case "CHALLENGER-0014":
+            message = "코드에 등록된 학교가 요청자 소속과 일치하지 않습니다."
+        case "CHALLENGER-0016":
+            message = "챌린저 기록 코드를 먼저 입력해주세요."
+        default:
+            message = sanitizedErrorMessage(from: error.userMessage)
+        }
+
+        alertPrompt = AlertPrompt(
+            title: "인증 실패",
+            message: message,
+            positiveBtnTitle: "확인"
+        )
+    }
+
+    @MainActor
+    private func logout(
+        container: DIContainer,
+        appFlow: AppFlow,
+        errorHandler: ErrorHandler
+    ) async {
+        guard !isLoggingOut else { return }
+        isLoggingOut = true
+        defer { isLoggingOut = false }
+
+        UserDefaults.standard.set(false, forKey: AppStorageKey.canAutoLogin)
+
+        do {
+            try await container.resolve(NetworkClient.self).logout()
+            container.resetCache()
+            appFlow.showLogin()
+        } catch {
+            errorHandler.handle(
+                error,
+                context: .init(
+                    feature: "Auth",
+                    action: "logoutFromPendingApproval"
+                )
+            )
+        }
+    }
+
+    @MainActor
+    private func deleteAccount(
+        container: DIContainer,
+        appFlow: AppFlow,
+        errorHandler: ErrorHandler
+    ) async {
+        guard !isDeletingAccount else { return }
+        isDeletingAccount = true
+        defer { isDeletingAccount = false }
+
+        do {
+            let provider = container.resolve(MyPageUseCaseProviding.self)
+            try await provider.deleteMemberUseCase.execute()
+            try await container.resolve(NetworkClient.self).logout()
+            container.resetCache()
+            appFlow.showLogin()
+        } catch {
+            errorHandler.handle(
+                error,
+                context: .init(
+                    feature: "Auth",
+                    action: "deleteMemberFromPendingApproval"
+                )
+            )
+        }
+    }
+
+    private func syncProfileToStorage(
+        _ profile: HomeProfileResult,
+        container: DIContainer
+    ) {
+        let defaults = UserDefaults.standard
+        let latestRole = latestHighestPriorityRole(in: profile.roles)
+        let resolvedRole = ManagementTeam.highestPriority(
+            in: profile.roles.map(\.roleType)
+        ) ?? latestRole?.roleType ?? .challenger
+
+        defaults.set(profile.memberId, forKey: AppStorageKey.memberId)
+        defaults.set(profile.schoolId, forKey: AppStorageKey.schoolId)
+        defaults.set(profile.schoolName, forKey: AppStorageKey.schoolName)
+        defaults.set(profile.latestGisuId ?? 0, forKey: AppStorageKey.gisuId)
+        defaults.set(profile.latestChallengerId ?? 0, forKey: AppStorageKey.challengerId)
+        defaults.set(profile.chapterId ?? 0, forKey: AppStorageKey.chapterId)
+        defaults.set(profile.chapterName, forKey: AppStorageKey.chapterName)
+        defaults.set(profile.part?.apiValue ?? "", forKey: AppStorageKey.responsiblePart)
+        defaults.set(
+            latestRole?.organizationType.rawValue ?? OrganizationType.chapter.rawValue,
+            forKey: AppStorageKey.organizationType
+        )
+        defaults.set(
+            latestRole?.organizationId ?? (profile.chapterId ?? 0),
+            forKey: AppStorageKey.organizationId
+        )
+        defaults.set(resolvedRole.rawValue, forKey: AppStorageKey.memberRole)
+        defaults.set(
+            profile.roles.map(\.roleType.rawValue),
+            forKey: AppStorageKey.memberRoles
+        )
+        defaults.set(isApprovedProfile(profile), forKey: AppStorageKey.canAutoLogin)
+
+        container.resolve(UserSessionManager.self).updateRole(resolvedRole)
+        NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
+    }
+
+    private func isApprovedProfile(_ profile: HomeProfileResult) -> Bool {
+        if !profile.generations.isEmpty {
+            return true
+        }
+
+        for seasonType in profile.seasonTypes {
+            if case .gens(let generations) = seasonType, !generations.isEmpty {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func latestHighestPriorityRole(
+        in roles: [ChallengerRole]
+    ) -> ChallengerRole? {
+        guard let latestGisu = roles.map(\.gisu).max() else {
+            return nil
+        }
+
+        return roles
+            .filter { $0.gisu == latestGisu }
+            .max { lhs, rhs in
+                lhs.roleType < rhs.roleType
+            }
+    }
+
+    private func sanitizedErrorMessage(from message: String) -> String {
+        let pattern = #"^[A-Z]+-\d{4}\s*[:\-]?\s*"#
+        let sanitized = message.replacingOccurrences(
+            of: pattern,
+            with: "",
+            options: .regularExpression
+        )
+        let trimmed = sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "인증에 실패했습니다. 다시 시도해주세요." : trimmed
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
@@ -15,8 +15,7 @@ struct FailedVerificationUMC: View {
 
     // MARK: - Property
 
-    /// 경고 아이콘 애니메이션 활성화 상태
-    @State var showWarning: Bool = false
+    @State private var viewModel = FailedVerificationUMCViewModel()
 
     /// URL을 외부 브라우저로 여는 환경 값
     @Environment(\.openURL) private var openURL
@@ -26,17 +25,6 @@ struct FailedVerificationUMC: View {
 
     /// 카카오톡 채널 연동 매니저
     let kakaoPlusManager: KakaoPlusManager = .init()
-
-    /// 코드 입력 얼럿 표시 상태
-    @State private var showCodeAlert: Bool = false
-    /// 공통 알럿 프롬프트 상태
-    @State private var alertPrompt: AlertPrompt?
-    /// 전송 중 상태
-    @State private var isSubmitting: Bool = false
-    /// 계정 삭제 진행 상태
-    @State private var isDeletingAccount: Bool = false
-    /// 입력된 챌린저 코드
-    @State private var challengerCode: String = ""
     
     // MARK: - Constant
 
@@ -83,8 +71,9 @@ struct FailedVerificationUMC: View {
             .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
             .toolbar {
                 ToolBarCollection.FailedVerificationBottomToolbar(
-                    isSubmitting: isSubmitting,
-                    isDeletingAccount: isDeletingAccount,
+                    isSubmitting: viewModel.isSubmitting,
+                    isDeletingAccount: viewModel.isDeletingAccount,
+                    isLoggingOut: viewModel.isLoggingOut,
                     onHome: {
                         if let url = URL(string: Constants.homePageURL) {
                             openURL(url)
@@ -93,24 +82,40 @@ struct FailedVerificationUMC: View {
                     onInquiry: {
                         kakaoPlusManager.openKakaoChannel()
                     },
+                    onLogout: {
+                        viewModel.presentLogoutPrompt(
+                            container: di,
+                            appFlow: appFlow,
+                            errorHandler: errorHandler
+                        )
+                    },
                     onDeleteAccount: {
-                        presentDeleteAccountPrompt()
+                        viewModel.presentDeleteAccountPrompt(
+                            container: di,
+                            appFlow: appFlow,
+                            errorHandler: errorHandler
+                        )
                     }
                 )
             }
-            .alert("기존 챌린저 코드 입력", isPresented: $showCodeAlert) {
-                TextField("6자리 코드", text: $challengerCode)
+            .alert("기존 챌린저 코드 입력", isPresented: $viewModel.showCodeAlert) {
+                TextField("6자리 코드", text: $viewModel.challengerCode)
                     .keyboardType(.asciiCapable)
                 Button("닫기", role: .cancel) {
-                    challengerCode = ""
+                    viewModel.dismissCodeAlert()
                 }
                 Button("전송") {
-                    submitChallengerCode()
+                    Task {
+                        await viewModel.submitChallengerCode(
+                            container: di,
+                            appFlow: appFlow
+                        )
+                    }
                 }
             } message: {
                 Text("운영진에게 발급받은 6자리 코드를 입력해주세요.")
             }
-            .alertPrompt(item: $alertPrompt)
+            .alertPrompt(item: $viewModel.alertPrompt)
         }
     }
     
@@ -126,9 +131,9 @@ struct FailedVerificationUMC: View {
             .aspectRatio(contentMode: .fit)
             .frame(width: Constants.warningIconSize, height: Constants.warningIconSize)
             .foregroundStyle(.red)
-            .symbolEffect(.pulse, isActive: showWarning)
+            .symbolEffect(.pulse, isActive: viewModel.showWarning)
             .task {
-                showWarning.toggle()
+                viewModel.showWarning.toggle()
             }
     }
 
@@ -151,220 +156,18 @@ struct FailedVerificationUMC: View {
     /// 제목/부제목 하단의 기존 챌린저 인증 텍스트 버튼
     private var existingChallengerTextButton: some View {
         Button {
-            showCodeAlert = true
+            viewModel.presentCodeAlert()
         } label: {
             Text(Constants.verifyTextButtonTitle)
                 .underline()
                 .appFont(.callout, weight: .semibold, color: .indigo500)
         }
         .padding(.top, DefaultSpacing.spacing16)
-        .disabled(isSubmitting || isDeletingAccount)
-    }
-
-    // MARK: - Private Function
-
-    /// 기존 챌린저 인증 코드를 서버에 전송합니다.
-    private func submitChallengerCode() {
-        let trimmedCode = challengerCode.trimmingCharacters(in: .whitespacesAndNewlines)
-        let isAlphanumeric = trimmedCode.unicodeScalars.allSatisfy(CharacterSet.alphanumerics.contains)
-        guard trimmedCode.count == 6, isAlphanumeric else {
-            presentInvalidCodePrompt()
-            return
-        }
-
-        isSubmitting = true
-        Task {
-            do {
-                try await di.resolve(AuthUseCaseProviding.self)
-                    .registerExistingChallengerUseCase
-                    .execute(code: trimmedCode)
-                let profile = try await di.resolve(HomeUseCaseProviding.self)
-                    .fetchMyProfileUseCase
-                    .execute()
-                await MainActor.run {
-                    syncProfileToStorage(profile)
-                    isSubmitting = false
-                    challengerCode = ""
-                    presentSuccessPrompt()
-                }
-            } catch let error as RepositoryError {
-                await MainActor.run {
-                    isSubmitting = false
-                    challengerCode = ""
-                    presentCodeFailurePrompt(for: error)
-                }
-            } catch {
-                await MainActor.run {
-                    isSubmitting = false
-                    challengerCode = ""
-                    presentInvalidCodePrompt()
-                }
-            }
-        }
-    }
-
-    /// 인증 성공 안내 프롬프트를 표시합니다.
-    private func presentSuccessPrompt() {
-        alertPrompt = AlertPrompt(
-            title: "인증 완료",
-            message: "기존 챌린저로 인증되었습니다.",
-            positiveBtnTitle: "확인",
-            positiveBtnAction: {
-                UserDefaults.standard.set(
-                    true,
-                    forKey: AppStorageKey.canAutoLogin
-                )
-                appFlow.showMain()
-            }
+        .disabled(
+            viewModel.isSubmitting ||
+            viewModel.isDeletingAccount ||
+            viewModel.isLoggingOut
         )
-    }
-
-    /// 인증 실패 안내 프롬프트를 표시합니다.
-    private func presentInvalidCodePrompt() {
-        alertPrompt = AlertPrompt(
-            title: "인증 실패",
-            message: "입력 코드가 존재하지 않습니다.",
-            positiveBtnTitle: "확인"
-        )
-    }
-
-    /// 서버 에러 코드에 맞는 인증 실패 안내 프롬프트를 표시합니다.
-    private func presentCodeFailurePrompt(for error: RepositoryError) {
-        let message: String
-
-        switch error.code {
-        case "CHALLENGER-0002":
-            message = "이미 등록된 사용자입니다."
-        case "CHALLENGER-0012":
-            message = "이미 사용된 챌린저 기록 추가용 코드입니다."
-        case "CHALLENGER-0013":
-            message = "코드에 등록된 사용자 이름이 요청자와 일치하지 않습니다."
-        case "CHALLENGER-0014":
-            message = "코드에 등록된 학교가 요청자 소속과 일치하지 않습니다."
-        case "CHALLENGER-0016":
-            message = "챌린저 기록 코드를 먼저 입력해주세요."
-        default:
-            message = sanitizedErrorMessage(from: error.userMessage)
-        }
-
-        alertPrompt = AlertPrompt(
-            title: "인증 실패",
-            message: message,
-            positiveBtnTitle: "확인"
-        )
-    }
-
-    /// 계정 삭제 확인 프롬프트를 표시합니다.
-    private func presentDeleteAccountPrompt() {
-        alertPrompt = AlertPrompt(
-            title: "계정 삭제",
-            message: "계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다. 정말 삭제하시겠습니까?",
-            positiveBtnTitle: "삭제",
-            positiveBtnAction: {
-                Task {
-                    await deleteAccount()
-                }
-            },
-            negativeBtnTitle: "취소",
-            isPositiveBtnDestructive: true
-        )
-    }
-
-    /// 승인 대기 화면에서 계정 삭제를 수행합니다.
-    @MainActor
-    private func deleteAccount() async {
-        guard !isDeletingAccount else { return }
-        isDeletingAccount = true
-        defer { isDeletingAccount = false }
-
-        do {
-            let provider = di.resolve(MyPageUseCaseProviding.self)
-            try await provider.deleteMemberUseCase.execute()
-            try await di.resolve(NetworkClient.self).logout()
-            di.resetCache()
-            appFlow.showLogin()
-        } catch {
-            errorHandler.handle(
-                error,
-                context: .init(
-                    feature: "Auth",
-                    action: "deleteMemberFromPendingApproval"
-                )
-            )
-        }
-    }
-
-    private func syncProfileToStorage(_ profile: HomeProfileResult) {
-        let defaults = UserDefaults.standard
-        let latestRole = latestHighestPriorityRole(in: profile.roles)
-        let resolvedRole = ManagementTeam.highestPriority(
-            in: profile.roles.map(\.roleType)
-        ) ?? latestRole?.roleType ?? .challenger
-
-        defaults.set(profile.memberId, forKey: AppStorageKey.memberId)
-        defaults.set(profile.schoolId, forKey: AppStorageKey.schoolId)
-        defaults.set(profile.schoolName, forKey: AppStorageKey.schoolName)
-        defaults.set(profile.latestGisuId ?? 0, forKey: AppStorageKey.gisuId)
-        defaults.set(profile.latestChallengerId ?? 0, forKey: AppStorageKey.challengerId)
-        defaults.set(profile.chapterId ?? 0, forKey: AppStorageKey.chapterId)
-        defaults.set(profile.chapterName, forKey: AppStorageKey.chapterName)
-        defaults.set(profile.part?.apiValue ?? "", forKey: AppStorageKey.responsiblePart)
-        defaults.set(
-            latestRole?.organizationType.rawValue ?? OrganizationType.chapter.rawValue,
-            forKey: AppStorageKey.organizationType
-        )
-        defaults.set(
-            latestRole?.organizationId ?? (profile.chapterId ?? 0),
-            forKey: AppStorageKey.organizationId
-        )
-        defaults.set(resolvedRole.rawValue, forKey: AppStorageKey.memberRole)
-        defaults.set(
-            profile.roles.map(\.roleType.rawValue),
-            forKey: AppStorageKey.memberRoles
-        )
-        defaults.set(isApprovedProfile(profile), forKey: AppStorageKey.canAutoLogin)
-
-        di.resolve(UserSessionManager.self).updateRole(resolvedRole)
-        NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
-    }
-
-    private func isApprovedProfile(_ profile: HomeProfileResult) -> Bool {
-        if !profile.generations.isEmpty {
-            return true
-        }
-
-        for seasonType in profile.seasonTypes {
-            if case .gens(let generations) = seasonType, !generations.isEmpty {
-                return true
-            }
-        }
-
-        return false
-    }
-
-    private func latestHighestPriorityRole(
-        in roles: [ChallengerRole]
-    ) -> ChallengerRole? {
-        guard let latestGisu = roles.map(\.gisu).max() else {
-            return nil
-        }
-
-        return roles
-            .filter { $0.gisu == latestGisu }
-            .max { lhs, rhs in
-                lhs.roleType < rhs.roleType
-            }
-    }
-
-    private func sanitizedErrorMessage(from message: String) -> String {
-        let pattern = #"^[A-Z]+-\d{4}\s*[:\-]?\s*"#
-        let sanitized = message.replacingOccurrences(
-            of: pattern,
-            with: "",
-            options: .regularExpression
-        )
-        let trimmed = sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? "인증에 실패했습니다. 다시 시도해주세요." : trimmed
     }
 }
 

--- a/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
+++ b/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
@@ -629,8 +629,10 @@ struct ToolBarCollection {
     struct FailedVerificationBottomToolbar: ToolbarContent {
         let isSubmitting: Bool
         let isDeletingAccount: Bool
+        let isLoggingOut: Bool
         let onHome: () -> Void
         let onInquiry: () -> Void
+        let onLogout: () -> Void
         let onDeleteAccount: () -> Void
 
         private enum Constants {
@@ -659,13 +661,22 @@ struct ToolBarCollection {
             }
 
             ToolbarItem(placement: .bottomBar) {
-                actionButton(
-                    icon: "person.crop.circle.badge.xmark",
-                    title: "계정 삭제",
-                    color: .red,
-                    disabled: isSubmitting || isDeletingAccount,
-                    action: onDeleteAccount
-                )
+                Menu {
+                    Button(action: onLogout) {
+                        Label("로그아웃", systemImage: "rectangle.portrait.and.arrow.right")
+                    }
+
+                    Button(role: .destructive, action: onDeleteAccount) {
+                        Label("회원 탈퇴", systemImage: "person.crop.circle.badge.xmark")
+                    }
+                } label: {
+                    actionLabel(
+                        icon: "person.crop.circle.badge.xmark",
+                        title: "계정",
+                        color: .red
+                    )
+                }
+                .disabled(isSubmitting || isDeletingAccount || isLoggingOut)
             }
         }
 
@@ -690,6 +701,24 @@ struct ToolBarCollection {
                 .frame(maxWidth: .infinity)
             }
             .disabled(disabled)
+        }
+
+        private func actionLabel(
+            icon: String,
+            title: String,
+            color: Color
+        ) -> some View {
+            VStack(spacing: DefaultSpacing.spacing4) {
+                Image(systemName: icon)
+                    .font(.system(size: Constants.iconSize, weight: .semibold))
+                    .foregroundStyle(color)
+
+                Text(title)
+                    .appFont(.caption2, weight: .medium, color: .black)
+                    .lineLimit(1)
+            }
+            .padding()
+            .frame(maxWidth: .infinity)
         }
     }
 }

--- a/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
+++ b/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
@@ -2,7 +2,7 @@
 //  SignUpViewModelTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/10/26.
+//  Created by euijjang97 on 3/10/26.
 //
 
 @testable import AppProduct

--- a/AppProduct/AppProductTests/CommunityTest/CommunityPostViewModelTests.swift
+++ b/AppProduct/AppProductTests/CommunityTest/CommunityPostViewModelTests.swift
@@ -2,7 +2,7 @@
 //  CommunityPostViewModelTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/10/26.
+//  Created by euijjang97 on 3/10/26.
 //
 
 @testable import AppProduct

--- a/AppProduct/AppProductTests/HomeTest/ScheduleClassifierRegressionTests.swift
+++ b/AppProduct/AppProductTests/HomeTest/ScheduleClassifierRegressionTests.swift
@@ -2,7 +2,7 @@
 //  ScheduleClassifierRegressionTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/10/26.
+//  Created by euijjang97 on 3/10/26.
 //
 
 @testable import AppProduct

--- a/AppProduct/AppProductTests/HomeTest/SearchChallengerViewModelTests.swift
+++ b/AppProduct/AppProductTests/HomeTest/SearchChallengerViewModelTests.swift
@@ -2,7 +2,7 @@
 //  SearchChallengerViewModelTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/10/26.
+//  Created by euijjang97 on 3/10/26.
 //
 
 @testable import AppProduct


### PR DESCRIPTION
## ✨ PR 유형

Feature - 대기 승인(FailedVerification) 화면에 로그아웃/회원 탈퇴 기능 추가 (#456)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 대기 승인 화면 하단 "계정" 버튼 탭 시 로그아웃/회원 탈퇴 메뉴가 표시되는지 확인해주세요 -->

## 🛠️ 작업내용

### ViewModel 분리
- `FailedVerificationUMCViewModel` 신규 생성 — View에 있던 모든 상태/로직을 `@Observable` ViewModel로 이관
- 챌린저 코드 제출, 프로필 동기화, 계정 삭제 로직 모두 ViewModel로 이동

### 로그아웃 기능 추가
- `presentLogoutPrompt()` — 로그아웃 확인 Alert 표시
- `logout()` — canAutoLogin 해제 → 세션 정리 → 로그인 화면 이동
- `isLoggingOut` 상태로 중복 호출 방지

### 하단 툴바 UI 변경
- 기존 "계정 삭제" 단독 버튼 → `Menu`로 변경 (로그아웃 / 회원 탈퇴 선택)
- `ToolBarCollection.FailedVerificationBottomToolbar`에 `onLogout`, `isLoggingOut` 파라미터 추가

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Auth/Presentation/ViewModels/FailedVerificationUMCViewModel.swift` - ViewModel 전체 로직 (로그아웃/삭제/코드 제출) 확인
- `Features/Auth/Presentation/Views/FailedVerificationUMC.swift` - View에서 ViewModel 바인딩 및 로직 제거 확인
- `Utilities/ToolBar/ToolBarCollection.swift` - FailedVerificationBottomToolbar Menu UI 및 actionLabel 헬퍼 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)