### PR TITLE
✨[Feat] 활동 탭 지도 주소 컨텍스트 메뉴 (복사/지도 열기) (#483)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/ActivityCompactMapView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/ActivityCompactMapView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 /// 활동 상세 화면에서 사용하는 컴팩트 지도 뷰
 ///
@@ -64,6 +65,8 @@ fileprivate struct LocationStatusBarView: View {
         static let statusBarPadding: CGFloat = 16
         static let verifyIconSize: CGFloat = 12
         static let statusBarSpacing: CGFloat = 4
+        static let contextMenuIconSize: CGFloat = 12
+        static let addressVerticalPadding: CGFloat = 4
         static let animationOffset: CGFloat = 240
         static let animationDuration: Double = 8
     }
@@ -71,14 +74,26 @@ fileprivate struct LocationStatusBarView: View {
     var body: some View {
         HStack(spacing: Constants.statusBarSpacing) {
             verifyLocationStatus
-
-            Spacer(minLength: 0)
-
             address
         }
         .padding(DefaultConstant.defaultBtnPadding)
         .glassEffect()
         .safeAreaPadding(DefaultConstant.defaultSafeHorizon)
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button("클립보드로 복사", systemImage: "doc.on.doc") {
+                copyAddress()
+            }
+
+            Button("애플 지도로 검색", systemImage: "map") {
+                mapViewModel.openSessionLocationInMaps()
+            }
+        } preview: {
+            LocationStatusBarContextPreview(
+                isUserInsideGeofence: mapViewModel.isUserInsideGeofence,
+                sessionAddress: mapViewModel.sessionAddress ?? "주소를 알 수 없습니다."
+            )
+        }
     }
     
     /// 지오펜스 내 위치 인증 상태 표시
@@ -99,26 +114,86 @@ fileprivate struct LocationStatusBarView: View {
     }
     
     /// 세션 위치의 주소 (역지오코딩 결과)
-    /// - Note: animation modifier 분리로 뷰 재등장 시 애니메이션 중첩 방지
     private var address: some View {
-        Text(mapViewModel.sessionAddress ?? "주소를 알 수 없습니다.")
-            .appFont(.caption1, color: .grey600)
-            .offset(x: animate ? -Constants.animationOffset : 0)
-            .animation(
-                animate
-                    ? .linear(duration: Constants.animationDuration)
-                        .repeatForever(autoreverses: false)
-                    : .linear(duration: 0),
-                value: animate
-            )
-            .frame(maxWidth: .infinity, alignment: .trailing)
-            .clipped()
-            .onAppear {
-                animate = true
+        HStack(spacing: DefaultSpacing.spacing4) {
+            Spacer(minLength: 0)
+
+            Text(mapViewModel.sessionAddress ?? "주소를 알 수 없습니다.")
+                .appFont(.caption1, color: .grey600)
+                .offset(x: animate ? -Constants.animationOffset : 0)
+                .animation(
+                    animate
+                        ? .linear(duration: Constants.animationDuration)
+                            .repeatForever(autoreverses: false)
+                        : .linear(duration: 0),
+                    value: animate
+                )
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .clipped()
+                .onAppear {
+                    animate = true
+                }
+                .onDisappear {
+                    animate = false
+                }
+
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: Constants.contextMenuIconSize))
+                .foregroundStyle(.grey500)
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .padding(.vertical, Constants.addressVerticalPadding)
+        .padding(.leading, DefaultSpacing.spacing8)
+        .accessibilityHint("길게 눌러 주소 관련 메뉴를 엽니다")
+    }
+
+    private func copyAddress() {
+        guard let address = mapViewModel.sessionAddress?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !address.isEmpty else { return }
+
+        UIPasteboard.general.string = address
+        triggerCopyHaptic()
+    }
+
+    private func triggerCopyHaptic() {
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+    }
+}
+
+private struct LocationStatusBarContextPreview: View {
+    let isUserInsideGeofence: Bool
+    let sessionAddress: String
+
+    private enum Constants {
+        static let verifyIconSize: CGFloat = 12
+        static let spacing: CGFloat = 4
+        static let previewWidth: CGFloat = 320
+    }
+
+    var body: some View {
+        HStack(spacing: Constants.spacing) {
+            HStack(spacing: Constants.spacing) {
+                Image(.Map.verifyLocation)
+                    .resizable()
+                    .frame(width: Constants.verifyIconSize, height: Constants.verifyIconSize)
+
+                Text(isUserInsideGeofence ? "위치 인증됨" : "위치 미인증")
+                    .appFont(.caption1, color: isUserInsideGeofence ? .indigo500 : .red)
             }
-            .onDisappear {
-                animate = false
-            }
+
+            Spacer(minLength: 0)
+
+            Text(sessionAddress)
+                .appFont(.caption1, color: .grey600)
+                .lineLimit(1)
+
+            Image(systemName: "ellipsis.circle")
+                .foregroundStyle(.grey500)
+        }
+        .padding(DefaultConstant.defaultBtnPadding)
+        .frame(width: Constants.previewWidth)
+        .glassEffect()
     }
 }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Map/BaseMapViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Map/BaseMapViewModel.swift
@@ -107,4 +107,17 @@ final class BaseMapViewModel {
                 error, context: .init(feature: "Activity", action: "updateAddressForSession"))
         }
     }
+
+    /// Apple Maps에서 세션 위치를 엽니다.
+    func openSessionLocationInMaps() {
+        let mapItem = MKMapItem(
+            location: CLLocation(
+                latitude: sessionLocation.latitude,
+                longitude: sessionLocation.longitude
+            ),
+            address: nil
+        )
+        mapItem.name = sessionAddress
+        mapItem.openInMaps()
+    }
 }


### PR DESCRIPTION
## ✨ PR 유형

Feature — 활동 탭 지도 하단 주소 영역에 컨텍스트 메뉴(클립보드 복사, 애플 지도 검색) 추가

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 주소 바 long-press 시 컨텍스트 메뉴 및 프리뷰가 노출됩니다. 스크린샷/영상 첨부 부탁드립니다. -->

## 🛠️ 작업내용

- 주소 상태바(`LocationStatusBarView`)에 `contextMenu` 적용 — 길게 눌러 메뉴 진입
- **클립보드 복사 액션**: `UIPasteboard.general.string`에 주소 복사 + `UINotificationFeedbackGenerator` 성공 햅틱
- **애플 지도 검색 액션**: `BaseMapViewModel.openSessionLocationInMaps()`로 `MKMapItem.openInMaps()` 호출
- 컨텍스트 메뉴 프리뷰용 `LocationStatusBarContextPreview` 컴포넌트 추가 (위치 인증 상태 + 주소 표시)
- 주소 영역 우측에 `ellipsis.circle` 힌트 아이콘 배치

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Components/Map/ActivityCompactMapView.swift` — contextMenu 구조, 프리뷰 컴포넌트 레이아웃, 클립보드 복사 로직
- `Features/Activity/Presentation/ViewModels/Map/BaseMapViewModel.swift` — `openSessionLocationInMaps()` MKMapItem 생성 방식

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)