### PR TITLE
💄[Design] 일정 생성 화면 로딩 프로그레스 및 confirmDialog 개선 (#485)

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -56,7 +56,7 @@ class ScheduleRegistrationViewModel {
     /// 선택된 카테고리 태그 목록
     var tag: [ScheduleIconCategory] = .init()
 
-    /// 일정 생성 API 상태 (로딩 overlay + 성공 시 dismiss 제어)
+    /// 일정 생성/수정 API 상태 (툴바 로딩 + 성공 시 dismiss 제어)
     private(set) var submitState: Loadable<Bool> = .idle
 
     /// 수정 모드일 때 대상 일정 ID

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -18,28 +18,35 @@ struct ScheduleRegistrationView: View {
     /// 일정 등록 뷰 모델
     @State var viewModel: ScheduleRegistrationViewModel
 
-    /// 전역 에러 핸들러
-    @Environment(ErrorHandler.self) var errorHandler
     @Environment(\.dismiss) var dismiss
 
+    /// 일정 생성 요청에 필요한 현재 기수 식별자입니다.
     @AppStorage(AppStorageKey.gisuId) private var gisuId: Int = 0
+    /// 현재 로그인 사용자의 역할입니다.
     @AppStorage(AppStorageKey.memberRole) private var memberRole: ManagementTeam = .challenger
+    /// 운영진 생성 플로우에서 출석부 생성 여부 확인 다이얼로그 표시 상태입니다.
     @State private var showApprovalConfirmationDialog: Bool = false
+    /// 화면이 생성 모드인지 수정 모드인지 구분합니다.
     private let mode: Mode
 
+    /// 일정 등록 화면의 동작 모드입니다.
     enum Mode {
         case create
         case edit
     }
 
-    private enum Constants {
-        static let createLoadingMessage: String = "일정 생성 중입니다."
-        static let editLoadingMessage: String = "일정 수정 중입니다."
-    }
+    // MARK: - Initializer
 
-    // MARK: - Init
-
-    /// 초기화 메서드
+    /// 일정 등록 화면을 초기화합니다.
+    ///
+    /// 수정 모드에서는 `prefill` 값을 즉시 반영해 기존 일정을 편집 가능한 상태로 구성합니다.
+    ///
+    /// - Parameters:
+    ///   - container: Home Feature 의존성을 조립한 `DIContainer`입니다.
+    ///   - errorHandler: 화면에서 사용할 전역 `ErrorHandler`입니다.
+    ///   - mode: 화면의 동작 모드입니다.
+    ///   - prefill: 수정 모드에서 사용할 기존 일정 정보입니다.
+    ///   - prefillRoadAddress: 장소 프리필 시 우선 노출할 도로명 주소입니다.
     init(
         container: DIContainer,
         errorHandler: ErrorHandler,
@@ -60,49 +67,22 @@ struct ScheduleRegistrationView: View {
     
     // MARK: - Body
 
+    /// 일정 등록 폼과 상단 툴바를 조합한 화면 본문입니다.
     var body: some View {
         formContent
-        .scrollDismissesKeyboard(.immediately) // 스크롤 시 키보드 내림
-        .navigation(naviTitle: navigationTitle, displayMode: .inline)
-        .toolbar { toolbarContent }
-        .confirmationDialog(
-            "일정 생성",
-            isPresented: $showApprovalConfirmationDialog,
-            titleVisibility: .visible
-        ) {
-            Button("네, 출석부 생성합니다") {
-                Task {
-                    await viewModel.submitSchedule(
-                        gisuId: gisuId,
-                        requiresApproval: true
-                    )
+            .scrollDismissesKeyboard(.immediately)
+            .navigation(naviTitle: navigationTitle, displayMode: .inline)
+            .toolbar { toolbarContent }
+            .onChange(of: viewModel.submitState) {
+                if case .loaded = viewModel.submitState {
+                    dismiss()
                 }
             }
-
-            Button("아니요, 일정만 생성할게요") {
-                Task {
-                    await viewModel.submitSchedule(
-                        gisuId: gisuId,
-                        requiresApproval: false
-                    )
-                }
-            }
-
-            Button("취소", role: .cancel) {}
-        } message: {
-            Text("출석을 체크하시겠습니까?")
-        }
-        .overlay { submittingOverlay }
-        // 생성 성공 시 화면 자동 닫기
-        .onChange(of: viewModel.submitState) {
-            if case .loaded = viewModel.submitState {
-                dismiss()
-            }
-        }
     }
 
-    // MARK: - Content
+    // MARK: - Private Function
 
+    /// 입력 섹션을 순서대로 배치한 기본 폼입니다.
     private var formContent: some View {
         Form {
             section(.title, .place)
@@ -113,6 +93,7 @@ struct ScheduleRegistrationView: View {
         }
     }
 
+    /// 모드에 따라 상단 툴바 구성을 분기합니다.
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         if mode == .edit {
@@ -124,36 +105,110 @@ struct ScheduleRegistrationView: View {
                     }
                 },
                 disable: isActionDisabled,
+                isLoading: isSubmitting,
                 dismissOnTap: false,
             )
         } else {
-            ToolBarCollection.AddBtn(
-                action: { submitCreateAction() },
-                disable: isActionDisabled
-            )
-        }
-    }
-
-    @ViewBuilder
-    private var submittingOverlay: some View {
-        if isSubmitting {
-            ZStack {
-                Color.black.opacity(0.3)
-                    .ignoresSafeArea()
-                Progress(
-                    progressColor: .white,
-                    message: mode == .edit ? Constants.editLoadingMessage : Constants.createLoadingMessage,
-                    messageColor: .white,
-                    size: .regular
-                )
-                .padding(24)
+            ToolbarItem(placement: .topBarTrailing) {
+                createToolbarButton
             }
-            .allowsHitTesting(true)
         }
     }
 
-    // MARK: - Section Builder
+    // MARK: - Helper
 
+    /// 현재 모드에 맞는 내비게이션 타이틀입니다.
+    private var navigationTitle: NavigationModifier.Navititle {
+        mode == .create ? .registration : .registrationEdit
+    }
+
+    /// 생성 모드에서 노출되는 우측 상단 추가 버튼입니다.
+    ///
+    /// 로딩 중에는 아이콘 대신 `ProgressView`를 노출하고, 운영진인 경우
+    /// 탭 시 출석부 생성 여부를 확인하는 `confirmationDialog`를 띄웁니다.
+    private var createToolbarButton: some View {
+        Button {
+            guard !isActionDisabled, !isSubmitting else { return }
+            submitCreateAction()
+        } label: {
+            ZStack {
+                Image(systemName: "plus")
+                    .opacity(isSubmitting ? 0 : 1)
+
+                if isSubmitting {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(.indigo500)
+                }
+            }
+        }
+        .tint((isActionDisabled || isSubmitting) ? .grey300 : .indigo500)
+        .disabled(isActionDisabled || isSubmitting)
+        .confirmationDialog(
+            "일정 생성",
+            isPresented: $showApprovalConfirmationDialog,
+            titleVisibility: .visible
+        ) {
+            approvalConfirmationActions()
+        } message: {
+            approvalConfirmationMessage()
+        }
+    }
+
+    /// 운영진 생성 플로우에서 표시할 확인 다이얼로그 액션 목록입니다.
+    @ViewBuilder
+    private func approvalConfirmationActions() -> some View {
+        if memberRole != .challenger {
+            Button("출석부 생성합니다", role: .destructive) {
+                Task {
+                    await viewModel.submitSchedule(
+                        gisuId: gisuId,
+                        requiresApproval: true
+                    )
+                }
+            }
+
+            Button("일정만 생성할게요") {
+                Task {
+                    await viewModel.submitSchedule(
+                        gisuId: gisuId,
+                        requiresApproval: false
+                    )
+                }
+            }
+        }
+    }
+
+    /// 출석부 생성 여부를 묻는 확인 다이얼로그 안내 문구입니다.
+    @ViewBuilder
+    private func approvalConfirmationMessage() -> some View {
+        if memberRole != .challenger {
+            Text("출석을 체크하시겠습니까?")
+        }
+    }
+
+    /// 일정 생성 또는 수정 요청이 진행 중인지 여부입니다.
+    private var isSubmitting: Bool {
+        if case .loading = viewModel.submitState {
+            return true
+        }
+        return false
+    }
+
+    /// 현재 입력 상태에서 저장 액션을 비활성화해야 하는지 계산합니다.
+    ///
+    /// 생성 모드는 필수값 충족 여부만 확인하고, 수정 모드는 변경 사항 존재 여부를 함께 확인합니다.
+    private var isActionDisabled: Bool {
+        let hasRequired = !viewModel.title.isEmpty && !viewModel.tag.isEmpty
+        if mode == .edit {
+            return !hasRequired || !viewModel.hasChangesInEditMode || isSubmitting
+        }
+        return !hasRequired || isSubmitting
+    }
+
+    /// 전달된 섹션 타입 배열을 하나의 `Section`으로 묶어 렌더링합니다.
+    ///
+    /// - Parameter types: 동일 섹션에 포함할 `ScheduleGenerationType` 목록입니다.
     @ViewBuilder
     private func section(_ types: ScheduleGenerationType...) -> some View {
         Section {
@@ -163,31 +218,12 @@ struct ScheduleRegistrationView: View {
         }
     }
 
-    // MARK: - Helper
+    // MARK: - Function
 
-    private var navigationTitle: NavigationModifier.Navititle {
-        mode == .create ? .registration : .registrationEdit
-    }
-
-    private var isSubmitting: Bool {
-        if case .loading = viewModel.submitState {
-            return true
-        }
-        return false
-    }
-
-    private var isActionDisabled: Bool {
-        let hasRequired = !viewModel.title.isEmpty && !viewModel.tag.isEmpty
-        if mode == .edit {
-            return !hasRequired || !viewModel.hasChangesInEditMode || isSubmitting
-        }
-        return !hasRequired || isSubmitting
-    }
-
-    // MARK: - Action
-
+    /// 생성 모드의 추가 버튼 탭 동작을 처리합니다.
+    ///
+    /// 챌린저는 출석부 없이 바로 일정을 생성하고, 운영진은 출석부 동시 생성 여부를 먼저 확인합니다.
     private func submitCreateAction() {
-        // 챌린저: 출석부 없이 바로 생성, 운영진: Alert으로 출석부 포함 여부 선택
         if memberRole == .challenger {
             Task {
                 await viewModel.submitSchedule(
@@ -199,11 +235,12 @@ struct ScheduleRegistrationView: View {
             showApprovalConfirmationDialog = true
         }
     }
-    
+
     // MARK: - Section Components
     
-    /// 각 섹션 타입에 맞는 뷰를 반환합니다.
-    /// - Parameter type: 일정 생성 화면의 섹션 타입 (제목, 장소, 시간 등)
+    /// 섹션 타입에 대응하는 입력 뷰를 반환합니다.
+    ///
+    /// - Parameter type: 일정 생성 화면의 섹션 타입입니다.
     @ViewBuilder
     private func sectionView(_ type: ScheduleGenerationType) -> some View {
         switch type {
@@ -228,7 +265,7 @@ struct ScheduleRegistrationView: View {
             Memo(memo: $viewModel.memo)
                 .equatable()
         case .participation:
-            PariticipantSection(challenger: $viewModel.participatn)
+            ParticipantSection(challenger: $viewModel.participatn)
         case .tag:
             TagSection(tag: $viewModel.tag)
         }
@@ -248,14 +285,14 @@ fileprivate struct TitleView: View, Equatable {
     }
     
     var body: some View {
-        TextField("", text: $text, prompt: placeholer)
-            .submitLabel(.return) // 키보드 'return' 버튼
-            .tint(.indigo500)     // 커서 색상
+        TextField("", text: $text, prompt: placeholder)
+            .submitLabel(.return)
+            .tint(.indigo500)
             .appFont(.body, color: .black)
     }
     
     /// 플레이스홀더 텍스트 뷰
-    private var placeholer: Text {
+    private var placeholder: Text {
         Text(ScheduleGenerationType.title.placeholder ?? "")
             .font(ScheduleGenerationType.title.placeholderFont)
             .foregroundStyle(ScheduleGenerationType.title.placeholderColor)
@@ -296,13 +333,14 @@ fileprivate struct DateTimeSection: View {
     @Binding var startDate: Date
     @Binding var endDate: Date
     
-    // Picker 표시 상태 바인딩 (하나가 열리면 나머지는 닫히는 로직을 상위에서 제어)
+    /// 하나의 Picker만 열리도록 상위 화면에서 제어하는 표시 상태 바인딩입니다.
     @Binding var showStartDatePicker: Bool
     @Binding var showStartTimePicker: Bool
     @Binding var showEndDatePicker: Bool
     @Binding var showEndTimePicker: Bool
     
-    @ViewBuilder
+    // MARK: - Body
+
     var body: some View {
         Group {
             startDateRow
@@ -332,6 +370,8 @@ fileprivate struct DateTimeSection: View {
         }
     }
     
+    // MARK: - Helper
+
     /// 시작 날짜/시간 표시 행
     private var startDateRow: some View {
         DateTimeRow(
@@ -436,7 +476,7 @@ fileprivate struct TagSection: View {
     @Binding var tag: [ScheduleIconCategory]
     
     /// 태그 선택 시트 표시 여부
-    @State var showTagList: Bool = false
+    @State private var showTagList: Bool = false
   
     private enum Constants {
         static let tagText: String = "태그"
@@ -444,21 +484,21 @@ fileprivate struct TagSection: View {
     }
     
     var body: some View {
-        Button(action: {
+        Button {
             showTagList.toggle()
-        }, label: {
+        } label: {
             HStack {
                 Text(Constants.tagText)
                     .foregroundStyle(.black)
                 Spacer()
                 tagCount
             }
-        })
-        .sheet(isPresented: $showTagList, content: {
+        }
+        .sheet(isPresented: $showTagList) {
             TagListView(tagList: $tag)
                 .presentationDragIndicator(.visible)
                 .interactiveDismissDisabled()
-        })
+        }
     }
     
     /// 선택된 태그 개수 표시
@@ -478,13 +518,13 @@ fileprivate struct TagSection: View {
 // MARK: - Participant Section
 
 /// 참여자(챌린저) 선택 및 관리 섹션
-fileprivate struct PariticipantSection: View {
+fileprivate struct ParticipantSection: View {
     
     /// 선택된 참여자 리스트 바인딩
     @Binding var challenger: [ChallengerInfo]
     
     /// 참여자 선택 시트 표시 여부
-    @State var showPariticipant: Bool = false
+    @State private var showParticipantSheet: Bool = false
     
     private enum Constants {
         static let challengerText: String = "초대받은 챌린저"
@@ -492,20 +532,20 @@ fileprivate struct PariticipantSection: View {
     }
     
     var body: some View {
-        Button(action: {
-            showPariticipant.toggle()
-        }, label: {
+        Button {
+            showParticipantSheet.toggle()
+        } label: {
             HStack {
                 Text(Constants.challengerText)
                     .foregroundStyle(.black)
                 Spacer()
                 participant
             }
-        })
-        .sheet(isPresented: $showPariticipant, content: {
+        }
+        .sheet(isPresented: $showParticipantSheet) {
             SelectedChallengerView(challenger: $challenger)
                 .interactiveDismissDisabled()
-        })
+        }
     }
     
     /// 선택된 참여자 수 표시
@@ -536,26 +576,19 @@ fileprivate struct Memo: View, Equatable {
     
     private enum Constants {
         static let textEditorHeight: CGFloat = 200
-        static let editorPadding: CGFloat = 4
         static let placeholderPadding: EdgeInsets = .init(top: 8, leading: 4, bottom: 8, trailing: 4)
     }
     
     var body: some View {
         TextEditor(text: $memo)
-            .overlay(alignment: .topLeading, content: {
-                // 메모가 비어있을 때 플레이스홀더 표시
+            .overlay(alignment: .topLeading) {
                 if memo.isEmpty {
                     Text(ScheduleGenerationType.memo.placeholder ?? "")
                         .font(ScheduleGenerationType.memo.placeholderFont)
                         .foregroundStyle(ScheduleGenerationType.memo.placeholderColor)
                         .padding(Constants.placeholderPadding)
                 }
-            })
+            }
             .frame(height: Constants.textEditorHeight)
     }
-}
-
-#Preview {
-    ScheduleRegistrationView(container: DIContainer(), errorHandler: ErrorHandler())
-        .environment(ErrorHandler())
 }

--- a/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
+++ b/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
@@ -12,39 +12,44 @@ import SwiftUI
 ///
 /// 취소/확인/추가 등 공통 액션 버튼과 필터 메뉴를 제공합니다.
 struct ToolBarCollection {
+
+    // MARK: - Primary Action Buttons
     
-    /// 뒤로 가기 버튼
+    /// 기본 시스템 뒤로 가기 동작과 추가 후처리를 함께 수행하는 툴바 버튼입니다.
     struct BackBtn: ToolbarContent {
         @Environment(\.dismiss) var dismiss
         var action: () -> Void
         
         var body: some ToolbarContent {
-            ToolbarItem(placement: .cancellationAction, content: {
+            ToolbarItem(placement: .cancellationAction) {
                 Button(role: .cancel, action: {
                     action()
                     dismiss()
                 })
-            })
+            }
         }
     }
     
     
-    /// 취소 버튼
+    /// 시트나 편집 화면에서 취소 동작을 제공하는 툴바 버튼입니다.
     struct CancelBtn: ToolbarContent {
         @Environment(\.dismiss) var dismiss
         var action: () -> Void
         
         var body: some ToolbarContent {
-            ToolbarItem(placement: .cancellationAction, content: {
+            ToolbarItem(placement: .cancellationAction) {
                 Button(role: .cancel, action: {
                     action()
                     dismiss()
                 })
-            })
+            }
         }
     }
     
-    /// 확인 버튼
+    /// 저장, 완료 같은 확인 액션에 사용하는 공용 툴바 버튼입니다.
+    ///
+    /// `isLoading`이 `true`이면 체크 아이콘 대신 `ProgressView`를 노출하고,
+    /// 탭 입력도 함께 막아 중복 제출을 방지합니다.
     struct ConfirmBtn: ToolbarContent {
         @Environment(\.dismiss) var dismiss
         let action: () -> Void
@@ -68,7 +73,7 @@ struct ToolBarCollection {
         }
         
         var body: some ToolbarContent {
-            ToolbarItem(placement: .confirmationAction, content: {
+            ToolbarItem(placement: .confirmationAction) {
                 Button(role: .confirm, action: {
                     guard !isLoading, !disable else { return }
                     action()
@@ -89,11 +94,11 @@ struct ToolBarCollection {
                 })
                 .tint((disable || isLoading) ? .grey300 : tintColor)
                 .disabled(disable || isLoading)
-            })
+            }
         }
     }
     
-    /// 반려 버튼
+    /// 파괴적이거나 취소 성격이 강한 좌측 상단 액션에 사용하는 버튼입니다.
     struct RejectBtn: ToolbarContent {
         @Environment(\.dismiss) var dismiss
         let action: () -> Void
@@ -118,7 +123,9 @@ struct ToolBarCollection {
         }
     }
     
-    /// 추가 버튼
+    /// 생성, 추가 같은 우측 상단 액션에 사용하는 공용 버튼입니다.
+    ///
+    /// 타이틀 없이 사용하면 시스템 아이콘 버튼으로, `title`을 전달하면 텍스트 버튼으로 동작합니다.
     struct AddBtn: ToolbarContent {
         @Environment(\.dismiss) private var dismiss
         let action: () -> Void
@@ -148,88 +155,98 @@ struct ToolBarCollection {
         }
         
         var body: some ToolbarContent {
-            ToolbarItem(placement: .topBarTrailing, content: {
-                Button(action: {
-                    guard !disable, !isLoading else { return }
-                    action()
-                    if dismissOnTap {
-                        dismiss()
-                    }
-                }, label: {
-                    ZStack {
-                        if let title {
-                            Text(title)
-                                .opacity(isLoading ? 0 : 1)
-                        } else {
-                            Image(systemName: imageSystemName)
-                                .opacity(isLoading ? 0 : 1)
-                        }
+            ToolbarItem(placement: .topBarTrailing) {
+                baseButton
+            }
+        }
 
-                        if isLoading {
-                            ProgressView()
-                                .controlSize(.small)
-                                .tint(.indigo500)
-                        }
+        private var baseButton: some View {
+            Button(action: {
+                guard !disable, !isLoading else { return }
+                action()
+                if dismissOnTap {
+                    dismiss()
+                }
+            }, label: {
+                ZStack {
+                    if let title {
+                        Text(title)
+                            .opacity(isLoading ? 0 : 1)
+                    } else {
+                        Image(systemName: imageSystemName)
+                            .opacity(isLoading ? 0 : 1)
                     }
-                })
-                .tint(disable ? .grey300 : tintColor)
-                .disabled(disable)
+
+                    if isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                            .tint(.indigo500)
+                    }
+                }
             })
+            .tint((disable || isLoading) ? .grey300 : tintColor)
+            .disabled(disable || isLoading)
         }
     }
+
+    // MARK: - Icon Buttons
     
-    /// 좌측 커스텀 아이콘 버튼
+    /// 좌측 상단에 임의의 SF Symbol 액션을 배치하는 버튼입니다.
     struct LeadingButton: ToolbarContent {
         let image: String
         let action: () -> Void
         
         var body: some ToolbarContent {
-            ToolbarItem(placement: .topBarLeading, content: {
+            ToolbarItem(placement: .topBarLeading) {
                 Button(action: {
                     action()
                 }, label: {
                     Image(systemName: image)
                 })
-            })
+            }
         }
     }
     
-    /// 상단 알림 히스토리 버튼
+    /// 알림함 진입 버튼입니다.
+    ///
+    /// `recentPush`가 `true`이면 배지 포함 심볼을 사용해 새 알림 존재를 표현합니다.
     struct BellBtn: ToolbarContent {
         let action: () -> Void
         var tintColor: Color = .grey900
         let recentPush: Bool = false
         
         var body: some ToolbarContent {
-            ToolbarItem(placement: .topBarTrailing, content: {
+            ToolbarItem(placement: .topBarTrailing) {
                 Button(action: { action() }, label: {
                     Image(systemName: recentPush ? "bell.badge" : "bell")
                 })
                 .tint(tintColor)
-            })
+            }
         }
     }
     
-    /// 상단 로고 툴바
+    /// 앱 브랜딩용 로고를 상단 좌측에 배치하는 툴바입니다.
     struct Logo: ToolbarContent {
         let image: ImageResource
         @Namespace var namespace
         
         var body: some ToolbarContent {
-            ToolbarItem(placement: .topBarLeading, content: {
+            ToolbarItem(placement: .topBarLeading) {
                 Image(image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 80, height: 40)
                     .padding(EdgeInsets(top: 8, leading: 6, bottom: 8, trailing: 6))
                     .disabled(true)
-            })
+            }
             .sharedBackgroundVisibility(.hidden)
             .matchedTransitionSource(id: "logo", in: namespace)
         }
     }
+
+    // MARK: - Filters
     
-    /// 기수 필터
+    /// 기수 선택 메뉴를 상단 좌측에 배치하는 필터 툴바입니다.
     struct GenerationFilter: ToolbarContent {
         let title: String
         let generations: [Generation]
@@ -245,6 +262,7 @@ struct ToolBarCollection {
             }
         }
         
+        /// 등록된 기수 목록을 inline 스타일로 보여주는 Picker입니다.
         private var generationPicker: some View {
             Picker("기수 선택", selection: $selection) {
                 ForEach(generations) { generation in
@@ -254,6 +272,7 @@ struct ToolBarCollection {
             .pickerStyle(.inline)
         }
         
+        /// 현재 필터 타이틀을 표시하는 메뉴 라벨입니다.
         private var menuLabel: some View {
             Text(title)
                 .font(.callout)
@@ -261,7 +280,7 @@ struct ToolBarCollection {
         }
     }
     
-    /// 커뮤니티 주차별 필터
+    /// 커뮤니티 화면에서 주차를 선택하는 필터 툴바입니다.
     struct CommunityWeekFilter: ToolbarContent {
         let weeks: [Int]
         @Binding var selection: Int
@@ -277,6 +296,7 @@ struct ToolBarCollection {
             }
         }
         
+        /// 주차 값을 선택하는 inline Picker입니다.
         private var weekPicker: some View {
             Picker("주차 선택", selection: $selection) {
                 ForEach(weeks, id: \.self) { week in
@@ -288,7 +308,7 @@ struct ToolBarCollection {
         }
     }
     
-    /// 커뮤니티 학교 필터
+    /// 커뮤니티 목록을 학교 기준으로 좁혀보는 필터 툴바입니다.
     struct CommunityUnivFilter: ToolbarContent {
         @Binding var selectedUniversity: String
         let universities: [String]
@@ -304,6 +324,7 @@ struct ToolBarCollection {
             }
         }
 
+        /// 학교 목록을 선택 가능한 메뉴 형태로 구성한 Picker입니다.
         private var universityPicker: some View {
             Picker("학교 선택", selection: $selectedUniversity) {
                 Text("전체")
@@ -318,7 +339,7 @@ struct ToolBarCollection {
         }
     }
     
-    /// 커뮤니티 파트 필터
+    /// 커뮤니티 목록을 파트 기준으로 좁혀보는 필터 툴바입니다.
     struct CommunityPartFilter: ToolbarContent {
         @Binding var selectedPart: UMCPartType?
         let parts: [UMCPartType]
@@ -334,6 +355,7 @@ struct ToolBarCollection {
             }
         }
 
+        /// 파트 목록을 inline 메뉴로 렌더링하는 Picker입니다.
         private var partPicker: some View {
             Picker("파트 선택", selection: $selectedPart) {
                 Label("전체", systemImage: "person.2.fill")
@@ -347,6 +369,8 @@ struct ToolBarCollection {
             .pickerStyle(.inline)
         }
     }
+
+    // MARK: - Menus
     
     /// 상단 중앙 섹션 메뉴 툴바 (시스템 ToolbarTitleMenu 기반)
     ///
@@ -397,10 +421,11 @@ struct ToolBarCollection {
         }
     }
     
-    /// 상단 오른쪽 섹션 메뉴 툴바 (•••)
+    /// 우측 상단의 `ellipsis` 메뉴를 공통 액션 목록으로 렌더링합니다.
     struct ToolbarTrailingMenu: ToolbarContent {
         let actions: [ActionItem]
         
+        /// `ToolbarTrailingMenu`가 노출할 단일 메뉴 액션 모델입니다.
         struct ActionItem: Identifiable {
             let id = UUID()
             let title: String
@@ -466,6 +491,7 @@ struct ToolBarCollection {
         
         // MARK: - View Components
         
+        /// 선택 모드에서 승인/거절 관련 액션을 묶어 보여주는 메뉴입니다.
         private var approvalMenu: some View {
             Menu {
                 Section {
@@ -495,6 +521,7 @@ struct ToolBarCollection {
             }
         }
         
+        /// 선택 모드를 종료하고 기본 표시 상태로 복귀시키는 버튼입니다.
         private var closeButton: some View {
             Button {
                 withAnimation(.snappy(duration: DefaultConstant.animationTime)) {
@@ -507,6 +534,7 @@ struct ToolBarCollection {
             }
         }
         
+        /// 일반 모드에서 선택 모드로 진입시키는 버튼입니다.
         private var selectButton: some View {
             Button {
                 withAnimation(.snappy(duration: DefaultConstant.animationTime)) {
@@ -522,7 +550,7 @@ struct ToolBarCollection {
     
     // MARK: - Study Management Filters
     
-    /// 스터디 주차 필터
+    /// 스터디 관리 화면의 주차 선택 메뉴입니다.
     struct StudyWeekFilter: ToolbarContent {
         let weeks: [Int]
         @Binding var selection: Int
@@ -539,6 +567,7 @@ struct ToolBarCollection {
             }
         }
         
+        /// 주차 변경 시 외부 `onChange`까지 연결하는 Picker입니다.
         private var weekPicker: some View {
             Picker("주차", selection: $selection) {
                 ForEach(weeks, id: \.self) { week in
@@ -552,7 +581,7 @@ struct ToolBarCollection {
         }
     }
     
-    /// 스터디 그룹 필터
+    /// 스터디 그룹별 세부 목록을 전환하는 우측 상단 필터입니다.
     struct StudyGroupFilter: ToolbarContent {
         let studyGroups: [StudyGroupItem]
         @Binding var selection: StudyGroupItem
@@ -572,6 +601,7 @@ struct ToolBarCollection {
             }
         }
         
+        /// 스터디 그룹 선택과 변경 이벤트 전달을 담당하는 Picker입니다.
         private var groupPicker: some View {
             Picker("스터디 그룹", selection: $selection) {
                 ForEach(studyGroups, id: \.self) { group in
@@ -585,7 +615,7 @@ struct ToolBarCollection {
         }
     }
     
-    /// 공지 열람 현황 필터 (학교/지부)
+    /// 공지 열람 현황 화면의 학교/지부 필터 메뉴입니다.
     struct ReadStatusFilter<Item: Identifiable & Hashable>: ToolbarContent {
         let items: [Item]
         @Binding var selection: Item
@@ -625,7 +655,11 @@ struct ToolBarCollection {
         }
     }
 
-    /// 챌린저 인증 실패 화면 하단 툴바
+    // MARK: - Specialized Bottom Toolbar
+
+    /// 챌린저 인증 실패 화면 전용 하단 툴바입니다.
+    ///
+    /// 홈페이지 이동, 문의하기, 계정 관련 액션을 하단 바에 고정된 형태로 제공합니다.
     struct FailedVerificationBottomToolbar: ToolbarContent {
         let isSubmitting: Bool
         let isDeletingAccount: Bool
@@ -680,6 +714,7 @@ struct ToolBarCollection {
             }
         }
 
+        /// 단일 하단 바 액션 버튼을 렌더링합니다.
         private func actionButton(
             icon: String,
             title: String,
@@ -703,6 +738,7 @@ struct ToolBarCollection {
             .disabled(disabled)
         }
 
+        /// 계정 메뉴의 커스텀 라벨을 구성합니다.
         private func actionLabel(
             icon: String,
             title: String,


### PR DESCRIPTION
## ✨ PR 유형

Design — 일정 생성 화면의 로딩 UX 개선 및 confirmationDialog 리팩토링

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 로딩 프로그레스가 전체화면 오버레이 → 툴바 버튼 내 ProgressView로 변경되었습니다. 스크린샷/영상 첨부 부탁드립니다. -->

## 🛠️ 작업내용

- **로딩 프로그레스 변경**: 전체 화면 반투명 오버레이(`Progress` + `Color.black.opacity(0.3)`) → 툴바 버튼 내 인라인 `ProgressView`로 교체
- **confirmationDialog 개선**: 기존 `body` 최상위 바인딩에서 생성 버튼에 직접 연결하고, 운영진(`memberRole != .challenger`) 조건 분기 추가
- **ToolBarCollection 정리**: `AddBtn`에 `isLoading` 시 `disabled` + tint 색상 처리 추가, 트레일링 클로저 문법 통일
- **오타 수정**: `PariticipantSection` → `ParticipantSection`, `placeholer` → `placeholder`
- 미사용 `#Preview` 코드 및 `ErrorHandler` Environment 제거

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift` — 생성 버튼 + confirmationDialog 연결 구조, 운영진/챌린저 분기 로직
- `Utilities/ToolBar/ToolBarCollection.swift` — `AddBtn`의 `isLoading` disabled 처리 및 `baseButton` 분리

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)