### PR TITLE
🐛[Fix] 공지 리스트 기수 변경 시 필터 미갱신 수정 (#489)

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
@@ -9,6 +9,10 @@ import Foundation
 
 extension NoticeViewModel {
 
+    private enum GenerationFilterDefaults {
+        static let mainFilter: NoticeMainFilterType = .central
+    }
+
     // MARK: - Context & Filter
 
     /// 공지 탭 메뉴에 쓰이는 사용자 컨텍스트를 반영합니다.
@@ -72,11 +76,13 @@ extension NoticeViewModel {
                 selectedGeneration = latestGen
 
                 if generationStates[latestGen.value] == nil {
-                    generationStates[latestGen.value] = GenerationFilterState()
+                    generationStates[latestGen.value] = GenerationFilterState(
+                        mainFilter: GenerationFilterDefaults.mainFilter
+                    )
                 }
 
-                Task {
-                    await fetchNotices()
+                Task { @MainActor in
+                    await refreshSelectedGenerationContext(resetFilters: true)
                 }
             } else {
                 isGisuListLoaded = false
@@ -109,11 +115,8 @@ extension NoticeViewModel {
     func selectGeneration(_ generation: Generation) {
         guard gisuPairs.contains(where: { $0.gen == generation.value && $0.gisuId > 0 }) else { return }
         selectedGeneration = generation
-        if generationStates[generation.value] == nil {
-            generationStates[generation.value] = GenerationFilterState()
-        }
-        Task {
-            await fetchNotices()
+        Task { @MainActor in
+            await refreshSelectedGenerationContext(resetFilters: true)
         }
     }
 
@@ -166,5 +169,52 @@ extension NoticeViewModel {
     func currentSelectedGisuId() -> Int? {
         guard isGisuListLoaded else { return nil }
         return gisuPairs.first(where: { $0.gen == selectedGeneration.value && $0.gisuId > 0 })?.gisuId
+    }
+
+    /// 선택 기수 기준으로 필터 옵션을 다시 불러오고 목록을 재조회합니다.
+    @MainActor
+    func refreshSelectedGenerationContext(resetFilters: Bool) async {
+        if resetFilters {
+            resetSelectionStateForCurrentGeneration()
+        } else if generationStates[selectedGeneration.value] == nil {
+            generationStates[selectedGeneration.value] = GenerationFilterState(
+                mainFilter: GenerationFilterDefaults.mainFilter
+            )
+        }
+
+        await loadTargetStateForCurrentGeneration()
+        await fetchNotices()
+    }
+
+    /// 기수 전환 시 필터 선택 상태를 기본값으로 되돌립니다.
+    @MainActor
+    func resetSelectionStateForCurrentGeneration() {
+        generationStates[selectedGeneration.value] = GenerationFilterState(
+            mainFilter: GenerationFilterDefaults.mainFilter
+        )
+        pagingState.reset()
+        isSearchMode = false
+        searchQuery = ""
+    }
+
+    /// 현재 선택 기수의 지부/학교 필터 옵션을 조회합니다.
+    @MainActor
+    func loadTargetStateForCurrentGeneration() async {
+        guard let gisuId = currentSelectedGisuId(), gisuId > 0 else {
+            generationTargetStates[selectedGeneration.value] = NoticeGenerationTargetState()
+            return
+        }
+
+        async let branchesTask = try? noticeEditorTargetUseCase.fetchBranches(gisuId: gisuId)
+        async let schoolsTask = try? noticeEditorTargetUseCase.fetchSchools(gisuId: gisuId)
+
+        let branches = await branchesTask ?? []
+        let schools = await schoolsTask ?? []
+
+        branches.forEach { chapterNameCache[$0.id] = $0.name }
+        generationTargetStates[selectedGeneration.value] = NoticeGenerationTargetState(
+            branches: branches,
+            schools: schools
+        )
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -159,7 +159,7 @@ extension NoticeViewModel {
 
         selectedGeneration = Generation(value: fallback.gen)
         if generationStates[fallback.gen] == nil {
-            generationStates[fallback.gen] = GenerationFilterState()
+            generationStates[fallback.gen] = GenerationFilterState(mainFilter: .central)
         }
         return fallback.gisuId
     }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
@@ -54,6 +54,8 @@ final class NoticeViewModel {
 
     /// 기수별 필터 상태 저장소
     var generationStates: [Int: GenerationFilterState] = [:]
+    /// 기수별 지부/학교 필터 옵션 저장소
+    var generationTargetStates: [Int: NoticeGenerationTargetState] = [:]
 
     /// 기수 목록
     var generations: [Generation] = []
@@ -128,12 +130,17 @@ final class NoticeViewModel {
         currentMainFilterState.selectedPart
     }
 
+    /// 현재 선택 기수에 매핑된 지부/학교 타겟 옵션
+    var currentTargetState: NoticeGenerationTargetState {
+        generationTargetStates[selectedGeneration.value] ?? NoticeGenerationTargetState()
+    }
+
     /// 역할(memberRole) 기반으로 노출할 메인필터 항목 목록을 반환합니다.
     ///
     /// 권한과 무관하게 상위 조직 필터는 UMC 공지/본인 지부/본인 학교를 노출합니다.
     /// 파트 필터는 별도 Nested Menu에서 제공합니다.
     var mainFilterItems: [NoticeMainFilterType] {
-        [.central, .branch(userContext.branchName), .school(userContext.schoolName)]
+        [.central, .branch(currentBranchFilterTitle), .school(currentSchoolFilterTitle)]
     }
 
     /// 상단 메인 메뉴에 표시할 기본 조직 필터 목록(파트 제외)
@@ -175,5 +182,17 @@ final class NoticeViewModel {
 
     var pageSort: [String] {
         Pagination.sort
+    }
+
+    private var currentBranchFilterTitle: String {
+        currentTargetState.branches
+            .first(where: { $0.id == chapterId })?
+            .name ?? NoticeUserContext.empty.branchName
+    }
+
+    private var currentSchoolFilterTitle: String {
+        currentTargetState.schools
+            .first(where: { $0.id == schoolId })?
+            .name ?? NoticeUserContext.empty.schoolName
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeViewModelSupport.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeViewModelSupport.swift
@@ -34,6 +34,13 @@ struct NoticeUserContext {
 
 }
 
+// MARK: - NoticeGenerationTargetState
+/// 선택 기수별 지부/학교 필터 옵션 캐시입니다.
+struct NoticeGenerationTargetState: Equatable {
+    var branches: [NoticeTargetOption] = []
+    var schools: [NoticeTargetOption] = []
+}
+
 // MARK: - NoticePagingState
 /// 공지 목록/검색 공통 페이징 상태입니다.
 struct NoticePagingState {

--- a/AppProduct/AppProductTests/NoticeTest/NoticeViewModelTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticeViewModelTests.swift
@@ -1,0 +1,299 @@
+//
+//  NoticeViewModelTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/11/26.
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+struct NoticeViewModelTests {
+
+    @Test("기수 변경 시 상단 필터 라벨을 새 기수 기준으로 갱신하고 기존 선택을 초기화한 뒤 재조회한다")
+    func refreshGenerationScopedFiltersWhenGenerationChanges() async {
+        let targetUseCase = MockNoticeListTargetUseCase(
+            branchesByGisu: [
+                2: [NoticeTargetOption(id: 21, name: "Ain")]
+            ],
+            schoolsByGisu: [
+                2: [NoticeTargetOption(id: 2, name: "가천대학교")]
+            ]
+        )
+        let noticeUseCase = MockNoticeUseCase()
+
+        let viewModel = await MainActor.run {
+            makeSUT(
+                noticeUseCase: noticeUseCase,
+                targetUseCase: targetUseCase
+            )
+        }
+
+        await MainActor.run {
+            viewModel.applyUserContext(
+                schoolName: "중앙대학교",
+                chapterName: "Xenon",
+                responsiblePart: "IOS",
+                organizationTypeRawValue: "CENTRAL",
+                chapterId: 14,
+                schoolId: 1,
+                memberRoleRawValue: "CHALLENGER"
+            )
+            viewModel.gisuPairs = [(gen: 9, gisuId: 3), (gen: 8, gisuId: 2)]
+            viewModel.generations = [Generation(value: 9), Generation(value: 8)]
+            viewModel.isGisuListLoaded = true
+            viewModel.selectedGeneration = Generation(value: 9)
+            viewModel.generationStates[9] = GenerationFilterState(mainFilter: .part(.ios))
+        }
+
+        await MainActor.run {
+            viewModel.selectGeneration(Generation(value: 8))
+        }
+
+        await waitUntil {
+            let targetCalls = await targetUseCase.fetchBranchesCalls()
+            let hasNoticeRequest = await noticeUseCase.hasRequest(gisuId: 2)
+            return targetCalls.contains(2) && hasNoticeRequest
+        }
+
+        let labels = await MainActor.run {
+            viewModel.mainFilterItems.map(\.labelText)
+        }
+        let selectedMainFilterLabel = await MainActor.run {
+            viewModel.selectedMainFilter.labelText
+        }
+        let searchState = await MainActor.run {
+            (viewModel.isSearchMode, viewModel.searchQuery)
+        }
+        let latestRequest = await noticeUseCase.latestRequestSummary()
+
+        #expect(labels == ["UMC 공지", "지부", "학교"])
+        #expect(selectedMainFilterLabel == "UMC 공지")
+        #expect(searchState.0 == false)
+        #expect(searchState.1.isEmpty)
+        #expect(latestRequest?.gisuId == 2)
+        #expect(latestRequest?.chapterId == nil)
+        #expect(latestRequest?.schoolId == nil)
+        #expect(latestRequest?.part == nil)
+    }
+
+    @MainActor
+    private func makeSUT(
+        noticeUseCase: MockNoticeUseCase,
+        targetUseCase: MockNoticeListTargetUseCase
+    ) -> NoticeViewModel {
+        let container = DIContainer()
+        container.register(NoticeUseCaseProtocol.self) { noticeUseCase }
+        container.register(NoticeEditorTargetUseCaseProtocol.self) { targetUseCase }
+        container.register(ChallengerGenRepositoryProtocol.self) {
+            MockNoticeGenRepository()
+        }
+
+        return NoticeViewModel(container: container)
+    }
+
+    private func waitUntil(
+        maxAttempts: Int = 100,
+        condition: @escaping () async -> Bool
+    ) async {
+        for _ in 0..<maxAttempts {
+            if await condition() {
+                return
+            }
+            await Task.yield()
+        }
+    }
+}
+
+private actor MockNoticeListTargetUseCase: NoticeEditorTargetUseCaseProtocol {
+    private let branchesByGisu: [Int: [NoticeTargetOption]]
+    private let schoolsByGisu: [Int: [NoticeTargetOption]]
+    private var recordedFetchBranchesCalls: [Int] = []
+
+    init(
+        branchesByGisu: [Int: [NoticeTargetOption]] = [:],
+        schoolsByGisu: [Int: [NoticeTargetOption]] = [:]
+    ) {
+        self.branchesByGisu = branchesByGisu
+        self.schoolsByGisu = schoolsByGisu
+    }
+
+    func fetchAllBranches() async throws -> [NoticeTargetOption] {
+        []
+    }
+
+    func fetchBranches(gisuId: Int) async throws -> [NoticeTargetOption] {
+        recordedFetchBranchesCalls.append(gisuId)
+        return branchesByGisu[gisuId] ?? []
+    }
+
+    func fetchBranchName(chapterId: Int) async throws -> String {
+        branchesByGisu.values
+            .flatMap { $0 }
+            .first(where: { $0.id == chapterId })?
+            .name ?? ""
+    }
+
+    func fetchAllSchools() async throws -> [NoticeTargetOption] {
+        []
+    }
+
+    func fetchSchools(gisuId: Int) async throws -> [NoticeTargetOption] {
+        schoolsByGisu[gisuId] ?? []
+    }
+
+    func fetchSchools(inChapterId chapterId: Int, gisuId: Int) async throws -> [NoticeTargetOption] {
+        schoolsByGisu[gisuId] ?? []
+    }
+
+    func fetchBranchesCalls() -> [Int] {
+        recordedFetchBranchesCalls
+    }
+}
+
+private actor MockNoticeUseCase: NoticeUseCaseProtocol {
+    private var requests: [NoticeListRequestDTO] = []
+
+    func uploadNoticeAttachmentImage(imageData: Data, fileName: String?) async throws -> String {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func createNotice(
+        title: String,
+        content: String,
+        shouldNotify: Bool,
+        targetInfo: TargetInfoDTO,
+        links: [String],
+        imageIds: [String]
+    ) async throws -> NoticeDetail {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func addVote(
+        noticeId: Int,
+        title: String,
+        isAnonymous: Bool,
+        allowMultipleChoice: Bool,
+        startsAt: Date,
+        endsAtExclusive: Date,
+        options: [String]
+    ) async throws -> AddVoteResponseDTO {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func addLink(noticeId: Int, links: [String]) async throws -> NoticeItemModel {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func addImage(noticeId: Int, imageIds: [String]) async throws -> NoticeItemModel {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func readNotice(noticeId: Int) async throws {}
+
+    func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws {}
+
+    func sendReminder(noticeId: Int, targetIds: [Int]) async throws {}
+
+    func updateNotice(
+        noticeId: Int,
+        title: String,
+        content: String
+    ) async throws -> NoticeDetail {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func updateLinks(
+        noticeId: Int,
+        links: [String]
+    ) async throws -> NoticeDetail {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func updateImages(
+        noticeId: Int,
+        imageIds: [String]
+    ) async throws -> NoticeDetail {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func getAllNotices(request: NoticeListRequestDTO) async throws -> NoticePageDTO<NoticeDTO> {
+        requests.append(request)
+        return NoticePageDTO(
+            content: [],
+            page: "0",
+            size: "20",
+            totalElements: "0",
+            totalPages: "0",
+            hasNext: false,
+            hasPrevious: false
+        )
+    }
+
+    func getDetailNotice(noticeId: Int) async throws -> NoticeDetail {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func getReadStatics(noticeId: Int) async throws -> NoticeReadStaticsDTO {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func getReadStatusList(
+        noticeId: Int,
+        cursorId: Int,
+        filterType: String,
+        organizationIds: [Int],
+        status: String
+    ) async throws -> NoticeReadStatusResponseDTO {
+        fatalError("Not used in NoticeViewModelTests")
+    }
+
+    func searchNotice(
+        keyword: String,
+        request: NoticeListRequestDTO
+    ) async throws -> NoticePageDTO<NoticeDTO> {
+        requests.append(request)
+        return NoticePageDTO(
+            content: [],
+            page: "0",
+            size: "20",
+            totalElements: "0",
+            totalPages: "0",
+            hasNext: false,
+            hasPrevious: false
+        )
+    }
+
+    func deleteNotice(noticeId: Int) async throws {}
+
+    func deleteVote(noticeId: Int) async throws {}
+
+    func recordedRequests() -> [NoticeListRequestDTO] {
+        requests
+    }
+
+    func hasRequest(gisuId: Int) -> Bool {
+        requests.contains { $0.gisuId == gisuId }
+    }
+
+    func latestRequestSummary() -> (gisuId: Int, chapterId: Int?, schoolId: Int?, part: String?)? {
+        guard let latest = requests.last else { return nil }
+        return (
+            gisuId: latest.gisuId,
+            chapterId: latest.chapterId,
+            schoolId: latest.schoolId,
+            part: latest.part?.apiValue
+        )
+    }
+}
+
+private struct MockNoticeGenRepository: ChallengerGenRepositoryProtocol {
+    func replaceMappings(_ pairs: [(gen: Int, gisuId: Int)]) throws {
+        _ = pairs
+    }
+
+    func fetchGenGisuIdPairs() throws -> [(gen: Int, gisuId: Int)] {
+        []
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

공지 리스트에서 기수를 변경했을 때 상단 필터(지부/학교)가 갱신되지 않는 버그 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 기수 변경 후 필터가 올바르게 갱신되는 모습 영상 첨부 필요 -->

## 🛠️ 작업내용

- 기수 전환 시 `refreshSelectedGenerationContext`로 필터 초기화 및 공지 목록 재조회
- 기수별 지부/학교 필터 옵션을 `generationTargetStates` 딕셔너리로 캐시
- `NoticeGenerationTargetState` 모델 추가 (지부/학교 옵션 저장)
- `mainFilterItems`에서 기수별 지부/학교 이름을 동적으로 표시
- `GenerationFilterDefaults`로 기본 메인필터(`.central`) 통일
- `loadTargetStateForCurrentGeneration`에서 지부/학교 API 병렬 호출
- `NoticeViewModelTests` 테스트 추가

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift` - `refreshSelectedGenerationContext`, `loadTargetStateForCurrentGeneration` 기수 전환 흐름 확인
- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift` - `generationTargetStates` 캐시 및 `mainFilterItems` 동적 이름 로직
- `Features/Notice/Presentation/ViewModels/NoticeViewModelSupport.swift` - `NoticeGenerationTargetState` 모델 구조
- `AppProductTests/NoticeTest/NoticeViewModelTests.swift` - 기수 전환 필터 갱신 테스트

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)