### PR TITLE
🐛[Fix] 공지 리스트 기수 변경 시 필터/조직 미갱신 수정 (#489)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
@@ -50,6 +50,8 @@ enum AppStorageKey {
     static let memberRole: String = "memberRole"
     /// 사용자가 보유한 전체 역할 목록 (`[ManagementTeam.rawValue]`)
     static let memberRoles: String = "memberRoles"
+    /// 기수별 소속 조직 정보(JSON 문자열)
+    static let generationOrganizations: String = "generationOrganizations"
     /// 소속 조직 타입 (`OrganizationType.rawValue` 문자열)
     static let organizationType: String = "organizationType"
     /// 소속 조직 ID (`organizationType`에 따라 지부/학교 ID)

--- a/AppProduct/AppProduct/Core/Common/Model/GenerationOrganizationContext.swift
+++ b/AppProduct/AppProduct/Core/Common/Model/GenerationOrganizationContext.swift
@@ -1,0 +1,17 @@
+//
+//  GenerationOrganizationContext.swift
+//  AppProduct
+//
+//  Created by Codex on 3/11/26.
+//
+
+import Foundation
+
+/// 기수별 사용자 소속 조직 정보를 저장/복원하기 위한 모델입니다.
+struct GenerationOrganizationContext: Codable, Equatable {
+    let gen: Int
+    let chapterId: Int?
+    let chapterName: String?
+    let schoolId: Int?
+    let schoolName: String?
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/FailedVerificationUMCViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/FailedVerificationUMCViewModel.swift
@@ -337,10 +337,22 @@ final class FailedVerificationUMCViewModel {
             profile.roles.map(\.roleType.rawValue),
             forKey: AppStorageKey.memberRoles
         )
+        defaults.set(
+            encodeGenerationOrganizations(profile.generationOrganizations),
+            forKey: AppStorageKey.generationOrganizations
+        )
         defaults.set(isApprovedProfile(profile), forKey: AppStorageKey.canAutoLogin)
 
         container.resolve(UserSessionManager.self).updateRole(resolvedRole)
         NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
+    }
+
+    private func encodeGenerationOrganizations(_ contexts: [GenerationOrganizationContext]) -> String {
+        guard let data = try? JSONEncoder().encode(contexts),
+              let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return json
     }
 
     /// 프로필이 승인 완료 상태인지 판별합니다.

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
@@ -207,6 +207,7 @@ extension MyProfileResponseDTO {
             .days(0),
             .gens(mergedGens)
         ]
+        let generationOrganizations = buildGenerationOrganizations(records: records, roles: roles)
 
         return HomeProfileResult(
             memberId: id,
@@ -219,8 +220,42 @@ extension MyProfileResponseDTO {
             part: latestRecord.flatMap { UMCPartType(apiValue: $0.part) },
             seasonTypes: resolvedSeasonTypes,
             roles: challengerRoles,
-            generations: generations
+            generations: generations,
+            generationOrganizations: generationOrganizations
         )
+    }
+
+    private func buildGenerationOrganizations(
+        records: [ChallengerMemberDTO],
+        roles: [RoleDTO]
+    ) -> [GenerationOrganizationContext] {
+        var byGen: [Int: GenerationOrganizationContext] = [:]
+
+        for record in records where record.gisu > 0 {
+            byGen[record.gisu] = GenerationOrganizationContext(
+                gen: record.gisu,
+                chapterId: record.chapterId,
+                chapterName: record.chapterName,
+                schoolId: record.schoolId > 0 ? record.schoolId : nil,
+                schoolName: record.schoolName.isEmpty ? nil : record.schoolName
+            )
+        }
+
+        for role in roles where role.gisu > 0 {
+            let existing = byGen[role.gisu]
+            let chapterId = role.organizationType == .chapter ? role.organizationId : existing?.chapterId
+            let schoolId = role.organizationType == .school ? role.organizationId : existing?.schoolId
+
+            byGen[role.gisu] = GenerationOrganizationContext(
+                gen: role.gisu,
+                chapterId: chapterId,
+                chapterName: existing?.chapterName,
+                schoolId: schoolId,
+                schoolName: existing?.schoolName
+            )
+        }
+
+        return byGen.values.sorted { $0.gen < $1.gen }
     }
 }
 

--- a/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ChallengerRole.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ChallengerRole.swift
@@ -51,4 +51,6 @@ struct HomeProfileResult: Equatable {
     let roles: [ChallengerRole]
     /// 프로필 응답에서 파생한 기수별 패널티 데이터
     let generations: [GenerationData]
+    /// 기수별 사용자 소속 조직 정보
+    let generationOrganizations: [GenerationOrganizationContext] = []
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -135,9 +135,21 @@ final class HomeViewModel {
             result.roles.map(\.roleType.rawValue),
             forKey: AppStorageKey.memberRoles
         )
+        defaults.set(
+            encodeGenerationOrganizations(result.generationOrganizations),
+            forKey: AppStorageKey.generationOrganizations
+        )
         defaults.set(isApproved, forKey: AppStorageKey.canAutoLogin)
         container.resolve(UserSessionManager.self).updateRole(resolvedRole)
         NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
+    }
+
+    private func encodeGenerationOrganizations(_ contexts: [GenerationOrganizationContext]) -> String {
+        guard let data = try? JSONEncoder().encode(contexts),
+              let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return json
     }
 
     private func isApprovedProfile(_ result: HomeProfileResult) -> Bool {

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
@@ -64,6 +64,7 @@ extension NoticeDTO {
         let scope = targetInfo.resolvedScope
         let category = targetInfo.resolvedCategory
         let scopeDisplayName = scopeDisplayNameOverride ?? targetInfo.resolvedScopeDisplayName
+        let targetsAllGenerations = generation <= 0 && targetInfo.targetsAllGenerations
         
         return NoticeItemModel(
             noticeId: id,
@@ -83,7 +84,7 @@ extension NoticeDTO {
             vote: nil,
             viewCount: Int(viewCount) ?? 0,
             scopeDisplayName: scopeDisplayName,
-            targetsAllGenerations: targetInfo.targetsAllGenerations,
+            targetsAllGenerations: targetsAllGenerations,
             parts: targetInfo.resolvedParts
         )
     }

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
@@ -78,14 +78,11 @@ struct NoticeItemModel: Equatable, Identifiable {
     
     /// UI 표시용 태그 목록
     var tags: [NoticeItemTag] {
-        if targetsAllGenerations {
-            return [
-                NoticeItemTag(text: "모든 기수", backColor: .blue)
-            ]
-        }
-
         var items: [NoticeItemTag] = [
-            NoticeItemTag(text: "\(generation)기", backColor: .blue)
+            NoticeItemTag(
+                text: targetsAllGenerations ? "모든 기수" : "\(generation)기",
+                backColor: .blue
+            )
         ]
 
         if let scopeTag {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -20,7 +20,7 @@ extension NoticeDetailViewModel {
 
         do {
             let noticeDetail = try await noticeUseCase.getDetailNotice(noticeId: noticeID)
-            let mergedDetail = mergeAuthorDisplayIfNeeded(
+            let mergedDetail = Self.mergeFetchedNoticeDetail(
                 fetched: noticeDetail,
                 fallback: noticeState.value
             )
@@ -80,13 +80,17 @@ extension NoticeDetailViewModel {
         }
     }
 
-    private func mergeAuthorDisplayIfNeeded(
+    static func mergeFetchedNoticeDetail(
         fetched: NoticeDetail,
         fallback: NoticeDetail?
     ) -> NoticeDetail {
         guard let fallback else { return fetched }
 
         let resolvedGeneration = fetched.generation > 0 ? fetched.generation : fallback.generation
+        let resolvedTargetAudience = resolvedTargetAudience(
+            primary: fetched.targetAudience,
+            fallback: fallback.targetAudience
+        )
         let resolvedNickname = resolvedAuthorField(
             primary: fetched.authorNickname,
             fallback: fallback.authorNickname
@@ -111,7 +115,7 @@ extension NoticeDetailViewModel {
             authorImageURL: fetched.authorImageURL,
             createdAt: fetched.createdAt,
             updatedAt: fetched.updatedAt,
-            targetAudience: fetched.targetAudience,
+            targetAudience: resolvedTargetAudience,
             hasPermission: fetched.hasPermission,
             images: fetched.images,
             imageItems: fetched.imageItems,
@@ -120,7 +124,24 @@ extension NoticeDetailViewModel {
         )
     }
 
-    private func resolvedAuthorField(primary: String?, fallback: String?) -> String? {
+    private static func resolvedTargetAudience(
+        primary: TargetAudience,
+        fallback: TargetAudience
+    ) -> TargetAudience {
+        let resolvedGeneration = primary.generation > 0 ? primary.generation : fallback.generation
+
+        return TargetAudience(
+            generation: resolvedGeneration,
+            scope: primary.scope,
+            parts: primary.parts,
+            chapterId: primary.chapterId,
+            schoolId: primary.schoolId,
+            branches: primary.branches,
+            schools: primary.schools
+        )
+    }
+
+    private static func resolvedAuthorField(primary: String?, fallback: String?) -> String? {
         let trimmedPrimary = primary?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !trimmedPrimary.isEmpty, trimmedPrimary != "알 수 없음" {
             return trimmedPrimary

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift
@@ -32,7 +32,8 @@ extension NoticeViewModel {
         organizationTypeRawValue: String,
         chapterId: Int,
         schoolId: Int,
-        memberRoleRawValue: String
+        memberRoleRawValue: String,
+        generationOrganizationsJSON: String
     ) {
         self.userContext = NoticeUserContext(
             schoolName: schoolName,
@@ -43,6 +44,7 @@ extension NoticeViewModel {
         self.memberRole = ManagementTeam(rawValue: memberRoleRawValue)
         self.chapterId = chapterId
         self.schoolId = schoolId
+        self.generationOrganizations = decodeGenerationOrganizations(from: generationOrganizationsJSON)
 
         let validMainFilters = mainFilterItems
         let isCurrentPartSelectionValid: Bool = {
@@ -57,6 +59,15 @@ extension NoticeViewModel {
             state.mainFilter = validMainFilters.first ?? .all
             currentState = state
         }
+    }
+
+    private func decodeGenerationOrganizations(from json: String) -> [Int: GenerationOrganizationContext] {
+        guard let data = json.data(using: .utf8),
+              let contexts = try? JSONDecoder().decode([GenerationOrganizationContext].self, from: data) else {
+            return [:]
+        }
+
+        return Dictionary(uniqueKeysWithValues: contexts.map { ($0.gen, $0) })
     }
 
     /// 기수 목록 조회

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -298,8 +298,8 @@ extension NoticeViewModel {
             gisuId: gisuId,
             page: page,
             selectedMainFilter: selectedMainFilter,
-            chapterId: chapterId,
-            schoolId: schoolId,
+            chapterId: selectedGenerationChapterId,
+            schoolId: selectedGenerationSchoolId,
             pageSize: pageSize,
             sort: pageSort
         )

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
@@ -39,6 +39,7 @@ final class NoticeViewModel {
     var memberRole: ManagementTeam?
     var chapterId: Int = 0
     var schoolId: Int = 0
+    var generationOrganizations: [Int: GenerationOrganizationContext] = [:]
 
     /// 기수-기수ID 쌍 목록
     var gisuPairs: [(gen: Int, gisuId: Int)] = []
@@ -185,14 +186,28 @@ final class NoticeViewModel {
     }
 
     private var currentBranchFilterTitle: String {
+        let resolvedChapterId = selectedGenerationOrganization?.chapterId ?? 0
         currentTargetState.branches
-            .first(where: { $0.id == chapterId })?
-            .name ?? NoticeUserContext.empty.branchName
+            .first(where: { $0.id == resolvedChapterId })?
+            .name ?? selectedGenerationOrganization?.chapterName ?? NoticeUserContext.empty.branchName
     }
 
     private var currentSchoolFilterTitle: String {
+        let resolvedSchoolId = selectedGenerationOrganization?.schoolId ?? 0
         currentTargetState.schools
-            .first(where: { $0.id == schoolId })?
-            .name ?? NoticeUserContext.empty.schoolName
+            .first(where: { $0.id == resolvedSchoolId })?
+            .name ?? selectedGenerationOrganization?.schoolName ?? NoticeUserContext.empty.schoolName
+    }
+
+    var selectedGenerationOrganization: GenerationOrganizationContext? {
+        generationOrganizations[selectedGeneration.value]
+    }
+
+    var selectedGenerationChapterId: Int {
+        selectedGenerationOrganization?.chapterId ?? 0
+    }
+
+    var selectedGenerationSchoolId: Int {
+        selectedGenerationOrganization?.schoolId ?? 0
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeView.swift
@@ -21,6 +21,7 @@ struct NoticeView: View {
     @AppStorage(AppStorageKey.memberRole) private var memberRoleRaw: String = ""
     @AppStorage(AppStorageKey.chapterId) private var chapterId: Int = 0
     @AppStorage(AppStorageKey.schoolId) private var schoolId: Int = 0
+    @AppStorage(AppStorageKey.generationOrganizations) private var generationOrganizationsJSON: String = "[]"
     @AppStorage(AppStorageKey.noticeSelectedGisuId) private var noticeSelectedGisuId: Int = 0
     @State private var viewModel: NoticeViewModel
     @State private var search: String = ""
@@ -235,7 +236,8 @@ struct NoticeView: View {
             organizationTypeRawValue: organizationType,
             chapterId: chapterId,
             schoolId: schoolId,
-            memberRoleRawValue: memberRoleRaw
+            memberRoleRawValue: memberRoleRaw,
+            generationOrganizationsJSON: generationOrganizationsJSON
         )
     }
 
@@ -246,7 +248,16 @@ struct NoticeView: View {
 
     /// 사용자 컨텍스트 변경 감지를 위한 서명 문자열입니다.
     private var userContextSignature: String {
-        [schoolName, chapterName, responsiblePart, organizationType, memberRoleRaw, String(chapterId), String(schoolId)]
+        [
+            schoolName,
+            chapterName,
+            responsiblePart,
+            organizationType,
+            memberRoleRaw,
+            String(chapterId),
+            String(schoolId),
+            generationOrganizationsJSON
+        ]
             .joined(separator: Constants.userContextSeparator)
     }
     

--- a/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticePresentationTests.swift
@@ -13,8 +13,8 @@ struct NoticePresentationTests {
 
     // MARK: - Tag Tests
 
-    @Test("전체 기수 공지는 모든 기수 태그만 노출한다")
-    func allGenerationNoticeUsesSingleTag() {
+    @Test("전체 기수 중앙 공지는 모든 기수 태그만 노출한다")
+    func allGenerationCentralNoticeShowsOnlyGenerationTag() {
         let model = NoticeItemModel(
             generation: 0,
             scope: .central,
@@ -55,6 +55,59 @@ struct NoticePresentationTests {
         )
 
         #expect(model.tags.map { $0.text } == ["9기", "Ain", "iOS"])
+    }
+
+    @Test("지부 공지는 targetGisu 없이 targetGisuId만 있어도 모든 기수로 표시하지 않는다")
+    func branchNoticeUsesResolvedGenerationInsteadOfAllGenerationsTag() throws {
+        let json = """
+        {
+          "id": "1",
+          "title": "공지",
+          "content": "내용",
+          "shouldSendNotification": false,
+          "viewCount": "0",
+          "createdAt": "2026-03-11T10:00:00Z",
+          "targetInfo": {
+            "targetGisu": null,
+            "targetGisuId": "3",
+            "targetChapterId": "14",
+            "targetSchoolId": null,
+            "targetChapterName": "Ain",
+            "targetParts": []
+          },
+          "authorChallengerId": null,
+          "authorMemberId": null,
+          "authorNickname": "닉네임",
+          "authorName": "작성자"
+        }
+        """
+        let dto = try JSONDecoder().decode(NoticeDTO.self, from: Data(json.utf8))
+
+        let item = dto.toItemModel(generationOverride: 9)
+
+        #expect(item.tags.map { $0.text } == ["9기", "Ain"])
+    }
+
+    @Test("전체 기수 교내 공지는 모든 기수와 교내 태그를 함께 노출한다")
+    func allGenerationCampusNoticeShowsGenerationAndCampusTags() {
+        let model = NoticeItemModel(
+            generation: 0,
+            scope: .campus,
+            category: .general,
+            mustRead: false,
+            isAlert: false,
+            date: Date(),
+            title: "공지",
+            content: "내용",
+            writer: "작성자",
+            links: [],
+            images: [],
+            vote: nil,
+            viewCount: 0,
+            targetsAllGenerations: true
+        )
+
+        #expect(model.tags.map { $0.text } == ["모든 기수", "교내"])
     }
 
     @Test("공지 상세 태그는 targetInfo의 지부명을 사용한다")
@@ -233,6 +286,77 @@ struct NoticePresentationTests {
         )
 
         #expect(mergedDetail.defaultAuthorDisplayName == "하늘카카오/박경운-9th")
+    }
+
+    @Test("상세 재조회 시 targetAudience 기수가 비어 있으면 목록 기수를 이어받아 태그를 유지한다")
+    func noticeDetailKeepsFallbackTargetAudienceGeneration() {
+        let fallback = NoticeDetail(
+            id: "32",
+            generation: 9,
+            scope: .branch,
+            category: .general,
+            isMustRead: false,
+            title: "공지",
+            content: "내용",
+            authorID: "11",
+            authorMemberId: "22",
+            authorNickname: "하늘카카오",
+            authorName: "박경운",
+            authorImageURL: nil,
+            createdAt: Date(),
+            updatedAt: nil,
+            targetAudience: TargetAudience(
+                generation: 9,
+                scope: .branch,
+                parts: [],
+                chapterId: 14,
+                schoolId: nil,
+                branches: ["Ain"],
+                schools: []
+            ),
+            hasPermission: false,
+            images: [],
+            links: [],
+            vote: nil
+        )
+
+        let fetched = NoticeDetail(
+            id: "32",
+            generation: 0,
+            scope: .branch,
+            category: .general,
+            isMustRead: false,
+            title: "공지",
+            content: "내용",
+            authorID: "11",
+            authorMemberId: "22",
+            authorNickname: nil,
+            authorName: "알 수 없음",
+            authorImageURL: nil,
+            createdAt: Date(),
+            updatedAt: nil,
+            targetAudience: TargetAudience(
+                generation: 0,
+                scope: .branch,
+                parts: [],
+                chapterId: 14,
+                schoolId: nil,
+                branches: ["Ain"],
+                schools: []
+            ),
+            hasPermission: false,
+            images: [],
+            links: [],
+            vote: nil
+        )
+
+        let merged = NoticeDetailViewModel.mergeFetchedNoticeDetail(
+            fetched: fetched,
+            fallback: fallback
+        )
+
+        #expect(merged.targetAudience.generation == 9)
+        #expect(merged.tags.map { $0.text } == ["9기", "Ain"])
     }
 
     // MARK: - Read Status Permission Tests

--- a/AppProduct/AppProductTests/NoticeTest/NoticeViewModelTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticeViewModelTests.swift
@@ -38,7 +38,8 @@ struct NoticeViewModelTests {
                 organizationTypeRawValue: "CENTRAL",
                 chapterId: 14,
                 schoolId: 1,
-                memberRoleRawValue: "CHALLENGER"
+                memberRoleRawValue: "CHALLENGER",
+                generationOrganizationsJSON: "[]"
             )
             viewModel.gisuPairs = [(gen: 9, gisuId: 3), (gen: 8, gisuId: 2)]
             viewModel.generations = [Generation(value: 9), Generation(value: 8)]
@@ -76,6 +77,74 @@ struct NoticeViewModelTests {
         #expect(latestRequest?.chapterId == nil)
         #expect(latestRequest?.schoolId == nil)
         #expect(latestRequest?.part == nil)
+    }
+
+    @Test("기수별 조직 정보가 저장돼 있으면 상단 라벨과 필터 요청이 선택 기수 기준으로 바뀐다")
+    func useGenerationScopedOrganizationWhenGenerationChanges() async throws {
+        let targetUseCase = MockNoticeListTargetUseCase(
+            branchesByGisu: [
+                2: [NoticeTargetOption(id: 21, name: "Ain")]
+            ],
+            schoolsByGisu: [
+                2: [NoticeTargetOption(id: 7, name: "중앙대학교")]
+            ]
+        )
+        let noticeUseCase = MockNoticeUseCase()
+        let contexts = [
+            GenerationOrganizationContext(
+                gen: 8,
+                chapterId: 21,
+                chapterName: "Ain",
+                schoolId: 7,
+                schoolName: "중앙대학교"
+            )
+        ]
+        let contextsData = try JSONEncoder().encode(contexts)
+        let contextsJSON = String(decoding: contextsData, as: UTF8.self)
+
+        let viewModel = await MainActor.run {
+            makeSUT(
+                noticeUseCase: noticeUseCase,
+                targetUseCase: targetUseCase
+            )
+        }
+
+        await MainActor.run {
+            viewModel.applyUserContext(
+                schoolName: "가천대학교",
+                chapterName: "Xenon",
+                responsiblePart: "IOS",
+                organizationTypeRawValue: "CENTRAL",
+                chapterId: 14,
+                schoolId: 1,
+                memberRoleRawValue: "CHALLENGER",
+                generationOrganizationsJSON: contextsJSON
+            )
+            viewModel.gisuPairs = [(gen: 9, gisuId: 3), (gen: 8, gisuId: 2)]
+            viewModel.generations = [Generation(value: 9), Generation(value: 8)]
+            viewModel.isGisuListLoaded = true
+            viewModel.selectedGeneration = Generation(value: 8)
+            viewModel.generationStates[8] = GenerationFilterState(mainFilter: .branch("지부"))
+        }
+
+        await MainActor.run {
+            viewModel.selectMainFilter(.branch("지부"))
+        }
+
+        await waitUntil {
+            let latestRequest = await noticeUseCase.latestRequestSummary()
+            return latestRequest?.gisuId == 2 && latestRequest?.chapterId == 21
+        }
+
+        let labels = await MainActor.run {
+            viewModel.mainFilterItems.map(\.labelText)
+        }
+        let latestRequest = await noticeUseCase.latestRequestSummary()
+
+        #expect(labels == ["UMC 공지", "Ain", "중앙대학교"])
+        #expect(latestRequest?.gisuId == 2)
+        #expect(latestRequest?.chapterId == 21)
+        #expect(latestRequest?.schoolId == nil)
     }
 
     @MainActor


### PR DESCRIPTION
## ✨ PR 유형

공지 리스트에서 기수 변경 시 필터가 갱신되지 않고, 다른 기수의 조직 ID로 필터 요청이 나가는 버그 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 기수 변경 후 필터 라벨 및 공지 목록이 올바르게 갱신되는 모습 영상 첨부 필요 -->

## 🛠️ 작업내용

### 기수별 필터 갱신
- 기수 전환 시 `refreshSelectedGenerationContext`로 필터 초기화 및 공지 목록 재조회
- 기수별 지부/학교 필터 옵션을 `generationTargetStates` 딕셔너리로 캐시
- `NoticeGenerationTargetState` 모델 추가

### 기수별 조직 ID 매핑
- `GenerationOrganizationContext` 모델 추가 (기수별 chapterId/schoolId 저장)
- 프로필 조회 시 기수별 조직 정보를 AppStorage에 JSON으로 저장
- 공지 필터 API 요청에서 고정 chapterId/schoolId 대신 선택 기수 기준 조직 ID 사용
- 상단 필터 라벨도 선택 기수의 지부/학교 이름으로 동적 표시

### 공지 상세 targetAudience 병합
- `mergeFetchedNoticeDetail`에서 `targetAudience.generation`도 fallback 병합
- 지부/학교 공지의 `targetsAllGenerations` 판정 조건 보정
- `NoticeItemModel.tags` 태그 분기 통합

### 테스트
- `NoticeViewModelTests` 기수 전환 필터 갱신 테스트
- 기수별 조직 정보 기반 필터 요청 테스트
- 상세 targetAudience 기수 병합 테스트
- 지부 공지 모든 기수 태그 미표시 테스트

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Core/Common/Model/GenerationOrganizationContext.swift` - 기수별 조직 매핑 모델 구조
- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift` - `selectedGenerationOrganization` 및 동적 필터 라벨 로직
- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Context.swift` - `refreshSelectedGenerationContext`, `loadTargetStateForCurrentGeneration` 흐름
- `Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel+Fetch.swift` - 필터 요청 시 `selectedGenerationChapterId`/`selectedGenerationSchoolId` 사용
- `Features/Home/Data/DTO/MyProfileDTO.swift` - `buildGenerationOrganizations` 프로필에서 기수별 조직 정보 추출
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift` - `mergeFetchedNoticeDetail` targetAudience 기수 병합

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)