### PR TITLE
🐛[Fix] 공지 상세 작성자 조회 및 수신확인 권한 수정 (#477)

### DIFF
--- a/AppProduct/AppProduct/App/AppDelegate.swift
+++ b/AppProduct/AppProduct/App/AppDelegate.swift
@@ -60,11 +60,6 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         configureFirebaseIfNeeded()
         Messaging.messaging().delegate = self
         UNUserNotificationCenter.current().delegate = self
-        logDeviceIdentifiers()
-        seedAPITestTokenIfNeeded()
-        seedAppStorageProfileIfNeeded()
-        seedAuthTokenFromEnvironmentIfNeeded()
-        injectDebugTokensIfNeeded()
         registerRemoteNotificationsIfAuthorized()
         NotificationCenter.default.addObserver(
             self,
@@ -83,22 +78,14 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let tokenString = deviceToken.map { String(format: "%02x", $0)}.joined()
-        
-        #if DEBUG
-        print("디바이스 토큰: \(tokenString)")
-        #endif
-        
+
         Messaging.messaging().apnsToken = deviceToken
         NotificationCenter.default.post(name: .deviceTokenReceived, object: tokenString)
-        logCurrentFCMToken()
     }
     
-    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: any Error) {
-        print("Failed to register: \(error.localizedDescription)")
-    }
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: any Error) {}
     
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        print("포그라운드에서 푸시 수신: \(notification.request.content.userInfo)")
         saveNoticeHistory(from: notification.request.content)
         completionHandler([.banner, .sound, .badge])
     }
@@ -119,18 +106,10 @@ extension AppDelegate: MessagingDelegate {
     /// FCM 토큰이 갱신되면 UserDefaults에 저장하고 서버 동기화를 시도합니다.
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         guard let fcmToken = fcmToken else { return }
-        
-        #if DEBUG
-        print("FCM 토큰 수신: \(fcmToken)")
-        #endif
-        
+
         let storedFcmToken = UserDefaults.standard.string(forKey: AppStorageKey.userFCMToken) ?? ""
         
         if storedFcmToken != fcmToken {
-            #if DEBUG
-            print("FCM 토큰이 변경됨: \(storedFcmToken) → \(fcmToken)")
-            #endif
-            
             UserDefaults.standard.set(fcmToken, forKey: AppStorageKey.userFCMToken)
             NotificationCenter.default.post(name: .fcmTokenReceived, object: fcmToken)
             Task { @MainActor in
@@ -172,30 +151,17 @@ private extension AppDelegate {
         guard let container else { return }
         let memberId = UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
         let fcmToken = UserDefaults.standard.string(forKey: AppStorageKey.userFCMToken) ?? ""
-        guard memberId != 0, !fcmToken.isEmpty else {
-            #if DEBUG
-            print("[FCM] skip upload (\(trigger)) memberId=\(memberId), tokenEmpty=\(fcmToken.isEmpty)")
-            #endif
-            return
-        }
+        guard memberId != 0, !fcmToken.isEmpty else { return }
 
         if let lastFailed = lastFailedFCMUpload,
            lastFailed.memberId == memberId,
            lastFailed.token == fcmToken {
-            #if DEBUG
-            print("[FCM] skip upload (\(trigger)) last attempt failed for same member/token")
-            #endif
             return
         }
 
         let uploadedToken = UserDefaults.standard.string(forKey: AppStorageKey.uploadedFCMToken) ?? ""
         let uploadedMemberId = UserDefaults.standard.integer(forKey: AppStorageKey.uploadedFCMMemberId)
-        guard uploadedToken != fcmToken || uploadedMemberId != memberId else {
-            #if DEBUG
-            print("[FCM] already uploaded memberId=\(memberId)")
-            #endif
-            return
-        }
+        guard uploadedToken != fcmToken || uploadedMemberId != memberId else { return }
 
         do {
             let provider = container.resolve(HomeUseCaseProviding.self)
@@ -205,14 +171,8 @@ private extension AppDelegate {
             lastFailedFCMUpload = nil
             UserDefaults.standard.set(fcmToken, forKey: AppStorageKey.uploadedFCMToken)
             UserDefaults.standard.set(memberId, forKey: AppStorageKey.uploadedFCMMemberId)
-            #if DEBUG
-            print("[FCM] upload success memberId=\(memberId)")
-            #endif
         } catch {
             lastFailedFCMUpload = (memberId: memberId, token: fcmToken)
-            #if DEBUG
-            print("[FCM] upload failed: \(error)")
-            #endif
         }
     }
 
@@ -235,210 +195,7 @@ private extension AppDelegate {
             createdAt: .now
         )
         modelContext.insert(notice)
-        do {
-            try modelContext.save()
-            #if DEBUG
-            print("[PushHistory] saved title=\(title)")
-            #endif
-        } catch {
-            #if DEBUG
-            print("[PushHistory] save failed: \(error)")
-            #endif
-        }
-    }
-
-    func logDeviceIdentifiers() {
-        let vendorId = UIDevice.current.identifierForVendor?.uuidString ?? "nil"
-        #if targetEnvironment(simulator)
-        let simulatorUDID = ProcessInfo.processInfo.environment["SIMULATOR_UDID"] ?? "nil"
-        print("[Device] simulatorUDID=\(simulatorUDID), identifierForVendor=\(vendorId)")
-        #else
-        print("[Device] identifierForVendor=\(vendorId)")
-        #endif
-    }
-
-    func seedAPITestTokenIfNeeded() {
-        #if DEBUG
-        let environment = ProcessInfo.processInfo.environment
-        guard let rawAccessToken = environment["UMC_API_TEST_ACCESS_TOKEN"] else { return }
-        let accessToken = rawAccessToken.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !accessToken.isEmpty else { return }
-        let refreshToken = accessToken
-
-        Task {
-            do {
-                try await KeychainTokenStore().save(
-                    accessToken: accessToken,
-                    refreshToken: refreshToken
-                )
-                print("[Auth] Seeded API test access token from scheme environment.")
-            } catch {
-                print("[Auth] Failed to seed API test token: \(error)")
-            }
-        }
-        #endif
-    }
-
-    /// HomeDebug 스킴 Pre-action이 생성한 토큰 파일을 읽어 Keychain에 직접 주입
-    func injectDebugTokensIfNeeded() {
-        #if DEBUG
-        let path = "/tmp/umc_debug_tokens.json"
-        guard let data = FileManager.default.contents(atPath: path),
-              let json = try? JSONSerialization.jsonObject(with: data)
-                  as? [String: Any],
-              let access = json["accessToken"] as? String,
-              !access.isEmpty,
-              let refresh = json["refreshToken"] as? String,
-              !refresh.isEmpty,
-              let memberId = json["memberId"] as? Int
-        else { return }
-
-        writeToKeychain(key: "accessToken", value: access)
-        writeToKeychain(key: "refreshToken", value: refresh)
-        UserDefaults.standard.set(
-            memberId,
-            forKey: AppStorageKey.memberId
-        )
-        try? FileManager.default.removeItem(atPath: path)
-        print("[DebugTokens] 주입 완료 (memberId: \(memberId))")
-        #endif
-    }
-
-    func writeToKeychain(key: String, value: String) {
-        let service = "com.ump.product"
-        guard let data = value.data(using: .utf8) else { return }
-        let deleteQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key
-        ]
-        SecItemDelete(deleteQuery as CFDictionary)
-        let addQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-            kSecValueData as String: data,
-            kSecAttrAccessible as String:
-                kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-        ]
-        SecItemAdd(addQuery as CFDictionary, nil)
-    }
-
-    func seedAppStorageProfileIfNeeded() {
-        #if DEBUG
-        let args = ProcessInfo.processInfo.arguments
-        let hasLegacySeedFlag = args.contains("--seed-appstorage-dummy")
-            || args.contains("--seed-appstorage-dummy-central")
-            || args.contains("--seed-appstorage-dummy-chapter")
-            || args.contains("--seed-appstorage-dummy-school")
-            || args.contains("--seed-appstorage-dummy-challenger")
-        let seededRoleFromArgument = parseSeededMemberRole(from: args)
-        guard hasLegacySeedFlag || seededRoleFromArgument != nil
-        else { return }
-        let defaults = UserDefaults.standard
-
-        let isCentralSeed = args.contains("--seed-appstorage-dummy-central")
-        let isChapterSeed = args.contains("--seed-appstorage-dummy-chapter")
-        let isSchoolSeed = args.contains("--seed-appstorage-dummy-school")
-        let isChallengerSeed = args.contains("--seed-appstorage-dummy-challenger")
-        let seededRole: ManagementTeam = seededRoleFromArgument ?? {
-            if isCentralSeed { return .centralOperatingTeamMember }
-            if isChallengerSeed { return .challenger }
-            if isSchoolSeed { return .schoolPresident }
-            if isChapterSeed { return .chapterPresident }
-            return .centralOperatingTeamMember
-        }()
-        defaults.set(123, forKey: AppStorageKey.memberId)
-        defaults.set(9, forKey: AppStorageKey.gisuId)
-        defaults.set(5318, forKey: AppStorageKey.challengerId)
-        defaults.set(9, forKey: AppStorageKey.schoolId)
-        defaults.set("중앙대학교", forKey: AppStorageKey.schoolName)
-        defaults.set(11, forKey: AppStorageKey.chapterId)
-        defaults.set("Product", forKey: AppStorageKey.chapterName)
-        defaults.set("ANDROID", forKey: AppStorageKey.responsiblePart)
-        let seededOrganizationType = organizationType(for: seededRole)
-        defaults.set(seededOrganizationType.rawValue, forKey: AppStorageKey.organizationType)
-        defaults.set(11, forKey: AppStorageKey.organizationId)
-        defaults.set(seededRole.rawValue, forKey: AppStorageKey.memberRole)
-
-        let seededType = seededOrganizationType.rawValue
-        print("[AppStorage] seeded dummy profile for scheme (\(seededType), role=\(seededRole.rawValue))")
-        #endif
-    }
-
-    #if DEBUG
-    /// 스킴 인자에서 공지 권한 검증용 `memberRole` 값을 파싱합니다.
-    ///
-    /// 지원 형식:
-    /// - `-seed-member-role <ManagementTeam.rawValue>`
-    /// - `--seed-appstorage-role-<kebab-case-role>`
-    private func parseSeededMemberRole(from args: [String]) -> ManagementTeam? {
-        if let index = args.firstIndex(of: "-seed-member-role"),
-           args.indices.contains(index + 1),
-           let role = ManagementTeam(rawValue: args[index + 1]) {
-            return role
-        }
-
-        let roleFlags: [(flag: String, role: ManagementTeam)] = [
-            ("--seed-appstorage-role-super-admin", .superAdmin),
-            ("--seed-appstorage-role-central-president", .centralPresident),
-            ("--seed-appstorage-role-central-vice-president", .centralVicePresident),
-            ("--seed-appstorage-role-central-operating-team-member", .centralOperatingTeamMember),
-            ("--seed-appstorage-role-central-education-team-member", .centralEducationTeamMember),
-            ("--seed-appstorage-role-chapter-president", .chapterPresident),
-            ("--seed-appstorage-role-school-president", .schoolPresident),
-            ("--seed-appstorage-role-school-vice-president", .schoolVicePresident),
-            ("--seed-appstorage-role-school-part-leader", .schoolPartLeader),
-            ("--seed-appstorage-role-school-etc-admin", .schoolEtcAdmin),
-            ("--seed-appstorage-role-challenger", .challenger)
-        ]
-
-        for roleFlag in roleFlags where args.contains(roleFlag.flag) {
-            return roleFlag.role
-        }
-        return nil
-    }
-
-    /// 디버그 시드 역할에 대응하는 조직 타입을 반환합니다.
-    private func organizationType(for role: ManagementTeam) -> OrganizationType {
-        switch role {
-        case .superAdmin,
-                .centralPresident,
-                .centralVicePresident,
-                .centralOperatingTeamMember,
-                .centralEducationTeamMember:
-            return .central
-        case .chapterPresident:
-            return .chapter
-        case .schoolPresident,
-                .schoolVicePresident,
-                .schoolPartLeader,
-                .schoolEtcAdmin,
-                .challenger:
-            return .school
-        }
-    }
-    #endif
-
-    func seedAuthTokenFromEnvironmentIfNeeded() {
-        #if DEBUG
-        let environment = ProcessInfo.processInfo.environment
-        let accessToken = environment["UMC_API_TEST_ACCESS_TOKEN"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !accessToken.isEmpty else { return }
-
-        Task {
-            do {
-                try await KeychainTokenStore().save(
-                    accessToken: accessToken,
-                    refreshToken: accessToken
-                )
-                print("[AuthDebug] Seeded access token from scheme environment")
-            } catch {
-                print("[AuthDebug] Failed to seed access token: \(error)")
-            }
-        }
-        #endif
+        try? modelContext.save()
     }
 
     /// 푸시 알림 권한 상태를 확인하고, 허용 시 원격 알림을 등록합니다.
@@ -454,44 +211,15 @@ private extension AppDelegate {
             case .notDetermined:
                 UNUserNotificationCenter.current().requestAuthorization(
                     options: [.alert, .badge, .sound]
-                ) { granted, error in
-                    #if DEBUG
-                    if let error {
-                        print("[Push] notification permission request failed: \(error)")
-                    } else {
-                        print("[Push] notification permission requested: granted=\(granted)")
-                    }
-                    #endif
+                ) { granted, _ in
                     guard granted else { return }
                     DispatchQueue.main.async {
                         UIApplication.shared.registerForRemoteNotifications()
                     }
                 }
             default:
-                #if DEBUG
-                print("[Push] notification permission not granted: \(settings.authorizationStatus.rawValue)")
-                #endif
+                break
             }
-        }
-    }
-
-    func logCurrentFCMToken() {
-        guard Messaging.messaging().apnsToken != nil else {
-            #if DEBUG
-            print("[FCM] skip token fetch: APNS token not set yet")
-            #endif
-            return
-        }
-        Messaging.messaging().token { token, error in
-            if let error {
-                #if DEBUG
-                print("[FCM] token fetch error: \(error)")
-                #endif
-                return
-            }
-            #if DEBUG
-            print("[FCM] current token: \(token ?? "nil")")
-            #endif
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
@@ -40,6 +40,8 @@ struct ChallengerMemberDTO: Codable {
     let schoolName: String
     /// 프로필 이미지 URL
     let profileImageLink: String?
+    /// 챌린저 역할 목록
+    let roles: [ChallengerRoleDTO]
     /// 멤버 상태 (ACTIVE / INACTIVE / WITHDRAWN)
     let status: MemberStatus
 
@@ -58,6 +60,7 @@ struct ChallengerMemberDTO: Codable {
         case schoolId
         case schoolName
         case profileImageLink
+        case roles
         case status
     }
 
@@ -82,10 +85,45 @@ struct ChallengerMemberDTO: Codable {
         schoolId = try container.decodeIntFlexibleIfPresent(forKey: .schoolId) ?? 0
         schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
         profileImageLink = try container.decodeIfPresent(String.self, forKey: .profileImageLink)
+        roles = try container.decodeIfPresent([ChallengerRoleDTO].self, forKey: .roles) ?? []
         let fallbackContainer = try decoder.container(keyedBy: FallbackCodingKeys.self)
         status = try container.decodeIfPresent(MemberStatus.self, forKey: .status)
             ?? (try fallbackContainer.decodeIfPresent(MemberStatus.self, forKey: .memberStatus))
             ?? .inactive
+    }
+}
+
+struct ChallengerRoleDTO: Codable {
+    let challengerRoleId: String
+    let challengerId: String
+    let roleType: ManagementTeam
+    let organizationType: OrganizationType
+    let organizationId: String?
+    let responsiblePart: String?
+    let gisuId: String
+    let gisu: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerRoleId
+        case challengerId
+        case roleType
+        case organizationType
+        case organizationId
+        case responsiblePart
+        case gisuId
+        case gisu
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        challengerRoleId = try container.decodeFlexibleString(forKey: .challengerRoleId)
+        challengerId = try container.decodeFlexibleString(forKey: .challengerId)
+        roleType = try container.decode(ManagementTeam.self, forKey: .roleType)
+        organizationType = try container.decode(OrganizationType.self, forKey: .organizationType)
+        organizationId = try container.decodeFlexibleStringIfPresent(forKey: .organizationId)
+        responsiblePart = try container.decodeIfPresent(String.self, forKey: .responsiblePart)
+        gisuId = try container.decodeFlexibleString(forKey: .gisuId)
+        gisu = try container.decodeFlexibleStringIfPresent(forKey: .gisu)
     }
 }
 
@@ -176,6 +214,32 @@ enum PointType: String, Codable {
 }
 
 private extension KeyedDecodingContainer {
+    func decodeFlexibleString(forKey key: Key) throws -> String {
+        if let value = try? decode(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(Int(value))
+        }
+        throw DecodingError.typeMismatch(
+            String.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected String/Int/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeFlexibleStringIfPresent(forKey key: Key) throws -> String? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        return try? decodeFlexibleString(forKey: key)
+    }
+
     func decodeIntFlexible(forKey key: Key) throws -> Int {
         if let value = try? decode(Int.self, forKey: key) {
             return value
@@ -207,6 +271,19 @@ private extension KeyedDecodingContainer {
 // MARK: - toDomain
 
 extension ChallengerMemberDTO {
+    func toMemberProfileSummary() -> MemberProfileSummary {
+        let resolvedRoleName = ManagementTeam.highestPriority(in: roles.map(\.roleType))?.korean ?? "챌린저"
+
+        return MemberProfileSummary(
+            memberId: String(memberId),
+            name: name,
+            nickname: nickname,
+            generation: gisu,
+            roleName: resolvedRoleName,
+            profileImageURL: profileImageLink
+        )
+    }
+
     /// DTO → GenerationData 변환 (홈 화면 패널티 카드용)
     ///
     /// - Parameter gisuId: MyProfileDTO의 RoleDTO에서 전달받은 기수 식별 ID

--- a/AppProduct/AppProduct/Features/MyPage/Data/Repository/Mock/MockMyPageRepository.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Repository/Mock/MockMyPageRepository.swift
@@ -28,6 +28,21 @@ final class MockMyPageRepository: MyPageRepositoryProtocol {
         )
     }
 
+    func fetchChallengerProfile(challengerId: Int) async throws -> MemberProfileSummary {
+        let profile = MyPageMockData.profile
+        let latestRole = profile.activityLogs
+            .sorted { $0.role > $1.role }
+            .first
+        return MemberProfileSummary(
+            memberId: "\(challengerId)",
+            name: profile.challangerInfo.name,
+            nickname: profile.challangerInfo.nickname,
+            generation: profile.challangerInfo.gen,
+            roleName: latestRole?.role.korean ?? "챌린저",
+            profileImageURL: profile.challangerInfo.profileImage
+        )
+    }
+
     func addChallengerRecord(code: String) async throws {
         _ = code
     }

--- a/AppProduct/AppProduct/Features/MyPage/Data/Repository/MyPageRepository.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Repository/MyPageRepository.swift
@@ -53,6 +53,18 @@ final class MyPageRepository: MyPageRepositoryProtocol, @unchecked Sendable {
         return try apiResponse.unwrap().toMemberProfileSummary()
     }
 
+    /// 특정 챌린저 프로필 조회
+    func fetchChallengerProfile(challengerId: Int) async throws -> MemberProfileSummary {
+        let response = try await adapter.request(
+            MyPageRouter.getChallengerProfile(challengerId: challengerId)
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<ChallengerMemberDTO>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap().toMemberProfileSummary()
+    }
+
     /// 운영진 발급 코드로 기존 챌린저 기록을 추가합니다.
     func addChallengerRecord(code: String) async throws {
         do {

--- a/AppProduct/AppProduct/Features/MyPage/Data/Router/MyPageRouter.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Router/MyPageRouter.swift
@@ -17,6 +17,8 @@ enum MyPageRouter {
     case getMyProfile
     /// 특정 멤버 프로필 조회
     case getMemberProfile(memberId: Int)
+    /// 특정 챌린저 프로필 조회
+    case getChallengerProfile(challengerId: Int)
     /// 기존 챌린저 기록 추가
     case addChallengerRecord(code: String)
     /// 회원 정보 수정 (프로필 이미지 ID 반영)
@@ -45,6 +47,8 @@ extension MyPageRouter: BaseTargetType {
             return "/api/v1/member/me"
         case .getMemberProfile(let memberId):
             return "/api/v1/member/profile/\(memberId)"
+        case .getChallengerProfile(let challengerId):
+            return "/api/v1/challenger/\(challengerId)"
         case .addChallengerRecord:
             return "/api/v1/challenger-record/member"
         case .patchMember:
@@ -70,6 +74,8 @@ extension MyPageRouter: BaseTargetType {
             return .get
         case .getMemberProfile:
             return .get
+        case .getChallengerProfile:
+            return .get
         case .addChallengerRecord:
             return .post
         case .patchMember:
@@ -89,7 +95,7 @@ extension MyPageRouter: BaseTargetType {
         switch self {
         case .getMyProfile, .deleteMember:
             return .requestPlain
-        case .getMemberProfile:
+        case .getMemberProfile, .getChallengerProfile:
             return .requestPlain
         case .addChallengerRecord(let code):
             return .requestJSONEncodable(

--- a/AppProduct/AppProduct/Features/MyPage/Domain/Interface/MyPageRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Domain/Interface/MyPageRepositoryProtocol.swift
@@ -16,6 +16,9 @@ protocol MyPageRepositoryProtocol: Sendable {
     /// 특정 멤버 프로필 조회
     func fetchMemberProfile(memberId: Int) async throws -> MemberProfileSummary
 
+    /// 특정 챌린저 프로필 조회
+    func fetchChallengerProfile(challengerId: Int) async throws -> MemberProfileSummary
+
     /// 운영진 발급 코드로 챌린저 기록을 추가합니다.
     func addChallengerRecord(code: String) async throws
 

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailDTO.swift
@@ -137,6 +137,7 @@ extension NoticeDetailDTO {
         let mappedImages = images.map { NoticeAttachmentImage(id: $0.id, url: $0.url) }
         let imageURLs = mappedImages.map(\.url)
         let linkURLs = links.map(\.url)
+        let resolvedAuthorName = resolvedAuthorName()
 
         return NoticeDetail(
             id: id,
@@ -148,7 +149,7 @@ extension NoticeDetailDTO {
             content: content,
             authorID: authorChallengerId ?? "0",
             authorMemberId: authorMemberId,
-            authorName: authorName ?? "알 수 없음",
+            authorName: resolvedAuthorName,
             authorImageURL: authorProfileImageUrl,
             createdAt: createdAt.toISO8601Date(),
             updatedAt: updatedAt?.toISO8601Date(),
@@ -159,6 +160,12 @@ extension NoticeDetailDTO {
             links: linkURLs,
             vote: mappedVote
         )
+    }
+
+    private func resolvedAuthorName() -> String {
+        [authorName, authorNickname]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { !$0.isEmpty }) ?? "알 수 없음"
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift
@@ -14,6 +14,7 @@ extension NoticeDetailViewModel {
     /// 공지 열람 현황 Sheet 표시
     @MainActor
     func openReadStatusSheet() {
+        guard canViewReadStatus else { return }
         showReadStatusSheet = true
         if readStatusState.isIdle {
             Task { await fetchReadStatus() }
@@ -26,6 +27,7 @@ extension NoticeDetailViewModel {
     /// 상세 목록(read-status)은 시트 진입 시점에만 로드합니다.
     @MainActor
     func prefetchReadStaticsIfNeeded(forceReload: Bool = false) async {
+        guard canViewReadStatus else { return }
         guard forceReload || !hasPrefetchedReadStatics else { return }
         guard noticeID > 0 else { return }
         if forceReload == false, readStatics != nil { return }
@@ -83,6 +85,7 @@ extension NoticeDetailViewModel {
     /// 공지 열람 현황 데이터 로드 (통계 + 상세)
     @MainActor
     func fetchReadStatus(showLoadingState: Bool = true) async {
+        guard canViewReadStatus else { return }
         if showLoadingState {
             readStatusState = .loading
         }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -36,6 +36,10 @@ final class NoticeDetailViewModel {
         container.resolve(ChallengerGenRepositoryProtocol.self)
     }
 
+    var userSessionManager: UserSessionManager {
+        container.resolve(UserSessionManager.self)
+    }
+
     // MARK: - Core State
 
     /// 공지 상세 상태
@@ -117,6 +121,11 @@ final class NoticeDetailViewModel {
 
     /// 수정 화면 진입에 필요한 상세 데이터 준비 완료 여부
     var isDetailPreparedForEdit: Bool = false
+
+    /// 수신 확인 현황 접근 가능 여부 (운영진 이상)
+    var canViewReadStatus: Bool {
+        resolvedMemberRole.canAccessAdminMode
+    }
 
     // MARK: - Read Status Computed
 
@@ -217,9 +226,9 @@ final class NoticeDetailViewModel {
 
     // MARK: - Author Profile
 
-    /// 공지 작성자의 멤버 프로필을 조회하여 "닉네임/이름-기수TH UMC 직책" 형식의 표시명을 갱신합니다.
+    /// 공지 작성자의 챌린저 프로필을 조회하여 "닉네임/이름-기수TH UMC 직책" 형식의 표시명을 갱신합니다.
     ///
-    /// `authorMemberId`가 유효한 경우 비동기로 프로필 API를 호출하고,
+    /// 현재 서버 응답의 `authorMemberId`는 작성자 `challengerId`로 해석하여 조회하며,
     /// 실패 시 `defaultAuthorDisplayName`을 폴백으로 사용합니다.
     @MainActor
     func refreshAuthorDisplayName(for detail: NoticeDetail) {
@@ -232,23 +241,23 @@ final class NoticeDetailViewModel {
         }
 
         guard
-            let rawMemberId = detail.authorMemberId,
-            let memberId = Int(rawMemberId),
-            memberId > 0
+            let rawChallengerId = detail.authorMemberId,
+            let challengerId = Int(rawChallengerId),
+            challengerId > 0
         else {
             return
         }
 
         Task {
-            await loadAuthorDisplayName(memberId: memberId, fallback: fallback)
+            await loadAuthorDisplayName(challengerId: challengerId, fallback: fallback)
         }
     }
 
-    /// 멤버 프로필 API를 호출하여 작성자 표시명을 비동기 로드합니다.
+    /// 챌린저 프로필 API를 호출하여 작성자 표시명을 비동기 로드합니다.
     @MainActor
-    private func loadAuthorDisplayName(memberId: Int, fallback: String) async {
+    private func loadAuthorDisplayName(challengerId: Int, fallback: String) async {
         do {
-            let profile = try await myPageRepository.fetchMemberProfile(memberId: memberId)
+            let profile = try await myPageRepository.fetchChallengerProfile(challengerId: challengerId)
             authorDisplayName = buildAuthorDisplayName(
                 nickname: profile.nickname,
                 name: profile.name,
@@ -261,7 +270,7 @@ final class NoticeDetailViewModel {
                 error,
                 context: ErrorContext(
                     feature: "Notice",
-                    action: "loadAuthorDisplayName(memberId:\(memberId))"
+                    action: "loadAuthorDisplayName(challengerId:\(challengerId))"
                 )
             )
             authorDisplayName = fallback
@@ -377,5 +386,16 @@ final class NoticeDetailViewModel {
         } catch {
             return value
         }
+    }
+
+    private var resolvedMemberRole: ManagementTeam {
+        let storedRole = UserDefaults.standard.string(forKey: AppStorageKey.memberRole)
+            .flatMap(ManagementTeam.init(rawValue:))
+
+        guard let storedRole else {
+            return userSessionManager.currentRole
+        }
+
+        return max(userSessionManager.currentRole, storedRole)
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -445,6 +445,7 @@ struct NoticeDetailView: View {
 
     /// 상세 로드 실패/로딩 상태에서는 하단 수신 확인 inset을 숨깁니다.
     private var shouldShowReadStatusInset: Bool {
+        guard viewModel.canViewReadStatus else { return false }
         if case .loaded = viewModel.noticeState {
             return true
         }

--- a/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
@@ -11,6 +11,8 @@ import Testing
 
 struct NoticePresentationTests {
 
+    // MARK: - Tag Tests
+
     @Test("전체 기수 공지는 모든 기수 태그만 노출한다")
     func allGenerationNoticeUsesSingleTag() {
         let model = NoticeItemModel(
@@ -91,5 +93,46 @@ struct NoticePresentationTests {
         )
 
         #expect(detail.tags.map { $0.text } == ["9기", "Ain", "iOS"])
+    }
+
+    // MARK: - Detail Mapping Tests
+
+    @Test("공지 상세 작성자명은 authorName이 비어 있으면 authorNickname으로 폴백한다")
+    func noticeDetailUsesNicknameFallbackWhenAuthorNameIsMissing() throws {
+        let json = """
+        {
+          "id": "1",
+          "title": "공지",
+          "content": "내용",
+          "shouldSendNotification": true,
+          "viewCount": "0",
+          "createdAt": "2026-03-11T10:00:00Z",
+          "updatedAt": null,
+          "targetInfo": {
+            "targetGisu": "9",
+            "targetGisuId": "3",
+            "targetChapterId": null,
+            "targetSchoolId": null,
+            "targetParts": []
+          },
+          "authorChallengerId": "11",
+          "authorMemberId": "22",
+          "authorNickname": "제옹",
+          "authorName": "   ",
+          "authorProfileImageUrl": null,
+          "vote": null,
+          "images": [],
+          "links": [],
+          "scope": "CENTRAL",
+          "category": "GENERAL",
+          "isMustRead": false,
+          "hasPermission": false
+        }
+        """
+
+        let dto = try JSONDecoder().decode(NoticeDetailDTO.self, from: Data(json.utf8))
+        let detail = dto.toDomain()
+
+        #expect(detail.authorName == "제옹")
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix — 공지 상세 화면의 작성자 프로필 조회 방식 변경, 수신확인 권한 제한, 작성자명 폴백 처리

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 변경 없음 -->

## 🛠️ 작업내용

- 공지 작성자 프로필 조회를 `memberId` 대신 `challengerId` 기반으로 변경 (서버 응답 필드 해석 수정)
- `authorName`이 공백/빈 문자열일 때 `authorNickname`으로 폴백하는 `resolvedAuthorName()` 로직 추가
- 수신확인 현황(readStatus) 접근을 운영진 이상 권한(`canAccessAdminMode`)으로 제한
  - `openReadStatusSheet`, `prefetchReadStaticsIfNeeded`, `fetchReadStatus` 진입부에 guard 추가
  - `shouldShowReadStatusInset`에도 권한 체크 적용
- `ChallengerMemberDTO`에 `roles` 필드 및 `ChallengerRoleDTO` 모델 추가
- `MyPageRepository`에 `fetchChallengerProfile(challengerId:)` API 추가
- `AppDelegate` 디버그 전용 시드/로깅 코드 제거 (약 200줄 클린업)
- 작성자명 폴백 로직 단위 테스트 추가

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `Features/Notice/Data/DTOs/NoticeDetailDTO.swift` — `resolvedAuthorName()` 폴백 로직 적절성
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift` — `resolvedMemberRole` 계산 로직 및 `canViewReadStatus` 권한 체크
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift` — guard 추가 위치 확인
- `Features/Home/Data/DTO/ChallengerMemeberDTO.swift` — `ChallengerRoleDTO` 디코딩 및 `toMemberProfileSummary()` 변환
- `Features/MyPage/Data/Router/MyPageRouter.swift` — `getChallengerProfile` 라우터 경로

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)