### PR TITLE
🐛[Fix] D-Day 부호 반전 수정, 공지/커뮤니티 작성자 표기 서버 응답 기반 변경 (#507)

### DIFF
--- a/AppProduct/AppProduct/Features/Community/DTO/CommunityPostResponseDTO.swift
+++ b/AppProduct/AppProduct/Features/Community/DTO/CommunityPostResponseDTO.swift
@@ -16,6 +16,7 @@ struct PostDetailDTO: Codable {
     let authorId: String?
     let authorName: String?
     let authorNickname: String?
+    let challengerNickname: String?
     let authorProfileImage: String?
     let authorPart: String?
     let lightningInfo: LightningInfoDTO?
@@ -35,6 +36,7 @@ struct PostDetailDTO: Codable {
         case authorId
         case authorName
         case authorNickname
+        case challengerNickname
         case authorProfileImage
         case authorPart
         case lightningInfo
@@ -55,7 +57,10 @@ struct PostDetailDTO: Codable {
         category = try container.decode(String.self, forKey: .category)
         authorId = container.decodeFlexibleOptionalString(forKey: .authorId)
         authorName = try container.decodeIfPresent(String.self, forKey: .authorName)
-        authorNickname = try container.decodeIfPresent(String.self, forKey: .authorNickname)
+        authorNickname = container.decodeFirstNonEmptyString(
+            forKeys: [.authorNickname, .challengerNickname]
+        )
+        challengerNickname = try container.decodeIfPresent(String.self, forKey: .challengerNickname)
         authorProfileImage = try container.decodeIfPresent(String.self, forKey: .authorProfileImage)
         authorPart = try container.decodeIfPresent(String.self, forKey: .authorPart)
         lightningInfo = try container.decodeIfPresent(LightningInfoDTO.self, forKey: .lightningInfo)
@@ -80,6 +85,7 @@ struct PostListItemDTO: Codable {
     let authorMemberId: String?
     let authorName: String?
     let authorNickname: String?
+    let challengerNickname: String?
     let authorProfileImage: String?
     let authorPart: String?
     let createdAt: String
@@ -99,6 +105,7 @@ struct PostListItemDTO: Codable {
         case authorMemberId
         case authorName
         case authorNickname
+        case challengerNickname
         case authorProfileImage
         case authorPart
         case createdAt
@@ -119,7 +126,10 @@ struct PostListItemDTO: Codable {
         authorChallengerId = container.decodeFlexibleOptionalString(forKey: .authorChallengerId)
         authorMemberId = container.decodeFlexibleOptionalString(forKey: .authorMemberId)
         authorName = try container.decodeIfPresent(String.self, forKey: .authorName)
-        authorNickname = try container.decodeIfPresent(String.self, forKey: .authorNickname)
+        authorNickname = container.decodeFirstNonEmptyString(
+            forKeys: [.authorNickname, .challengerNickname]
+        )
+        challengerNickname = try container.decodeIfPresent(String.self, forKey: .challengerNickname)
         authorProfileImage = try container.decodeIfPresent(String.self, forKey: .authorProfileImage)
         authorPart = try container.decodeIfPresent(String.self, forKey: .authorPart)
         createdAt = try container.decode(String.self, forKey: .createdAt)
@@ -247,6 +257,13 @@ private func resolvedDisplayName(authorName: String?) -> String {
 }
 
 private extension KeyedDecodingContainer {
+    func decodeFirstNonEmptyString(forKeys keys: [Key]) -> String? {
+        keys
+            .compactMap { try? decodeIfPresent(String.self, forKey: $0) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { !$0.isEmpty })
+    }
+
     func decodeFlexibleString(forKey key: Key) throws -> String {
         if let value = try? decode(String.self, forKey: key) {
             return value

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/HomeScheduleDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/HomeScheduleDTO.swift
@@ -21,7 +21,7 @@ struct HomeScheduleResponseDTO: Codable {
     let endsAt: String
     /// 참여 상태 (예: "참여 예정")
     let status: String
-    /// D-Day 값 (음수: 지남, 양수: 남음)
+    /// D-Day 값 (양수: 미래, 음수: 과거)
     let dDay: Int
 
     private enum CodingKeys: String, CodingKey {

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleDetailDTO.swift
@@ -36,7 +36,7 @@ struct ScheduleDetailDTO: Codable, Sendable, Equatable {
     let longitude: Double
     /// 참여 상태 (예: "참여 예정")
     let status: String
-    /// D-Day 값 (음수: 미래, 양수: 과거)
+    /// D-Day 값 (양수: 미래, 음수: 과거)
     let dDay: Int
     /// 출석 승인 필요 여부
     let requiresAttendanceApproval: Bool

--- a/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ScheduleData.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ScheduleData.swift
@@ -7,10 +7,29 @@
 
 import Foundation
 
+protocol ScheduleDDayDisplayable {
+    var dDay: Int { get }
+}
+
+extension ScheduleDDayDisplayable {
+    /// 서버의 dDay 부호 규칙에 맞춰 화면 표시용 문자열을 반환합니다.
+    ///
+    /// 양수는 미래 일정(D-N), 음수는 지난 일정(D+N), 0은 오늘 일정(D-Day)입니다.
+    var dDayText: String {
+        if dDay > 0 {
+            return "D-\(dDay)"
+        }
+        if dDay < 0 {
+            return "D+\(abs(dDay))"
+        }
+        return "D-Day"
+    }
+}
+
 /// 달력 스케줄 리스트 데이터 모델
 ///
 /// 특정 날짜에 선택된 일정들을 리스트 형태로 표시할 때 사용되는 일정 데이터입니다.
-struct ScheduleData: Equatable, Identifiable {
+struct ScheduleData: Equatable, Identifiable, ScheduleDDayDisplayable {
 
     /// 고유 식별자
     var id: Int { scheduleId }
@@ -30,6 +49,6 @@ struct ScheduleData: Equatable, Identifiable {
     /// 참여 상태 (예: "참여 예정")
     let status: String
 
-    /// D-Day
+    /// D-Day 값 (양수: 미래, 음수: 과거)
     let dDay: Int
 }

--- a/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ScheduleDetailData.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ScheduleDetailData.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 일정 상세 도메인 모델
-struct ScheduleDetailData: Equatable, Identifiable {
+struct ScheduleDetailData: Equatable, Identifiable, ScheduleDDayDisplayable {
     // MARK: - Property
 
     var id: UUID = .init()
@@ -23,6 +23,7 @@ struct ScheduleDetailData: Equatable, Identifiable {
     let latitude: Double
     let longitude: Double
     let status: String
+    /// D-Day 값 (양수: 미래, 음수: 과거)
     let dDay: Int
     let requiresAttendanceApproval: Bool
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/ScheduleListCard.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/ScheduleListCard.swift
@@ -104,13 +104,7 @@ struct ScheduleListCard: View, Equatable {
     }
 
     private var dDayText: String {
-        if data.dDay < 0 {
-            return "D-\(abs(data.dDay))"
-        }
-        if data.dDay > 0 {
-            return "D+\(data.dDay)"
-        }
-        return "D-Day"
+        data.dDayText
     }
     
     private var chevron: some View {
@@ -129,7 +123,7 @@ struct ScheduleListCard: View, Equatable {
         ))
         ScheduleListCard(data: .init(
             scheduleId: 2, title: "데모데이",
-            startsAt: .now, endsAt: .now, status: "참여 예정", dDay: 14
+            startsAt: .now, endsAt: .now, status: "참여 예정", dDay: -14
         ))
     }
     .safeAreaPadding(.horizontal, 16)

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDTO.swift
@@ -49,7 +49,7 @@ struct NoticeDTO: Codable {
         authorChallengerId = try? container.decode(String.self, forKey: .authorChallengerId)
         authorMemberId = try? container.decode(String.self, forKey: .authorMemberId)
         authorNickname = try container.decodeIfPresent(String.self, forKey: .authorNickname) ?? ""
-        authorName = try container.decodeIfPresent(String.self, forKey: .authorName) ?? authorNickname
+        authorName = try container.decodeIfPresent(String.self, forKey: .authorName) ?? ""
     }
 }
 
@@ -66,6 +66,8 @@ extension NoticeDTO {
         let scopeDisplayName = scopeDisplayNameOverride ?? targetInfo.resolvedScopeDisplayName
         let targetsAllGenerations = generation <= 0 && targetInfo.targetsAllGenerations
         
+        let resolvedAuthorName = resolvedAuthorName(authorName)
+
         return NoticeItemModel(
             noticeId: id,
             generation: generation,
@@ -76,9 +78,9 @@ extension NoticeDTO {
             date: createdAt.toISO8601Date(),
             title: title,
             content: content,
-            writer: authorName.isEmpty ? authorNickname : authorName,
+            writer: resolvedAuthorName,
             authorNickname: authorNickname.isEmpty ? nil : authorNickname,
-            authorName: authorName.isEmpty ? nil : authorName,
+            authorName: resolvedAuthorName == "알 수 없음" ? nil : resolvedAuthorName,
             links: [],  // 기본 조회에는 없음
             images: [],  // 기본 조회에는 없음
             vote: nil,
@@ -89,6 +91,11 @@ extension NoticeDTO {
             isRead: false
         )
     }
+}
+
+private func resolvedAuthorName(_ authorName: String) -> String {
+    let trimmedAuthorName = authorName.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmedAuthorName.isEmpty ? "알 수 없음" : trimmedAuthorName
 }
 
 // MARK: - TargetInfo DTO

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailDTO.swift
@@ -164,9 +164,8 @@ extension NoticeDetailDTO {
     }
 
     private func resolvedAuthorName() -> String {
-        [authorName, authorNickname]
-            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .first(where: { !$0.isEmpty }) ?? "알 수 없음"
+        let trimmedAuthorName = authorName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedAuthorName.isEmpty ? "알 수 없음" : trimmedAuthorName
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
@@ -66,7 +66,7 @@ struct NoticeDetail: Equatable, Identifiable, Hashable {
         let trimmedName = authorName.trimmingCharacters(in: .whitespacesAndNewlines)
         let generationText = generationOrdinalText
 
-        if trimmedNickname.isEmpty && (trimmedName.isEmpty || trimmedName == "알 수 없음") {
+        if trimmedName.isEmpty || trimmedName == "알 수 없음" {
             return "알 수 없음"
         }
 

--- a/AppProduct/AppProductTests/CommunityTest/CommunityPostResponseDTOTests.swift
+++ b/AppProduct/AppProductTests/CommunityTest/CommunityPostResponseDTOTests.swift
@@ -1,0 +1,78 @@
+//
+//  CommunityPostResponseDTOTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/12/26.
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+struct CommunityPostResponseDTOTests {
+
+    @Test("게시글 리스트 DTO는 challengerNickname을 authorNickname fallback으로 사용한다")
+    func postListItemUsesChallengerNicknameFallback() throws {
+        let data = Data(
+            """
+            {
+              "postId": "1",
+              "title": "테스트",
+              "content": "내용",
+              "category": "FREE",
+              "authorId": "10",
+              "authorName": "정의찬",
+              "challengerNickname": "제옹",
+              "authorProfileImage": null,
+              "authorPart": "SPRINGBOOT",
+              "createdAt": "2026-03-12T08:28:00.248106Z",
+              "commentCount": "2",
+              "likeCount": "1",
+              "isLiked": false,
+              "isAuthor": false,
+              "lightningInfo": null
+            }
+            """.utf8
+        )
+
+        let dto = try JSONDecoder().decode(PostListItemDTO.self, from: data)
+        let model = dto.toCommunityItemModel()
+
+        #expect(dto.authorNickname == "제옹")
+        #expect(model.displayUserName == "정의찬/제옹")
+    }
+
+    @Test("게시글 상세 DTO는 authorNickname이 비어있으면 challengerNickname을 사용한다")
+    func postDetailUsesChallengerNicknameWhenAuthorNicknameIsEmpty() throws {
+        let data = Data(
+            """
+            {
+              "postId": "1",
+              "title": "테스트",
+              "content": "내용",
+              "category": "FREE",
+              "authorId": "10",
+              "authorName": "정의찬",
+              "authorNickname": "",
+              "challengerNickname": "제옹",
+              "authorProfileImage": null,
+              "authorPart": "SPRINGBOOT",
+              "commentCount": "2",
+              "writeTime": "2026-03-12T08:28:00.248106Z",
+              "likeCount": "1",
+              "isLiked": false,
+              "isAuthor": false,
+              "scrapCount": "0",
+              "isScrapped": false,
+              "lightningInfo": null
+            }
+            """.utf8
+        )
+
+        let dto = try JSONDecoder().decode(PostDetailDTO.self, from: data)
+        let model = dto.toCommunityItemModel()
+
+        #expect(dto.authorNickname == "제옹")
+        #expect(model.displayUserName == "정의찬/제옹")
+    }
+}

--- a/AppProduct/AppProductTests/HomeTest/ScheduleDDayFormattingTests.swift
+++ b/AppProduct/AppProductTests/HomeTest/ScheduleDDayFormattingTests.swift
@@ -1,0 +1,62 @@
+//
+//  ScheduleDDayFormattingTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/12/26.
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+struct ScheduleDDayFormattingTests {
+
+    @Test("미래 일정 dDay는 D-N 형식으로 표시한다")
+    func futureScheduleFormatsAsDMinus() {
+        let data = ScheduleData(
+            scheduleId: 1,
+            title: "해커톤",
+            startsAt: .now,
+            endsAt: .now,
+            status: "참여 예정",
+            dDay: 3
+        )
+
+        #expect(data.dDayText == "D-3")
+    }
+
+    @Test("오늘 일정 dDay는 D-Day로 표시한다")
+    func todayScheduleFormatsAsDDay() {
+        let data = ScheduleDetailData(
+            scheduleId: 1,
+            name: "정기 세션",
+            description: "",
+            tags: [],
+            startsAt: .now,
+            endsAt: .now,
+            isAllDay: false,
+            locationName: "",
+            latitude: 0,
+            longitude: 0,
+            status: "진행 예정",
+            dDay: 0,
+            requiresAttendanceApproval: false
+        )
+
+        #expect(data.dDayText == "D-Day")
+    }
+
+    @Test("지난 일정 dDay는 D+N 형식으로 표시한다")
+    func pastScheduleFormatsAsDPlus() {
+        let data = ScheduleData(
+            scheduleId: 1,
+            title: "데모데이",
+            startsAt: .now,
+            endsAt: .now,
+            status: "종료됨",
+            dDay: -5
+        )
+
+        #expect(data.dDayText == "D+5")
+    }
+}

--- a/AppProduct/AppProductTests/NoticeTest/NoticeAuthorFallbackTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticeAuthorFallbackTests.swift
@@ -1,0 +1,85 @@
+//
+//  NoticeAuthorFallbackTests.swift
+//  AppProductTests
+//
+//  Created by Codex on 3/13/26.
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+struct NoticeAuthorFallbackTests {
+
+    @Test("공지 리스트는 authorName이 없으면 알 수 없음으로 표시한다")
+    func noticeListFallsBackToUnknownWhenAuthorNameIsMissing() throws {
+        let data = Data(
+            """
+            {
+              "id": "1",
+              "title": "공지",
+              "content": "내용",
+              "shouldSendNotification": false,
+              "viewCount": "10",
+              "createdAt": "2026-03-13T00:00:00Z",
+              "targetInfo": {
+                "targetGisuId": "1",
+                "targetChapterId": null,
+                "targetSchoolId": null,
+                "targetParts": []
+              },
+              "authorChallengerId": "1",
+              "authorMemberId": "1",
+              "authorNickname": "닉네임",
+              "authorName": null
+            }
+            """.utf8
+        )
+
+        let dto = try JSONDecoder().decode(NoticeDTO.self, from: data)
+        let model = dto.toItemModel()
+
+        #expect(model.writer == "알 수 없음")
+    }
+
+    @Test("공지 상세는 authorName이 없으면 알 수 없음으로 표시한다")
+    func noticeDetailFallsBackToUnknownWhenAuthorNameIsMissing() throws {
+        let data = Data(
+            """
+            {
+              "id": "1",
+              "title": "공지",
+              "content": "내용",
+              "shouldSendNotification": false,
+              "viewCount": "10",
+              "createdAt": "2026-03-13T00:00:00Z",
+              "updatedAt": null,
+              "targetInfo": {
+                "targetGisuId": "1",
+                "targetChapterId": null,
+                "targetSchoolId": null,
+                "targetParts": []
+              },
+              "authorChallengerId": "1",
+              "authorMemberId": "1",
+              "authorNickname": "닉네임",
+              "authorName": null,
+              "authorProfileImageUrl": null,
+              "vote": null,
+              "images": [],
+              "links": [],
+              "scope": "CENTRAL",
+              "category": "GENERAL",
+              "isMustRead": false,
+              "hasPermission": false
+            }
+            """.utf8
+        )
+
+        let dto = try JSONDecoder().decode(NoticeDetailDTO.self, from: data)
+        let detail = dto.toDomain()
+
+        #expect(detail.authorName == "알 수 없음")
+        #expect(detail.defaultAuthorDisplayName == "알 수 없음")
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix — D-Day 표시 off-by-one(부호 반전) 수정 및 공지/커뮤니티 작성자 표기 로직 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- D-Day 표시 전후 비교 스크린샷 첨부 필요 -->

## 🛠️ 작업내용

### D-Day 표시 수정
- D-Day 부호 규칙 통일: 양수=미래(`D-N`), 음수=과거(`D+N`), 0=당일(`D-Day`)
- `ScheduleDDayDisplayable` 프로토콜 추가로 dDayText 로직 중앙화 (ScheduleData, ScheduleDetailData 공용)
- ScheduleListCard의 인라인 dDayText 로직을 프로토콜 기본 구현으로 대체
- HomeScheduleDTO / ScheduleDetailDTO 주석 통일 (`양수: 미래, 음수: 과거`)

### 커뮤니티 작성자 닉네임 개선
- PostDetailDTO / PostListItemDTO에 `challengerNickname` 필드 추가
- `authorNickname`을 `authorNickname` → `challengerNickname` 우선순위로 디코딩 (`decodeFirstNonEmptyString`)

### 공지 작성자 표기 변경
- NoticeDTO: `authorName` 서버 응답 기반으로 변경 (닉네임 폴백 제거)
- NoticeDetailDTO: `resolvedAuthorName()`을 `authorName` 단독 기준으로 통일
- NoticeDetailModel: `displayAuthorName`에서 닉네임 단독 표시 케이스 제거

### 테스트 추가
- `ScheduleDDayFormattingTests` — D-Day 포맷팅 검증
- `CommunityPostResponseDTOTests` — 커뮤니티 DTO 닉네임 디코딩 검증
- `NoticeAuthorFallbackTests` — 공지 작성자 폴백 로직 검증

### 출석 승인 대기 목록 개선 (기존 커밋)
- N+1 개별 호출을 일괄 조회 API(`SchedulePendingGroupDTO`)로 전환 (#505)

## 📋 추후 진행 상황

- 서버 dDay 부호 규칙 최종 확인 후 추가 조정 필요 시 대응

## 📌 리뷰 포인트

- `Features/Home/Domain/Models/Home/ScheduleData.swift` — `ScheduleDDayDisplayable` 프로토콜 설계 및 부호 로직
- `Features/Community/DTO/CommunityPostResponseDTO.swift` — `decodeFirstNonEmptyString` 헬퍼 및 닉네임 우선순위 디코딩
- `Features/Notice/Data/DTOs/NoticeDTO.swift` — 작성자 이름 폴백 로직 변경 (`authorNickname` 폴백 제거)
- `Features/Notice/Domain/Models/NoticeDetailModel.swift` — `displayAuthorName` 닉네임 단독 표시 제거

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)