### PR TITLE
✨[Feat] 번개글 오픈채팅 링크 URL 검증 (#495)

### DIFF
--- a/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift
@@ -11,6 +11,11 @@ import Foundation
 class CommunityPostViewModel {
     // MARK: - Properties
 
+    private enum Constants {
+        static let openChatURLPrefix = "https://open.kakao.com/"
+        static let openChatValidationMessage = "오픈채팅 링크는 https://open.kakao.com/ 로 시작해야 합니다."
+    }
+
     private let useCaseProvider: CommunityUseCaseProviding
     private let errorHandler: ErrorHandler
 
@@ -38,14 +43,21 @@ class CommunityPostViewModel {
     }
 
     var isValid: Bool {
-        let hasBasicInfo = !titleText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !contentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasBasicInfo = !trimmedTitleText.isEmpty && !trimmedContentText.isEmpty
         if selectedCategory == .lighting {
             let hasPlace = !selectedPlace.name.isEmpty
-            let hasLink = !linkText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            let hasLink = !trimmedLinkText.isEmpty
 
-            return hasBasicInfo && hasPlace && hasLink
+            return hasBasicInfo && hasPlace && hasLink && isOpenChatURLValid
         }
         return hasBasicInfo
+    }
+
+    var openChatValidationMessage: String? {
+        guard selectedCategory == .lighting else { return nil }
+        guard !trimmedLinkText.isEmpty else { return nil }
+        guard !isOpenChatURLValid else { return nil }
+        return Constants.openChatValidationMessage
     }
 
     /// 수정 모드에서 초기값 대비 변경 사항이 있는지 확인합니다.
@@ -57,13 +69,13 @@ class CommunityPostViewModel {
     /// 현재 폼 상태의 스냅샷을 생성합니다.
     private var currentEditSnapshot: EditFormSnapshot {
         EditFormSnapshot(
-            title: titleText,
-            content: contentText,
+            title: trimmedTitleText,
+            content: trimmedContentText,
             category: selectedCategory,
             meetAt: selectedCategory == .lighting ? selectedDate : nil,
             maxParticipants: selectedCategory == .lighting ? maxParticipants : nil,
             location: selectedCategory == .lighting ? Self.serializePlace(selectedPlace) : nil,
-            openChatUrl: selectedCategory == .lighting ? linkText : nil
+            openChatUrl: selectedCategory == .lighting ? trimmedLinkText : nil
         )
     }
 
@@ -106,12 +118,12 @@ class CommunityPostViewModel {
                 let meetAtString = ServerDateTimeConverter.toUTCDateTimeString(selectedDate)
 
                 let request = CreateLightningPostRequestDTO(
-                    title: titleText,
-                    content: contentText,
+                    title: trimmedTitleText,
+                    content: trimmedContentText,
                     meetAt: meetAtString,
                     location: Self.serializePlace(selectedPlace),
                     maxParticipants: maxParticipants,
-                    openChatUrl: linkText
+                    openChatUrl: trimmedLinkText
                 )
 
                 try await useCaseProvider.createLightningUseCase.execute(request: request)
@@ -119,8 +131,8 @@ class CommunityPostViewModel {
             } else {
                 // 일반 게시글 생성 (질문/자유)
                 let request = PostRequestDTO(
-                    title: titleText,
-                    content: contentText,
+                    title: trimmedTitleText,
+                    content: trimmedContentText,
                     category: selectedCategory.rawValue
                 )
 
@@ -163,12 +175,12 @@ class CommunityPostViewModel {
                 let meetAtString = ServerDateTimeConverter.toUTCDateTimeString(selectedDate)
 
                 let request = CreateLightningPostRequestDTO(
-                    title: titleText,
-                    content: contentText,
+                    title: trimmedTitleText,
+                    content: trimmedContentText,
                     meetAt: meetAtString,
                     location: Self.serializePlace(selectedPlace),
                     maxParticipants: maxParticipants,
-                    openChatUrl: linkText
+                    openChatUrl: trimmedLinkText
                 )
 
                 try await useCaseProvider.updateLightningUseCase.execute(
@@ -179,8 +191,8 @@ class CommunityPostViewModel {
             } else {
                 // 일반 게시글 수정 (질문/자유)
                 let request = PostRequestDTO(
-                    title: titleText,
-                    content: contentText,
+                    title: trimmedTitleText,
+                    content: trimmedContentText,
                     category: selectedCategory.rawValue
                 )
 
@@ -213,6 +225,10 @@ class CommunityPostViewModel {
 
     @MainActor
     func submit() async {
+        guard isValid else {
+            return
+        }
+
         if editingPostId != nil {
             await updatePost()
         } else {
@@ -255,5 +271,23 @@ class CommunityPostViewModel {
         guard !trimmedAddress.isEmpty else { return trimmedName }
         guard !trimmedName.isEmpty, trimmedName != trimmedAddress else { return trimmedAddress }
         return "\(trimmedAddress), \(trimmedName)"
+    }
+
+    // MARK: - Validation Helpers
+
+    private var trimmedTitleText: String {
+        titleText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedContentText: String {
+        contentText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedLinkText: String {
+        linkText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isOpenChatURLValid: Bool {
+        trimmedLinkText.hasPrefix(Constants.openChatURLPrefix)
     }
 }

--- a/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityPostView.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityPostView.swift
@@ -146,11 +146,20 @@ struct CommunityPostView: View {
     }
 
     private func linkSection(vm: CommunityPostViewModel) -> some View {
-        TextField("오픈채팅 링크를 입력하세요.", text: $vm.linkText)
-            .appFont(.callout)
-            .keyboardType(.URL)
-            .autocapitalization(.none)
-            .autocorrectionDisabled()
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            TextField("오픈채팅 링크를 입력하세요.", text: $vm.linkText)
+                .appFont(.callout)
+                .keyboardType(.URL)
+                .autocapitalization(.none)
+                .autocorrectionDisabled()
+                .tint(vm.openChatValidationMessage == nil ? .indigo500 : .red500)
+
+            if let validationMessage = vm.openChatValidationMessage {
+                Text(validationMessage)
+                    .appFont(.footnote, color: .red500)
+                    .padding(.leading, DefaultSpacing.spacing4)
+            }
+        }
     }
     
     @ViewBuilder


### PR DESCRIPTION
## ✨ PR 유형

Feature — 번개글 작성 시 오픈채팅 링크 `https://open.kakao.com/` prefix 검증 추가

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 잘못된 URL 입력 시 인라인 에러 메시지가 표시됩니다. 스크린샷/영상 첨부 부탁드립니다. -->

## 🛠️ 작업내용

- 오픈채팅 링크가 `https://open.kakao.com/`으로 시작하는지 프론트 검증 추가
- 검증 실패 시 링크 입력 필드 하단에 인라인 에러 메시지 표시 + 커서 색상 red 전환
- `isValid` 조건에 `isOpenChatURLValid` 포함 → 검증 실패 시 생성/수정 버튼 비활성화
- `submit()` 진입 시 `isValid` guard 추가로 이중 안전장치 확보
- ViewModel 내 `trimmedTitleText`, `trimmedContentText`, `trimmedLinkText` 헬퍼 추출로 whitespace 처리 통일

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift` — `isOpenChatURLValid` 검증 로직, `openChatValidationMessage` 조건 분기
- `Features/Community/Presentation/Views/CommunityPostView.swift` — `linkSection` 인라인 에러 메시지 UI

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)