### PR TITLE
💄 [Design] 일정 생성 출석부 확인을 confirmationDialog로 전환

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -59,8 +59,6 @@ class ScheduleRegistrationViewModel {
     /// 일정 생성 API 상태 (로딩 overlay + 성공 시 dismiss 제어)
     private(set) var submitState: Loadable<Bool> = .idle
 
-    /// 출석부 포함 여부 확인 Alert 데이터
-    var alertPrompt: AlertPrompt?
     /// 수정 모드일 때 대상 일정 ID
     private(set) var editingScheduleId: Int?
     /// 수정 모드 초기값 스냅샷
@@ -260,33 +258,5 @@ class ScheduleRegistrationViewModel {
                 }
             ))
         }
-    }
-    
-    /// 운영진용 일정 생성 Alert을 표시합니다.
-    ///
-    /// 출석부 동시 생성 여부를 선택하는 3버튼 Alert을 띄웁니다.
-    /// - Parameter gisuId: 기수 식별 ID
-    func alertAction(gisuId: Int) {
-        alertPrompt = AlertPrompt(
-            title: "일정 생성",
-            message: "출석을 체크하시겠습니까?",
-            positiveBtnTitle: "네, 출석부도 같이 생성할게요",
-            positiveBtnAction: { [weak self] in
-                Task { @MainActor in
-                    await self?.submitSchedule(
-                        gisuId: gisuId, requiresApproval: true
-                    )
-                }
-            },
-            secondaryBtnTitle: "아니요, 일정만 생성할게요",
-            secondaryBtnAction: { [weak self] in
-                Task { @MainActor in
-                    await self?.submitSchedule(
-                        gisuId: gisuId, requiresApproval: false
-                    )
-                }
-            },
-            negativeBtnTitle: "취소"
-        )
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -24,6 +24,7 @@ struct ScheduleRegistrationView: View {
 
     @AppStorage(AppStorageKey.gisuId) private var gisuId: Int = 0
     @AppStorage(AppStorageKey.memberRole) private var memberRole: ManagementTeam = .challenger
+    @State private var showApprovalConfirmationDialog: Bool = false
     private let mode: Mode
 
     enum Mode {
@@ -64,7 +65,33 @@ struct ScheduleRegistrationView: View {
         .scrollDismissesKeyboard(.immediately) // 스크롤 시 키보드 내림
         .navigation(naviTitle: navigationTitle, displayMode: .inline)
         .toolbar { toolbarContent }
-        .alertPrompt(item: $viewModel.alertPrompt)
+        .confirmationDialog(
+            "일정 생성",
+            isPresented: $showApprovalConfirmationDialog,
+            titleVisibility: .visible
+        ) {
+            Button("네, 출석부 생성합니다") {
+                Task {
+                    await viewModel.submitSchedule(
+                        gisuId: gisuId,
+                        requiresApproval: true
+                    )
+                }
+            }
+
+            Button("아니요, 일정만 생성할게요") {
+                Task {
+                    await viewModel.submitSchedule(
+                        gisuId: gisuId,
+                        requiresApproval: false
+                    )
+                }
+            }
+
+            Button("취소", role: .cancel) {}
+        } message: {
+            Text("출석을 체크하시겠습니까?")
+        }
         .overlay { submittingOverlay }
         // 생성 성공 시 화면 자동 닫기
         .onChange(of: viewModel.submitState) {
@@ -169,7 +196,7 @@ struct ScheduleRegistrationView: View {
                 )
             }
         } else {
-            viewModel.alertAction(gisuId: gisuId)
+            showApprovalConfirmationDialog = true
         }
     }
     


### PR DESCRIPTION
## ✨ PR 유형

Design - 일정 생성 시 출석부 생성 확인 UI를 confirmationDialog로 전환 (#451)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- iOS 26 Liquid Glass 스타일의 confirmationDialog가 정상 표시되는지 확인해주세요 -->

## 🛠️ 작업내용

- 일정 생성 시 출석부 생성 확인을 `AlertPrompt` 기반 3버튼 Alert → SwiftUI `confirmationDialog`로 전환
- iOS 26 Liquid Glass 스타일 자동 적용 (긍정 버튼 파란색 배경)
- `ScheduleRegistrationViewModel`에서 `alertAction()`, `alertPrompt` 프로퍼티 제거
- `ScheduleRegistrationView`에서 `showApprovalConfirmationDialog` 상태로 다이얼로그 직접 제어
- `submitSchedule` 호출을 View의 confirmationDialog 버튼에서 직접 수행

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift` - confirmationDialog 구성 및 submitSchedule 호출 확인
- `Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift` - alertAction/alertPrompt 제거 후 submitSchedule 접근 제어 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)