### PR TITLE
✨ [Feat] 마이페이지 소셜 연동 해제 기능 구현 (#471)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/SocialType.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/SocialType.swift
@@ -14,6 +14,17 @@ enum SocialType: String, CaseIterable, Hashable {
     case kakao = "Kakao"
     /// 애플 로그인
     case apple = "Apple"
+    /// 구글 로그인
+    case google = "Google"
+
+    static var allCases: [SocialType] {
+        [.kakao, .apple, .google]
+    }
+
+    /// 앱에서 직접 로그인/연동 추가를 지원하는 소셜 목록입니다.
+    static var appConnectableCases: [SocialType] {
+        [.kakao, .apple]
+    }
 
     /// 소셜 타입에 해당하는 ImageResource를 반환합니다.
     var imageResource: ImageResource {
@@ -22,6 +33,8 @@ enum SocialType: String, CaseIterable, Hashable {
             return .kakaoIcon
         case .apple:
             return .appleIcon
+        case .google:
+            return .kakaoIcon
         }
     }
     
@@ -32,6 +45,8 @@ enum SocialType: String, CaseIterable, Hashable {
             return Image(.kakao) // 카카오 로고 에셋
         case .apple:
             return Image(.apple) // 애플 로고 에셋
+        case .google:
+            return Image(.kakao)
         }
     }
     
@@ -42,6 +57,8 @@ enum SocialType: String, CaseIterable, Hashable {
             return Color.kakao // 카카오 고유 노란색
         case .apple:
             return Color.black // 애플 고유 검정색
+        case .google:
+            return Color(red: 0.26, green: 0.52, blue: 0.96)
         }
     }
     
@@ -52,6 +69,8 @@ enum SocialType: String, CaseIterable, Hashable {
             return .black // 노란 배경엔 검은 글씨
         case .apple:
             return .white // 검은 배경엔 흰 글씨
+        case .google:
+            return .white
         }
     }
 
@@ -62,6 +81,8 @@ enum SocialType: String, CaseIterable, Hashable {
             self = .kakao
         case "APPLE":
             self = .apple
+        case "GOOGLE":
+            self = .google
         default:
             return nil
         }

--- a/AppProduct/AppProduct/Core/Mock/MyPageMockData.swift
+++ b/AppProduct/AppProduct/Core/Mock/MyPageMockData.swift
@@ -20,7 +20,10 @@ enum MyPageMockData {
             profileImage: nil,
             part: .front(type: .ios)
         ),
-        socialConnected: [.kakao, .apple],
+        socialConnections: [
+            .init(memberOAuthId: 1, socialType: .kakao),
+            .init(memberOAuthId: 2, socialType: .apple)
+        ],
         activityLogs: [
             .init(
                 part: .front(type: .ios),

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/DeleteMemberOAuthRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/DeleteMemberOAuthRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  DeleteMemberOAuthRequestDTO.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 3/10/26.
+//
+
+import Foundation
+
+/// 로그인 OAuth 수단 연동 해제 요청 DTO
+struct DeleteMemberOAuthRequestDTO: Codable, Sendable, Equatable {
+    /// Google 연동 해제 검증용 액세스 토큰
+    let googleAccessToken: String?
+
+    /// Kakao 연동 해제 검증용 액세스 토큰
+    let kakaoAccessToken: String?
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -130,6 +130,31 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         return try apiResponse.unwrap().map { $0.toDomain() }
     }
 
+    /// OAuth 수단 연동을 해제합니다.
+    ///
+    /// - Parameters:
+    ///   - memberOAuthId: 해제할 OAuth 연동 ID
+    ///   - googleAccessToken: Google 해제 검증용 액세스 토큰
+    ///   - kakaoAccessToken: Kakao 해제 검증용 액세스 토큰
+    func deleteMemberOAuth(
+        memberOAuthId: Int,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws {
+        let response = try await adapter.request(
+            AuthRouter.deleteMemberOAuth(
+                memberOAuthId: memberOAuthId,
+                googleAccessToken: googleAccessToken,
+                kakaoAccessToken: kakaoAccessToken
+            )
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<EmptyResult>.self,
+            from: response.data
+        )
+        try apiResponse.validateSuccess()
+    }
+
     /// 이메일 인증 코드를 발송합니다.
     ///
     /// - Parameter email: 인증할 이메일 주소

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
@@ -84,6 +84,14 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         ]
     }
 
+    func deleteMemberOAuth(
+        memberOAuthId: Int,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws {
+        try await Task.sleep(for: .milliseconds(300))
+    }
+
     func sendEmailVerification(
         email: String
     ) async throws -> String {

--- a/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
@@ -28,6 +28,12 @@ enum AuthRouter: BaseTargetType {
     case getMyOAuth
     /// 로그인 OAuth 수단 추가 연동
     case addMemberOAuth(oAuthVerificationToken: String)
+    /// 로그인 OAuth 수단 연동 해제
+    case deleteMemberOAuth(
+        memberOAuthId: Int,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    )
     /// 이메일 인증 발송
     case sendEmailVerification(email: String)
     /// 이메일 인증코드 검증
@@ -58,6 +64,8 @@ enum AuthRouter: BaseTargetType {
             return "/api/v1/member-oauth/me"
         case .addMemberOAuth:
             return "/api/v1/member-oauth"
+        case .deleteMemberOAuth(let memberOAuthId, _, _):
+            return "/api/v1/member-oauth/\(memberOAuthId)"
         case .sendEmailVerification:
             return "/api/v1/auth/email-verification"
         case .verifyEmailCode:
@@ -83,6 +91,8 @@ enum AuthRouter: BaseTargetType {
             return .post
         case .addMemberOAuth:
             return .post
+        case .deleteMemberOAuth:
+            return .delete
         case .getMyOAuth, .getSchools, .getTerms:
             return .get
         }
@@ -127,6 +137,17 @@ enum AuthRouter: BaseTargetType {
             return .requestJSONEncodable(
                 AddMemberOAuthRequestDTO(
                     oAuthVerificationToken: oAuthVerificationToken
+                )
+            )
+        case .deleteMemberOAuth(
+            _,
+            let googleAccessToken,
+            let kakaoAccessToken
+        ):
+            return .requestJSONEncodable(
+                DeleteMemberOAuthRequestDTO(
+                    googleAccessToken: googleAccessToken,
+                    kakaoAccessToken: kakaoAccessToken
                 )
             )
         case .sendEmailVerification(let email):

--- a/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
@@ -50,6 +50,17 @@ protocol AuthRepositoryProtocol: Sendable {
         oAuthVerificationToken: String
     ) async throws -> [MemberOAuth]
 
+    /// 로그인 OAuth 수단 연동 해제
+    /// - Parameters:
+    ///   - memberOAuthId: 해제할 OAuth 연동 ID
+    ///   - googleAccessToken: Google 해제 검증용 액세스 토큰
+    ///   - kakaoAccessToken: Kakao 해제 검증용 액세스 토큰
+    func deleteMemberOAuth(
+        memberOAuthId: Int,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws
+
     /// 이메일 인증 발송
     /// - Parameter email: 인증할 이메일 주소
     /// - Returns: 이메일 인증 ID

--- a/AppProduct/AppProduct/Features/Auth/Domain/Models/OAuthProvider.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Models/OAuthProvider.swift
@@ -9,13 +9,15 @@ import Foundation
 
 /// OAuth provider 타입
 ///
-/// 스웨거 enum 기준(APPLE, KAKAO)으로 모델링합니다.
+/// 스웨거 enum 기준(APPLE, KAKAO, GOOGLE)으로 모델링합니다.
 /// 지원하지 않는 값은 .unknown으로 디코딩하여 화면에서 무시합니다.
 enum OAuthProvider: Equatable, Sendable {
     /// Apple 로그인
     case apple
     /// Kakao 로그인
     case kakao
+    /// Google 로그인
+    case google
     /// 서버에서 내려온 알 수 없는 provider (하위 호환용)
     case unknown(String)
 }
@@ -23,7 +25,7 @@ enum OAuthProvider: Equatable, Sendable {
 // MARK: - Codable
 
 extension OAuthProvider: Codable {
-    /// 서버 raw 문자열("APPLE", "KAKAO")을 enum case로 변환
+    /// 서버 raw 문자열("APPLE", "KAKAO", "GOOGLE")을 enum case로 변환
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let raw = try container.decode(String.self)
@@ -33,6 +35,8 @@ extension OAuthProvider: Codable {
             self = .apple
         case "KAKAO":
             self = .kakao
+        case "GOOGLE":
+            self = .google
         default:
             self = .unknown(raw)
         }
@@ -46,6 +50,8 @@ extension OAuthProvider: Codable {
             try container.encode("APPLE")
         case .kakao:
             try container.encode("KAKAO")
+        case .google:
+            try container.encode("GOOGLE")
         case .unknown(let raw):
             try container.encode(raw)
         }
@@ -64,6 +70,8 @@ extension OAuthProvider {
             return .apple
         case .kakao:
             return .kakao
+        case .google:
+            return .google
         case .unknown:
             return nil
         }

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/DeleteMemberOAuthUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/DeleteMemberOAuthUseCaseProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  DeleteMemberOAuthUseCaseProtocol.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 3/10/26.
+//
+
+import Foundation
+
+/// 로그인 OAuth 수단 연동 해제 UseCase Protocol
+protocol DeleteMemberOAuthUseCaseProtocol {
+    /// OAuth 연동을 해제합니다.
+    func execute(
+        memberOAuthId: Int,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/DeleteMemberOAuthUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/DeleteMemberOAuthUseCase.swift
@@ -1,0 +1,35 @@
+//
+//  DeleteMemberOAuthUseCase.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 3/10/26.
+//
+
+import Foundation
+
+/// OAuth 수단 연동 해제 UseCase 구현체
+final class DeleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol {
+    // MARK: - Property
+
+    private let repository: AuthRepositoryProtocol
+
+    // MARK: - Init
+
+    init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    func execute(
+        memberOAuthId: Int,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws {
+        try await repository.deleteMemberOAuth(
+            memberOAuthId: memberOAuthId,
+            googleAccessToken: googleAccessToken,
+            kakaoAccessToken: kakaoAccessToken
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
@@ -15,6 +15,8 @@ protocol AuthUseCaseProviding {
     var fetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol { get }
     /// OAuth 수단 추가 연동 UseCase
     var addMemberOAuthUseCase: AddMemberOAuthUseCaseProtocol { get }
+    /// OAuth 수단 연동 해제 UseCase
+    var deleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol { get }
     /// 이메일 인증 발송 UseCase
     var sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol { get }
     /// 이메일 인증코드 검증 UseCase
@@ -37,6 +39,7 @@ final class AuthUseCaseProvider: AuthUseCaseProviding {
     let loginUseCase: LoginUseCaseProtocol
     let fetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol
     let addMemberOAuthUseCase: AddMemberOAuthUseCaseProtocol
+    let deleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol
     let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
     let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
     let registerUseCase: RegisterUseCaseProtocol
@@ -59,6 +62,9 @@ final class AuthUseCaseProvider: AuthUseCaseProviding {
             repository: repository
         )
         self.addMemberOAuthUseCase = AddMemberOAuthUseCase(
+            repository: repository
+        )
+        self.deleteMemberOAuthUseCase = DeleteMemberOAuthUseCase(
             repository: repository
         )
         self.sendEmailVerificationUseCase = SendEmailVerificationUseCase(

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -128,13 +128,15 @@ fileprivate struct BottomSocialBtns: View {
 
     var body: some View {
         VStack(spacing: Constants.btnSpacing) {
-            ForEach(SocialType.allCases, id: \.self) { btn in
+            ForEach(SocialType.appConnectableCases, id: \.self) { btn in
                 Button(action: {
                     switch btn {
                     case .kakao:
                         onKakaoTapped()
                     case .apple:
                         onAppleTapped()
+                    case .google:
+                        break
                     }
                 }, label: {
                     btn.image

--- a/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
@@ -261,7 +261,7 @@ extension MyPageProfileResponseDTO {
         return ProfileData(
             challengeId: latestRecord?.challengerId.intValue ?? latestRole?.challengerId.intValue ?? 0,
             challangerInfo: challengerInfo,
-            socialConnected: [],
+            socialConnections: [],
             activityLogs: logs,
             profileLink: profileLinks
         )

--- a/AppProduct/AppProduct/Features/MyPage/Domain/Models/ProfileData.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Domain/Models/ProfileData.swift
@@ -19,13 +19,29 @@ struct ProfileData: Identifiable, Equatable, Hashable {
     var challangerInfo: ChallengerInfo
     
     /// 현재 연동된 소셜 계정 목록
-    var socialConnected: [SocialType]
+    var socialConnections: [SocialConnection]
     
     /// 활동 이력 목록 (기수별, 역할별)
     var activityLogs: [ActivityLog]
     
     /// 외부 프로필 링크 목록 (Github, Blog 등)
     var profileLink: [ProfileLink]
+
+    /// 화면 표시용 연동 소셜 타입 목록
+    var socialConnected: [SocialType] {
+        socialConnections.map(\.socialType)
+    }
+}
+
+/// 연동된 소셜 계정의 서버 식별자와 타입을 나타내는 모델입니다.
+struct SocialConnection: Identifiable, Equatable, Hashable {
+    /// OAuth 연동 ID
+    let memberOAuthId: Int
+
+    /// 연동된 소셜 타입
+    let socialType: SocialType
+
+    var id: Int { memberOAuthId }
 }
 
 /// 특정 기수/파트에서의 활동 기록을 나타내는 모델입니다.
@@ -61,7 +77,6 @@ struct ProfileLink: Identifiable, Equatable, Hashable {
             .replacingOccurrences(of: "http://", with: "")
     }
 }
-
 
 
 

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/ConnectionSocial.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/ConnectionSocial.swift
@@ -11,31 +11,39 @@ import SwiftUI
 ///
 /// 사용자가 연동한 소셜 로그인 서비스(Google, Kakao, Apple 등)를
 /// 태그 형태로 표시합니다.
-struct ConnectionSocial: View, Equatable {
+struct ConnectionSocial: View {
 
     // MARK: - Property
 
     /// 연동된 소셜 계정 타입 배열
-    let socialConnected: [SocialType]
+    let socialConnections: [SocialConnection]
+
+    /// 현재 해제 진행 중인 소셜 타입
+    let disconnectingSocialType: SocialType?
 
     /// 섹션 헤더 타이틀
     let header: String
 
+    /// 연동 해제 버튼 탭 시 호출되는 클로저
+    let onDisconnect: (SocialConnection) -> Void
+
     // MARK: - Body
 
     var body: some View {
-        Section {
-            socialTagView
-        } header: {
-            SectionHeaderView(title: header)
+        if !socialConnections.isEmpty {
+            Section {
+                socialTagView
+            } header: {
+                SectionHeaderView(title: header)
+            }
         }
     }
 
     /// 소셜 계정 태그들을 가로로 나열하는 컨테이너
     private var socialTagView: some View {
         HStack(spacing: DefaultSpacing.spacing8) {
-            ForEach(socialConnected, id: \.rawValue) { social in
-                socialType(social)
+            ForEach(socialConnections) { connection in
+                socialType(connection)
             }
         }
     }
@@ -44,12 +52,24 @@ struct ConnectionSocial: View, Equatable {
     ///
     /// 각 소셜 서비스별 브랜드 컬러와 아이콘을 적용한 태그를 생성합니다.
     ///
-    /// - Parameter social: 소셜 타입 (Google, Kakao, Apple 등)
+    /// - Parameter connection: 소셜 연동 정보
     /// - Returns: 스타일이 적용된 태그 뷰
-    private func socialType(_ social: SocialType) -> some View {
-        Text(social.rawValue)
+    private func socialType(_ connection: SocialConnection) -> some View {
+        let social = connection.socialType
+
+        return Button {
+            onDisconnect(connection)
+        } label: {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Text(social.rawValue)
+                Image(systemName: disconnectingSocialType == social ? "hourglass" : "minus.circle.fill")
+                    .font(.caption)
+            }
             .appFont(.caption1Emphasis, color: social.fontColor)
             .padding(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
             .glassEffect(.clear.tint(social.color), in: .capsule)
+        }
+        .buttonStyle(.plain)
+        .disabled(disconnectingSocialType != nil)
     }
 }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/SocialSection.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/SocialSection.swift
@@ -22,7 +22,7 @@ struct SocialSection: View {
     ///
     /// 전체 소셜 타입 중 이미 연동된 타입을 제외한 나머지를 반환합니다.
     private var availableSocialTypes: [SocialType] {
-        SocialType.allCases.filter { !socialType.contains($0) }
+        SocialType.appConnectableCases.filter { !socialType.contains($0) }
     }
 
     // MARK: - Body

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageProfileViewModel.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageProfileViewModel.swift
@@ -19,6 +19,8 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
     /// 프로파일 정보
     var profileData: ProfileData
     private let useCaseProvider: MyPageUseCaseProviding
+    private let authUseCaseProvider: AuthUseCaseProviding
+    private let kakaoLoginManager = KakaoLoginManager()
 
     // MARK: - 이미지 선택 관련
 
@@ -37,15 +39,20 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
     /// 활동 이력 추가 API 진행 상태
     var isAddingActivityLog: Bool = false
 
+    /// 소셜 연동 해제 API 진행 상태
+    var disconnectingSocialType: SocialType?
+
     /// 최초 조회/수정 화면 진입 시 링크 스냅샷
     private var initialProfileLinkState: [SocialLinkType: String]
     
     init(
         profileData: ProfileData,
-        useCaseProvider: MyPageUseCaseProviding
+        useCaseProvider: MyPageUseCaseProviding,
+        authUseCaseProvider: AuthUseCaseProviding
     ) {
         self.profileData = profileData
         self.useCaseProvider = useCaseProvider
+        self.authUseCaseProvider = authUseCaseProvider
         self.initialProfileLinkState = Self.makeProfileLinkState(from: profileData.profileLink)
     }
     
@@ -95,6 +102,7 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
         defer { isUpdatingProfileImage = false }
 
         var updatedProfile = profileData
+        let currentSocialConnections = profileData.socialConnections
 
         if hasImageUpdate, let imageData = selectedImageData {
             let fileName = "profile_\(Int(Date().timeIntervalSince1970)).jpg"
@@ -113,6 +121,7 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
                 .execute(profileLinks: normalizedProfileLinksForSubmit)
         }
 
+        updatedProfile.socialConnections = currentSocialConnections
         profileData = updatedProfile
         initialProfileLinkState = Self.makeProfileLinkState(from: updatedProfile.profileLink)
         selectedImageData = nil
@@ -129,9 +138,35 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
         isAddingActivityLog = true
         defer { isAddingActivityLog = false }
 
+        let currentSocialConnections = profileData.socialConnections
         try await useCaseProvider.addChallengerRecordUseCase.execute(code: code)
         profileData = try await useCaseProvider.fetchMyPageProfileUseCase.execute()
+        profileData.socialConnections = currentSocialConnections
         initialProfileLinkState = Self.makeProfileLinkState(from: profileData.profileLink)
+    }
+
+    /// 특정 소셜 연동을 해제하고 최신 연동 목록으로 갱신합니다.
+    @MainActor
+    func disconnectSocial(_ connection: SocialConnection) async throws {
+        guard disconnectingSocialType == nil else {
+            return
+        }
+
+        disconnectingSocialType = connection.socialType
+        defer { disconnectingSocialType = nil }
+
+        let verification = try await makeDeleteVerification(for: connection.socialType)
+
+        try await authUseCaseProvider.deleteMemberOAuthUseCase.execute(
+            memberOAuthId: connection.memberOAuthId,
+            googleAccessToken: verification.googleAccessToken,
+            kakaoAccessToken: verification.kakaoAccessToken
+        )
+
+        let oauths = try await authUseCaseProvider.fetchMyOAuthUseCase.execute()
+        let updatedConnections = oauths.compactMap(Self.makeSocialConnection(from:))
+        profileData.socialConnections = updatedConnections
+        SocialType.saveConnected(updatedConnections.map(\.socialType))
     }
 
     // MARK: - Private Method
@@ -164,6 +199,36 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
             uniqueKeysWithValues: SocialLinkType.allCases.map { type in
                 (type, mapped[type] ?? "")
             }
+        )
+    }
+
+    private func makeDeleteVerification(
+        for socialType: SocialType
+    ) async throws -> (googleAccessToken: String?, kakaoAccessToken: String?) {
+        switch socialType {
+        case .kakao:
+            let accessToken = try await kakaoLoginManager.fetchAccessToken()
+            return (nil, accessToken)
+        case .apple:
+            return (nil, nil)
+        case .google:
+            throw AuthError.socialLoginFailed(
+                provider: socialType.rawValue,
+                reason: "현재 앱에서는 Google 연동 해제를 지원하지 않습니다."
+            )
+        }
+    }
+
+    private static func makeSocialConnection(
+        from memberOAuth: MemberOAuth
+    ) -> SocialConnection? {
+        guard let socialType = memberOAuth.provider.socialType else {
+            return nil
+        }
+
+        return SocialConnection(
+            memberOAuthId: memberOAuth.memberOAuthId,
+            socialType: socialType
         )
     }
 }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
@@ -55,10 +55,10 @@ class MyPageViewModel {
             var profile = try await provider.fetchMyPageProfileUseCase.execute()
 
             // 소셜 연동 노출 기준은 /member-oauth/me 응답만 사용합니다.
-            if let syncedSocials = await syncConnectedSocials(container: container) {
-                profile.socialConnected = syncedSocials
+            if let syncedConnections = await syncConnectedSocials(container: container) {
+                profile.socialConnections = syncedConnections
             } else {
-                profile.socialConnected = []
+                profile.socialConnections = []
             }
 
             profileData = .loaded(profile)
@@ -75,16 +75,13 @@ class MyPageViewModel {
     @MainActor
     private func syncConnectedSocials(
         container: DIContainer
-    ) async -> [SocialType]? {
+    ) async -> [SocialConnection]? {
         do {
             let authProvider = container.resolve(AuthUseCaseProviding.self)
             let oauths = try await authProvider.fetchMyOAuthUseCase.execute()
-            let set = Set(
-                oauths.compactMap { $0.provider.socialType }
-            )
-            let socials = SocialType.allCases.filter { set.contains($0) }
-            SocialType.saveConnected(socials)
-            return socials
+            let connections = oauths.compactMap(Self.makeSocialConnection(from:))
+            SocialType.saveConnected(connections.map(\.socialType))
+            return connections
         } catch {
             return nil
         }
@@ -115,14 +112,11 @@ class MyPageViewModel {
             oAuthVerificationToken: verificationToken
         )
 
-        let connectedSet = Set(
-            linked.compactMap { $0.provider.socialType }
-        )
-        let connected = SocialType.allCases.filter { connectedSet.contains($0) }
-        SocialType.saveConnected(connected)
+        let connected = linked.compactMap(Self.makeSocialConnection(from:))
+        SocialType.saveConnected(connected.map(\.socialType))
 
         if case .loaded(var profile) = profileData {
-            profile.socialConnected = connected
+            profile.socialConnections = connected
             profileData = .loaded(profile)
         }
     }
@@ -157,6 +151,11 @@ class MyPageViewModel {
                 authorizationCode: authorizationCode,
                 email: nil,
                 fullName: nil
+            )
+        case .google:
+            throw AuthError.socialLoginFailed(
+                provider: social.rawValue,
+                reason: "현재 앱에서는 Google 연동 추가를 지원하지 않습니다."
             )
         }
 
@@ -200,5 +199,18 @@ class MyPageViewModel {
                 reason: "이미 연동된 계정이거나 연동 가능한 검증 토큰이 없습니다."
             )
         }
+    }
+
+    private static func makeSocialConnection(
+        from memberOAuth: MemberOAuth
+    ) -> SocialConnection? {
+        guard let socialType = memberOAuth.provider.socialType else {
+            return nil
+        }
+
+        return SocialConnection(
+            memberOAuthId: memberOAuth.memberOAuthId,
+            socialType: socialType
+        )
     }
 }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyActivePostsView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyActivePostsView.swift
@@ -227,7 +227,9 @@ private struct FetchMyPageProfilePreviewUseCase: FetchMyPageProfileUseCaseProtoc
                 profileImage: nil,
                 part: .front(type: .ios)
             ),
-            socialConnected: [.kakao],
+            socialConnections: [
+                .init(memberOAuthId: 1, socialType: .kakao)
+            ],
             activityLogs: [],
             profileLink: []
         )

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
@@ -23,10 +23,12 @@ struct MyPageProfileView: View {
 
     init(container: DIContainer, profileData: ProfileData) {
         let provider = container.resolve(MyPageUseCaseProviding.self)
+        let authProvider = container.resolve(AuthUseCaseProviding.self)
         self._viewModel = .init(
             initialValue: .init(
                 profileData: profileData,
-                useCaseProvider: provider
+                useCaseProvider: provider,
+                authUseCaseProvider: authProvider
             )
         )
     }
@@ -66,7 +68,12 @@ struct MyPageProfileView: View {
         // 프로필 이미지 수정
         ProfileImagePicker(selectedPhotoItem: $viewModel.selectedPhotoItem, selectedImage: viewModel.selectedImage, profileImage: viewModel.profileData.challangerInfo.profileImage)
         // 연동된 소셜 계정 정보
-        ConnectionSocial(socialConnected: profile.socialConnected.wrappedValue, header: "연동된 계정")
+        ConnectionSocial(
+            socialConnections: profile.socialConnections.wrappedValue,
+            disconnectingSocialType: viewModel.disconnectingSocialType,
+            header: "연동된 계정",
+            onDisconnect: presentDisconnectPrompt
+        )
         // 이름 및 닉네임 (읽기 전용)
         NameAndNickname(name: profile.challangerInfo.wrappedValue.name, nickaname: profile.challangerInfo.wrappedValue.nickname, header: "이름/닉네임")
         // 학교 (읽기 전용)
@@ -261,6 +268,30 @@ struct MyPageProfileView: View {
         let trimmed = sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "인증에 실패했습니다. 다시 시도해주세요." : trimmed
     }
+
+    private func presentDisconnectPrompt(_ connection: SocialConnection) {
+        alertPrompt = AlertPrompt(
+            title: "연동 해제",
+            message: "\(connection.socialType.rawValue) 계정 연동을 해제할까요?",
+            positiveBtnTitle: "해제",
+            positiveBtnAction: { disconnectSocial(connection) },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    private func disconnectSocial(_ connection: SocialConnection) {
+        Task {
+            do {
+                try await viewModel.disconnectSocial(connection)
+            } catch {
+                errorHandler.handle(
+                    error,
+                    context: .init(feature: "MyPage", action: "disconnectSocial")
+                )
+            }
+        }
+    }
 }
 
 #if DEBUG
@@ -271,6 +302,12 @@ private var myPageProfilePreviewContainer: DIContainer {
     container.register(PathStore.self) { PathStore() }
     container.register(MyPageUseCaseProviding.self) {
         MyPageUseCaseProvider(repository: MockMyPageRepository())
+    }
+    container.register(AuthUseCaseProviding.self) {
+        AuthUseCaseProvider(
+            repositoryProvider: AuthRepositoryProvider.mock(),
+            tokenStore: KeychainTokenStore()
+        )
     }
     return container
 }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageView.swift
@@ -53,8 +53,8 @@ struct MyPageView: View {
                 .navigationDestination(for: NavigationDestination.self) { destination in
                     NavigationRoutingView(destination: destination)
                 }
-                .task {
-                    guard shouldFetchOnAppear else { return }
+                .task(id: pathStore.mypagePath.count) {
+                    guard shouldFetchOnAppear, pathStore.mypagePath.isEmpty else { return }
                     await viewModel.fetchProfile(container: di)
                 }
         }

--- a/AppProduct/AppProductTests/NoticeTest/NoticeEditorViewModelTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticeEditorViewModelTests.swift
@@ -2,7 +2,7 @@
 //  NoticeEditorViewModelTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/10/26.
+//  Created by euijjang97 on 3/10/26.
 //
 
 @testable import AppProduct

--- a/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
@@ -2,7 +2,7 @@
 //  NoticePresentationTests.swift
 //  AppProductTests
 //
-//  Created by Codex on 3/10/26.
+//  Created by euijjang97 on 3/10/26.
 //
 
 @testable import AppProduct


### PR DESCRIPTION
## ✨ PR 유형

Feature - 마이페이지에서 소셜 계정 연동 해제 기능 추가

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->

## 🛠️ 작업내용

- `SocialType`에 Google 케이스 추가 및 `appConnectableCases` (앱에서 직접 연동 가능한 소셜) 분리
- `DeleteMemberOAuthUseCaseProtocol` / `DeleteMemberOAuthUseCase` 구현 (소셜 연동 해제 비즈니스 로직)
- `DeleteMemberOAuthRequestDTO` 추가
- `AuthRepository` / `AuthRouter`에 소셜 연동 해제 API 엔드포인트 추가
- `AuthUseCaseProvider`에 연동 해제 UseCase 등록
- `MyPageProfileViewModel`에 연동 해제 요청 로직 및 AlertPrompt 확인 다이얼로그 추가
- `ConnectionSocial` 컴포넌트에 연동/해제 상태 표시 및 해제 버튼 추가
- `MyPageProfileView`에 소셜 계정 관리 섹션 추가
- `ProfileData`에 연결된 소셜 계정 목록(`connectedSocials`) 필드 추가
- `MyPageProfileDTO` 소셜 계정 목록 파싱 지원

## 📋 추후 진행 상황

- Google 로그인 아이콘 에셋 추가 (현재 임시로 카카오 아이콘 사용)
- 소셜 계정 연동 추가 기능 (현재는 해제만 지원)

## 📌 리뷰 포인트

- `Features/Auth/Domain/UseCases/DeleteMemberOAuthUseCaseProtocol.swift` - 연동 해제 UseCase 설계
- `Features/Auth/Data/Repositories/AuthRepository.swift` - 연동 해제 API 호출 로직
- `Features/MyPage/Presentation/ViewModels/MyPageProfileViewModel.swift` - 연동 해제 요청 및 AlertPrompt 처리
- `Features/MyPage/Presentation/Components/Section/MyPageProfileSection/ConnectionSocial.swift` - 연동 상태 UI 및 해제 버튼
- `Core/Common/Enum/SocialType.swift` - Google 추가 및 appConnectableCases 분리 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)