### PR TITLE
🐛[Fix] 일정 생성 후 홈 즉시 반영 및 장소 검색 지도 모드 추가 (#492)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/MapPlacePickerView.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/MapPlacePickerView.swift
@@ -1,0 +1,402 @@
+//
+//  MapPlacePickerView.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 3/11/26.
+//
+
+import CoreLocation
+import MapKit
+import SwiftUI
+
+/// Apple 지도에서 핀을 찍어 장소를 선택하는 뷰
+///
+/// 선택한 좌표를 역지오코딩해 `PlaceSearchInfo`로 변환하고,
+/// 확정 시 상위 화면에 선택 결과를 전달합니다.
+struct MapPlacePickerView: View {
+
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+
+    /// 편집 모드에서 전달되는 기존 장소 정보입니다.
+    private let initialPlace: PlaceSearchInfo
+    /// 장소 선택 완료 시 상위 화면에 결과를 전달하는 콜백입니다.
+    private let placeSelected: (PlaceSearchInfo) -> Void
+
+    /// 현재 지도 카메라 위치입니다.
+    @State private var cameraPosition: MapCameraPosition = .region(
+        MKCoordinateRegion(
+            center: Constants.defaultCenter,
+            span: Constants.defaultSpan
+        )
+    )
+    /// 지도에 표시 중인 선택 좌표입니다.
+    @State private var selectedCoordinate: CLLocationCoordinate2D?
+    /// 선택 좌표를 장소 정보로 변환한 결과입니다.
+    @State private var selectedPlace: PlaceSearchInfo?
+    /// 역지오코딩 진행 상태입니다.
+    @State private var isResolvingPlace: Bool = false
+    /// 초기 카메라/선택 상태를 한 번만 구성하기 위한 플래그입니다.
+    @State private var hasInitializedState: Bool = false
+
+    /// 레이아웃과 지도 기본값을 모아둔 상수입니다.
+    private enum Constants {
+        static let defaultCenter = CLLocationCoordinate2D(
+            latitude: 37.5665,
+            longitude: 126.9780
+        )
+        static let defaultSpan = MKCoordinateSpan(
+            latitudeDelta: 0.02,
+            longitudeDelta: 0.02
+        )
+        static let pinSize: CGFloat = 28
+        static let bottomPadding: CGFloat = 16
+    }
+
+    // MARK: - Initializer
+
+    /// 지도 선택 화면을 초기화합니다.
+    ///
+    /// - Parameters:
+    ///   - initialPlace: 기존 선택값이 있는 경우 초기 핀 위치로 사용할 장소 정보입니다.
+    ///   - placeSelected: 사용자가 위치 선택을 확정했을 때 호출되는 클로저입니다.
+    init(
+        initialPlace: PlaceSearchInfo,
+        placeSelected: @escaping (PlaceSearchInfo) -> Void
+    ) {
+        self.initialPlace = initialPlace
+        self.placeSelected = placeSelected
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .bottom) {
+                mapContent
+                selectionCard
+            }
+            .navigationTitle("지도에서 선택")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    currentLocationButton
+                }
+            }
+            .task {
+                await configureInitialStateIfNeeded()
+            }
+        }
+    }
+
+    // MARK: - Private View
+
+    /// 핀 선택과 사용자 위치를 표시하는 지도 본문입니다.
+    private var mapContent: some View {
+        MapReader { proxy in
+            Map(position: $cameraPosition) {
+                if let selectedCoordinate {
+                    Annotation(
+                        "선택한 위치",
+                        coordinate: selectedCoordinate,
+                        anchor: .bottom
+                    ) {
+                        SelectionPinView(pinSize: Constants.pinSize)
+                    }
+                }
+                UserAnnotation()
+            }
+            .mapStyle(.standard)
+            .mapControls {
+                MapCompass()
+            }
+            .simultaneousGesture(
+                SpatialTapGesture()
+                    .onEnded { value in
+                        handleMapTap(value, proxy: proxy)
+                    }
+            )
+        }
+    }
+
+    /// 선택한 장소 정보와 확정 액션을 제공하는 하단 카드입니다.
+    private var selectionCard: some View {
+        SelectionCardView(
+            selectedPlace: selectedPlace,
+            isResolvingPlace: isResolvingPlace,
+            confirmSelection: confirmSelection
+        )
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .padding(.bottom, Constants.bottomPadding)
+    }
+
+    /// 현재 위치로 카메라를 이동하고 핀을 갱신하는 툴바 버튼입니다.
+    private var currentLocationButton: some View {
+        Button(action: {
+            Task {
+                await moveToCurrentLocation()
+            }
+        }) {
+            CurrentLocationIcon()
+        }
+        .accessibilityLabel("현재 위치로 이동")
+    }
+
+    // MARK: - Private Function
+
+    /// 지도 탭 위치를 좌표로 변환한 뒤 선택 상태를 갱신합니다.
+    ///
+    /// - Parameters:
+    ///   - value: 사용자의 탭 위치 정보입니다.
+    ///   - proxy: 화면 좌표를 지도 좌표로 변환하는 `MapProxy`입니다.
+    private func handleMapTap(_ value: SpatialTapGesture.Value, proxy: MapProxy) {
+        guard let coordinate = proxy.convert(
+            value.location,
+            from: .local
+        ) else {
+            return
+        }
+
+        Task {
+            await selectCoordinate(coordinate)
+        }
+    }
+
+    /// 초기 진입 시 기존 선택값 또는 현재 위치를 기준으로 지도를 설정합니다.
+    ///
+    /// 기존 장소가 있으면 해당 좌표에 핀과 카메라를 맞추고,
+    /// 없으면 현재 위치 권한을 요청한 뒤 가능한 경우 현재 위치로 카메라를 이동합니다.
+    @MainActor
+    private func configureInitialStateIfNeeded() async {
+        guard !hasInitializedState else { return }
+        hasInitializedState = true
+
+        if initialPlace.coordinate.latitude != 0
+            || initialPlace.coordinate.longitude != 0 {
+            let coordinate = CLLocationCoordinate2D(
+                latitude: initialPlace.coordinate.latitude,
+                longitude: initialPlace.coordinate.longitude
+            )
+            selectedCoordinate = coordinate
+            selectedPlace = initialPlace
+            moveCamera(to: coordinate)
+            return
+        }
+
+        LocationManager.shared.requestAuthorization()
+        if let currentLocation = try? await LocationManager.shared
+            .getCurrentLocation() {
+            moveCamera(to: currentLocation)
+        }
+    }
+
+    /// 현재 위치를 조회한 뒤 해당 좌표를 선택 상태로 반영합니다.
+    @MainActor
+    private func moveToCurrentLocation() async {
+        do {
+            let coordinate = try await LocationManager.shared.getCurrentLocation()
+            await selectCoordinate(coordinate)
+        } catch {
+            LocationManager.shared.requestAuthorization()
+        }
+    }
+
+    /// 사용자가 선택한 좌표를 핀과 장소 정보 상태에 반영합니다.
+    ///
+    /// - Parameter coordinate: 지도에서 선택한 좌표입니다.
+    @MainActor
+    private func selectCoordinate(_ coordinate: CLLocationCoordinate2D) async {
+        selectedCoordinate = coordinate
+        moveCamera(to: coordinate)
+        isResolvingPlace = true
+        selectedPlace = await reverseGeocodePlaceInfo(for: coordinate)
+        isResolvingPlace = false
+    }
+
+    /// 지정한 좌표가 화면 중심에 오도록 카메라를 갱신합니다.
+    ///
+    /// - Parameter coordinate: 카메라 중심으로 이동할 좌표입니다.
+    @MainActor
+    private func moveCamera(to coordinate: CLLocationCoordinate2D) {
+        cameraPosition = .region(
+            MKCoordinateRegion(
+                center: coordinate,
+                span: Constants.defaultSpan
+            )
+        )
+    }
+
+    /// 현재 선택된 장소를 상위 화면에 전달하고 시트를 닫습니다.
+    private func confirmSelection() {
+        guard let selectedPlace else { return }
+        placeSelected(selectedPlace)
+        dismiss()
+    }
+
+    /// 좌표를 `PlaceSearchInfo`로 역지오코딩합니다.
+    ///
+    /// Apple Maps의 역지오코딩 결과를 우선 사용하고,
+    /// 실패하면 좌표 문자열 기반의 폴백 장소 정보를 반환합니다.
+    ///
+    /// - Parameter coordinate: 역지오코딩할 좌표입니다.
+    /// - Returns: 화면에서 바로 사용할 수 있는 `PlaceSearchInfo`입니다.
+    private func reverseGeocodePlaceInfo(
+        for coordinate: CLLocationCoordinate2D
+    ) async -> PlaceSearchInfo {
+        let location = CLLocation(
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude
+        )
+
+        guard let request = MKReverseGeocodingRequest(location: location) else {
+            return fallbackPlaceInfo(for: coordinate)
+        }
+
+        do {
+            let mapItems = try await request.mapItems
+            guard let first = mapItems.first else {
+                return fallbackPlaceInfo(for: coordinate)
+            }
+
+            let address =
+                first.address?.shortAddress
+                ?? first.address?.fullAddress
+                ?? first.addressRepresentations?.fullAddress(
+                    includingRegion: false,
+                    singleLine: true
+                )
+                ?? fallbackAddress(for: coordinate)
+
+            return PlaceSearchInfo(
+                name: first.name ?? address,
+                address: address,
+                coordinate: Coordinate(
+                    latitude: coordinate.latitude,
+                    longitude: coordinate.longitude
+                )
+            )
+        } catch {
+            return fallbackPlaceInfo(for: coordinate)
+        }
+    }
+
+    /// 역지오코딩에 실패했을 때 사용할 기본 장소 정보를 생성합니다.
+    ///
+    /// - Parameter coordinate: 표시용 좌표입니다.
+    /// - Returns: 좌표 문자열을 포함한 기본 `PlaceSearchInfo`입니다.
+    private func fallbackPlaceInfo(
+        for coordinate: CLLocationCoordinate2D
+    ) -> PlaceSearchInfo {
+        let address = fallbackAddress(for: coordinate)
+        return PlaceSearchInfo(
+            name: "지도에서 선택한 위치",
+            address: address,
+            coordinate: Coordinate(
+                latitude: coordinate.latitude,
+                longitude: coordinate.longitude
+            )
+        )
+    }
+
+    /// 좌표를 짧은 주소 문자열 형태로 변환합니다.
+    ///
+    /// - Parameter coordinate: 문자열로 표시할 좌표입니다.
+    /// - Returns: 위도/경도를 소수점 다섯 자리까지 표현한 문자열입니다.
+    private func fallbackAddress(for coordinate: CLLocationCoordinate2D) -> String {
+        String(
+            format: "%.5f, %.5f",
+            coordinate.latitude,
+            coordinate.longitude
+        )
+    }
+}
+
+// MARK: - Private Subviews
+
+/// 선택한 좌표를 나타내는 기본 핀 아이콘입니다.
+private struct SelectionPinView: View {
+    let pinSize: CGFloat
+
+    var body: some View {
+        Image(.Map.mapPin)
+            .resizable()
+            .scaledToFit()
+            .frame(width: pinSize, height: pinSize)
+    }
+}
+
+/// 현재 위치 이동 버튼에 사용하는 아이콘 뷰입니다.
+private struct CurrentLocationIcon: View {
+    var body: some View {
+        Image(systemName: "location.fill")
+            .foregroundStyle(.indigo500)
+    }
+}
+
+/// 선택 상태, 로딩 상태, 확정 버튼을 조합한 하단 카드입니다.
+private struct SelectionCardView: View {
+
+    let selectedPlace: PlaceSearchInfo?
+    let isResolvingPlace: Bool
+    let confirmSelection: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            content
+            confirmButton
+        }
+        .padding(DefaultSpacing.spacing16)
+        .background(
+            ConcentricRectangle(
+                corners: .concentric(
+                    minimum: DefaultConstant.concentricRadius
+                ),
+                isUniform: true
+            )
+            .fill(.white)
+            .glass()
+        )
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let selectedPlace {
+            selectedPlaceContent(selectedPlace)
+        } else if isResolvingPlace {
+            resolvingContent
+        } else {
+            Text("지도를 탭해서 위치를 선택하세요.")
+                .appFont(.subheadline, color: .grey600)
+        }
+    }
+
+    private func selectedPlaceContent(_ selectedPlace: PlaceSearchInfo) -> some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            Text(selectedPlace.name)
+                .appFont(.calloutEmphasis, color: .black)
+
+            Text(selectedPlace.address)
+                .appFont(.subheadline, color: .grey600)
+                .multilineTextAlignment(.leading)
+        }
+    }
+
+    private var resolvingContent: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("선택한 위치를 확인하는 중입니다.")
+                .appFont(.subheadline, color: .grey600)
+        }
+    }
+
+    private var confirmButton: some View {
+        Button(action: confirmSelection) {
+            Text("이 위치 사용")
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.glassProminent)
+        .disabled(selectedPlace == nil || isResolvingPlace)
+    }
+}

--- a/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/PlaceSelectView.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/PlaceSelectView.swift
@@ -17,11 +17,11 @@ struct PlaceSelectView: View {
     @Binding var place: PlaceSearchInfo
     
     /// 지도 검색 모달 표시 여부
-    @State var showSearchMap: Bool = false
+    @State private var showSearchMap: Bool = false
     
     /// 에러 핸들러 (지도 검색 중 에러 발생 시 처리)
     @Environment(ErrorHandler.self) var errorHandler
-    
+
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.place == rhs.place
     }
@@ -34,13 +34,12 @@ struct PlaceSelectView: View {
         }, label: {
             HStack(spacing: DefaultSpacing.spacing8) {
                 if place.name.isEmpty {
-                    emptyPlace // 장소 미선택 시 뷰
+                    emptyPlace
                 } else {
-                    selectedPlace // 장소 선택 시 정보 뷰
+                    selectedPlace
                 }
                 Spacer()
-                
-                // 장소 선택 취소 버튼
+
                 if !place.name.isEmpty {
                     clearButton
                 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/ScheduleListCard.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/ScheduleListCard.swift
@@ -104,6 +104,9 @@ struct ScheduleListCard: View, Equatable {
     }
 
     private var dDayText: String {
+        if data.dDay < 0 {
+            return "D-\(abs(data.dDay))"
+        }
         if data.dDay > 0 {
             return "D+\(data.dDay)"
         }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
@@ -114,6 +114,11 @@ struct HomeView: View {
                 guard shouldFetchOnTask else { return }
                 await viewModel.fetchAllIfNeeded()
             }
+            .task(id: pathStore.homePath.count) {
+                guard shouldFetchOnTask else { return }
+                guard pathStore.homePath.isEmpty else { return }
+                await reloadVisibleScheduleMonth()
+            }
         }
     }
     
@@ -289,6 +294,15 @@ struct HomeView: View {
         schedules
             .map { "\($0.scheduleId):\($0.title)" }
             .joined(separator: "|")
+    }
+
+    @MainActor
+    private func reloadVisibleScheduleMonth() async {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = ServerDateTimeConverter.kstTimeZone
+        let year = calendar.component(.year, from: currentMonth)
+        let month = calendar.component(.month, from: currentMonth)
+        await viewModel.fetchSchedules(year: year, month: month)
     }
     
     // MARK: - Recent Notices

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/SearchPlaceView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/SearchPlaceView.swift
@@ -5,51 +5,83 @@
 //  Created by euijjang97 on 1/22/26.
 //
 
-import SwiftUI
+import CoreLocation
 import MapKit
+import SwiftUI
 
 struct SearchMapView: View {
     // MARK: - Property
+
     @Environment(\.dismiss) var dismiss
     @State var viewModel: SearchPlaceViewModel
     @FocusState var isFocused: Bool
-    
+    @State private var searchMode: SearchMode = .search
+    @State private var mapPickerState: InlineMapPickerState = .init()
+
     /// 장소가 선택되었을 때 호출되는 클로저
     var placeSelected: (PlaceSearchInfo) -> Void
-    
+
+    enum SearchMode: String, CaseIterable, Identifiable {
+        case search = "검색"
+        case map = "지도"
+
+        var id: String { rawValue }
+    }
+
     // MARK: - Header
-    /// 지도 뷰의 섹션 헤더 타입 정의
+
     enum MapHeaderType: String {
         case recent = "최근 검색"
         case search = "검색 위치"
     }
-    
+
     // MARK: - Constant
-    /// 상수 모음
+
     enum Constants {
         static let placeholder: String = "Apple 지도"
         static let magnifyingglass: String = "magnifyingglass"
         static let currentLocation: String = "location.fill"
     }
-    
+
     // MARK: - Init
-    /// 초기화 메서드
-    /// - Parameters:
-    ///   - errorHandler: 에러 핸들러 주입
-    ///   - placeSelected: 장소 선택 시 호출되는 클로저
-    init(errorHandler: ErrorHandler, placeSelected: @escaping (PlaceSearchInfo) -> Void) {
+
+    init(
+        errorHandler: ErrorHandler,
+        placeSelected: @escaping (PlaceSearchInfo) -> Void
+    ) {
         self._viewModel = .init(wrappedValue: .init(errorHandler: errorHandler))
         self.placeSelected = placeSelected
     }
-    
+
     var body: some View {
         NavigationStack {
+            content
+                .navigation(naviTitle: .placeSearch, displayMode: .inline)
+                .toolbar(content: {
+                    ToolbarItemGroup(placement: .topBarTrailing) {
+                        modeToggleButton
+                        currnetLocation
+                    }
+                })
+                .task {
+                    viewModel.loadRecentPlaces()
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch searchMode {
+        case .search:
             Form {
                 recentSearches
                 mapSearchResult
             }
-            .navigation(naviTitle: .placeSearch, displayMode: .inline)
-            .searchable(text: $viewModel.searchPlace, placement: .toolbarPrincipal, prompt: Constants.placeholder)
+            .searchable(
+                text: $viewModel.searchPlace,
+                placement: .toolbarPrincipal,
+                prompt: Constants.placeholder
+            )
             .searchFocused($isFocused)
             .onSubmit(of: .search, {
                 searchAction(viewModel.searchPlace)
@@ -57,22 +89,28 @@ struct SearchMapView: View {
             .onChange(of: viewModel.searchPlace, { _, new in
                 searchAction(new)
             })
-            .toolbar(content: {
-                ToolbarItem(placement: .topBarTrailing, content: {
-                    currnetLocation
-                })
-            })
             .searchPresentationToolbarBehavior(.avoidHidingContent)
-            .task {
-                viewModel.loadRecentPlaces()
-            }
+
+        case .map:
+            InlineMapPlacePicker(
+                state: mapPickerState,
+                placeSelected: { place in
+                    self.placeSelected(place)
+                }
+            )
+            .umcDefaultBackground()
         }
     }
-    
-    /// 현재 위치 버튼 뷰 (기능 미구현 상태로 보임)
+
+    /// 현재 위치 버튼 뷰
     private var currnetLocation: some View {
         Button(action: {
             Task {
+                if searchMode == .map {
+                    await mapPickerState.moveToCurrentLocation()
+                    return
+                }
+
                 if let currentPlace = await viewModel.getCurrnetLocation() {
                     let placeInfo = PlaceSearchInfo(
                         name: currentPlace.name,
@@ -89,7 +127,20 @@ struct SearchMapView: View {
                 .foregroundStyle(.indigo500)
         })
     }
-    
+
+    private var modeToggleButton: some View {
+        Button(action: {
+            withAnimation {
+                searchMode = searchMode == .search ? .map : .search
+            }
+        }) {
+            Image(systemName: searchMode == .search ? "map" : "magnifyingglass")
+                .renderingMode(.template)
+                .foregroundStyle(.indigo500)
+        }
+        .accessibilityLabel(searchMode == .search ? "지도로 보기" : "검색으로 보기")
+    }
+
     /// 최근 검색 위치 섹션 뷰
     @ViewBuilder
     private var recentSearches: some View {
@@ -98,20 +149,27 @@ struct SearchMapView: View {
                 if !viewModel.recentPlaces.isEmpty {
                     List {
                         ForEach(viewModel.recentPlaces, id: \.id) { place in
-                           recentBtn(place)
+                            recentBtn(place)
                         }
                         .onDelete(perform: rencetDataDelete)
                     }
                 } else {
-                    ContentUnavailableView("최근 검색 기록이 없습니다", systemImage: "magnifyingglass", description: Text("관심 있는 장소를 검색하여 찾아보세요."))
+                    ContentUnavailableView(
+                        "최근 검색 기록이 없습니다",
+                        systemImage: "magnifyingglass",
+                        description: Text("관심 있는 장소를 검색하여 찾아보세요.")
+                    )
                 }
             }, header: {
-                generateHeader(.recent, isShowBtn: viewModel.searchPlace.isEmpty ? false : true)
+                generateHeader(
+                    .recent,
+                    isShowBtn: !viewModel.recentPlaces.isEmpty
+                )
             })
         }
     }
-    
-    /// 위치 검색 결과(지도 기반) 섹션 뷰
+
+    /// 위치 검색 결과 섹션 뷰
     @ViewBuilder
     private var mapSearchResult: some View {
         if !viewModel.searchResult.isEmpty {
@@ -121,7 +179,11 @@ struct SearchMapView: View {
                         Task {
                             await viewModel.addRecentPlace(place)
                             await viewModel.clear()
-                            placeSelected(.init(name: place.name, address: place.address ?? "도로명 주소 없음", coordinate: place.coordinate))
+                            placeSelected(.init(
+                                name: place.name,
+                                address: place.address ?? "도로명 주소 없음",
+                                coordinate: place.coordinate
+                            ))
                             dismiss()
                         }
                     }
@@ -134,17 +196,15 @@ struct SearchMapView: View {
     }
 }
 
+// MARK: - Extension
 
-// MARK: - Exnsion
 extension SearchMapView {
-    /// 리스트 아이템의 아이콘 뷰
     private var labelIcon: some View {
         Image(systemName: Constants.magnifyingglass)
             .renderingMode(.template)
             .foregroundStyle(.grey700)
     }
-    
-    /// 최근 검색어 버튼을 생성하는 메서드
+
     private func recentBtn(_ place: RecentPlace) -> some View {
         Button(action: {
             viewModel.searchPlace = place.name
@@ -156,58 +216,56 @@ extension SearchMapView {
             .labelIconToTitleSpacing(DefaultSpacing.spacing8)
         })
     }
-    
-    
-    /// 뷰 내부 검색 액션 수행
-    /// - Parameter query: 검색어 쿼리
+
     private func searchAction(_ query: String) {
         Task {
             await viewModel.search(query: query)
         }
     }
-    
-    /// 리스트 아이템의 타이틀 뷰
+
     private func labelTitle(_ title: String) -> some View {
         Text(title)
             .appFont(.body, color: .black)
     }
-    
-    /// 섹션 헤더 뷰 생성해주는 도우미 함수
-    /// - Parameter type: 생성할 헤더의 타입 (최근 검색, 지도 위치 등)
-    /// - Returns: 설정된 스타일이 적용된 헤더 뷰
-    private func generateHeader(_ type: MapHeaderType, isShowBtn: Bool = false) -> some View {
+
+    private func generateHeader(
+        _ type: MapHeaderType,
+        isShowBtn: Bool = false
+    ) -> some View {
         HStack {
             Text(type.rawValue)
                 .font(.body)
                 .foregroundStyle(.gray)
                 .fontWeight(.semibold)
-            
+
             Spacer()
-            
+
             if isShowBtn {
                 Button(role: .destructive, action: {
                     viewModel.removeAll()
-                })
+                }) {
+                    Text("전체 삭제")
+                        .appFont(.footnote, color: .red500)
+                }
             }
         }
     }
-    
-    /// 최근 검색 기록을 삭제하는 메서드
+
     private func rencetDataDelete(index: IndexSet) {
         viewModel.recentPlaces.remove(atOffsets: index)
     }
 }
 
 // MARK: - SearchContent
-/// 검색 결과 리스트의 각 행을 구성하는 뷰
+
 fileprivate struct SearchContent: View, Equatable {
     let place: PlaceSearchResult
     let tapAction: () -> Void
-    
+
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.place == rhs.place
     }
-    
+
     var body: some View {
         Button(action: {
             tapAction()
@@ -215,7 +273,7 @@ fileprivate struct SearchContent: View, Equatable {
             HStack(spacing: DefaultSpacing.spacing8, content: {
                 MapMarkerIcon(category: place.category)
                     .equatable()
-                
+
                 VStack(alignment: .leading, spacing: DefaultSpacing.spacing4, content: {
                     Text(place.name)
                         .appFont(.calloutEmphasis, color: .black)
@@ -227,18 +285,14 @@ fileprivate struct SearchContent: View, Equatable {
     }
 }
 
-/// 지도 마커 아이콘을 표시하는 뷰
 fileprivate struct MapMarkerIcon: View, Equatable {
     let category: MKPointOfInterestCategory?
-    
-    /// 마커 아이콘 관련 상수
+
     enum Constants {
-        /// 원형 배경 크기
         static let circleSize: CGFloat = 40
-        /// 기본 마커 아이콘 이름
         static let circleIcon: String = "mappin"
     }
-    
+
     var body: some View {
         Circle()
             .fill(category?.backgroundColor ?? .gray)
@@ -253,10 +307,228 @@ fileprivate struct MapMarkerIcon: View, Equatable {
     }
 }
 
+// MARK: - InlineMapPlacePicker
+
+@Observable
+private final class InlineMapPickerState {
+    private static let defaultCenter = CLLocationCoordinate2D(
+        latitude: 37.5665,
+        longitude: 126.9780
+    )
+    private static let defaultSpan = MKCoordinateSpan(
+        latitudeDelta: 0.02,
+        longitudeDelta: 0.02
+    )
+
+    var cameraPosition: MapCameraPosition = .region(
+        MKCoordinateRegion(
+            center: defaultCenter,
+            span: defaultSpan
+        )
+    )
+    var selectedCoordinate: CLLocationCoordinate2D?
+    var selectedPlace: PlaceSearchInfo?
+    var isResolvingPlace: Bool = false
+    private var hasInitializedState: Bool = false
+
+    @MainActor
+    func configureInitialStateIfNeeded() async {
+        guard !hasInitializedState else { return }
+        hasInitializedState = true
+
+        LocationManager.shared.requestAuthorization()
+        if let currentLocation = try? await LocationManager.shared.getCurrentLocation() {
+            moveCamera(to: currentLocation)
+        }
+    }
+
+    @MainActor
+    func moveToCurrentLocation() async {
+        do {
+            let coordinate = try await LocationManager.shared.getCurrentLocation()
+            await selectCoordinate(coordinate)
+        } catch {
+            LocationManager.shared.requestAuthorization()
+        }
+    }
+
+    @MainActor
+    func selectCoordinate(_ coordinate: CLLocationCoordinate2D) async {
+        selectedCoordinate = coordinate
+        isResolvingPlace = true
+        selectedPlace = await reverseGeocodePlaceInfo(for: coordinate)
+        isResolvingPlace = false
+    }
+
+    @MainActor
+    private func moveCamera(to coordinate: CLLocationCoordinate2D) {
+        cameraPosition = .region(
+            MKCoordinateRegion(
+                center: coordinate,
+                span: Self.defaultSpan
+            )
+        )
+    }
+
+    private func reverseGeocodePlaceInfo(
+        for coordinate: CLLocationCoordinate2D
+    ) async -> PlaceSearchInfo {
+        let location = CLLocation(
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude
+        )
+
+        guard let request = MKReverseGeocodingRequest(location: location) else {
+            return fallbackPlaceInfo(for: coordinate)
+        }
+
+        do {
+            let mapItems = try await request.mapItems
+            guard let first = mapItems.first else {
+                return fallbackPlaceInfo(for: coordinate)
+            }
+
+            let address =
+                first.address?.shortAddress
+                ?? first.address?.fullAddress
+                ?? first.addressRepresentations?.fullAddress(
+                    includingRegion: false,
+                    singleLine: true
+                )
+                ?? fallbackAddress(for: coordinate)
+
+            return PlaceSearchInfo(
+                name: first.name ?? address,
+                address: address,
+                coordinate: Coordinate(
+                    latitude: coordinate.latitude,
+                    longitude: coordinate.longitude
+                )
+            )
+        } catch {
+            return fallbackPlaceInfo(for: coordinate)
+        }
+    }
+
+    private func fallbackPlaceInfo(
+        for coordinate: CLLocationCoordinate2D
+    ) -> PlaceSearchInfo {
+        let address = fallbackAddress(for: coordinate)
+        return PlaceSearchInfo(
+            name: "지도에서 선택한 위치",
+            address: address,
+            coordinate: Coordinate(
+                latitude: coordinate.latitude,
+                longitude: coordinate.longitude
+            )
+        )
+    }
+
+    private func fallbackAddress(
+        for coordinate: CLLocationCoordinate2D
+    ) -> String {
+        String(
+            format: "%.5f, %.5f",
+            coordinate.latitude,
+            coordinate.longitude
+        )
+    }
+}
+
+private struct InlineMapPlacePicker: View {
+
+    @Bindable var state: InlineMapPickerState
+    private let placeSelected: (PlaceSearchInfo) -> Void
+
+    init(
+        state: InlineMapPickerState,
+        placeSelected: @escaping (PlaceSearchInfo) -> Void
+    ) {
+        self.state = state
+        self.placeSelected = placeSelected
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            MapReader { proxy in
+                Map(position: $state.cameraPosition) {
+                    if let selectedCoordinate = state.selectedCoordinate {
+                        Annotation(
+                            state.selectedPlace?.name ?? "선택한 위치",
+                            coordinate: selectedCoordinate,
+                            anchor: .bottom
+                        ) {
+                            SelectedPlaceAnnotation(place: state.selectedPlace)
+                        }
+                    }
+                    UserAnnotation()
+                }
+                .mapStyle(.standard)
+                .mapControls {
+                    MapCompass()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .simultaneousGesture(
+                    SpatialTapGesture()
+                        .onEnded { value in
+                            guard let coordinate = proxy.convert(
+                                value.location,
+                                from: .local
+                            ) else {
+                                return
+                            }
+
+                            Task {
+                                await state.selectCoordinate(coordinate)
+                            }
+                        }
+                )
+            }
+        }
+        .task {
+            await state.configureInitialStateIfNeeded()
+        }
+        .onChange(of: state.selectedPlace) { _, newValue in
+            guard let newValue else { return }
+            placeSelected(newValue)
+        }
+    }
+}
+
+private struct SelectedPlaceAnnotation: View {
+    let place: PlaceSearchInfo?
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing8) {
+            if let place {
+                VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                    Text(place.name)
+                        .appFont(.caption1Emphasis, color: .black)
+                        .lineLimit(1)
+                    Text(place.address)
+                        .appFont(.caption2, color: .grey600)
+                        .lineLimit(2)
+                }
+                .padding(.horizontal, DefaultSpacing.spacing12)
+                .padding(.vertical, DefaultSpacing.spacing8)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(.white)
+                        .glass()
+                )
+            }
+
+            Image(.Map.mapPin)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 28, height: 28)
+        }
+    }
+}
 
 #Preview {
     @Previewable @State var show: Bool = false
-    
+
     VStack {
         Button(action: {
             show.toggle()
@@ -268,6 +540,6 @@ fileprivate struct MapMarkerIcon: View, Equatable {
         SearchMapView(errorHandler: .init()) { place in
             print(place)
         }
-            .presentationDragIndicator(.visible)
+        .presentationDragIndicator(.visible)
     })
 }

--- a/AppProduct/AppProduct/Utilities/Extensions/Notification+Error.swift
+++ b/AppProduct/AppProduct/Utilities/Extensions/Notification+Error.swift
@@ -26,4 +26,5 @@ extension Notification.Name {
     /// 운영진이 출석을 승인/반려하면 발송됩니다.
     /// 챌린저 ViewModel이 수신하여 `myHistory`를 갱신합니다.
     static let attendanceStatusChanged = Notification.Name("attendanceStatusChanged")
+
 }


### PR DESCRIPTION
## ✨ PR 유형

Fix + Feature — 일정 생성 후 홈 화면 미반영 버그 수정, D-Day 표시 수정, 장소 검색에 지도 직접 선택 모드 추가

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 장소 검색 화면에 지도 모드 토글이 추가되었습니다. 스크린샷/영상 첨부 부탁드립니다. -->

## 🛠️ 작업내용

### Bug Fix (#492)
- 일정 생성/수정 후 홈 화면 복귀 시 현재 월 일정 자동 재조회 (`pathStore.homePath.count` 감지)
- `ScheduleListCard` D-Day 음수값(미래 일정) 표시 오류 수정 (`D-N` 형식 정상화)

### Feature — 장소 검색 지도 모드
- `SearchMapView`에 검색/지도 모드 토글 버튼 추가
- `InlineMapPlacePicker`: 지도 탭으로 좌표 직접 선택 → `MKReverseGeocodingRequest` 역지오코딩 → 장소 정보 반환
- `SelectedPlaceAnnotation`: 선택된 위치에 이름/주소 말풍선 Annotation 표시
- 현재 위치 버튼이 지도 모드에서도 동작하도록 분기 처리
- `PlaceSelectView` 접근 제어자 정리 및 코드 스타일 통일

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/HomeView.swift` — `task(id: pathStore.homePath.count)` 재조회 트리거 방식
- `Features/Home/Presentation/Views/Registration/SearchPlaceView.swift` — `InlineMapPlacePicker` 역지오코딩 로직 및 `SearchMode` 토글
- `Features/Home/Presentation/Components/Card/ScheduleListCard.swift` — D-Day 음수 분기 처리

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)