### PR TITLE
🐛 [Fix] 공지사항 작성 시 기수 표시값 및 지부 필터링 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
@@ -77,7 +77,8 @@ extension NoticeDTO {
             images: [],  // 기본 조회에는 없음
             vote: nil,
             viewCount: Int(viewCount) ?? 0,
-            scopeDisplayName: scopeDisplayName
+            scopeDisplayName: scopeDisplayName,
+            targetsAllGenerations: targetInfo.targetsAllGenerations
         )
     }
 }
@@ -151,9 +152,20 @@ struct NoticeTargetInfoDTO: Codable {
             .first(where: { !$0.isEmpty })
     }
 
+    var resolvedSchoolName: String? {
+        let candidates = [targetSchoolName, schoolName]
+        return candidates
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { !$0.isEmpty })
+    }
+
     var targetChapterIdValue: Int? {
         guard let targetChapterId else { return nil }
         return Int(targetChapterId)
+    }
+
+    var targetsAllGenerations: Bool {
+        generationValue <= 0
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
@@ -62,12 +62,13 @@ extension NoticeTargetInfoDTO {
     // MARK: - Function
     /// TargetAudience 도메인 모델로 변환합니다.
     func toTargetAudience(scope: NoticeScope? = nil) -> TargetAudience {
-        TargetAudience(
+        let targetScope = scope ?? resolvedScope
+        return TargetAudience(
             generation: generationValue,
-            scope: scope ?? resolvedScope,
+            scope: targetScope,
             parts: resolvedParts,
-            branches: [],
-            schools: []
+            branches: targetScope == .branch ? [resolvedChapterName].compactMap { $0 } : [],
+            schools: targetScope == .campus ? [resolvedSchoolName].compactMap { $0 } : []
         )
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeEditorTargetRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeEditorTargetRepository.swift
@@ -41,6 +41,14 @@ struct NoticeEditorTargetRepository: NoticeEditorTargetRepositoryProtocol {
         }
     }
 
+    /// 기수별 지부/학교 응답에서 지부 목록만 추출합니다.
+    func fetchBranches(gisuId: Int) async throws -> [NoticeTargetOption] {
+        try await fetchChaptersWithSchools(gisuId: gisuId).compactMap { chapter in
+            guard let id = Int(chapter.chapterId) else { return nil }
+            return NoticeTargetOption(id: id, name: chapter.chapterName)
+        }
+    }
+
     /// 지부 ID로 지부명을 조회합니다.
     func fetchBranchName(chapterId: Int) async throws -> String {
         let response = try await adapter.request(NoticeEditorTargetRouter.getChapter(chapterId: chapterId))
@@ -64,16 +72,24 @@ struct NoticeEditorTargetRepository: NoticeEditorTargetRepositoryProtocol {
         }
     }
 
+    /// 기수별 지부/학교 응답을 평탄화해 학교 목록을 반환합니다.
+    func fetchSchools(gisuId: Int) async throws -> [NoticeTargetOption] {
+        let chapters = try await fetchChaptersWithSchools(gisuId: gisuId)
+        let schools = chapters.flatMap(\.schools)
+        let uniqueSchools = Dictionary(grouping: schools, by: \.schoolId).compactMap { _, grouped in
+            grouped.first
+        }
+
+        return uniqueSchools.compactMap { school in
+            guard let id = Int(school.schoolId) else { return nil }
+            return NoticeTargetOption(id: id, name: school.schoolName)
+        }
+        .sorted { $0.name < $1.name }
+    }
+
     /// 기수별 지부/학교 조회 API 결과에서 내 지부의 학교만 추출합니다.
     func fetchSchools(inChapterId chapterId: Int, gisuId: Int) async throws -> [NoticeTargetOption] {
-        let response = try await adapter.request(
-            NoticeEditorTargetRouter.getChaptersWithSchools(gisuId: gisuId)
-        )
-        let apiResponse = try decoder.decode(
-            APIResponse<ChapterWithSchoolsResponseDTO>.self,
-            from: response.data
-        )
-        let chapters = try apiResponse.unwrap().chapters
+        let chapters = try await fetchChaptersWithSchools(gisuId: gisuId)
         let chapterIdString = String(chapterId)
         let targetSchools = chapters
             .first(where: { $0.chapterId == chapterIdString })?
@@ -82,5 +98,19 @@ struct NoticeEditorTargetRepository: NoticeEditorTargetRepositoryProtocol {
             guard let id = Int(school.schoolId) else { return nil }
             return NoticeTargetOption(id: id, name: school.schoolName)
         }
+    }
+
+    // MARK: - Private
+
+    /// 기수별 지부/학교 응답을 공통 디코딩합니다.
+    private func fetchChaptersWithSchools(gisuId: Int) async throws -> [ChapterWithSchoolsDTO] {
+        let response = try await adapter.request(
+            NoticeEditorTargetRouter.getChaptersWithSchools(gisuId: gisuId)
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<ChapterWithSchoolsResponseDTO>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap().chapters
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
@@ -415,7 +415,8 @@ private extension NoticeDetail {
             links: links,
             images: images,
             vote: vote,
-            viewCount: 0
+            viewCount: 0,
+            targetsAllGenerations: targetAudience.generation <= 0
         )
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Domain/Enums/NoticeItemTag.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Enums/NoticeItemTag.swift
@@ -12,40 +12,6 @@ struct NoticeItemTag: Equatable {
 
     // MARK: - Property
 
-    let scope: NoticeScope
-    let category: NoticeCategory
-    let scopeDisplayName: String?
-
-    // MARK: - Computed Property
-
-    /// 태그 텍스트
-    var text: String {
-        switch category {
-        case .general:
-            switch scope {
-            case .central: return "중앙"
-            case .branch:
-                let displayName = scopeDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                return displayName.isEmpty ? "지부" : displayName
-            case .campus: return "교내"
-            }
-        case .part(let part):
-            return NoticePart(umcPartType: part)?.displayName ?? "파트"
-        }
-    }
-
-    /// 태그 배경색
-    var backColor: Color {
-        switch category {
-        case .general:
-            switch scope {
-            case .central: return .blue
-            case .branch: return .orange500
-            case .campus: return .green500
-            }
-        case .part(let part):
-            // Activity 탭과 동일한 파트 색상 규칙을 사용합니다.
-            return part.color
-        }
-    }
+    let text: String
+    let backColor: Color
 }

--- a/AppProduct/AppProduct/Features/Notice/Domain/Interfaces/NoticeEditorTargetRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Interfaces/NoticeEditorTargetRepositoryProtocol.swift
@@ -11,10 +11,14 @@ import Foundation
 protocol NoticeEditorTargetRepositoryProtocol {
     /// 전체 지부 목록을 조회합니다.
     func fetchAllBranches() async throws -> [NoticeTargetOption]
+    /// 특정 기수에 속한 지부 목록을 조회합니다.
+    func fetchBranches(gisuId: Int) async throws -> [NoticeTargetOption]
     /// 지부 ID로 지부명을 조회합니다.
     func fetchBranchName(chapterId: Int) async throws -> String
     /// 전체 학교 목록을 조회합니다.
     func fetchAllSchools() async throws -> [NoticeTargetOption]
+    /// 특정 기수에 속한 학교 목록을 조회합니다.
+    func fetchSchools(gisuId: Int) async throws -> [NoticeTargetOption]
     /// 특정 지부(챕터)에 속한 학교 목록을 조회합니다.
     /// - Parameters:
     ///   - chapterId: 지부 ID

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
@@ -79,6 +79,28 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
         }
     }
 
+    /// 목록/상세에서 공통으로 사용할 태그 목록
+    var tags: [NoticeItemTag] {
+        NoticeItemModel(
+            noticeId: id,
+            generation: generation,
+            scope: scope,
+            category: category,
+            mustRead: isMustRead,
+            isAlert: false,
+            date: createdAt,
+            title: title,
+            content: content,
+            writer: authorName,
+            links: links,
+            images: images,
+            vote: vote,
+            viewCount: 0,
+            scopeDisplayName: targetAudience.branches.first,
+            targetsAllGenerations: targetAudience.generation <= 0
+        ).tags
+    }
+
     init(
         id: String,
         generation: Int,
@@ -139,35 +161,32 @@ struct TargetAudience: Equatable, Hashable {
     let branches: [String]
     let schools: [String]
     
-    /// 수신 대상 표시 텍스트 (예: "12기 / 전체")
+    /// 수신 대상 표시 텍스트
+    ///
+    /// 레거시 호환용 속성입니다. 신규 UI는 `NoticeDetail.tags`를 사용합니다.
     var displayText: String {
-        var components: [String] = ["\(generation)기"]
-        
-        switch scope {
-        case .central:
-            if parts.isEmpty {
-                components.append("전체")
-            } else {
-                components.append(
-                    parts.map { NoticePart(umcPartType: $0)?.displayName ?? $0.name }
-                        .joined(separator: ", ")
-                )
-            }
-        case .branch:
-            if branches.isEmpty {
-                components.append("전체 지부")
-            } else {
-                components.append(branches.joined(separator: ", "))
-            }
-        case .campus:
-            if schools.isEmpty {
-                components.append("전체")
-            } else {
-                components.append(schools.joined(separator: ", "))
-            }
-        }
-        
-        return components.joined(separator: " / ")
+        NoticeDetail(
+            id: "",
+            generation: generation,
+            scope: scope,
+            category: parts.first.map { .part($0) } ?? .general,
+            isMustRead: false,
+            title: "",
+            content: "",
+            authorID: "",
+            authorName: "",
+            authorImageURL: nil,
+            createdAt: .now,
+            updatedAt: nil,
+            targetAudience: self,
+            hasPermission: false,
+            images: [],
+            links: [],
+            vote: nil
+        )
+        .tags
+        .map(\.text)
+        .joined(separator: " / ")
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
@@ -29,6 +29,7 @@ struct NoticeItemModel: Equatable, Identifiable {
     let vote: NoticeVote?
     let viewCount: Int
     let scopeDisplayName: String?
+    let targetsAllGenerations: Bool
 
     init(
         noticeId: String = UUID().uuidString,
@@ -45,7 +46,8 @@ struct NoticeItemModel: Equatable, Identifiable {
         images: [String],
         vote: NoticeVote?,
         viewCount: Int,
-        scopeDisplayName: String? = nil
+        scopeDisplayName: String? = nil,
+        targetsAllGenerations: Bool = false
     ) {
         self.noticeId = noticeId
         self.generation = generation
@@ -62,15 +64,59 @@ struct NoticeItemModel: Equatable, Identifiable {
         self.vote = vote
         self.viewCount = viewCount
         self.scopeDisplayName = scopeDisplayName
+        self.targetsAllGenerations = targetsAllGenerations
     }
     
-    /// UI 표시용 태그 (scope + category 조합)
-    var tag: NoticeItemTag {
-        NoticeItemTag(scope: scope, category: category, scopeDisplayName: scopeDisplayName)
+    /// UI 표시용 태그 목록
+    var tags: [NoticeItemTag] {
+        if targetsAllGenerations {
+            return [
+                NoticeItemTag(text: "모든 기수", backColor: .blue)
+            ]
+        }
+
+        var items: [NoticeItemTag] = [
+            NoticeItemTag(text: "\(generation)기", backColor: .blue)
+        ]
+
+        if let scopeTag {
+            items.append(scopeTag)
+        }
+
+        if let partTag {
+            items.append(partTag)
+        }
+
+        return items
     }
     
     var hasLink: Bool { !links.isEmpty }
     var hasVote: Bool { vote != nil }
+}
+
+private extension NoticeItemModel {
+    var scopeTag: NoticeItemTag? {
+        switch scope {
+        case .central:
+            return nil
+        case .branch:
+            let displayName = scopeDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return NoticeItemTag(
+                text: displayName.isEmpty ? "지부" : displayName,
+                backColor: .orange500
+            )
+        case .campus:
+            return NoticeItemTag(text: "교내", backColor: .green500)
+        }
+    }
+
+    var partTag: NoticeItemTag? {
+        guard case .part(let part) = category else { return nil }
+        return NoticeItemTag(
+            text: NoticePart(umcPartType: part)?.displayName ?? "파트",
+            backColor: part.color
+        )
+    }
 }
 
 extension NoticeItemModel {

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeEditorTargetUseCase.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeEditorTargetUseCase.swift
@@ -26,12 +26,20 @@ final class NoticeEditorTargetUseCase: NoticeEditorTargetUseCaseProtocol {
         try await repository.fetchAllBranches()
     }
 
+    func fetchBranches(gisuId: Int) async throws -> [NoticeTargetOption] {
+        try await repository.fetchBranches(gisuId: gisuId)
+    }
+
     func fetchBranchName(chapterId: Int) async throws -> String {
         try await repository.fetchBranchName(chapterId: chapterId)
     }
 
     func fetchAllSchools() async throws -> [NoticeTargetOption] {
         try await repository.fetchAllSchools()
+    }
+
+    func fetchSchools(gisuId: Int) async throws -> [NoticeTargetOption] {
+        try await repository.fetchSchools(gisuId: gisuId)
     }
 
     func fetchSchools(inChapterId chapterId: Int, gisuId: Int) async throws -> [NoticeTargetOption] {

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeEditorTargetUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeEditorTargetUseCaseProtocol.swift
@@ -11,10 +11,14 @@ import Foundation
 protocol NoticeEditorTargetUseCaseProtocol {
     /// 전체 지부 목록을 조회합니다.
     func fetchAllBranches() async throws -> [NoticeTargetOption]
+    /// 특정 기수에 속한 지부 목록을 조회합니다.
+    func fetchBranches(gisuId: Int) async throws -> [NoticeTargetOption]
     /// 지부 ID로 지부명을 조회합니다.
     func fetchBranchName(chapterId: Int) async throws -> String
     /// 전체 학교 목록을 조회합니다.
     func fetchAllSchools() async throws -> [NoticeTargetOption]
+    /// 특정 기수에 속한 학교 목록을 조회합니다.
+    func fetchSchools(gisuId: Int) async throws -> [NoticeTargetOption]
     /// 특정 지부(챕터)에 속한 학교 목록을 조회합니다.
     /// - Parameters:
     ///   - chapterId: 지부 ID

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeItem/NoticeItem.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeItem/NoticeItem.swift
@@ -85,7 +85,9 @@ private struct TopSection: View, Equatable {
 
     var body: some View {
         HStack(spacing: Constant.topHSpacing) {
-            tag(model.tag.text, color: model.tag.backColor)
+            ForEach(Array(model.tags.enumerated()), id: \.offset) { _, tagItem in
+                tag(tagItem.text, color: tagItem.backColor)
+            }
             
             if model.mustRead {
                 tag("필독", color: .red)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -226,6 +226,11 @@ final class NoticeDetailViewModel {
         let fallback = detail.defaultAuthorDisplayName
         authorDisplayName = fallback
 
+        let normalizedFallback = fallback.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedFallback != "알 수 없음" else {
+            return
+        }
+
         guard
             let rawMemberId = detail.authorMemberId,
             let memberId = Int(rawMemberId),

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
@@ -74,7 +74,9 @@ extension NoticeEditorViewModel {
             }
         } catch let error as NetworkError {
             createState = .failed(.network(error))
-            handleError(error, action: "createNotice")
+            if !presentNoticeRequestErrorAlert(for: error) {
+                handleError(error, action: "createNotice")
+            }
         } catch {
             createState = .failed(.unknown(message: error.localizedDescription))
             handleError(error, action: "createNotice")
@@ -159,7 +161,9 @@ extension NoticeEditorViewModel {
             }
         } catch let error as NetworkError {
             createState = .failed(.network(error))
-            handleError(error, action: "updateNotice")
+            if !presentNoticeRequestErrorAlert(for: error) {
+                handleError(error, action: "updateNotice")
+            }
         } catch {
             createState = .failed(.unknown(message: error.localizedDescription))
             handleError(error, action: "updateNotice")
@@ -364,6 +368,46 @@ extension NoticeEditorViewModel {
             "NOTICE-0010",
             "NOTICE-0011"
         ]
+    }
+
+    /// 권한 오류 등 HTTP 실패 응답의 서버 메시지를 작성 화면 Alert로 표시합니다.
+    @discardableResult
+    func presentNoticeRequestErrorAlert(for error: NetworkError) -> Bool {
+        guard case let .requestFailed(statusCode, data) = error else {
+            return false
+        }
+
+        guard let serverMessage = parseServerMessage(from: data) else {
+            return false
+        }
+
+        let alertTitle = statusCode == 403 ? "권한 없음" : "공지 저장 실패"
+        alertPrompt = AlertPrompt(
+            title: alertTitle,
+            message: serverMessage,
+            positiveBtnTitle: "확인"
+        )
+        return true
+    }
+
+    func parseServerMessage(from data: Data?) -> String? {
+        guard let data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        if let message = (json["message"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !message.isEmpty {
+            return message
+        }
+
+        if let result = (json["result"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !result.isEmpty {
+            return result
+        }
+
+        return nil
     }
 
     /// 저장 시점에만 파일 업로드 플로우를 실행하고 fileId 배열을 반환합니다.

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
@@ -24,6 +24,10 @@ extension NoticeEditorViewModel {
         targetValidationMessage == nil
     }
 
+    var shouldShowTargetExclusivityHint: Bool {
+        visibleSubCategories.contains(.branch) && visibleSubCategories.contains(.school)
+    }
+
     /// 공지 생성 시 타겟 조합 검증 메시지입니다.
     var targetValidationMessage: String? {
         guard !isEditMode else { return nil }
@@ -95,6 +99,7 @@ extension NoticeEditorViewModel {
     func updateUserContext(gisuId: Int, chapterId: Int) {
         userGisuId = gisuId
         userChapterId = chapterId
+        refreshSelectedGenerationValue()
 
         normalizeSelectionForCurrentCategory()
         Task { @MainActor in
@@ -120,25 +125,42 @@ extension NoticeEditorViewModel {
             case .central:
                 let canSelectBranch = visibleSubCategories.contains(.branch)
                 let canSelectSchool = visibleSubCategories.contains(.school)
+                let hasResolvedGisu = resolvedGisuId > 0
 
                 if canSelectBranch, canSelectSchool {
-                    async let branches = targetUseCase.fetchAllBranches()
-                    async let schools = targetUseCase.fetchAllSchools()
+                    async let branches = hasResolvedGisu
+                        ? targetUseCase.fetchBranches(gisuId: resolvedGisuId)
+                        : targetUseCase.fetchAllBranches()
+                    async let schools = hasResolvedGisu
+                        ? targetUseCase.fetchSchools(gisuId: resolvedGisuId)
+                        : targetUseCase.fetchAllSchools()
                     branchOptions = try await branches
                     schoolOptions = try await schools
                 } else if canSelectBranch {
-                    branchOptions = try await targetUseCase.fetchAllBranches()
+                    branchOptions = try await (
+                        hasResolvedGisu
+                        ? targetUseCase.fetchBranches(gisuId: resolvedGisuId)
+                        : targetUseCase.fetchAllBranches()
+                    )
                     schoolOptions = []
                 } else if canSelectSchool {
                     branchOptions = []
-                    schoolOptions = try await targetUseCase.fetchAllSchools()
+                    schoolOptions = try await (
+                        hasResolvedGisu
+                        ? targetUseCase.fetchSchools(gisuId: resolvedGisuId)
+                        : targetUseCase.fetchAllSchools()
+                    )
                 } else {
                     branchOptions = []
                     schoolOptions = []
                 }
             case .branch:
                 if visibleSubCategories.contains(.branch) {
-                    branchOptions = try await targetUseCase.fetchAllBranches()
+                    branchOptions = try await (
+                        resolvedGisuId > 0
+                        ? targetUseCase.fetchBranches(gisuId: resolvedGisuId)
+                        : targetUseCase.fetchAllBranches()
+                    )
                 } else {
                     branchOptions = []
                 }
@@ -153,7 +175,11 @@ extension NoticeEditorViewModel {
             case .school:
                 branchOptions = []
                 if visibleSubCategories.contains(.school) {
-                    schoolOptions = try await targetUseCase.fetchAllSchools()
+                    schoolOptions = try await (
+                        resolvedGisuId > 0
+                        ? targetUseCase.fetchSchools(gisuId: resolvedGisuId)
+                        : targetUseCase.fetchAllSchools()
+                    )
                 } else {
                     schoolOptions = []
                 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
@@ -28,6 +28,10 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
         container.resolve(NoticeEditorTargetUseCaseProtocol.self)
     }
 
+    var genRepository: ChallengerGenRepositoryProtocol {
+        container.resolve(ChallengerGenRepositoryProtocol.self)
+    }
+
     var errorHandler: ErrorHandler?
 
     // MARK: - Mode
@@ -58,6 +62,7 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
     /// 뷰에서 전달받는 사용자 컨텍스트(우선 적용)
     var userGisuId: Int?
     var userChapterId: Int?
+    var selectedGenerationValue: Int?
 
     var resolvedGisuId: Int {
         userGisuId ?? gisuId
@@ -65,6 +70,11 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
 
     var resolvedChapterId: Int {
         userChapterId ?? organizationId
+    }
+
+    var selectedGenerationTitle: String? {
+        guard let selectedGenerationValue else { return nil }
+        return "\(selectedGenerationValue)기"
     }
 
     // MARK: - View State
@@ -202,6 +212,29 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
 
         if case .edit(_, let notice) = mode {
             loadNoticeForEdit(notice)
+        }
+
+        refreshSelectedGenerationValue()
+    }
+
+    // MARK: - Helper
+
+    /// 선택된 gisuId를 사용자 표시용 기수 값으로 역매핑합니다.
+    func refreshSelectedGenerationValue() {
+        let currentGisuId = resolvedGisuId
+        guard currentGisuId > 0 else {
+            selectedGenerationValue = nil
+            return
+        }
+
+        do {
+            let selectedGeneration = try genRepository
+                .fetchGenGisuIdPairs()
+                .first(where: { $0.gisuId == currentGisuId })?
+                .gen
+            selectedGenerationValue = selectedGeneration ?? currentGisuId
+        } catch {
+            selectedGenerationValue = currentGisuId
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -32,6 +32,8 @@ struct NoticeDetailView: View {
         static let horizontalPadding: CGFloat = DefaultConstant.defaultSafeHorizon
         static let topSectionSpacing: CGFloat = DefaultSpacing.spacing16
         static let subInfoSpacing: CGFloat = DefaultSpacing.spacing8
+        static let tagSpacing: CGFloat = DefaultSpacing.spacing8
+        static let tagPadding: EdgeInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
         static let contentToImageSpacing: CGFloat = 20
         static let contentToLinkSpacing: CGFloat = 20
         static let imageToLinkSpacing: CGFloat = 10
@@ -45,8 +47,6 @@ struct NoticeDetailView: View {
         static let noticeDeleteTitle: String = "삭제하기"
         static let editIcon: String = "pencil"
         static let deleteIcon: String = "trash"
-        static let audienceLabelPrefix: String = "수신대상:"
-        static let audienceSystemImage: String = "paperplane"
         static let collapsedButtonSize: CGFloat = 60
         static let collapsedButtonIcon: String = "chart.bar.xaxis"
         static let collapsedButtonIconSize: CGFloat = 22
@@ -159,9 +159,25 @@ struct NoticeDetailView: View {
                 Text(data.createdAt.toYearMonthDay())
             }
             .appFont(.subheadline, color: .grey700)
-            Label("\(Constants.audienceLabelPrefix) \(data.targetAudience.displayText)", systemImage: Constants.audienceSystemImage)
-                .appFont(.footnote, color: .grey500)
+
+            FlowLayout(spacing: Constants.tagSpacing) {
+                ForEach(Array(data.tags.enumerated()), id: \.offset) { _, tag in
+                    detailTag(tag)
+                }
+            }
         }
+    }
+
+    private func detailTag(_ tag: NoticeItemTag) -> some View {
+        Text(tag.text)
+            .foregroundStyle(.grey000)
+            .appFont(.caption1Emphasis, weight: .regular)
+            .padding(Constants.tagPadding)
+            .background {
+                RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius)
+                    .fill(tag.backColor)
+            }
+            .glassEffect(.clear, in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius))
     }
 
     // MARK: - Bottom Section

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
@@ -169,7 +169,7 @@ struct NoticeEditorView: View {
 
     // MARK: - Top Safe Area
 
-    /// 상단 안전 영역: 게시판 분류 칩
+    /// 상단 안전 영역: 공지 대상 선택 칩
     @ViewBuilder
     private func topSafeAreaContent() -> some View {
         if viewModel.selectedCategory.hasSubCategories
@@ -179,15 +179,17 @@ struct NoticeEditorView: View {
         }
     }
 
-    /// 게시판 분류 칩 섹션
+    /// 공지 대상 선택 칩 섹션
     private var subCategorySection: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
             HStack(alignment: .center) {
-                Text("게시판 분류")
+                Text("공지 대상 선택")
                     .appFont(.calloutEmphasis)
 
-                Text("중복 선택 가능")
-                    .appFont(.footnote, color: .grey400)
+                if viewModel.shouldShowTargetExclusivityHint {
+                    Text("지부와 학교는 동시에 선택할 수 없습니다.")
+                        .appFont(.footnote, color: .grey400)
+                }
             }
 
             HStack(spacing: Constants.chipSpacing) {
@@ -452,9 +454,7 @@ struct NoticeEditorView: View {
     private func menuItemLabel(_ category: EditorMainCategory) -> String {
         switch category {
         case .central:
-            let targetGisu = selectedGisuId ?? gisuId
-            guard targetGisu > 0 else { return category.labelText }
-            return "\(targetGisu)기"
+            return viewModel.selectedGenerationTitle ?? category.labelText
         default:
             return category.labelText
         }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift
@@ -28,8 +28,8 @@ struct TargetSheetView: View {
         static let topPadding: CGFloat = DefaultSpacing.spacing16
         static let bottomPadding: CGFloat = DefaultSpacing.spacing24
         
-        static let branchGuideMessage: String = "지부를 한 개 선택해주세요."
-        static let schoolGuideMessage: String = "학교를 한 개 선택해주세요."
+        static let branchGuideMessage: String = "선택하지 않으면 전체 대상 공지로 발송됩니다."
+        static let schoolGuideMessage: String = "선택하지 않으면 전체 학교로 발송됩니다."
         static let partGuideMessage: String = "선택하지 않으면 전체 파트 대상 공지로 발송됩니다."
         static let failedTitle: String = "대상 목록을 불러오지 못했습니다."
         static let failedDescription: String = "일시적인 오류가 발생했습니다. 다시 시도해주세요."

--- a/AppProduct/AppProductTests/NoticeTest/NoticeEditorViewModelTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticeEditorViewModelTests.swift
@@ -1,0 +1,178 @@
+//
+//  NoticeEditorViewModelTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/10/26.
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+struct NoticeEditorViewModelTests {
+
+    @Test("공지 에디터는 선택된 gisuId를 실제 기수 표시값으로 보정한다")
+    func mapSelectedGisuIdToGenerationTitle() async {
+        let viewModel = await MainActor.run {
+            makeSUT(
+                selectedGisuId: 3,
+                targetUseCase: MockNoticeEditorTargetUseCase(),
+                genPairs: [(gen: 9, gisuId: 3)]
+            )
+        }
+
+        let generationTitle = await MainActor.run { viewModel.selectedGenerationTitle }
+
+        #expect(generationTitle == "9기")
+    }
+
+    @Test("특정 기수 공지 작성 시 지부 목록은 선택된 기수 기준으로 조회한다")
+    func loadFilteredBranchesForSelectedGisu() async throws {
+        let targetUseCase = MockNoticeEditorTargetUseCase(
+            branchesByGisu: [
+                3: [NoticeTargetOption(id: 14, name: "Ain")],
+                4: [NoticeTargetOption(id: 17, name: "Betelgeuse")]
+            ],
+            schoolsByGisu: [
+                3: [NoticeTargetOption(id: 1, name: "가천대학교")]
+            ]
+        )
+        let viewModel = await MainActor.run {
+            makeSUT(
+                selectedGisuId: 3,
+                initialCategory: .central,
+                targetUseCase: targetUseCase,
+                genPairs: [(gen: 9, gisuId: 3)]
+            )
+        }
+
+        await viewModel.loadTargetOptions()
+
+        let branchOptions = await MainActor.run { viewModel.branchOptions }
+        let fetchBranchesCalls = await targetUseCase.fetchBranchesCalls()
+
+        #expect(branchOptions == [NoticeTargetOption(id: 14, name: "Ain")])
+        #expect(fetchBranchesCalls == [3])
+    }
+
+    @Test("중앙 공지 작성 화면은 지부와 학교 동시 선택 불가 안내를 노출한다")
+    func showTargetExclusivityHintForCentralCategory() async {
+        let viewModel = await MainActor.run {
+            makeSUT(
+                selectedGisuId: 3,
+                initialCategory: .central,
+                targetUseCase: MockNoticeEditorTargetUseCase(),
+                genPairs: [(gen: 9, gisuId: 3)]
+            )
+        }
+
+        let shouldShowHint = await MainActor.run { viewModel.shouldShowTargetExclusivityHint }
+
+        #expect(shouldShowHint == true)
+    }
+
+    @Test("공지 생성 권한 오류는 서버 message를 그대로 Alert에 표시한다")
+    func showServerMessageForForbiddenCreateError() async {
+        let viewModel = await MainActor.run {
+            makeSUT(
+                selectedGisuId: 3,
+                targetUseCase: MockNoticeEditorTargetUseCase(),
+                genPairs: [(gen: 9, gisuId: 3)]
+            )
+        }
+        let errorData = #"{"success":false,"code":"NOTICE-0403","message":"공지 작성 권한이 없습니다.","result":null}"#
+            .data(using: .utf8)
+
+        let didPresentAlert = await MainActor.run {
+            viewModel.presentNoticeRequestErrorAlert(for: .requestFailed(statusCode: 403, data: errorData))
+        }
+        let alertMessage = await MainActor.run { viewModel.alertPrompt?.message }
+        let alertTitle = await MainActor.run { viewModel.alertPrompt?.title }
+
+        #expect(didPresentAlert == true)
+        #expect(alertTitle == "권한 없음")
+        #expect(alertMessage == "공지 작성 권한이 없습니다.")
+    }
+
+    @MainActor
+    private func makeSUT(
+        selectedGisuId: Int,
+        initialCategory: EditorMainCategory = .all,
+        targetUseCase: MockNoticeEditorTargetUseCase,
+        genPairs: [(gen: Int, gisuId: Int)]
+    ) -> NoticeEditorViewModel {
+        let container = DIContainer()
+        container.register(NoticeEditorTargetUseCaseProtocol.self) { targetUseCase }
+        container.register(ChallengerGenRepositoryProtocol.self) {
+            MockChallengerGenRepository(genPairs: genPairs)
+        }
+
+        return NoticeEditorViewModel(
+            container: container,
+            mode: .create,
+            selectedGisuId: selectedGisuId,
+            initialCategory: initialCategory
+        )
+    }
+}
+
+private actor MockNoticeEditorTargetUseCase: NoticeEditorTargetUseCaseProtocol {
+    private let allBranches: [NoticeTargetOption]
+    private let branchesByGisu: [Int: [NoticeTargetOption]]
+    private let allSchools: [NoticeTargetOption]
+    private let schoolsByGisu: [Int: [NoticeTargetOption]]
+    private var recordedFetchBranchesCalls: [Int] = []
+
+    init(
+        allBranches: [NoticeTargetOption] = [],
+        branchesByGisu: [Int: [NoticeTargetOption]] = [:],
+        allSchools: [NoticeTargetOption] = [],
+        schoolsByGisu: [Int: [NoticeTargetOption]] = [:]
+    ) {
+        self.allBranches = allBranches
+        self.branchesByGisu = branchesByGisu
+        self.allSchools = allSchools
+        self.schoolsByGisu = schoolsByGisu
+    }
+
+    func fetchAllBranches() async throws -> [NoticeTargetOption] {
+        allBranches
+    }
+
+    func fetchBranches(gisuId: Int) async throws -> [NoticeTargetOption] {
+        recordedFetchBranchesCalls.append(gisuId)
+        return branchesByGisu[gisuId] ?? []
+    }
+
+    func fetchBranchName(chapterId: Int) async throws -> String {
+        allBranches.first(where: { $0.id == chapterId })?.name ?? ""
+    }
+
+    func fetchAllSchools() async throws -> [NoticeTargetOption] {
+        allSchools
+    }
+
+    func fetchSchools(gisuId: Int) async throws -> [NoticeTargetOption] {
+        schoolsByGisu[gisuId] ?? []
+    }
+
+    func fetchSchools(inChapterId chapterId: Int, gisuId: Int) async throws -> [NoticeTargetOption] {
+        schoolsByGisu[gisuId] ?? []
+    }
+
+    func fetchBranchesCalls() -> [Int] {
+        recordedFetchBranchesCalls
+    }
+}
+
+private struct MockChallengerGenRepository: ChallengerGenRepositoryProtocol {
+    let genPairs: [(gen: Int, gisuId: Int)]
+
+    func replaceMappings(_ pairs: [(gen: Int, gisuId: Int)]) throws {
+        _ = pairs
+    }
+
+    func fetchGenGisuIdPairs() throws -> [(gen: Int, gisuId: Int)] {
+        genPairs
+    }
+}

--- a/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
@@ -1,0 +1,95 @@
+//
+//  NoticePresentationTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/10/26.
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+struct NoticePresentationTests {
+
+    @Test("전체 기수 공지는 모든 기수 태그만 노출한다")
+    func allGenerationNoticeUsesSingleTag() {
+        let model = NoticeItemModel(
+            generation: 0,
+            scope: .central,
+            category: .general,
+            mustRead: false,
+            isAlert: false,
+            date: Date(),
+            title: "공지",
+            content: "내용",
+            writer: "작성자",
+            links: [],
+            images: [],
+            vote: nil,
+            viewCount: 0,
+            targetsAllGenerations: true
+        )
+
+        #expect(model.tags.map { $0.text } == ["모든 기수"])
+    }
+
+    @Test("공지 리스트 태그는 기수, 지부/교내, 파트 순서를 유지한다")
+    func noticeListTagOrderIsGenerationScopePart() {
+        let model = NoticeItemModel(
+            generation: 9,
+            scope: .branch,
+            category: .part(.front(type: .ios)),
+            mustRead: false,
+            isAlert: false,
+            date: Date(),
+            title: "공지",
+            content: "내용",
+            writer: "작성자",
+            links: [],
+            images: [],
+            vote: nil,
+            viewCount: 0,
+            scopeDisplayName: "Ain"
+        )
+
+        #expect(model.tags.map { $0.text } == ["9기", "Ain", "iOS"])
+    }
+
+    @Test("공지 상세 태그는 targetInfo의 지부명을 사용한다")
+    func detailTagsUseResolvedBranchName() {
+        let audience = NoticeTargetInfoDTO(
+            targetGisu: "9",
+            targetGisuId: "3",
+            targetChapterId: "14",
+            targetSchoolId: nil,
+            targetChapterName: "Ain",
+            targetSchoolName: nil,
+            chapterName: nil,
+            schoolName: nil,
+            targetParts: [.front(type: .ios)]
+        )
+        .toTargetAudience(scope: .branch)
+
+        let detail = NoticeDetail(
+            id: "1",
+            generation: 9,
+            scope: .branch,
+            category: .part(.front(type: .ios)),
+            isMustRead: false,
+            title: "공지",
+            content: "내용",
+            authorID: "1",
+            authorName: "작성자",
+            authorImageURL: nil,
+            createdAt: Date(),
+            updatedAt: nil,
+            targetAudience: audience,
+            hasPermission: false,
+            images: [],
+            links: [],
+            vote: nil
+        )
+
+        #expect(detail.tags.map { $0.text } == ["9기", "Ain", "iOS"])
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 공지사항 작성 시 기수 선택 표시값 오류 및 지부 필터링 미적용 문제 수정 (#445)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 공지사항 작성 화면에서 기수 선택 시 generation 값 표시 및 해당 기수의 지부만 노출되는지 확인해주세요 -->

## 🛠️ 작업내용

### 기수 표시값 수정
- 기수 선택에서 `gisuId` 대신 `generation` 값을 사용자에게 표시
- `NoticeItemModel`/`NoticeDetailModel`에 generation 기반 태그 표시 로직 개선
- `NoticeItemTag`에서 하드코딩된 기수 매핑 제거, 서버 데이터 기반으로 전환

### 지부 필터링
- `NoticeEditorTargetRepository`에 기수별 지부 필터링 로직 구현
- `NoticeEditorTargetUseCaseProtocol`에 `fetchChaptersForGeneration` 추가
- `NoticeEditorViewModel+Targeting`에서 기수 변경 시 지부 목록 자동 갱신

### 데이터 모델 개선
- `NoticeTargetInfoDTO`에 `resolvedSchoolName`, `targetsAllGenerations` computed property 추가
- `NoticeItemModel`에 `targetsAllGenerations` 필드 추가로 전체 기수 대상 공지 구분
- `NoticeEditorViewModel+Submit`에서 수정 시 기존 타겟 정보 프리필 개선

### 테스트
- `NoticeEditorViewModelTests`, `NoticePresentationTests` 추가

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Notice/Data/Repositories/NoticeEditorTargetRepository.swift` - 기수별 지부 필터링 로직 확인
- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift` - 기수 변경 시 지부 갱신 흐름 확인
- `Features/Notice/Domain/Models/NoticeItemModel.swift` - generation 기반 태그 생성 로직 확인
- `Features/Notice/Domain/Enums/NoticeItemTag.swift` - 하드코딩 제거 후 서버 데이터 기반 전환 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)