### PR TITLE
💄 [Design] 초대할 챌린저 뷰 X 버튼을 Chevron 뒤로가기로 변경 (#475)

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift
@@ -14,6 +14,8 @@ struct SelectedChallengerView: View {
     
     // MARK: - Properties
 
+    @Environment(\.dismiss) private var dismiss
+
     /// DI 컨테이너
     @Environment(\.di) private var container
 
@@ -33,8 +35,10 @@ struct SelectedChallengerView: View {
                 .navigation(naviTitle: .participant, displayMode: .inline)
                 .navigationSubtitle("총 \(challenger.count)명")
                 .toolbar(content: {
-                    // 취소 버튼 (현재 기능 없음)
-                    ToolBarCollection.BackBtn(action: {})
+                    ToolBarCollection.LeadingButton(
+                        image: "chevron.left",
+                        action: { dismiss() }
+                    )
                     
                     // 챌린저 추가 버튼 (검색 화면으로 이동)
                     ToolBarCollection.AddBtn(action: {


### PR DESCRIPTION
## ✨ PR 유형

Design - 초대할 챌린저 뷰 네비게이션 버튼 스타일 변경

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->

## 🛠️ 작업내용

- `SelectedChallengerView` 상단 툴바의 X(BackBtn) 버튼을 `chevron.left` 뒤로가기 버튼으로 변경
- `@Environment(\.dismiss)` 연결하여 뒤로가기 동작 정상화
- 챌린저 검색 뷰(#444)와 동일한 네비게이션 스타일 통일

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift` - 툴바 버튼 변경 및 dismiss 동작 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)