### PR TITLE
✨ [Feat] 챌린저 검색 초기 화면에 ContentUnavailableView 표시

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
@@ -93,8 +93,14 @@ final class SearchChallengerViewModel {
     /// 화면 진입 또는 검색어 초기화 시 현재 검색 조건으로 첫 페이지를 로드합니다.
     @MainActor
     func loadInitialChallengers() async {
-        let requestID = prepareSearch(keyword: normalizedSearchText)
-        await fetchChallengers(keyword: normalizedSearchText, requestID: requestID)
+        let keyword = normalizedSearchText
+        guard !keyword.isEmpty else {
+            resetSearchState()
+            return
+        }
+
+        let requestID = prepareSearch(keyword: keyword)
+        await fetchChallengers(keyword: keyword, requestID: requestID)
     }
 
     /// 검색어 변경 시 디바운스를 적용해 챌린저 목록을 다시 조회합니다.
@@ -102,6 +108,13 @@ final class SearchChallengerViewModel {
     func scheduleSearch() {
         debounceTask?.cancel()
         let keyword = normalizedSearchText
+        guard !keyword.isEmpty else {
+            searchTask?.cancel()
+            latestRequestID = UUID()
+            resetSearchState()
+            return
+        }
+
         let requestID = prepareSearch(keyword: keyword)
 
         debounceTask = Task { [weak self] in
@@ -190,6 +203,16 @@ private extension SearchChallengerViewModel {
 
     var normalizedSearchText: String {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    @MainActor
+    func resetSearchState() {
+        allChallengers = []
+        currentKeyword = ""
+        nextCursor = nil
+        hasNext = false
+        isFetchingNextPage = false
+        loadState = .idle
     }
 }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
@@ -29,6 +29,9 @@ struct SearchChallengerView: View {
         static let failedTitle: String = "챌린저 검색에 실패했어요"
         static let failedSystemImage: String = "exclamationmark.triangle"
         static let failedRetryTitle: String = "다시 시도"
+        static let initialEmptyTitle: String = "검색된 챌린저가 없습니다"
+        static let initialEmptyDescription: String = "이름, 닉네임, 학교명으로 챌린저를 검색해보세요."
+        static let initialEmptySystemImage: String = "magnifyingglass"
     }
     
     // MARK: - Init
@@ -69,7 +72,6 @@ struct SearchChallengerView: View {
         .alertPrompt(item: $viewModel.alertPrompt)
         .task {
             initializeSelectedIds()
-            await viewModel.loadInitialChallengers()
         }
         .onChange(of: viewModel.searchText) {
             viewModel.scheduleSearch()
@@ -84,7 +86,10 @@ struct SearchChallengerView: View {
     @ViewBuilder
     private var stateContent: some View {
         switch viewModel.loadState {
-        case .idle, .loading:
+        case .idle:
+            initialEmptyView
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .loading:
             Progress(message: Constants.loadingMessage, size: .regular)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         case .loaded:
@@ -113,6 +118,14 @@ struct SearchChallengerView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    private var initialEmptyView: some View {
+        ContentUnavailableView(
+            Constants.initialEmptyTitle,
+            systemImage: Constants.initialEmptySystemImage,
+            description: Text(Constants.initialEmptyDescription)
+        )
     }
 
     /// 검색 결과가 없을 때 표시되는 뷰

--- a/AppProduct/AppProductTests/HomeTest/SearchChallengerViewModelTests.swift
+++ b/AppProduct/AppProductTests/HomeTest/SearchChallengerViewModelTests.swift
@@ -10,6 +10,29 @@ import Testing
 
 struct SearchChallengerViewModelTests {
 
+    @Test("검색어 없이 초기 진입하면 챌린저 검색 요청을 보내지 않는다")
+    func initialLoadWithoutKeywordDoesNotRequestSearch() async throws {
+        let useCase = MockSearchChallengersUseCase()
+        let viewModel = await MainActor.run {
+            SearchChallengerViewModel(searchChallengersUseCase: useCase)
+        }
+
+        await MainActor.run {
+            viewModel.searchText = "   "
+        }
+        await viewModel.loadInitialChallengers()
+
+        let snapshot = await useCase.snapshot()
+        #expect(snapshot.keywords.isEmpty)
+        let isIdle = await MainActor.run {
+            if case .idle = viewModel.loadState {
+                return true
+            }
+            return false
+        }
+        #expect(isIdle)
+    }
+
     @Test("챌린저 검색은 1초 디바운스 후 마지막 입력만 요청한다")
     func searchUsesOneSecondDebounce() async throws {
         let useCase = MockSearchChallengersUseCase()


### PR DESCRIPTION
## ✨ PR 유형

Feature - 챌린저 검색 화면 초기 진입 시 빈 상태 안내 UI 추가 (#454)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 검색 화면 진입 시 "검색된 챌린저가 없습니다" ContentUnavailableView가 표시되는지 확인해주세요 -->

## 🛠️ 작업내용

- 검색어 없이 화면 진입 시 자동 전체 챌린저 검색 API 호출 제거
- `SearchChallengerViewModel`에 `resetSearchState()` 추가 — 빈 검색어일 때 상태를 idle로 초기화
- `scheduleSearch()`에서 빈 검색어 입력 시 진행 중 태스크 취소 및 상태 리셋 처리
- `SearchChallengerView`에 `initialEmptyView` 추가 — `ContentUnavailableView`로 "검색된 챌린저가 없습니다" 안내 표시
- `idle`/`loading` 상태 분리하여 각각 빈 상태 안내/로딩 UI 표시
- `SearchChallengerViewModelTests`에 빈 검색어 테스트 추가

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift` - `resetSearchState()` 및 빈 검색어 가드 로직 확인
- `Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift` - idle 상태에서 `ContentUnavailableView` 표시 및 초기 API 호출 제거 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)