### PR TITLE
🐛 [Fix] 공지 리스트 기수 태그 ID 표시 수정 및 작성 화면 검증 로직 제거 (#476)

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
@@ -56,8 +56,11 @@ struct NoticeDTO: Codable {
 // MARK: - Mapping
 extension NoticeDTO {
     /// NoticeDTO → NoticeItemModel 변환 (공지 목록용)
-    func toItemModel(scopeDisplayNameOverride: String? = nil) -> NoticeItemModel {
-        let generation = targetInfo.generationValue
+    func toItemModel(
+        generationOverride: Int? = nil,
+        scopeDisplayNameOverride: String? = nil
+    ) -> NoticeItemModel {
+        let generation = generationOverride ?? targetInfo.generationValue
         let scope = targetInfo.resolvedScope
         let category = targetInfo.resolvedCategory
         let scopeDisplayName = scopeDisplayNameOverride ?? targetInfo.resolvedScopeDisplayName
@@ -78,7 +81,8 @@ extension NoticeDTO {
             vote: nil,
             viewCount: Int(viewCount) ?? 0,
             scopeDisplayName: scopeDisplayName,
-            targetsAllGenerations: targetInfo.targetsAllGenerations
+            targetsAllGenerations: targetInfo.targetsAllGenerations,
+            parts: targetInfo.resolvedParts
         )
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
@@ -16,7 +16,7 @@ extension NoticeTargetInfoDTO {
         if let targetGisu, let generation = Int(targetGisu), generation > 0 {
             return generation
         }
-        return Int(targetGisuId) ?? 0
+        return 0
     }
 
     /// targetInfo 기반으로 공지 출처(scope)를 추론합니다.

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
@@ -416,7 +416,8 @@ private extension NoticeDetail {
             images: images,
             vote: vote,
             viewCount: 0,
-            targetsAllGenerations: targetAudience.generation <= 0
+            targetsAllGenerations: targetAudience.generation <= 0,
+            parts: targetAudience.parts
         )
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
@@ -97,7 +97,8 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
             vote: vote,
             viewCount: 0,
             scopeDisplayName: targetAudience.branches.first,
-            targetsAllGenerations: targetAudience.generation <= 0
+            targetsAllGenerations: targetAudience.generation <= 0,
+            parts: targetAudience.parts
         ).tags
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
@@ -30,6 +30,7 @@ struct NoticeItemModel: Equatable, Identifiable {
     let viewCount: Int
     let scopeDisplayName: String?
     let targetsAllGenerations: Bool
+    let parts: [UMCPartType]
 
     init(
         noticeId: String = UUID().uuidString,
@@ -47,7 +48,8 @@ struct NoticeItemModel: Equatable, Identifiable {
         vote: NoticeVote?,
         viewCount: Int,
         scopeDisplayName: String? = nil,
-        targetsAllGenerations: Bool = false
+        targetsAllGenerations: Bool = false,
+        parts: [UMCPartType] = []
     ) {
         self.noticeId = noticeId
         self.generation = generation
@@ -65,6 +67,7 @@ struct NoticeItemModel: Equatable, Identifiable {
         self.viewCount = viewCount
         self.scopeDisplayName = scopeDisplayName
         self.targetsAllGenerations = targetsAllGenerations
+        self.parts = parts
     }
     
     /// UI 표시용 태그 목록
@@ -83,9 +86,7 @@ struct NoticeItemModel: Equatable, Identifiable {
             items.append(scopeTag)
         }
 
-        if let partTag {
-            items.append(partTag)
-        }
+        items.append(contentsOf: partTags)
 
         return items
     }
@@ -110,12 +111,38 @@ private extension NoticeItemModel {
         }
     }
 
-    var partTag: NoticeItemTag? {
-        guard case .part(let part) = category else { return nil }
-        return NoticeItemTag(
-            text: NoticePart(umcPartType: part)?.displayName ?? "파트",
-            backColor: part.color
-        )
+    var resolvedParts: [UMCPartType] {
+        if !parts.isEmpty {
+            return parts
+        }
+
+        if case .part(let part) = category {
+            return [part]
+        }
+
+        return []
+    }
+
+    var partTags: [NoticeItemTag] {
+        let visibleParts = Array(resolvedParts.prefix(2))
+        var items = visibleParts.map { part in
+            NoticeItemTag(
+                text: NoticePart(umcPartType: part)?.displayName ?? "파트",
+                backColor: part.color
+            )
+        }
+
+        let remainingCount = resolvedParts.count - visibleParts.count
+        if remainingCount > 0 {
+            items.append(
+                NoticeItemTag(
+                    text: "+\(remainingCount)",
+                    backColor: .grey500
+                )
+            )
+        }
+
+        return items
     }
 }
 
@@ -135,7 +162,13 @@ extension NoticeItemModel {
             authorImageURL: nil,
             createdAt: date,
             updatedAt: nil,
-            targetAudience: .all(generation: generation, scope: scope),
+            targetAudience: TargetAudience(
+                generation: generation,
+                scope: scope,
+                parts: parts,
+                branches: [],
+                schools: []
+            ),
             hasPermission: false,
             images: images,
             links: links,

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
@@ -32,16 +32,6 @@ extension NoticeEditorViewModel {
     /// 이미지 업로드 -> 공지 생성 -> 투표 첨부(선택) 순서로 진행됩니다.
     @MainActor
     func createNewNotice() async {
-        if let targetValidationMessage {
-            alertPrompt = AlertPrompt(
-                id: .init(),
-                title: "대상 설정 확인",
-                message: targetValidationMessage,
-                positiveBtnTitle: "확인"
-            )
-            return
-        }
-
         createState = .loading
 
         do {
@@ -345,7 +335,7 @@ extension NoticeEditorViewModel {
             return false
         }
 
-        guard let code, noticeAlertErrorCodes.contains(code) else {
+        guard let code, code.hasPrefix("NOTICE-") else {
             return false
         }
 
@@ -355,19 +345,6 @@ extension NoticeEditorViewModel {
             positiveBtnTitle: "확인"
         )
         return true
-    }
-
-    var noticeAlertErrorCodes: Set<String> {
-        [
-            "NOTICE-0001",
-            "NOTICE-0003",
-            "NOTICE-0004",
-            "NOTICE-0007",
-            "NOTICE-0008",
-            "NOTICE-0009",
-            "NOTICE-0010",
-            "NOTICE-0011"
-        ]
     }
 
     /// 권한 오류 등 HTTP 실패 응답의 서버 메시지를 작성 화면 Alert로 표시합니다.

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
@@ -19,66 +19,8 @@ extension NoticeEditorViewModel {
         )
     }
 
-    /// 공지 생성 시 현재 타겟 조합의 유효성입니다.
-    var isTargetSelectionValid: Bool {
-        targetValidationMessage == nil
-    }
-
     var shouldShowTargetExclusivityHint: Bool {
         visibleSubCategories.contains(.branch) && visibleSubCategories.contains(.school)
-    }
-
-    /// 공지 생성 시 타겟 조합 검증 메시지입니다.
-    var targetValidationMessage: String? {
-        guard !isEditMode else { return nil }
-
-        if memberRole == .superAdmin {
-            return "시스템 관리자는 공지 작성 권한이 없습니다."
-        }
-
-        let hasGisu = resolvedGisuId > 0
-        let hasBranch = subCategorySelection.selectedBranch != nil
-        let hasSchool = subCategorySelection.selectedSchool != nil
-        let hasParts = !subCategorySelection.selectedParts.isEmpty
-        let selectedSubCategories = subCategorySelection.selectedSubCategories
-
-        if selectedSubCategories.contains(.branch) && !hasBranch {
-            return "지부를 선택해주세요."
-        }
-        if selectedSubCategories.contains(.school) && !hasSchool {
-            return "학교를 선택해주세요."
-        }
-        if hasBranch && hasSchool {
-            return "지부와 학교는 동시에 선택할 수 없습니다."
-        }
-
-        if selectedCategory == .all {
-            if hasBranch || hasParts {
-                return "전체 기수 대상에서는 지부/파트를 함께 지정할 수 없습니다."
-            }
-            return nil
-        }
-
-        if !hasGisu {
-            return "선택 기수를 먼저 선택해주세요."
-        }
-
-        switch selectedCategory {
-        case .branch:
-            if hasSchool {
-                return "지부 공지에서는 학교를 함께 지정할 수 없습니다."
-            }
-        case .school:
-            if hasBranch {
-                return "학교 공지에서는 지부를 함께 지정할 수 없습니다."
-            }
-        case .central, .part:
-            break
-        case .all:
-            return nil
-        }
-
-        return nil
     }
 
     // MARK: - Public Action

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -201,7 +201,11 @@ extension NoticeViewModel {
         let items = filteredContent.map { dto in
             let chapterId = dto.targetInfo.targetChapterIdValue
             let scopeDisplayName = chapterId.flatMap { branchNameOverrides[$0] }
-            return dto.toItemModel(scopeDisplayNameOverride: scopeDisplayName)
+            let generation = resolvedGeneration(for: dto)
+            return dto.toItemModel(
+                generationOverride: generation,
+                scopeDisplayNameOverride: scopeDisplayName
+            )
         }
         pagingState.applySuccess(page: page, hasNextPage: response.hasNext)
 
@@ -253,6 +257,20 @@ extension NoticeViewModel {
             }
         }
         return resolved
+    }
+
+    private func resolvedGeneration(for dto: NoticeDTO) -> Int? {
+        if let targetGisu = dto.targetInfo.targetGisu,
+           let generation = Int(targetGisu),
+           generation > 0 {
+            return generation
+        }
+
+        guard let gisuId = Int(dto.targetInfo.targetGisuId), gisuId > 0 else {
+            return nil
+        }
+
+        return gisuPairs.first(where: { $0.gisuId == gisuId })?.gen
     }
 
     /// 조회 실패 상태를 반영합니다.


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 공지 리스트 기수 태그 표시 오류 수정, 파트 태그 표시 개선, 프론트 검증 로직 제거

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->

## 🛠️ 작업내용

### 기수 태그 표시 수정
- `NoticeViewModel+Fetch`에서 `gisuPairs` 조회를 통해 기수 ID → 기수 번호로 변환
- `NoticeTargetInfoMapper`에서 `targetGisuId` fallback 제거 (잘못된 ID 노출 방지)
- `NoticeDTO.toItemModel`에 `generationOverride` 파라미터 추가

### 파트 태그 최대 2개 표시
- `NoticeItemModel`에 `parts: [UMCPartType]` 필드 추가
- `partTags` 계산 프로퍼티에서 최대 2개 파트 표시 + 초과 시 "+N" 태그 추가
- 서버에서 내려주는 파트 목록 우선, 없으면 기존 category 기반 fallback

### 프론트 검증 로직 제거
- `NoticeEditorViewModel+Submit`에서 `targetValidationMessage` 기반 Alert 제거 (서버 검증 위임)
- `NoticeEditorViewModel+Targeting`에서 `targetValidationMessage`, `isTargetSelectionValid` 삭제
- 서버 에러 코드 매칭을 하드코딩 Set → `"NOTICE-"` prefix 기반으로 변경하여 신규 에러코드도 자동 처리

## 📋 추후 진행 상황

- 서버 에러 응답 메시지 Alert 표시 정상 동작 확인 (QA)

## 📌 리뷰 포인트

- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift` - `resolvedGeneration(for:)` 기수 ID→번호 변환 로직
- `Features/Notice/Domain/Models/NoticeItemModel.swift` - `partTags` 최대 2개 + "+N" 표시 로직
- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift` - 프론트 검증 제거 및 서버 에러 코드 prefix 매칭
- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift` - 검증 관련 코드 삭제 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)