### PR TITLE
💄[Design] 승인 대기 뷰 계정 Menu를 confirmationDialog로 변경 (#500)

### DIFF
--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -24,7 +24,7 @@ struct AppProductApp: App {
     @State private var container: DIContainer
     @State private var didConfigureAppDelegate: Bool = false
     @State private var errorHandler: ErrorHandler = .init()
-    @State private var appState: AppState = .pendingApproval
+    @State private var appState: AppState = .splash
     private let sharedModelContainer: ModelContainer
     
     // MARK: - AppState

--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -24,7 +24,7 @@ struct AppProductApp: App {
     @State private var container: DIContainer
     @State private var didConfigureAppDelegate: Bool = false
     @State private var errorHandler: ErrorHandler = .init()
-    @State private var appState: AppState = .splash
+    @State private var appState: AppState = .pendingApproval
     private let sharedModelContainer: ModelContainer
     
     // MARK: - AppState

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/FailedVerificationUMCViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/FailedVerificationUMCViewModel.swift
@@ -8,42 +8,57 @@
 import Foundation
 
 /// UMC 챌린저 인증 실패 화면의 상태와 액션을 관리하는 ViewModel
+///
+/// 기존 챌린저 코드 재인증, 승인 대기 상태에서의 로그아웃, 계정 삭제 흐름을
+/// 한 곳에서 조율하며, 화면에 필요한 얼럿 상태도 함께 제공합니다.
 @Observable
 final class FailedVerificationUMCViewModel {
 
     // MARK: - Property
 
-    /// 경고 아이콘 애니메이션 활성화 상태
+    /// 상단 경고 아이콘의 pulse 애니메이션 활성화 상태입니다.
     var showWarning: Bool = false
 
-    /// 코드 입력 얼럿 표시 상태
+    /// 기존 챌린저 코드 입력 얼럿 표시 상태입니다.
     var showCodeAlert: Bool = false
 
-    /// 공통 알럿 프롬프트 상태
+    /// 화면 전반에서 재사용하는 `AlertPrompt` 상태입니다.
     var alertPrompt: AlertPrompt?
 
-    /// 전송 중 상태
+    /// 기존 챌린저 코드 인증 요청 진행 상태입니다.
     var isSubmitting: Bool = false
 
-    /// 계정 삭제 진행 상태
+    /// 회원 탈퇴 요청 진행 상태입니다.
     var isDeletingAccount: Bool = false
 
-    /// 로그아웃 진행 상태
+    /// 로그아웃 요청 진행 상태입니다.
     var isLoggingOut: Bool = false
 
-    /// 입력된 챌린저 코드
+    /// 사용자가 입력한 기존 챌린저 코드입니다.
     var challengerCode: String = ""
 
     // MARK: - Function
 
+    /// 기존 챌린저 코드 입력 얼럿을 표시합니다.
     func presentCodeAlert() {
         showCodeAlert = true
     }
 
+    /// 코드 입력 얼럿을 닫기 전 입력값을 초기화합니다.
+    ///
+    /// 잘못 입력한 코드가 다음 시도에 남지 않도록 문자열을 비웁니다.
     func dismissCodeAlert() {
         challengerCode = ""
     }
 
+    /// 입력된 기존 챌린저 코드를 검증하고 재인증을 수행합니다.
+    ///
+    /// 성공 시 프로필을 다시 조회해 로컬 세션 저장소와 역할 정보를 동기화하고,
+    /// 메인 화면으로 이동할 수 있는 성공 프롬프트를 준비합니다.
+    ///
+    /// - Parameters:
+    ///   - container: 인증, 홈, 세션 관련 의존성을 조회하는 DI 컨테이너입니다.
+    ///   - appFlow: 인증 성공 후 루트 화면 전환에 사용하는 앱 플로우입니다.
     @MainActor
     func submitChallengerCode(
         container: DIContainer,
@@ -86,6 +101,15 @@ final class FailedVerificationUMCViewModel {
         }
     }
 
+    /// 회원 탈퇴 확인 프롬프트를 구성합니다.
+    ///
+    /// 사용자가 삭제를 확정하면 비동기 탈퇴 로직을 실행하도록 `AlertPrompt`에
+    /// 후속 액션을 연결합니다.
+    ///
+    /// - Parameters:
+    ///   - container: 마이페이지/네트워크 의존성을 조회하는 DI 컨테이너입니다.
+    ///   - appFlow: 탈퇴 완료 후 로그인 화면으로 복귀시키는 앱 플로우입니다.
+    ///   - errorHandler: 탈퇴 실패 시 전역 에러 처리를 담당합니다.
     func presentDeleteAccountPrompt(
         container: DIContainer,
         appFlow: AppFlow,
@@ -110,6 +134,15 @@ final class FailedVerificationUMCViewModel {
         )
     }
 
+    /// 로그아웃 확인 프롬프트를 구성합니다.
+    ///
+    /// 사용자가 로그아웃을 확정하면 토큰 정리와 화면 전환을 수행하는 비동기 작업을
+    /// `AlertPrompt`의 확인 액션에 연결합니다.
+    ///
+    /// - Parameters:
+    ///   - container: 네트워크 의존성을 조회하고 캐시를 초기화할 DI 컨테이너입니다.
+    ///   - appFlow: 로그아웃 완료 후 로그인 화면으로 전환하는 앱 플로우입니다.
+    ///   - errorHandler: 로그아웃 실패 시 전역 에러 처리를 담당합니다.
     func presentLogoutPrompt(
         container: DIContainer,
         appFlow: AppFlow,
@@ -136,6 +169,9 @@ final class FailedVerificationUMCViewModel {
 
     // MARK: - Private Function
 
+    /// 기존 챌린저 재인증 성공 프롬프트를 표시합니다.
+    ///
+    /// 확인 버튼을 누르면 자동 로그인 플래그를 활성화하고 메인 화면으로 이동합니다.
     private func presentSuccessPrompt(appFlow: AppFlow) {
         alertPrompt = AlertPrompt(
             title: "인증 완료",
@@ -151,6 +187,7 @@ final class FailedVerificationUMCViewModel {
         )
     }
 
+    /// 코드 형식이 유효하지 않거나 조회되지 않을 때의 실패 프롬프트를 표시합니다.
     private func presentInvalidCodePrompt() {
         alertPrompt = AlertPrompt(
             title: "인증 실패",
@@ -159,6 +196,9 @@ final class FailedVerificationUMCViewModel {
         )
     }
 
+    /// 서버 비즈니스 에러를 사용자 메시지로 변환해 실패 프롬프트를 표시합니다.
+    ///
+    /// - Parameter error: 코드 재인증 API에서 반환된 `RepositoryError`입니다.
     private func presentCodeFailurePrompt(for error: RepositoryError) {
         let message: String
 
@@ -184,6 +224,15 @@ final class FailedVerificationUMCViewModel {
         )
     }
 
+    /// 승인 대기 상태 화면에서 로그아웃을 수행합니다.
+    ///
+    /// 토큰과 DI 캐시를 정리한 뒤 로그인 화면으로 복귀시키며,
+    /// 실패 시 `ErrorHandler`로 전역 에러를 전달합니다.
+    ///
+    /// - Parameters:
+    ///   - container: `NetworkClient` 조회와 캐시 초기화에 사용하는 DI 컨테이너입니다.
+    ///   - appFlow: 로그인 화면 전환에 사용하는 앱 플로우입니다.
+    ///   - errorHandler: 실패 시 에러 컨텍스트를 기록할 핸들러입니다.
     @MainActor
     private func logout(
         container: DIContainer,
@@ -211,6 +260,15 @@ final class FailedVerificationUMCViewModel {
         }
     }
 
+    /// 승인 대기 상태 화면에서 회원 탈퇴를 수행합니다.
+    ///
+    /// 계정 삭제 완료 후 서버 로그아웃과 DI 캐시 초기화를 함께 수행하며,
+    /// 실패 시 `ErrorHandler`로 위임합니다.
+    ///
+    /// - Parameters:
+    ///   - container: 삭제 UseCase와 `NetworkClient`를 조회할 DI 컨테이너입니다.
+    ///   - appFlow: 완료 후 로그인 화면으로 전환하는 앱 플로우입니다.
+    ///   - errorHandler: 실패 시 에러 컨텍스트를 기록할 핸들러입니다.
     @MainActor
     private func deleteAccount(
         container: DIContainer,
@@ -238,6 +296,16 @@ final class FailedVerificationUMCViewModel {
         }
     }
 
+    // MARK: - Helper
+
+    /// 재조회한 프로필을 로컬 저장소와 세션 상태에 반영합니다.
+    ///
+    /// 승인 여부, 역할, 조직 정보, 기수/챌린저 식별자를 `UserDefaults`에 저장하고
+    /// `UserSessionManager`와 프로필 갱신 알림까지 함께 동기화합니다.
+    ///
+    /// - Parameters:
+    ///   - profile: 재인증 직후 서버에서 조회한 최신 프로필입니다.
+    ///   - container: 세션 관리자 조회에 사용하는 DI 컨테이너입니다.
     private func syncProfileToStorage(
         _ profile: HomeProfileResult,
         container: DIContainer
@@ -275,6 +343,10 @@ final class FailedVerificationUMCViewModel {
         NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
     }
 
+    /// 프로필이 승인 완료 상태인지 판별합니다.
+    ///
+    /// 기수 정보가 직접 존재하거나 `seasonTypes` 안에 기수 데이터가 하나라도 있으면
+    /// 승인된 사용자로 간주합니다.
     private func isApprovedProfile(_ profile: HomeProfileResult) -> Bool {
         if !profile.generations.isEmpty {
             return true
@@ -289,6 +361,10 @@ final class FailedVerificationUMCViewModel {
         return false
     }
 
+    /// 가장 최신 기수에서 우선순위가 가장 높은 역할을 찾습니다.
+    ///
+    /// - Parameter roles: 서버에서 전달받은 사용자 역할 목록입니다.
+    /// - Returns: 최신 기수 기준 최고 우선순위 역할. 역할이 없으면 `nil`을 반환합니다.
     private func latestHighestPriorityRole(
         in roles: [ChallengerRole]
     ) -> ChallengerRole? {
@@ -303,6 +379,10 @@ final class FailedVerificationUMCViewModel {
             }
     }
 
+    /// 서버 메시지 앞에 붙은 에러 코드를 제거해 사용자 노출 문구를 정리합니다.
+    ///
+    /// - Parameter message: 서버 원본 에러 메시지입니다.
+    /// - Returns: 코드 접두어와 불필요한 공백을 제거한 사용자 표시용 문자열입니다.
     private func sanitizedErrorMessage(from message: String) -> String {
         let pattern = #"^[A-Z]+-\d{4}\s*[:\-]?\s*"#
         let sanitized = message.replacingOccurrences(

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
@@ -15,26 +15,33 @@ struct FailedVerificationUMC: View {
 
     // MARK: - Property
 
+    /// 화면 상태와 사용자 액션을 관리하는 ViewModel입니다.
     @State private var viewModel = FailedVerificationUMCViewModel()
 
     /// URL을 외부 브라우저로 여는 환경 값
     @Environment(\.openURL) private var openURL
+    /// 루트 화면 전환을 담당하는 앱 플로우 환경 값입니다.
     @Environment(\.appFlow) private var appFlow
+    /// Feature 의존성을 조회하는 DI 컨테이너 환경 값입니다.
     @Environment(\.di) private var di
+    /// 전역 에러 처리를 담당하는 핸들러입니다.
     @Environment(ErrorHandler.self) private var errorHandler
 
     /// 카카오톡 채널 연동 매니저
-    let kakaoPlusManager: KakaoPlusManager = .init()
-    
+    private let kakaoPlusManager: KakaoPlusManager = .init()
+
     // MARK: - Constant
 
     /// 레이아웃 및 텍스트 상수
     private enum Constants {
         /// 상단 여백 높이
-        static let spacerHeight: CGFloat = 80
+        static let topSpacerHeight: CGFloat = 80
 
         /// 메인 컴포넌트 간 수직 간격
-        static let mianVspacing: CGFloat = 40
+        static let contentSpacing: CGFloat = 40
+
+        /// 기존 챌린저 인증 버튼 상단 여백입니다.
+        static let verifyButtonTopPadding: CGFloat = 16
 
         /// 경고 아이콘 크기
         static let warningIconSize: CGFloat = 120
@@ -46,80 +53,61 @@ struct FailedVerificationUMC: View {
         static let title: String = "UMC 챌린저 인증 실패"
 
         /// 서브타이틀 텍스트
-        static let subTitle: String = "죄송합니다. 입력하신 정보로 등록된 \nUMC 챌린저 정보를 찾을 수 없습니다."
+        static let subtitle: String = "죄송합니다. 입력하신 정보로 등록된 \nUMC 챌린저 정보를 찾을 수 없습니다."
 
-        /// 메인 버튼 텍스트
-        static let mainBtnText: String = "UMC 공식 홈페이지 방문"
-        /// 기존 챌린저 인증 버튼 텍스트
-        static let verifyBtnText: String = "기존 챌린저 코드 입력"
         /// 상단 텍스트 버튼용 기존 챌린저 인증 문구
         static let verifyTextButtonTitle: String = "기존 챌린저 인증하기"
+
+        /// 기존 챌린저 코드 입력 얼럿 제목
+        static let codeAlertTitle: String = "기존 챌린저 코드 입력"
+
+        /// 기존 챌린저 코드 입력 필드 플레이스홀더
+        static let codeTextFieldPlaceholder: String = "6자리 코드"
+
+        /// 기존 챌린저 코드 입력 안내 문구
+        static let codeAlertMessage: String = "운영진에게 발급받은 6자리 코드를 입력해주세요."
+
+        /// 코드 입력 얼럿 닫기 버튼 문구
+        static let closeButtonTitle: String = "닫기"
+
+        /// 코드 입력 얼럿 전송 버튼 문구
+        static let submitButtonTitle: String = "전송"
+
         /// UMC 공식 홈페이지 URL
         static let homePageURL: String = "https://umc.it.kr"
     }
-    
+
+    // MARK: - Body
+
+    /// 인증 실패 안내 화면을 구성합니다.
+    ///
+    /// 상단 설명 영역, 기존 챌린저 인증 버튼, 하단 툴바 액션과
+    /// 코드 입력 얼럿을 함께 조합해 제공합니다.
     var body: some View {
         NavigationStack {
             VStack {
-                Spacer().frame(maxHeight: Constants.spacerHeight)
+                Spacer().frame(maxHeight: Constants.topSpacerHeight)
                 topWarningImage
-                Spacer().frame(maxHeight: Constants.mianVspacing)
+                Spacer().frame(maxHeight: Constants.contentSpacing)
                 warningTitle
                 existingChallengerTextButton
                 Spacer()
             }
             .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
             .toolbar {
-                ToolBarCollection.FailedVerificationBottomToolbar(
-                    isSubmitting: viewModel.isSubmitting,
-                    isDeletingAccount: viewModel.isDeletingAccount,
-                    isLoggingOut: viewModel.isLoggingOut,
-                    onHome: {
-                        if let url = URL(string: Constants.homePageURL) {
-                            openURL(url)
-                        }
-                    },
-                    onInquiry: {
-                        kakaoPlusManager.openKakaoChannel()
-                    },
-                    onLogout: {
-                        viewModel.presentLogoutPrompt(
-                            container: di,
-                            appFlow: appFlow,
-                            errorHandler: errorHandler
-                        )
-                    },
-                    onDeleteAccount: {
-                        viewModel.presentDeleteAccountPrompt(
-                            container: di,
-                            appFlow: appFlow,
-                            errorHandler: errorHandler
-                        )
-                    }
-                )
+                bottomToolbar
             }
-            .alert("기존 챌린저 코드 입력", isPresented: $viewModel.showCodeAlert) {
-                TextField("6자리 코드", text: $viewModel.challengerCode)
-                    .keyboardType(.asciiCapable)
-                Button("닫기", role: .cancel) {
-                    viewModel.dismissCodeAlert()
-                }
-                Button("전송") {
-                    Task {
-                        await viewModel.submitChallengerCode(
-                            container: di,
-                            appFlow: appFlow
-                        )
-                    }
-                }
-            } message: {
-                Text("운영진에게 발급받은 6자리 코드를 입력해주세요.")
-            }
+            .alert(
+                Constants.codeAlertTitle,
+                isPresented: $viewModel.showCodeAlert,
+                actions: codeAlertActions,
+                message: codeAlertMessage
+            )
             .alertPrompt(item: $viewModel.alertPrompt)
         }
     }
-    
-    // MARK: - Top
+
+    // MARK: - Helper
 
     /// 상단 경고 아이콘
     ///
@@ -137,8 +125,6 @@ struct FailedVerificationUMC: View {
             }
     }
 
-    // MARK: - Middle
-
     /// 인증 실패 안내 문구
     ///
     /// 메인 타이틀과 서브타이틀로 구성된 텍스트 영역입니다.
@@ -147,7 +133,7 @@ struct FailedVerificationUMC: View {
             Text(Constants.title)
                 .appFont(.title1Emphasis, color: .grey900)
 
-            Text(Constants.subTitle)
+            Text(Constants.subtitle)
                 .appFont(.callout, weight: .medium, color: .grey600)
                 .multilineTextAlignment(.center)
         }
@@ -162,53 +148,101 @@ struct FailedVerificationUMC: View {
                 .underline()
                 .appFont(.callout, weight: .semibold, color: .indigo500)
         }
-        .padding(.top, DefaultSpacing.spacing16)
-        .disabled(
-            viewModel.isSubmitting ||
-            viewModel.isDeletingAccount ||
-            viewModel.isLoggingOut
+        .padding(.top, Constants.verifyButtonTopPadding)
+        .disabled(isInteractionDisabled)
+    }
+
+    /// 하단 툴바 액션 구성을 제공합니다.
+    ///
+    /// 하단 계정 버튼은 `confirmationDialog`를 직접 소유한 툴바 컴포넌트에
+    /// 액션 클로저만 전달합니다.
+    private var bottomToolbar: some ToolbarContent {
+        ToolBarCollection.FailedVerificationBottomToolbar(
+            isSubmitting: viewModel.isSubmitting,
+            isDeletingAccount: viewModel.isDeletingAccount,
+            isLoggingOut: viewModel.isLoggingOut,
+            onHome: openHomePage,
+            onInquiry: openInquiryChannel,
+            onLogout: presentLogoutPrompt,
+            onDeleteAccount: presentDeleteAccountPrompt
         )
     }
-}
 
-#if DEBUG
-#Preview {
-    FailedVerificationUMC()
-        .environment(\.di, failedVerificationPreviewContainer)
-        .environment(\.appFlow, .noop)
-        .environment(ErrorHandler())
-}
+    /// 기존 챌린저 코드 입력 얼럿의 버튼과 입력 필드를 구성합니다.
+    @ViewBuilder
+    private func codeAlertActions() -> some View {
+        TextField(
+            Constants.codeTextFieldPlaceholder,
+            text: $viewModel.challengerCode
+        )
+        .keyboardType(.asciiCapable)
 
-private var failedVerificationPreviewContainer: DIContainer {
-    let container = DIContainer()
-    container.register(AuthUseCaseProviding.self) {
-        AuthUseCaseProvider(
-            repositoryProvider: AuthRepositoryProvider.mock(),
-            tokenStore: KeychainTokenStore()
+        Button(Constants.closeButtonTitle, role: .cancel, action: dismissCodeAlert)
+        Button(Constants.submitButtonTitle, action: submitChallengerCode)
+    }
+
+    /// 기존 챌린저 코드 입력 얼럿의 안내 문구를 제공합니다.
+    @ViewBuilder
+    private func codeAlertMessage() -> some View {
+        Text(Constants.codeAlertMessage)
+    }
+
+    /// 화면 상의 주요 인터랙션을 잠글지 여부를 반환합니다.
+    ///
+    /// 요청 전송, 로그아웃, 회원 탈퇴 중에는 중복 액션을 막기 위해 `true`를 반환합니다.
+    private var isInteractionDisabled: Bool {
+        viewModel.isSubmitting ||
+        viewModel.isDeletingAccount ||
+        viewModel.isLoggingOut
+    }
+
+    // MARK: - Private Function
+
+    /// UMC 공식 홈페이지를 외부 브라우저로 엽니다.
+    ///
+    /// - Important: URL 생성에 실패하면 아무 동작도 하지 않습니다.
+    private func openHomePage() {
+        guard let url = URL(string: Constants.homePageURL) else { return }
+        openURL(url)
+    }
+
+    /// 카카오톡 문의 채널을 엽니다.
+    private func openInquiryChannel() {
+        kakaoPlusManager.openKakaoChannel()
+    }
+
+    /// 승인 대기 화면에서 로그아웃 확인 프롬프트를 표시합니다.
+    private func presentLogoutPrompt() {
+        viewModel.presentLogoutPrompt(
+            container: di,
+            appFlow: appFlow,
+            errorHandler: errorHandler
         )
     }
-    container.register(MyPageUseCaseProviding.self) {
-        MyPageUseCaseProvider(repository: MockMyPageRepository())
-    }
-    container.register(NetworkClient.self) {
-        AuthSystemFactory.makeTestNetworkClient(
-            tokenStore: FailedVerificationPreviewTokenStore(),
-            refreshService: FailedVerificationPreviewTokenRefreshService()
+
+    /// 승인 대기 화면에서 회원 탈퇴 확인 프롬프트를 표시합니다.
+    private func presentDeleteAccountPrompt() {
+        viewModel.presentDeleteAccountPrompt(
+            container: di,
+            appFlow: appFlow,
+            errorHandler: errorHandler
         )
     }
-    return container
-}
 
-private actor FailedVerificationPreviewTokenStore: TokenStore {
-    func getAccessToken() async -> String? { nil }
-    func getRefreshToken() async -> String? { nil }
-    func save(accessToken: String, refreshToken: String) async throws { }
-    func clear() async throws { }
-}
+    /// 코드 입력 얼럿을 닫고 입력값을 정리합니다.
+    private func dismissCodeAlert() {
+        viewModel.dismissCodeAlert()
+    }
 
-private struct FailedVerificationPreviewTokenRefreshService: TokenRefreshService {
-    func refresh(_ refreshToken: String) async throws -> TokenPair {
-        TokenPair(accessToken: "preview_access", refreshToken: "preview_refresh")
+    /// 입력된 기존 챌린저 코드를 서버로 전송합니다.
+    ///
+    /// 비동기 인증 요청은 `Task`로 감싸 UI 이벤트 처리 흐름과 분리합니다.
+    private func submitChallengerCode() {
+        Task {
+            await viewModel.submitChallengerCode(
+                container: di,
+                appFlow: appFlow
+            )
+        }
     }
 }
-#endif

--- a/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
+++ b/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
@@ -661,6 +661,8 @@ struct ToolBarCollection {
     ///
     /// 홈페이지 이동, 문의하기, 계정 관련 액션을 하단 바에 고정된 형태로 제공합니다.
     struct FailedVerificationBottomToolbar: ToolbarContent {
+        @State private var isAccountDialogPresented: Bool = false
+
         let isSubmitting: Bool
         let isDeletingAccount: Bool
         let isLoggingOut: Bool
@@ -695,23 +697,27 @@ struct ToolBarCollection {
             }
 
             ToolbarItem(placement: .bottomBar) {
-                Menu {
-                    Button(action: onLogout) {
-                        Label("로그아웃", systemImage: "rectangle.portrait.and.arrow.right")
-                    }
-
-                    Button(role: .destructive, action: onDeleteAccount) {
-                        Label("회원 탈퇴", systemImage: "person.crop.circle.badge.xmark")
-                    }
-                } label: {
+                Button(action: onAccountAction) {
                     actionLabel(
                         icon: "person.crop.circle.badge.xmark",
                         title: "계정",
                         color: .red
                     )
                 }
+                .confirmationDialog(
+                    "계정 관리",
+                    isPresented: $isAccountDialogPresented,
+                    titleVisibility: .hidden
+                ) {
+                    Button("로그아웃", action: onLogout)
+                    Button("탈퇴하기", role: .destructive, action: onDeleteAccount)
+                }
                 .disabled(isSubmitting || isDeletingAccount || isLoggingOut)
             }
+        }
+
+        private func onAccountAction() {
+            isAccountDialogPresented = true
         }
 
         /// 단일 하단 바 액션 버튼을 렌더링합니다.


### PR DESCRIPTION
## ✨ PR 유형

승인 대기(FailedVerificationUMC) 뷰에서 계정 관리 UI를 Menu에서 confirmationDialog로 변경

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 승인 대기 화면에서 탈퇴하기/로그아웃 확인 다이얼로그 동작 영상 첨부 필요 -->

## 🛠️ 작업내용

- 승인 대기 뷰 하단 툴바의 계정 Menu를 confirmationDialog로 변경
- FailedVerificationUMC 뷰 코드 정리 및 함수 분리
  - 인라인 클로저를 private 함수로 추출 (`openHomePage`, `presentLogoutPrompt` 등)
  - Alert actions/message를 `@ViewBuilder` 함수로 분리
  - `isInteractionDisabled` computed property 추출
- FailedVerificationUMCViewModel 문서화 주석 추가
- ToolBarCollection의 `FailedVerificationBottomToolbar` confirmationDialog 적용
- 디버그용 appState(.pendingApproval) 설정 원복

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Auth/Presentation/Views/FailedVerificationUMC.swift` - confirmationDialog 전환 및 코드 구조 개선 확인
- `Utilities/ToolBar/ToolBarCollection.swift` - FailedVerificationBottomToolbar의 confirmationDialog 적용

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)