### PR TITLE
💄[Design] 공지 작성 학교 선택 시트 스크롤 영역 확장 (#510)

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift
@@ -68,13 +68,9 @@ struct TargetSheetView: View {
     
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: Constants.rootContentSpacing) {
-                statefulSheetContent
-                Spacer(minLength: 0)
-            }
+            statefulSheetContent
             .padding(.horizontal, Constants.horizontalPadding)
             .padding(.top, Constants.topPadding)
-            .padding(.bottom, Constants.bottomPadding)
             .navigation(naviTitle: navigationTitle, displayMode: .inline)
             .navigationSubtitle(navigationSubtitle)
             .task {


### PR DESCRIPTION
## ✨ PR 유형

Design — 공지 작성 화면 학교 선택 시트의 스크롤 뷰 영역 확장

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 사항 스크린샷 첨부 필요 -->

## 🛠️ 작업내용

- `TargetSheetView`에서 VStack + Spacer 래핑 제거하여 `statefulSheetContent`가 전체 영역을 사용하도록 변경
- 하단 패딩(`bottomPadding`) 제거로 학교 목록 스크롤 가능 영역 확대

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift` — VStack + Spacer 제거 후 스크롤 영역이 정상 확장되는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)