### PR TITLE
🐛[Fix] 공지 수신확인 현황 권한을 공지 유형별로 세분화 (#487)

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
@@ -168,6 +168,11 @@ struct NoticeTargetInfoDTO: Codable {
         return Int(targetChapterId)
     }
 
+    var targetSchoolIdValue: Int? {
+        guard let targetSchoolId else { return nil }
+        return Int(targetSchoolId)
+    }
+
     var targetsAllGenerations: Bool {
         generationValue <= 0
     }

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeTargetInfoMapper.swift
@@ -67,6 +67,8 @@ extension NoticeTargetInfoDTO {
             generation: generationValue,
             scope: targetScope,
             parts: resolvedParts,
+            chapterId: targetChapterIdValue,
+            schoolId: targetSchoolIdValue,
             branches: targetScope == .branch ? [resolvedChapterName].compactMap { $0 } : [],
             schools: targetScope == .campus ? [resolvedSchoolName].compactMap { $0 } : []
         )

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
@@ -90,6 +90,8 @@ struct NoticeRepository: NoticeRepositoryProtocol {
                 generation: generation,
                 scope: scope,
                 parts: body.targetInfo.targetParts ?? [],
+                chapterId: body.targetInfo.targetChapterId,
+                schoolId: body.targetInfo.targetSchoolId,
                 branches: [],
                 schools: []
             ),

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
@@ -159,8 +159,28 @@ struct TargetAudience: Equatable, Hashable {
     let generation: Int
     let scope: NoticeScope
     let parts: [UMCPartType]
+    let chapterId: Int?
+    let schoolId: Int?
     let branches: [String]
     let schools: [String]
+
+    init(
+        generation: Int,
+        scope: NoticeScope,
+        parts: [UMCPartType],
+        chapterId: Int? = nil,
+        schoolId: Int? = nil,
+        branches: [String],
+        schools: [String]
+    ) {
+        self.generation = generation
+        self.scope = scope
+        self.parts = parts
+        self.chapterId = chapterId
+        self.schoolId = schoolId
+        self.branches = branches
+        self.schools = schools
+    }
     
     /// 수신 대상 표시 텍스트
     ///
@@ -198,6 +218,8 @@ extension TargetAudience {
             generation: generation,
             scope: scope,
             parts: [],
+            chapterId: nil,
+            schoolId: nil,
             branches: [],
             schools: []
         )

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -122,9 +122,15 @@ final class NoticeDetailViewModel {
     /// 수정 화면 진입에 필요한 상세 데이터 준비 완료 여부
     var isDetailPreparedForEdit: Bool = false
 
-    /// 수신 확인 현황 접근 가능 여부 (운영진 이상)
+    /// 수신 확인 현황 접근 가능 여부
     var canViewReadStatus: Bool {
-        resolvedMemberRole.canAccessAdminMode
+        guard let detail = noticeState.value else { return false }
+        return NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: resolvedMemberRoles,
+            userChapterId: resolvedChapterId,
+            userSchoolId: resolvedSchoolId,
+            targetAudience: detail.targetAudience
+        )
     }
 
     // MARK: - Read Status Computed
@@ -347,6 +353,8 @@ final class NoticeDetailViewModel {
             generation: resolvedGeneration,
             scope: detail.targetAudience.scope,
             parts: detail.targetAudience.parts,
+            chapterId: detail.targetAudience.chapterId,
+            schoolId: detail.targetAudience.schoolId,
             branches: detail.targetAudience.branches,
             schools: detail.targetAudience.schools
         )
@@ -388,14 +396,24 @@ final class NoticeDetailViewModel {
         }
     }
 
-    private var resolvedMemberRole: ManagementTeam {
-        let storedRole = UserDefaults.standard.string(forKey: AppStorageKey.memberRole)
+    private var resolvedMemberRoles: [ManagementTeam] {
+        let storedRoles = (UserDefaults.standard.array(forKey: AppStorageKey.memberRoles) as? [String] ?? [])
+            .compactMap(ManagementTeam.init(rawValue:))
+        let storedHighestRole = UserDefaults.standard.string(forKey: AppStorageKey.memberRole)
             .flatMap(ManagementTeam.init(rawValue:))
+        let combinedRoles = storedRoles + [userSessionManager.currentRole] + [storedHighestRole].compactMap { $0 }
 
-        guard let storedRole else {
-            return userSessionManager.currentRole
-        }
-
-        return max(userSessionManager.currentRole, storedRole)
+        return Array(Set(combinedRoles))
     }
+
+    private var resolvedChapterId: Int? {
+        let chapterId = UserDefaults.standard.integer(forKey: AppStorageKey.chapterId)
+        return chapterId > 0 ? chapterId : nil
+    }
+
+    private var resolvedSchoolId: Int? {
+        let schoolId = UserDefaults.standard.integer(forKey: AppStorageKey.schoolId)
+        return schoolId > 0 ? schoolId : nil
+    }
+
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeReadStatusPermissionEvaluator.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeReadStatusPermissionEvaluator.swift
@@ -1,0 +1,63 @@
+//
+//  NoticeReadStatusPermissionEvaluator.swift
+//  AppProduct
+//
+//  Created by Codex on 3/11/26.
+//
+
+import Foundation
+
+/// 공지 대상과 사용자 역할을 기준으로 수신 확인 현황 접근 가능 여부를 계산합니다.
+struct NoticeReadStatusPermissionEvaluator {
+
+    // MARK: - Role Sets
+
+    private static let executiveRoles: Set<ManagementTeam> = [
+        .superAdmin,
+        .centralPresident,
+        .centralVicePresident
+    ]
+
+    private static let centralOperationRoles: Set<ManagementTeam> = [
+        .centralOperatingTeamMember,
+        .centralEducationTeamMember
+    ]
+
+    private static let schoolAdminRoles: Set<ManagementTeam> = [
+        .schoolPresident,
+        .schoolVicePresident,
+        .schoolPartLeader,
+        .schoolEtcAdmin
+    ]
+
+    // MARK: - Function
+
+    static func canViewReadStatus(
+        roles: [ManagementTeam],
+        userChapterId: Int?,
+        userSchoolId: Int?,
+        targetAudience: TargetAudience
+    ) -> Bool {
+        let roleSet = Set(roles)
+
+        if !roleSet.isDisjoint(with: executiveRoles) {
+            return true
+        }
+
+        if let targetChapterId = targetAudience.chapterId {
+            guard let userChapterId, userChapterId > 0 else { return false }
+            return roleSet.contains(.chapterPresident) && userChapterId == targetChapterId
+        }
+
+        if let targetSchoolId = targetAudience.schoolId {
+            guard let userSchoolId, userSchoolId > 0 else { return false }
+            return !roleSet.isDisjoint(with: schoolAdminRoles) && userSchoolId == targetSchoolId
+        }
+
+        guard targetAudience.generation > 0 else {
+            return false
+        }
+
+        return !roleSet.isDisjoint(with: centralOperationRoles)
+    }
+}

--- a/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
@@ -135,4 +135,111 @@ struct NoticePresentationTests {
 
         #expect(detail.authorName == "제옹")
     }
+
+    // MARK: - Read Status Permission Tests
+
+    @Test("총괄단은 모든 공지의 수신 확인 현황을 볼 수 있다")
+    func executivesCanViewAllReadStatuses() {
+        let audience = TargetAudience.all(generation: 0, scope: .central)
+
+        let result = NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: [.centralPresident],
+            userChapterId: nil,
+            userSchoolId: nil,
+            targetAudience: audience
+        )
+
+        #expect(result == true)
+    }
+
+    @Test("지부 공지는 동일 지부의 지부장만 수신 확인 현황을 볼 수 있다")
+    func chapterNoticeRequiresMatchingChapterPresident() {
+        let audience = TargetAudience(
+            generation: 9,
+            scope: .branch,
+            parts: [],
+            chapterId: 14,
+            branches: ["Ain"],
+            schools: []
+        )
+
+        let allowed = NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: [.chapterPresident],
+            userChapterId: 14,
+            userSchoolId: nil,
+            targetAudience: audience
+        )
+        let denied = NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: [.chapterPresident],
+            userChapterId: 15,
+            userSchoolId: nil,
+            targetAudience: audience
+        )
+
+        #expect(allowed == true)
+        #expect(denied == false)
+    }
+
+    @Test("학교 공지는 동일 학교 운영진만 수신 확인 현황을 볼 수 있다")
+    func campusNoticeRequiresMatchingSchoolAdmin() {
+        let audience = TargetAudience(
+            generation: 9,
+            scope: .campus,
+            parts: [],
+            schoolId: 23,
+            branches: [],
+            schools: ["가천대학교"]
+        )
+
+        let allowed = NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: [.schoolVicePresident],
+            userChapterId: nil,
+            userSchoolId: 23,
+            targetAudience: audience
+        )
+        let denied = NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: [.schoolVicePresident],
+            userChapterId: nil,
+            userSchoolId: 99,
+            targetAudience: audience
+        )
+
+        #expect(allowed == true)
+        #expect(denied == false)
+    }
+
+    @Test("기수 대상 공지는 중앙 운영진만 수신 확인 현황을 볼 수 있다")
+    func generationNoticeRequiresCentralOperationRole() {
+        let audience = TargetAudience.all(generation: 9, scope: .central)
+
+        let allowed = NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: [.centralOperatingTeamMember],
+            userChapterId: nil,
+            userSchoolId: nil,
+            targetAudience: audience
+        )
+        let denied = NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: [.chapterPresident],
+            userChapterId: 14,
+            userSchoolId: nil,
+            targetAudience: audience
+        )
+
+        #expect(allowed == true)
+        #expect(denied == false)
+    }
+
+    @Test("모든 기수 공지는 총괄단이 아니면 수신 확인 현황을 볼 수 없다")
+    func allGenerationNoticeDeniesNonExecutiveRoles() {
+        let audience = TargetAudience.all(generation: 0, scope: .central)
+
+        let result = NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: [.centralEducationTeamMember],
+            userChapterId: nil,
+            userSchoolId: nil,
+            targetAudience: audience
+        )
+
+        #expect(result == false)
+    }
 }


### PR DESCRIPTION
## ✨ PR 유형

Fix — 공지 수신확인 현황 접근 권한을 단순 `canAccessAdminMode` 체크에서 공지 유형별(지부/학교/기수) 세분화된 권한 정책으로 변경

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 — 권한 없는 사용자에게는 수신확인 현황 버튼/영역이 숨겨집니다 -->

## 🛠️ 작업내용

- **`NoticeReadStatusPermissionEvaluator` 신규 추가**: 공지 대상별 권한 분기 로직 전담
  - 총괄단(`superAdmin`, `centralPresident`, `centralVicePresident`): 모든 공지 열람 가능
  - 지부 공지(`chapterId` 존재): 해당 지부의 `CHAPTER_PRESIDENT`만 가능
  - 학교 공지(`schoolId` 존재): 해당 학교 운영진(`SCHOOL_PRESIDENT`, `SCHOOL_VICE_PRESIDENT`, `SCHOOL_PART_LEADER`, `SCHOOL_ETC_ADMIN`)만 가능
  - 기수 공지: 중앙 운영진(`CENTRAL_OPERATING_TEAM_MEMBER`, `CENTRAL_EDUCATION_TEAM_MEMBER`)만 가능
- **`TargetAudience`에 `chapterId`, `schoolId` 필드 추가** — 서버 응답의 타겟 지부/학교 ID를 도메인 모델까지 전달
- **`NoticeDetailViewModel`**: `canViewReadStatus`를 Evaluator 기반으로 변경, `resolvedMemberRole` 단일값 → `resolvedMemberRoles` 배열로 확장
- **단위 테스트 5건 추가**: 총괄단/지부/학교/기수/모든기수 케이스별 권한 검증

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeReadStatusPermissionEvaluator.swift` — 권한 분기 로직 정확성, Role Set 구성
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift` — `resolvedMemberRoles` 조합 방식, `resolvedChapterId`/`resolvedSchoolId` 조회
- `Features/Notice/Domain/Models/NoticeDetailModel.swift` — `TargetAudience`에 `chapterId`/`schoolId` 추가 및 기존 코드 호환성
- `AppProductTests/NoticeTest/NoticePresentationTests.swift` — 5건 테스트 케이스 커버리지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)