### PR TITLE
💄 [Design] 오픈채팅방 배너 '참여 전 소통하기' 텍스트 색상 가독성 개선

### DIFF
--- a/AppProduct/AppProduct/Features/Community/Presentation/Components/CommunityPostCard/CommunityPostCard.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/Components/CommunityPostCard/CommunityPostCard.swift
@@ -111,7 +111,7 @@ struct CommunityPostCard: View {
                     Text("오픈채팅방으로 이동")
                         .appFont(.subheadlineEmphasis, color: .black)
                     Text("참여 전 소통하기")
-                        .appFont(.footnote, color: .grey300)
+                        .appFont(.footnote, color: .black.opacity(0.72))
                 }
                 Spacer()
                 Image(systemName: "chevron.right")


### PR DESCRIPTION
## ✨ PR 유형

Design - 번개글 오픈채팅방 이동 배너 텍스트 색상 개선 (#455)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 번개글 상세 화면의 오픈채팅방 배너에서 '참여 전 소통하기' 텍스트 가독성을 확인해주세요 -->

## 🛠️ 작업내용

- `CommunityPostCard`의 오픈채팅방 배너 "참여 전 소통하기" 텍스트 색상 변경
- `grey300` → `black.opacity(0.72)`로 변경하여 노란색 배경 대비 가독성 향상

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Community/Presentation/Components/CommunityPostCard/CommunityPostCard.swift` - 텍스트 색상 변경 및 노란 배경 대비 가독성 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)