### PR TITLE
🐛 [Fix] 운영진 출석 관리 하드코딩 제거 및 출석 UX 개선

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/ScheduleListDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/ScheduleListDTO.swift
@@ -1,0 +1,47 @@
+//
+//  ScheduleListDTO.swift
+//  AppProduct
+//
+//  Created by jaewon Lee on 3/11/26.
+//
+
+import Foundation
+
+/// 일정별 출석 통계 Response DTO
+///
+/// `GET /api/v1/schedules`
+/// - Note: 서버는 모든 숫자를 String으로 반환
+struct ScheduleListDTO: Codable, Sendable, Equatable {
+    let scheduleId: String
+    let name: String
+    let status: String
+    let date: String
+    let startTime: String
+    let endTime: String
+    let locationName: String
+    let sheetId: String
+    let totalCount: String
+    let presentCount: String
+    let pendingCount: String
+    let attendanceRate: String
+}
+
+// MARK: - toDomain
+
+extension ScheduleListDTO {
+
+    /// DTO → ScheduleAttendanceStats Domain 모델 변환
+    ///
+    /// - Note: 서버의 `attendanceRate`는 0-100 범위.
+    ///   iOS View(Gauge)는 0-1 범위를 기대하므로 `/100.0` 변환.
+    func toDomain() -> ScheduleAttendanceStats {
+        ScheduleAttendanceStats(
+            scheduleId: Int(scheduleId) ?? 0,
+            totalCount: Int(totalCount) ?? 0,
+            presentCount: Int(presentCount) ?? 0,
+            pendingCount: Int(pendingCount) ?? 0,
+            attendanceRate: (Double(attendanceRate) ?? 0.0)
+                / 100.0
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/AttendanceRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/AttendanceRepository.swift
@@ -97,6 +97,18 @@ final class AttendanceRepository: ChallengerAttendanceRepositoryProtocol,
         return try apiResponse.unwrap().map { $0.toDomain() }
     }
 
+    func getScheduleStats(
+    ) async throws -> [ScheduleAttendanceStats] {
+        let response = try await adapter.request(
+            ScheduleRouter.getScheduleList
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<[ScheduleListDTO]>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap().map { $0.toDomain() }
+    }
+
     // MARK: - 액션
 
     func approveAttendance(recordId: Int) async throws {

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockAttendanceRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockAttendanceRepository.swift
@@ -68,6 +68,19 @@ final class MockAttendanceRepository: ChallengerAttendanceRepositoryProtocol,
         try await getMyHistory()
     }
 
+    func getScheduleStats(
+    ) async throws -> [ScheduleAttendanceStats] {
+        [
+            ScheduleAttendanceStats(
+                scheduleId: 1,
+                totalCount: 40,
+                presentCount: 34,
+                pendingCount: 6,
+                attendanceRate: 0.85
+            )
+        ]
+    }
+
     func getAvailableSchedules(
     ) async throws -> [AvailableAttendanceSchedule] {
         [

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/OperatorAttendanceRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/OperatorAttendanceRepositoryProtocol.swift
@@ -24,6 +24,9 @@ protocol OperatorAttendanceRepositoryProtocol {
         challengerId: Int
     ) async throws -> [AttendanceHistoryItem]
 
+    /// 일정별 출석 통계 조회 (관리자)
+    func getScheduleStats() async throws -> [ScheduleAttendanceStats]
+
     // MARK: - 액션
 
     /// 출석 승인 (관리자)

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Attendance/AttendancePolicy.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Attendance/AttendancePolicy.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreLocation
 
 enum AttendancePolicy {
-    static let geofenceRadius: CLLocationDistance = 50.0
+    static let geofenceRadius: CLLocationDistance = 150.0
     static let onTimeThresholdMinutes: Int = 10
     static let lateThresholdMinutes: Int = 30
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Attendance/AttendancePolicy.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Attendance/AttendancePolicy.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreLocation
 
 enum AttendancePolicy {
-    static let geofenceRadius: CLLocationDistance = 150.0
+    static let geofenceRadius: CLLocationDistance = 100.0
     static let onTimeThresholdMinutes: Int = 10
     static let lateThresholdMinutes: Int = 30
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/ScheduleAttendanceStats.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/ScheduleAttendanceStats.swift
@@ -1,0 +1,20 @@
+//
+//  ScheduleAttendanceStats.swift
+//  AppProduct
+//
+//  Created by jaewon Lee on 3/11/26.
+//
+
+import Foundation
+
+/// 일정별 출석 통계
+///
+/// `GET /api/v1/schedules` 응답에서 출석 집계 필드만 추출한 모델.
+/// `attendanceRate`는 0.0-1.0 범위 (DTO에서 변환 완료).
+struct ScheduleAttendanceStats: Equatable, Sendable {
+    let scheduleId: Int
+    let totalCount: Int
+    let presentCount: Int
+    let pendingCount: Int
+    let attendanceRate: Double
+}

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/OperatorAttendanceUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/OperatorAttendanceUseCase.swift
@@ -49,4 +49,10 @@ final class OperatorAttendanceUseCase: OperatorAttendanceUseCaseProtocol {
             longitude: longitude
         )
     }
+
+    func fetchScheduleStats() async throws
+        -> [ScheduleAttendanceStats]
+    {
+        try await repository.getScheduleStats()
+    }
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/OperatorAttendanceUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/OperatorAttendanceUseCaseProtocol.swift
@@ -24,4 +24,7 @@ protocol OperatorAttendanceUseCaseProtocol {
         latitude: Double,
         longitude: Double
     ) async throws
+
+    /// 일정별 출석 통계 조회
+    func fetchScheduleStats() async throws -> [ScheduleAttendanceStats]
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceReasonSheet.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceReasonSheet.swift
@@ -52,7 +52,6 @@ struct ChallengerAttendanceReasonSheet: View {
             .scrollDisabled(true)
             .presentationDetents([.height(Constants.defaultSheetFraction)])
             .presentationDragIndicator(.visible)
-            .interactiveDismissDisabled()
         }
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorLocationChangeSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorLocationChangeSheetView.swift
@@ -72,7 +72,7 @@ struct OperatorLocationChangeSheetView: View {
             .navigationTitle("위치 변경")
             .navigationBarTitleDisplayMode(.inline)
             .presentationDetents([.height(320)])
-            .presentationDragIndicator(.hidden)
+            .presentationDragIndicator(.visible)
             .toolbar {
                 ToolBarCollection.CancelBtn {
                     onDismiss()

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Map/BaseMapViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Map/BaseMapViewModel.swift
@@ -56,7 +56,7 @@ final class BaseMapViewModel {
             center: .init(
                 latitude: info.location.latitude,
                 longitude: info.location.longitude),
-            span: .init(latitudeDelta: 0.0015, longitudeDelta: 0.0015)))
+            span: .init(latitudeDelta: 0.003, longitudeDelta: 0.003)))
     }
     
     /// 출석용 지오펜스 모니터링 시작

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
@@ -54,6 +54,19 @@ final class OperatorAttendanceViewModel {
         sessionsState = .loading
         var updatedSessions: [OperatorSessionAttendance] = []
 
+        // 출석 통계 조회 (실패 시 빈 딕셔너리)
+        let statsMap: [Int: ScheduleAttendanceStats]
+        do {
+            let statsList = try await useCase
+                .fetchScheduleStats()
+            statsMap = Dictionary(
+                statsList.map { ($0.scheduleId, $0) },
+                uniquingKeysWith: { _, last in last }
+            )
+        } catch {
+            statsMap = [:]
+        }
+
         for session in sessions {
             let scheduleIdString = session.id.value
             var pendingMembers: [OperatorPendingMember] = []
@@ -72,16 +85,36 @@ final class OperatorAttendanceViewModel {
                 }
             }
 
-            // TODO: 서버에서 출석 집계(total/attended/rate) 제공 시 해당 값으로 교체
-            let sessionStatus = OperatorSessionStatus.from(
-                startTime: session.info.startTime,
-                endTime: session.info.endTime
-            )
-            let totalCount = sessionStatus == .beforeStart ? 0 : 40
-            let attendedCount = max(0, totalCount - pendingMembers.count)
-            let attendanceRate = totalCount > 0
-                ? Double(attendedCount) / Double(totalCount)
-                : 0
+            // 서버 출석 통계 사용
+            let scheduleId = Int(scheduleIdString)
+            let stats = scheduleId.flatMap { statsMap[$0] }
+
+            let totalCount: Int
+            let attendedCount: Int
+            let attendanceRate: Double
+
+            if let stats {
+                totalCount = stats.totalCount
+                attendedCount = stats.presentCount
+                attendanceRate = stats.attendanceRate
+            } else {
+                // Fallback: API 실패 시 pending 기반 추정
+                let sessionStatus = OperatorSessionStatus.from(
+                    startTime: session.info.startTime,
+                    endTime: session.info.endTime
+                )
+                if sessionStatus != .beforeStart,
+                   !pendingMembers.isEmpty
+                {
+                    totalCount = pendingMembers.count
+                    attendedCount = 0
+                    attendanceRate = 0
+                } else {
+                    totalCount = 0
+                    attendedCount = 0
+                    attendanceRate = 0
+                }
+            }
 
             updatedSessions.append(OperatorSessionAttendance(
                 serverID: scheduleIdString,

--- a/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleRouter.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleRouter.swift
@@ -19,6 +19,8 @@ enum ScheduleRouter {
     case patchUpdateSchedule(scheduleId: Int, schedule: UpdateScheduleRequestDTO)
     /// 일정 + 출석부 통합 삭제
     case deleteScheduleWithAttendance(scheduleId: Int)
+    /// 일정별 출석 통계 목록 조회 (관리자)
+    case getScheduleList
 }
 
 extension ScheduleRouter: BaseTargetType {
@@ -33,6 +35,8 @@ extension ScheduleRouter: BaseTargetType {
             return "/api/v1/schedules/\(scheduleId)"
         case .deleteScheduleWithAttendance(let scheduleId):
             return "/api/v1/schedules/\(scheduleId)/with-attendance"
+        case .getScheduleList:
+            return "/api/v1/schedules"
         }
     }
 
@@ -46,6 +50,8 @@ extension ScheduleRouter: BaseTargetType {
             return .patch
         case .deleteScheduleWithAttendance:
             return .delete
+        case .getScheduleList:
+            return .get
         }
     }
 
@@ -57,7 +63,7 @@ extension ScheduleRouter: BaseTargetType {
             return .requestJSONEncodable(schedule)
         case .patchUpdateSchedule(_, let schedule):
             return .requestJSONEncodable(schedule)
-        case .deleteScheduleWithAttendance:
+        case .deleteScheduleWithAttendance, .getScheduleList:
             return .requestPlain
         }
     }


### PR DESCRIPTION
## ✨ PR 유형

🐛 Bug Fix — 운영진 출석 관리 하드코딩 값 제거 및 출석 관련 UX 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 여기에 추가해주세요 -->
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/e912caf6-d70e-4b78-8367-315166156cab" />


## 🛠️ 작업내용

- 운영진 출석 관리 전체 참여 인원 `totalCount = 40` 하드코딩 제거, `GET /api/v1/schedules` 서버 API 연동
- 서버 API 실패 시 fallback 처리 (승인 대기 멤버 수 기반 게이지 표시)
- 출석 지오펜스 반경 150m → 100m 조정
- 지도 초기 축적비 확대 (geofence 원이 지도에 여유 있게 표시)
- 사유 제출 시트 `.interactiveDismissDisabled()` 제거
- 위치 변경 시트 drag indicator `.visible`로 변경

**변경 파일: 13개 (신규 2, 수정 11)**

Closes #480

## 📋 추후 진행 상황

- [ ] 서버 `GET /api/v1/schedules` ORGANIZAITON-0017 에러 해결 후 실 데이터 검증
- [ ] #486 승인 대기 일괄 조회 API 전환 (N번 → 1번 호출)

## 📌 리뷰 포인트

- `Features/Activity/Data/` — ScheduleListDTO, Repository API 연동 확인
- `Features/Activity/Domain/` — UseCase, RepositoryProtocol 인터페이스 변경
- `Features/Activity/Presentation/ViewModels/` — ViewModel 하드코딩 제거 및 fallback 로직
- `Features/Home/Data/Router/` — ScheduleRouter에 getScheduleList case 추가

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)