### PR TITLE
♻️ [Refactor] 운영진 출석 승인 대기 목록 일괄 조회 API 전환

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/SchedulePendingGroupDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/SchedulePendingGroupDTO.swift
@@ -1,0 +1,109 @@
+//
+//  SchedulePendingGroupDTO.swift
+//  AppProduct
+//
+//  Created by jaewon Lee on 3/12/26.
+//
+
+import Foundation
+
+/// 일괄 조회 응답의 스케줄별 그룹 wrapper DTO
+///
+/// `GET /api/v1/attendances/pending` 응답 구조:
+/// ```json
+/// [
+///   {
+///     "scheduleId": 30,
+///     "scheduleName": "1주차 세션",
+///     "pendingAttendances": [ ... PendingAttendanceDTO ... ]
+///   }
+/// ]
+/// ```
+///
+/// - Note: `scheduleId`는 서버에서 Int 또는 String으로 반환될 수 있음.
+///   `MemberOAuthDTO`와 동일한 flexible decoding 패턴 적용.
+struct SchedulePendingGroupDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let scheduleId: Int
+    let scheduleName: String
+    let pendingAttendances: [PendingAttendanceDTO]
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case scheduleId
+        case scheduleName
+        case pendingAttendances
+    }
+
+    // MARK: - Init
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(
+            keyedBy: CodingKeys.self
+        )
+        scheduleId = try Self.decodeFlexibleInt(
+            from: container,
+            forKey: .scheduleId
+        )
+        scheduleName = try container.decode(
+            String.self,
+            forKey: .scheduleName
+        )
+        pendingAttendances = try container.decode(
+            [PendingAttendanceDTO].self,
+            forKey: .pendingAttendances
+        )
+    }
+
+    /// Int 또는 숫자 String을 Int로 디코딩
+    ///
+    /// 서버가 숫자를 Int 또는 String으로 반환할 수 있는
+    /// 불일치를 안전하게 처리합니다.
+    /// 참고: `MemberOAuthDTO.decodeFlexibleInt`
+    private static func decodeFlexibleInt(
+        from container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) throws -> Int {
+        if let intValue = try? container.decode(
+            Int.self, forKey: key
+        ) {
+            return intValue
+        }
+
+        if let stringValue = try? container.decode(
+            String.self, forKey: key
+        ),
+           let intValue = Int(stringValue) {
+            return intValue
+        }
+
+        throw DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(
+                codingPath: container.codingPath + [key],
+                debugDescription: """
+                    \(key.stringValue)는 \
+                    Int 또는 숫자 문자열이어야 합니다.
+                    """
+            )
+        )
+    }
+}
+
+// MARK: - toDomain
+
+extension SchedulePendingGroupDTO {
+
+    /// DTO 그룹 -> (scheduleId, [PendingAttendanceRecord]) 튜플 변환
+    ///
+    /// 내부 pendingAttendances를
+    /// 기존 PendingAttendanceDTO.toDomain()으로 domain 변환합니다.
+    func toDomainEntry() -> (Int, [PendingAttendanceRecord]) {
+        let records = pendingAttendances.map { $0.toDomain() }
+        return (scheduleId, records)
+    }
+}
+

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/AttendanceRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/AttendanceRepository.swift
@@ -59,6 +59,24 @@ final class AttendanceRepository: ChallengerAttendanceRepositoryProtocol,
         return try apiResponse.unwrap().map { $0.toDomain() }
     }
 
+    func getAllPendingAttendances(
+    ) async throws -> [Int: [PendingAttendanceRecord]] {
+        let response = try await adapter.request(
+            AttendanceRouter.getAllPending
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<[SchedulePendingGroupDTO]>.self,
+            from: response.data
+        )
+        let groups = try apiResponse.unwrap()
+        var result: [Int: [PendingAttendanceRecord]] = [:]
+        for group in groups {
+            let (scheduleId, records) = group.toDomainEntry()
+            result[scheduleId] = records
+        }
+        return result
+    }
+
     func getMyHistory() async throws -> [AttendanceHistoryItem] {
         let response = try await adapter.request(
             AttendanceRouter.getMyHistory

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockAttendanceRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockAttendanceRepository.swift
@@ -46,6 +46,25 @@ final class MockAttendanceRepository: ChallengerAttendanceRepositoryProtocol,
         ]
     }
 
+    func getAllPendingAttendances(
+    ) async throws -> [Int: [PendingAttendanceRecord]] {
+        [
+            1: [
+                PendingAttendanceRecord(
+                    attendanceId: 1,
+                    memberId: 1,
+                    memberName: "일일일",
+                    nickname: "길동이",
+                    profileImageLink: nil,
+                    schoolName: "중앙대학교",
+                    status: .pendingApproval,
+                    reason: "병원 방문으로 인한 지각",
+                    requestedAt: .now
+                )
+            ]
+        ]
+    }
+
     func getMyHistory() async throws -> [AttendanceHistoryItem] {
         [
             AttendanceHistoryItem(

--- a/AppProduct/AppProduct/Features/Activity/Data/Router/AttendanceRouter.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Router/AttendanceRouter.swift
@@ -21,6 +21,8 @@ enum AttendanceRouter {
     case getDetail(recordId: Int)
     /// 승인 대기 목록 조회 (관리자)
     case getPending(scheduleId: Int)
+    /// 승인 대기 목록 일괄 조회 (관리자)
+    case getAllPending
     /// 내 출석 이력 조회
     case getMyHistory
     /// 챌린저 출석 이력 조회
@@ -54,6 +56,8 @@ extension AttendanceRouter: BaseTargetType {
             return "/api/v1/attendances/\(recordId)"
         case .getPending(let scheduleId):
             return "/api/v1/attendances/pending/\(scheduleId)"
+        case .getAllPending:
+            return "/api/v1/attendances/pending"
         case .getMyHistory:
             return "/api/v1/attendances/history"
         case .getChallengerHistory(let challengerId):
@@ -77,7 +81,7 @@ extension AttendanceRouter: BaseTargetType {
 
     var method: Moya.Method {
         switch self {
-        case .getDetail, .getPending, .getMyHistory,
+        case .getDetail, .getPending, .getAllPending, .getMyHistory,
              .getChallengerHistory, .getAvailable:
             return .get
         case .reject, .approve, .submitReason, .check:
@@ -91,7 +95,7 @@ extension AttendanceRouter: BaseTargetType {
 
     var task: Moya.Task {
         switch self {
-        case .getDetail, .getPending, .getMyHistory,
+        case .getDetail, .getPending, .getAllPending, .getMyHistory,
              .getChallengerHistory, .getAvailable,
              .reject, .approve:
             return .requestPlain

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/OperatorAttendanceRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/OperatorAttendanceRepositoryProtocol.swift
@@ -19,6 +19,10 @@ protocol OperatorAttendanceRepositoryProtocol {
         scheduleId: Int
     ) async throws -> [PendingAttendanceRecord]
 
+    /// 전체 승인 대기 출석 목록 일괄 조회 (관리자)
+    /// - Returns: scheduleId별로 그룹핑된 Dictionary
+    func getAllPendingAttendances() async throws -> [Int: [PendingAttendanceRecord]]
+
     /// 챌린저 출석 이력 조회
     func getChallengerHistory(
         challengerId: Int

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/OperatorAttendanceUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/OperatorAttendanceUseCase.swift
@@ -28,6 +28,10 @@ final class OperatorAttendanceUseCase: OperatorAttendanceUseCaseProtocol {
         try await repository.getPendingAttendances(scheduleId: scheduleId)
     }
 
+    func fetchAllPendingAttendances() async throws -> [Int: [PendingAttendanceRecord]] {
+        try await repository.getAllPendingAttendances()
+    }
+
     func approveAttendance(recordId: Int) async throws {
         try await repository.approveAttendance(recordId: recordId)
     }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/OperatorAttendanceUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/OperatorAttendanceUseCaseProtocol.swift
@@ -12,6 +12,9 @@ import Foundation
 protocol OperatorAttendanceUseCaseProtocol {
     /// 승인 대기 멤버 목록 조회
     func fetchPendingAttendances(scheduleId: Int) async throws -> [PendingAttendanceRecord]
+    /// 전체 승인 대기 멤버 일괄 조회
+    /// - Returns: scheduleId별로 그룹핑된 Dictionary
+    func fetchAllPendingAttendances() async throws -> [Int: [PendingAttendanceRecord]]
     /// 개별 출석 승인
     func approveAttendance(recordId: Int) async throws
     /// 개별 출석 반려

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
@@ -67,26 +67,25 @@ final class OperatorAttendanceViewModel {
             statsMap = [:]
         }
 
+        // 승인 대기 목록 일괄 조회 (1번)
+        let pendingBySchedule: [Int: [PendingAttendanceRecord]]
+        do {
+            pendingBySchedule = try await useCase.fetchAllPendingAttendances()
+        } catch {
+            pendingBySchedule = [:]
+        }
+
         for session in sessions {
             let scheduleIdString = session.id.value
-            var pendingMembers: [OperatorPendingMember] = []
-
-            if let scheduleId = Int(scheduleIdString) {
-                do {
-                    let records = try await useCase
-                        .fetchPendingAttendances(
-                            scheduleId: scheduleId
-                        )
-                    pendingMembers = records.map {
-                        OperatorPendingMember(from: $0)
-                    }
-                } catch {
-                    // API 실패 시 빈 목록으로 진행
-                }
+            let scheduleId = Int(scheduleIdString)
+            let records = scheduleId.flatMap {
+                pendingBySchedule[$0]
+            } ?? []
+            let pendingMembers = records.map {
+                OperatorPendingMember(from: $0)
             }
 
             // 서버 출석 통계 사용
-            let scheduleId = Int(scheduleIdString)
             let stats = scheduleId.flatMap { statsMap[$0] }
 
             let totalCount: Int


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor — 운영진 출석 승인 대기 목록 API 호출 최적화

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (Data/Domain/ViewModel 레이어만 변경)

## 🛠️ 작업내용

- 세션 전체 조회 API가 개발됨에 따라 기존 세션별 `GET /api/v1/attendances/pending/{scheduleId}` N번 개별 호출 → `GET /api/v1/attendances/pending` 1번 일괄 조회로 전환
- API 호출 횟수: N+2회 → 2회 (통계 1회 + pending 일괄 1회)
- 서버 응답이 scheduleId별 그룹 구조이므로 클라이언트 그룹핑 불필요
- 새 wrapper DTO `SchedulePendingGroupDTO` 추가 (flexible Int/String decoding 포함)
- 기존 `getPending(scheduleId:)` API는 `@available(*, deprecated)` 처리하여 하위 호환성 유지
- 변경 파일: 8개 (7개 수정 + 1개 신규)

## 📋 추후 진행 상황

- `decodeFlexibleInt` 유틸리티가 `MemberOAuthDTO`, `SchedulePendingGroupDTO` 등에 중복 존재 — 공용 유틸로 추출 리팩토링 고려

## 📌 리뷰 포인트

- `Features/Activity/Data/DTOs/SchedulePendingGroupDTO.swift` — 신규 wrapper DTO, flexible decoding 패턴 확인
- `Features/Activity/Data/Router/AttendanceRouter.swift` — 일괄 조회 라우터 case 및 deprecated 어노테이션
- `Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift` — N-call 루프 → batch + Dictionary lookup 전환 로직

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #486