### PR TITLE
🐛 [Fix] 홈 일정 목록 스크롤 위치 초기화 문제 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ScheduleData.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ScheduleData.swift
@@ -13,7 +13,7 @@ import Foundation
 struct ScheduleData: Equatable, Identifiable {
 
     /// 고유 식별자
-    var id: UUID = .init()
+    var id: Int { scheduleId }
 
     /// 일정 서버 ID
     let scheduleId: Int


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 홈 일정 목록이 많을 때 스크롤이 강제 상단으로 올라가는 문제 수정 (#452)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 일정이 많은 상태에서 스크롤 후 위치가 유지되는지 확인해주세요 -->

## 🛠️ 작업내용

- `ScheduleData.id`를 `UUID()` → `scheduleId`(서버 ID) 기반 computed property로 변경
- 기존: 데이터 리프레시마다 새 UUID가 생성되어 SwiftUI가 전체 뷰를 재생성 → 스크롤 위치 초기화
- 변경: 서버 ID 기반 안정적 식별자로 동일 데이터는 뷰가 재사용되어 스크롤 위치 유지

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Home/Domain/Models/Home/ScheduleData.swift` - `id` computed property가 `scheduleId`를 반환하므로 scheduleId 유일성 보장 여부 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)