### PR TITLE
🐛 [Fix] 커리큘럼 주차 필터 중복 weekNo 크래시 방지

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
@@ -286,10 +286,11 @@ final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
             APIResponse<CurriculumWeeksDTO>.self,
             from: response.data
         )
-        let weeks = try apiResponse.unwrap()
-            .weeks
-            .compactMap { Int($0.weekNo) }
-            .sorted()
+        let weeks = Array(Set(
+            try apiResponse.unwrap()
+                .weeks
+                .compactMap { Int($0.weekNo) }
+        )).sorted()
 
         return weeks
     }


### PR DESCRIPTION
## ✨ PR 유형

🐛 Bug Fix

## 🛠️ 작업내용
- `StudyRepository.fetchWeeks()`에서 API 응답의 중복 weekNo를 제거하도록 `Array(Set(...)).sorted()` 적용
- `ToolBarCollection`의 `CommunityWeekFilter`, `StudyWeekFilter`에서 `ForEach(weeks, id: \.self)` 사용 시 중복 ID로 인한 SwiftUI 크래시 방지

#### 화면 확인
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/52aa2e04-80ae-4f0c-9bfd-4172bd507235" />

## 📋 추후 진행 상황

- 서버 측 중복 weekNo 반환 원인 확인 필요

## 📌 리뷰 포인트

- `Features/Activity/Data/Repositories/StudyRepository.swift` — `fetchWeeks()` 중복 제거 로직 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #460