### PR TITLE
✨ [Feat] 활동탭 출석 마감 이후 사유 제출 버튼 숨김 처리

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift
@@ -63,7 +63,9 @@ struct ChallengerAttendanceView: View, Equatable {
                 mapPlaceholder
             }
             attendanceActionView
-            lateReasonButton
+            if attendanceViewModel.shouldShowReasonButton(for: session) {
+                lateReasonButton
+            }
         }
         .animation(.smooth, value: session.attendanceStatus)
         .animation(.easeInOut(duration: 0.2), value: isMapReady)
@@ -286,7 +288,7 @@ private struct ChallengerAttendanceScenarioPreview: View {
 #Preview("마감 후 불참 사유") {
     ChallengerAttendanceScenarioPreview(
         title: "불참 사유 제출 세션",
-        subtitle: "출석 마감 후에도 사유 제출 가능, absent reason 경로 사용",
+        subtitle: "출석 마감 후에는 사유 제출 버튼이 숨김 처리됨",
         timeWindow: .expired
     )
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
@@ -267,6 +267,10 @@ final class ChallengerAttendanceViewModel {
         session.canSubmitReason()
     }
 
+    func shouldShowReasonButton(for session: Session) -> Bool {
+        currentTimeWindow(for: session.info) != .expired
+    }
+
     func buttonStyle(for session: Session) -> String {
         session.buttonTitle(
             isLocationAuthorized: challengeAttendanceUseCase.isLocationAuthorized,


### PR DESCRIPTION
## ✨ PR 유형

Feature - 출석 마감 이후 사유 제출 버튼 숨김 처리 (#453)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 출석 마감 전/후 상태에서 사유 제출 버튼 노출 여부를 확인해주세요 -->

## 🛠️ 작업내용

- `ChallengerAttendanceViewModel`에 `shouldShowReasonButton(for:)` 메서드 추가
- `currentTimeWindow`가 `.expired`인 경우 사유 제출 버튼 숨김 처리
- `ChallengerAttendanceView`에서 `lateReasonButton` 조건부 렌더링 적용
- Preview 시나리오 설명 업데이트

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift` - `shouldShowReasonButton` 로직 확인 (expired 판단 기준)
- `Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift` - 조건부 렌더링 및 애니메이션 동작 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)