### PR TITLE
🐛[Fix] 공지 작성자 표기를 서버 응답 기반으로 변경 (#493)

### DIFF
--- a/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityPostViewModel.swift
@@ -13,7 +13,7 @@ class CommunityPostViewModel {
 
     private enum Constants {
         static let openChatURLPrefix = "https://open.kakao.com/"
-        static let openChatValidationMessage = "오픈채팅 링크는 https://open.kakao.com/ 로 시작해야 합니다."
+        static let openChatValidationMessage = "https://open.kakao.com/ 로 시작해야 합니다."
     }
 
     private let useCaseProvider: CommunityUseCaseProviding

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
@@ -76,6 +76,8 @@ extension NoticeDTO {
             title: title,
             content: content,
             writer: authorName.isEmpty ? authorNickname : authorName,
+            authorNickname: authorNickname.isEmpty ? nil : authorNickname,
+            authorName: authorName.isEmpty ? nil : authorName,
             links: [],  // 기본 조회에는 없음
             images: [],  // 기본 조회에는 없음
             vote: nil,

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailDTO.swift
@@ -149,6 +149,7 @@ extension NoticeDetailDTO {
             content: content,
             authorID: authorChallengerId ?? "0",
             authorMemberId: authorMemberId,
+            authorNickname: authorNickname,
             authorName: resolvedAuthorName,
             authorImageURL: authorProfileImageUrl,
             createdAt: createdAt.toISO8601Date(),

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
@@ -60,18 +60,42 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
     /// 첨부 투표
     let vote: NoticeVote?
 
-    /// 작성자 표기 기본값 (닉네임/이름)
+    /// 작성자 표기 기본값 (닉네임/이름-xxth)
     var defaultAuthorDisplayName: String {
         let trimmedNickname = authorNickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let trimmedName = authorName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let generationText = generationOrdinalText
 
         if !trimmedNickname.isEmpty && !trimmedName.isEmpty {
-            return "\(trimmedNickname)/\(trimmedName)"
+            return "\(trimmedNickname)/\(trimmedName)\(generationText)"
         }
         if !trimmedNickname.isEmpty {
-            return trimmedNickname
+            return "\(trimmedNickname)\(generationText)"
         }
-        return trimmedName
+        return "\(trimmedName)\(generationText)"
+    }
+
+    private var generationOrdinalText: String {
+        guard generation > 0 else { return "" }
+        return "-\(generation)\(generationOrdinalSuffix)"
+    }
+
+    private var generationOrdinalSuffix: String {
+        let suffixBase = generation % 100
+        if (11...13).contains(suffixBase) {
+            return "th"
+        }
+
+        switch generation % 10 {
+        case 1:
+            return "st"
+        case 2:
+            return "nd"
+        case 3:
+            return "rd"
+        default:
+            return "th"
+        }
     }
 
     /// NoticeChip에 표시할 공지 타입

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
@@ -33,6 +33,8 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
     let authorID: String
     /// 작성자 멤버 ID (authorMemberId)
     let authorMemberId: String?
+    /// 작성자 닉네임
+    let authorNickname: String?
     /// 작성자 이름
     let authorName: String
     /// 작성자 프로필 이미지 URL
@@ -58,8 +60,19 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
     /// 첨부 투표
     let vote: NoticeVote?
 
-    /// 작성자 표기 기본값 (닉네임/이름-기수TH UMC 직책)
-    var defaultAuthorDisplayName: String { authorName }
+    /// 작성자 표기 기본값 (닉네임/이름)
+    var defaultAuthorDisplayName: String {
+        let trimmedNickname = authorNickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let trimmedName = authorName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !trimmedNickname.isEmpty && !trimmedName.isEmpty {
+            return "\(trimmedNickname)/\(trimmedName)"
+        }
+        if !trimmedNickname.isEmpty {
+            return trimmedNickname
+        }
+        return trimmedName
+    }
 
     /// NoticeChip에 표시할 공지 타입
     var noticeType: NoticeType {
@@ -112,6 +125,7 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
         content: String,
         authorID: String,
         authorMemberId: String? = nil,
+        authorNickname: String? = nil,
         authorName: String,
         authorImageURL: String?,
         createdAt: Date,
@@ -132,6 +146,7 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
         self.content = content
         self.authorID = authorID
         self.authorMemberId = authorMemberId
+        self.authorNickname = authorNickname
         self.authorName = authorName
         self.authorImageURL = authorImageURL
         self.createdAt = createdAt
@@ -195,6 +210,7 @@ struct TargetAudience: Equatable, Hashable {
             title: "",
             content: "",
             authorID: "",
+            authorNickname: nil,
             authorName: "",
             authorImageURL: nil,
             createdAt: .now,

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
@@ -24,6 +24,8 @@ struct NoticeItemModel: Equatable, Identifiable {
     let title: String
     let content: String
     let writer: String
+    let authorNickname: String?
+    let authorName: String?
     let links: [String]
     let images: [String]
     let vote: NoticeVote?
@@ -43,6 +45,8 @@ struct NoticeItemModel: Equatable, Identifiable {
         title: String,
         content: String,
         writer: String,
+        authorNickname: String? = nil,
+        authorName: String? = nil,
         links: [String],
         images: [String],
         vote: NoticeVote?,
@@ -61,6 +65,8 @@ struct NoticeItemModel: Equatable, Identifiable {
         self.title = title
         self.content = content
         self.writer = writer
+        self.authorNickname = authorNickname
+        self.authorName = authorName
         self.links = links
         self.images = images
         self.vote = vote
@@ -158,7 +164,8 @@ extension NoticeItemModel {
             title: title,
             content: content,
             authorID: "temp-\(id)",
-            authorName: writer,
+            authorNickname: authorNickname,
+            authorName: authorName ?? writer,
             authorImageURL: nil,
             createdAt: date,
             updatedAt: nil,

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -20,7 +20,11 @@ extension NoticeDetailViewModel {
 
         do {
             let noticeDetail = try await noticeUseCase.getDetailNotice(noticeId: noticeID)
-            let normalizedDetail = normalizeTargetGenerationIfNeeded(in: noticeDetail)
+            let mergedDetail = mergeAuthorDisplayIfNeeded(
+                fetched: noticeDetail,
+                fallback: noticeState.value
+            )
+            let normalizedDetail = normalizeTargetGenerationIfNeeded(in: mergedDetail)
             noticeState = .loaded(normalizedDetail)
             refreshAuthorDisplayName(for: normalizedDetail)
             isDetailPreparedForEdit = true
@@ -74,6 +78,55 @@ extension NoticeDetailViewModel {
                 )
             )
         }
+    }
+
+    private func mergeAuthorDisplayIfNeeded(
+        fetched: NoticeDetail,
+        fallback: NoticeDetail?
+    ) -> NoticeDetail {
+        guard let fallback else { return fetched }
+
+        let resolvedNickname = resolvedAuthorField(
+            primary: fetched.authorNickname,
+            fallback: fallback.authorNickname
+        )
+        let resolvedName = resolvedAuthorField(
+            primary: fetched.authorName,
+            fallback: fallback.authorName
+        ) ?? ""
+
+        return NoticeDetail(
+            id: fetched.id,
+            generation: fetched.generation,
+            scope: fetched.scope,
+            category: fetched.category,
+            isMustRead: fetched.isMustRead,
+            title: fetched.title,
+            content: fetched.content,
+            authorID: fetched.authorID,
+            authorMemberId: fetched.authorMemberId,
+            authorNickname: resolvedNickname,
+            authorName: resolvedName,
+            authorImageURL: fetched.authorImageURL,
+            createdAt: fetched.createdAt,
+            updatedAt: fetched.updatedAt,
+            targetAudience: fetched.targetAudience,
+            hasPermission: fetched.hasPermission,
+            images: fetched.images,
+            imageItems: fetched.imageItems,
+            links: fetched.links,
+            vote: fetched.vote
+        )
+    }
+
+    private func resolvedAuthorField(primary: String?, fallback: String?) -> String? {
+        let trimmedPrimary = primary?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedPrimary.isEmpty, trimmedPrimary != "알 수 없음" {
+            return trimmedPrimary
+        }
+
+        let trimmedFallback = fallback?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedFallback.isEmpty ? nil : trimmedFallback
     }
 
     /// 공지 리소스 권한 조회

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -86,6 +86,7 @@ extension NoticeDetailViewModel {
     ) -> NoticeDetail {
         guard let fallback else { return fetched }
 
+        let resolvedGeneration = fetched.generation > 0 ? fetched.generation : fallback.generation
         let resolvedNickname = resolvedAuthorField(
             primary: fetched.authorNickname,
             fallback: fallback.authorNickname
@@ -97,7 +98,7 @@ extension NoticeDetailViewModel {
 
         return NoticeDetail(
             id: fetched.id,
-            generation: fetched.generation,
+            generation: resolvedGeneration,
             scope: fetched.scope,
             category: fetched.category,
             isMustRead: fetched.isMustRead,

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -23,11 +23,6 @@ final class NoticeDetailViewModel {
         container.resolve(NoticeUseCaseProtocol.self)
     }
 
-    /// 작성자 프로필 조회용 MyPage Repository
-    var myPageRepository: MyPageRepositoryProtocol {
-        container.resolve(MyPageRepositoryProtocol.self)
-    }
-
     var authorizationUseCase: AuthorizationUseCaseProtocol {
         container.resolve(AuthorizationUseCaseProtocol.self)
     }
@@ -212,10 +207,7 @@ final class NoticeDetailViewModel {
         self.noticeState = .loaded(model)
         let normalizedModel = normalizeTargetGenerationIfNeeded(in: model)
         noticeState = .loaded(normalizedModel)
-        authorDisplayName = normalizedModel.authorName
-        Task { [weak self] in
-            self?.refreshAuthorDisplayName(for: normalizedModel)
-        }
+        authorDisplayName = normalizedModel.defaultAuthorDisplayName
     }
 
     // MARK: - Function
@@ -232,107 +224,15 @@ final class NoticeDetailViewModel {
 
     // MARK: - Author Profile
 
-    /// 공지 작성자의 챌린저 프로필을 조회하여 "닉네임/이름-기수TH UMC 직책" 형식의 표시명을 갱신합니다.
-    ///
-    /// 현재 서버 응답의 `authorMemberId`는 작성자 `challengerId`로 해석하여 조회하며,
-    /// 실패 시 `defaultAuthorDisplayName`을 폴백으로 사용합니다.
+    /// 공지 작성자 표기명을 목록/상세 응답에 포함된 닉네임/이름 값으로 갱신합니다.
     @MainActor
     func refreshAuthorDisplayName(for detail: NoticeDetail) {
-        let fallback = detail.defaultAuthorDisplayName
-        authorDisplayName = fallback
-
-        let normalizedFallback = fallback.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard normalizedFallback != "알 수 없음" else {
-            return
-        }
-
-        guard
-            let rawChallengerId = detail.authorMemberId,
-            let challengerId = Int(rawChallengerId),
-            challengerId > 0
-        else {
-            return
-        }
-
-        Task {
-            await loadAuthorDisplayName(challengerId: challengerId, fallback: fallback)
-        }
+        authorDisplayName = detail.defaultAuthorDisplayName
     }
 
-    /// 챌린저 프로필 API를 호출하여 작성자 표시명을 비동기 로드합니다.
-    @MainActor
-    private func loadAuthorDisplayName(challengerId: Int, fallback: String) async {
-        do {
-            let profile = try await myPageRepository.fetchChallengerProfile(challengerId: challengerId)
-            authorDisplayName = buildAuthorDisplayName(
-                nickname: profile.nickname,
-                name: profile.name,
-                generation: profile.generation,
-                roleName: profile.roleName,
-                fallback: fallback
-            )
-        } catch {
-            errorHandler.handle(
-                error,
-                context: ErrorContext(
-                    feature: "Notice",
-                    action: "loadAuthorDisplayName(challengerId:\(challengerId))"
-                )
-            )
-            authorDisplayName = fallback
-        }
-    }
-
-    /// "닉네임/이름-기수TH UMC 직책" 형식의 작성자 표시명을 조합합니다.
-    private func buildAuthorDisplayName(
-        nickname: String,
-        name: String,
-        generation: Int,
-        roleName: String,
-        fallback: String
-    ) -> String {
-        let cleanedNickname = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
-        let cleanedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard !cleanedNickname.isEmpty || !cleanedName.isEmpty else {
-            return fallback
-        }
-
-        let identity = "\(cleanedNickname)/\(cleanedName)"
-        let generationText = authorGenerationText(from: generation)
-        let roleText = roleName.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        if roleText.isEmpty {
-            return identity.isEmpty ? fallback : "\(identity)-\(generationText) 참여자"
-        }
-        return identity.isEmpty ? fallback : "\(identity)-\(generationText) \(roleText)"
-    }
-
-    /// 기수 숫자를 "NTH UMC" 형식의 문자열로 변환합니다.
-    private func authorGenerationText(from generation: Int) -> String {
-        guard generation > 0 else {
-            return "UMC"
-        }
-        return "\(generation)\(generationOrdinalSuffix(generation)) UMC"
-    }
-
-    /// 영어 서수 접미사를 반환합니다 (1st, 2nd, 3rd, 4th...).
-    private func generationOrdinalSuffix(_ value: Int) -> String {
-        let suffixBase = value % 100
-        if (11...13).contains(suffixBase) {
-            return "th"
-        }
-
-        switch value % 10 {
-        case 1:
-            return "st"
-        case 2:
-            return "nd"
-        case 3:
-            return "rd"
-        default:
-            return "th"
-        }
+    /// 화면에 즉시 노출할 작성자명을 반환합니다.
+    func displayedAuthorName(for detail: NoticeDetail) -> String {
+        authorDisplayName.isEmpty ? detail.defaultAuthorDisplayName : authorDisplayName
     }
 
     // MARK: - Generation Helper
@@ -369,6 +269,7 @@ final class NoticeDetailViewModel {
             content: detail.content,
             authorID: detail.authorID,
             authorMemberId: detail.authorMemberId,
+            authorNickname: detail.authorNickname,
             authorName: detail.authorName,
             authorImageURL: detail.authorImageURL,
             createdAt: detail.createdAt,

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -153,7 +153,7 @@ struct NoticeDetailView: View {
                     Image(data.authorImageURL ?? Constants.defaultProfileImageName)
                         .resizable()
                         .frame(width: Constants.profileSize.width, height: Constants.profileSize.height)
-                    Text(viewModel.authorDisplayName.isEmpty ? data.authorName : viewModel.authorDisplayName)
+                    Text(viewModel.displayedAuthorName(for: data))
                 }
                 Spacer()
                 Text(data.createdAt.toYearMonthDay())

--- a/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
@@ -136,6 +136,33 @@ struct NoticePresentationTests {
         #expect(detail.authorName == "제옹")
     }
 
+    @Test("공지 상세 기본 작성자 표기는 목록에서 전달한 닉네임과 이름을 사용한다")
+    func noticeDetailDefaultAuthorDisplayUsesNicknameAndName() {
+        let detail = NoticeDetail(
+            id: "1",
+            generation: 9,
+            scope: .central,
+            category: .general,
+            isMustRead: false,
+            title: "공지",
+            content: "내용",
+            authorID: "11",
+            authorMemberId: "22",
+            authorNickname: "하늘카카오",
+            authorName: "박경운",
+            authorImageURL: nil,
+            createdAt: Date(),
+            updatedAt: nil,
+            targetAudience: .all(generation: 9, scope: .central),
+            hasPermission: false,
+            images: [],
+            links: [],
+            vote: nil
+        )
+
+        #expect(detail.defaultAuthorDisplayName == "하늘카카오/박경운")
+    }
+
     // MARK: - Read Status Permission Tests
 
     @Test("총괄단은 모든 공지의 수신 확인 현황을 볼 수 있다")

--- a/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
@@ -136,7 +136,7 @@ struct NoticePresentationTests {
         #expect(detail.authorName == "제옹")
     }
 
-    @Test("공지 상세 기본 작성자 표기는 목록에서 전달한 닉네임과 이름을 사용한다")
+    @Test("공지 상세 기본 작성자 표기는 목록에서 전달한 닉네임과 이름에 선택 기수 서수를 붙인다")
     func noticeDetailDefaultAuthorDisplayUsesNicknameAndName() {
         let detail = NoticeDetail(
             id: "1",
@@ -160,7 +160,79 @@ struct NoticePresentationTests {
             vote: nil
         )
 
-        #expect(detail.defaultAuthorDisplayName == "하늘카카오/박경운")
+        #expect(detail.defaultAuthorDisplayName == "하늘카카오/박경운-9th")
+    }
+
+    @Test("모든 기수 공지는 상세 재조회 후에도 목록에서 선택한 기수 서수를 유지한다")
+    func noticeDetailKeepsSelectedGenerationWhenFetchedDetailTargetsAllGenerations() {
+        let initialDetail = NoticeDetail(
+            id: "32",
+            generation: 9,
+            scope: .central,
+            category: .general,
+            isMustRead: false,
+            title: "공지",
+            content: "내용",
+            authorID: "11",
+            authorMemberId: "22",
+            authorNickname: "하늘카카오",
+            authorName: "박경운",
+            authorImageURL: nil,
+            createdAt: Date(),
+            updatedAt: nil,
+            targetAudience: .all(generation: 9, scope: .central),
+            hasPermission: false,
+            images: [],
+            links: [],
+            vote: nil
+        )
+
+        let fetchedDetail = NoticeDetail(
+            id: "32",
+            generation: 0,
+            scope: .central,
+            category: .general,
+            isMustRead: false,
+            title: "공지",
+            content: "내용",
+            authorID: "0",
+            authorMemberId: "22",
+            authorNickname: nil,
+            authorName: "알 수 없음",
+            authorImageURL: nil,
+            createdAt: Date(),
+            updatedAt: nil,
+            targetAudience: .all(generation: 0, scope: .central),
+            hasPermission: false,
+            images: [],
+            links: [],
+            vote: nil
+        )
+
+        let resolvedGeneration = fetchedDetail.generation > 0 ? fetchedDetail.generation : initialDetail.generation
+        let mergedDetail = NoticeDetail(
+            id: fetchedDetail.id,
+            generation: resolvedGeneration,
+            scope: fetchedDetail.scope,
+            category: fetchedDetail.category,
+            isMustRead: fetchedDetail.isMustRead,
+            title: fetchedDetail.title,
+            content: fetchedDetail.content,
+            authorID: fetchedDetail.authorID,
+            authorMemberId: fetchedDetail.authorMemberId,
+            authorNickname: initialDetail.authorNickname,
+            authorName: initialDetail.authorName,
+            authorImageURL: fetchedDetail.authorImageURL,
+            createdAt: fetchedDetail.createdAt,
+            updatedAt: fetchedDetail.updatedAt,
+            targetAudience: fetchedDetail.targetAudience,
+            hasPermission: fetchedDetail.hasPermission,
+            images: fetchedDetail.images,
+            links: fetchedDetail.links,
+            vote: fetchedDetail.vote
+        )
+
+        #expect(mergedDetail.defaultAuthorDisplayName == "하늘카카오/박경운-9th")
     }
 
     // MARK: - Read Status Permission Tests


### PR DESCRIPTION
## ✨ PR 유형

Fix — 공지 작성자 프로필 API 호출을 제거하고, 서버 응답에 포함된 닉네임/이름 값으로 직접 표기하도록 변경

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 작성자 표기가 "닉네임/이름" 형식으로 변경됩니다 -->

## 🛠️ 작업내용

- **챌린저 프로필 API 호출 제거**: `loadAuthorDisplayName`, `buildAuthorDisplayName` 등 프로필 API 기반 로직 삭제
- **`refreshAuthorDisplayName` 단순화**: `detail.defaultAuthorDisplayName` 값을 그대로 사용
- **`NoticeDetail`에 `authorNickname` 필드 추가**: 서버 응답의 닉네임을 도메인 모델까지 전달
- **`defaultAuthorDisplayName` 자동 조합**: "닉네임/이름" 형식으로 조합, 한쪽이 비어있으면 나머지만 표시
- **`mergeAuthorDisplayIfNeeded` 추가**: 상세 API 응답에 작성자 정보가 누락된 경우 목록 응답 값으로 병합
- **`NoticeItemModel`에 `authorNickname`, `authorName` 필드 추가**: 목록→상세 전환 시 작성자 정보 전달
- **`myPageRepository` 의존성 제거**: `NoticeDetailViewModel`에서 `MyPageRepositoryProtocol` 참조 삭제
- 오픈채팅 URL 검증 에러 메시지 간결화
- 작성자 표기 단위 테스트 추가

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `Features/Notice/Domain/Models/NoticeDetailModel.swift` — `defaultAuthorDisplayName` 조합 로직, `authorNickname` 추가
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift` — `mergeAuthorDisplayIfNeeded` 병합 로직
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift` — 프로필 API 관련 코드 삭제 범위
- `Features/Notice/Domain/Models/NoticeItemModel.swift` — 목록→상세 변환 시 `authorNickname`/`authorName` 전달

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)