### PR TITLE
🐛[Fix] 공지/커뮤니티 작성자 프로필, 마이페이지 유연 디코딩, 멤버 패널티 권한 및 자동 태그 분류

### DIFF
--- a/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
+++ b/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
@@ -279,6 +279,9 @@ extension DIContainer {
                 scheduleRepository: container.resolve(
                     ScheduleRepositoryProtocol.self
                 ),
+                classifierRepository: container.resolve(
+                    ScheduleClassifierRepository.self
+                ),
                 challengerSearchRepository: container.resolve(
                     ChallengerSearchRepositoryProtocol.self
                 )

--- a/AppProduct/AppProduct/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
@@ -25,6 +25,8 @@ protocol HomeUseCaseProviding {
     var updateScheduleUseCase: UpdateScheduleUseCaseProtocol { get }
     /// 일정 + 출석부 통합 삭제 UseCase
     var deleteScheduleUseCase: DeleteScheduleUseCaseProtocol { get }
+    /// 일정 제목 기반 태그 분류 UseCase
+    var classifyScheduleUseCase: ClassifyScheduleUseCase { get }
     /// 챌린저 검색 UseCase
     var searchChallengersUseCase: SearchChallengersUseCaseProtocol { get }
 }
@@ -45,6 +47,7 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
     let generateScheduleUseCase: GenerateScheduleUseCaseProtocol
     let updateScheduleUseCase: UpdateScheduleUseCaseProtocol
     let deleteScheduleUseCase: DeleteScheduleUseCaseProtocol
+    let classifyScheduleUseCase: ClassifyScheduleUseCase
     let searchChallengersUseCase: SearchChallengersUseCaseProtocol
 
     // MARK: - Init
@@ -52,6 +55,7 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
     init(
         homeRepository: HomeRepositoryProtocol,
         scheduleRepository: ScheduleRepositoryProtocol,
+        classifierRepository: ScheduleClassifierRepository,
         challengerSearchRepository: ChallengerSearchRepositoryProtocol
     ) {
         self.fetchMyProfileUseCase = FetchMyProfileUseCase(
@@ -77,6 +81,9 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
         )
         self.deleteScheduleUseCase = DeleteScheduleUseCase(
             repository: scheduleRepository
+        )
+        self.classifyScheduleUseCase = ClassifyScheduleUseCaseImpl(
+            repository: classifierRepository
         )
         self.searchChallengersUseCase = SearchChallengersUseCase(
             repository: challengerSearchRepository

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -18,6 +18,8 @@ class ScheduleRegistrationViewModel {
     private let generateScheduleUseCase: GenerateScheduleUseCaseProtocol
     /// 일정 수정 UseCase
     private let updateScheduleUseCase: UpdateScheduleUseCaseProtocol
+    /// 일정 제목 기반 태그 자동 추천 UseCase
+    private let classifyScheduleUseCase: ClassifyScheduleUseCase
 
     /// 전역 에러 핸들러 (실패 시 Alert 표시용)
     private let errorHandler: ErrorHandler
@@ -69,13 +71,30 @@ class ScheduleRegistrationViewModel {
     private(set) var editingScheduleId: Int?
     /// 수정 모드 초기값 스냅샷
     private var initialEditSnapshot: EditFormSnapshot?
+    /// 사용자가 태그를 직접 조정했는지 여부
+    private var isTagManuallyOverridden: Bool = false
 
     // MARK: - Init
 
-    init(container: DIContainer, errorHandler: ErrorHandler) {
+    convenience init(container: DIContainer, errorHandler: ErrorHandler) {
         let provider = container.resolve(HomeUseCaseProviding.self)
-        self.generateScheduleUseCase = provider.generateScheduleUseCase
-        self.updateScheduleUseCase = provider.updateScheduleUseCase
+        self.init(
+            generateScheduleUseCase: provider.generateScheduleUseCase,
+            updateScheduleUseCase: provider.updateScheduleUseCase,
+            classifyScheduleUseCase: provider.classifyScheduleUseCase,
+            errorHandler: errorHandler
+        )
+    }
+
+    init(
+        generateScheduleUseCase: GenerateScheduleUseCaseProtocol,
+        updateScheduleUseCase: UpdateScheduleUseCaseProtocol,
+        classifyScheduleUseCase: ClassifyScheduleUseCase,
+        errorHandler: ErrorHandler
+    ) {
+        self.generateScheduleUseCase = generateScheduleUseCase
+        self.updateScheduleUseCase = updateScheduleUseCase
+        self.classifyScheduleUseCase = classifyScheduleUseCase
         self.errorHandler = errorHandler
     }
 
@@ -99,6 +118,7 @@ class ScheduleRegistrationViewModel {
         tag = detail.tags
             .compactMap(Self.mapScheduleTag)
             .filter { !$0.isDeprecated }
+        isTagManuallyOverridden = !tag.isEmpty
         initialEditSnapshot = currentEditSnapshot
     }
 
@@ -133,6 +153,54 @@ class ScheduleRegistrationViewModel {
     }
 
     // MARK: - Function
+
+    /// 제목 변경 시 자동 태그 추천을 반영합니다.
+    ///
+    /// 사용자가 태그를 직접 변경한 이후에는 자동 추천이 기존 선택을 덮어쓰지 않습니다.
+    @MainActor
+    func titleDidChange(to newTitle: String) async {
+        title = newTitle
+
+        let trimmedTitle = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            if !isTagManuallyOverridden {
+                tag.removeAll()
+            }
+            return
+        }
+
+        guard !isTagManuallyOverridden else {
+            return
+        }
+
+        let suggestedTag = await classifyScheduleUseCase.execute(title: trimmedTitle)
+        let latestTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard latestTitle == trimmedTitle else {
+            return
+        }
+        guard !isTagManuallyOverridden else {
+            return
+        }
+
+        tag = [suggestedTag]
+    }
+
+    /// 태그 선택을 사용자 입력으로 반영합니다.
+    ///
+    /// 사용자가 태그를 비우면 이후 제목 변경 시 자동 추천이 다시 동작합니다.
+    func updateTagsFromUser(_ tags: [ScheduleIconCategory]) {
+        let sanitized = Array(Set(tags.filter { !$0.isDeprecated })).sorted {
+            $0.rawValue < $1.rawValue
+        }
+
+        if tag == sanitized {
+            return
+        }
+
+        tag = sanitized
+        isTagManuallyOverridden = !sanitized.isEmpty
+    }
 
     /// 일정을 서버에 생성합니다.
     ///

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -244,7 +244,17 @@ struct ScheduleRegistrationView: View {
     private func sectionView(_ type: ScheduleGenerationType) -> some View {
         switch type {
         case .title:
-            TitleView(text: $viewModel.title)
+            TitleView(
+                text: Binding(
+                    get: { viewModel.title },
+                    set: { newValue in
+                        viewModel.title = newValue
+                        Task { @MainActor in
+                            await viewModel.titleDidChange(to: newValue)
+                        }
+                    }
+                )
+            )
                 .equatable()
         case .place:
             PlaceSelectView(place: $viewModel.place)
@@ -266,7 +276,14 @@ struct ScheduleRegistrationView: View {
         case .participation:
             ParticipantSection(challenger: $viewModel.participatn)
         case .tag:
-            TagSection(tag: $viewModel.tag)
+            TagSection(
+                tag: Binding(
+                    get: { viewModel.tag },
+                    set: { newValue in
+                        viewModel.updateTagsFromUser(newValue)
+                    }
+                )
+            )
         }
     }
 

--- a/AppProduct/AppProductTests/HomeTest/ScheduleRegistrationViewModelTests.swift
+++ b/AppProduct/AppProductTests/HomeTest/ScheduleRegistrationViewModelTests.swift
@@ -1,0 +1,73 @@
+//
+//  ScheduleRegistrationViewModelTests.swift
+//  AppProductTests
+//
+//  Created by euijjang97 on 3/13/26.
+//
+
+@testable import AppProduct
+import Testing
+
+@MainActor
+struct ScheduleRegistrationViewModelTests {
+
+    @Test("제목 입력 시 자동 추천 태그를 반영한다")
+    func appliesSuggestedTagWhenTitleChanges() async {
+        let viewModel = makeViewModel(suggestedTag: .project)
+
+        await viewModel.titleDidChange(to: "UMC 앱 프로젝트 발표")
+
+        #expect(viewModel.tag == [.project])
+    }
+
+    @Test("사용자가 태그를 직접 변경한 뒤에는 자동 추천이 덮어쓰지 않는다")
+    func preservesManualOverrideAfterUserSelection() async {
+        let viewModel = makeViewModel(suggestedTag: .project)
+
+        await viewModel.titleDidChange(to: "UMC 앱 프로젝트 발표")
+        viewModel.updateTagsFromUser([.meeting])
+        await viewModel.titleDidChange(to: "운영진 회의")
+
+        #expect(viewModel.tag == [.meeting])
+    }
+
+    @Test("사용자가 태그를 모두 비우면 자동 추천을 다시 허용한다")
+    func reEnablesSuggestionAfterClearingManualTags() async {
+        let viewModel = makeViewModel(suggestedTag: .study)
+
+        viewModel.updateTagsFromUser([.meeting])
+        viewModel.updateTagsFromUser([])
+        await viewModel.titleDidChange(to: "알고리즘 스터디")
+
+        #expect(viewModel.tag == [.study])
+    }
+
+    private func makeViewModel(
+        suggestedTag: ScheduleIconCategory
+    ) -> ScheduleRegistrationViewModel {
+        ScheduleRegistrationViewModel(
+            generateScheduleUseCase: MockGenerateScheduleUseCase(),
+            updateScheduleUseCase: MockUpdateScheduleUseCase(),
+            classifyScheduleUseCase: MockClassifyScheduleUseCase(
+                suggestedTag: suggestedTag
+            ),
+            errorHandler: ErrorHandler()
+        )
+    }
+}
+
+private struct MockGenerateScheduleUseCase: GenerateScheduleUseCaseProtocol {
+    func execute(schedule: GenerateScheduleRequetDTO) async throws { }
+}
+
+private struct MockUpdateScheduleUseCase: UpdateScheduleUseCaseProtocol {
+    func execute(scheduleId: Int, schedule: UpdateScheduleRequestDTO) async throws { }
+}
+
+private struct MockClassifyScheduleUseCase: ClassifyScheduleUseCase {
+    let suggestedTag: ScheduleIconCategory
+
+    func execute(title: String) async -> ScheduleIconCategory {
+        suggestedTag
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Fix + Feature — 공지/커뮤니티 작성자 프로필 조회 개선, 마이페이지 DTO 유연 디코딩, 멤버 패널티 권한 분리, CoreML 자동 태그 분류

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 사항 스크린샷/영상 첨부 필요 -->

## 🛠️ 작업내용

### 공지사항 작성자 프로필 개선
- 공지 상세 작성자 프로필을 MyPage API로 추가 조회 (`fetchAuthorProfileIfNeeded`)
- 작성자 영역에 `RemoteImage` 적용 및 로딩 플레이스홀더 표시
- `displayedAuthorProfileLine` — 기수·역할·닉네임/이름 한 줄 표시
- 공지 리스트 `displayWriter`에 이름/닉네임 병합 표시 추가
- `NoticeRepository`에서 `authorNickname`/`authorName` pass-through

### 커뮤니티 작성자 표기
- `displayUserName` 순서를 **닉네임/이름**으로 변경 (CommentModel, ItemModel)

### 멤버 관리 패널티 권한 분리
- `MemberManagementItem`에 `canViewPenaltyHistory` 플래그 추가
- 본인이 아닌 멤버의 아웃 히스토리 열람/추가/삭제 차단 UI 분기
- 본인 멤버 프로필 조회 시 `MyPageRouter`로 폴백하여 권한 에러 방지
- `MemberManagementProfileDTO`에 `MyPageProfileResponseDTO` 변환 이니셜라이저 추가
- `memberPenaltyUpdated` 알림으로 홈 프로필 즉시 갱신

### 마이페이지 DTO 유연 디코딩
- `MyPageProfileResponseDTO` email/status 옵셔널 디코딩 및 `.active` 폴백
- `MyPageChallengerRecordDTO`에 `chapterName` 필드 추가
- `MemberProfileSummary`에 `organizationName` 추가 (chapterName/schoolName)
- `MyPageRepository.fetchMemberProfile` API 응답 래핑/비래핑 폴백 디코딩

### 마이페이지 UI 개선
- 이름/닉네임을 별도 `ReadOnlyTextField` 섹션으로 분리
- `AuthSection`에 섹션 헤더 추가
- 활동 이력 추가 성공 시 "추가되었습니다" 피드백 (2초 후 자동 복귀)

### 일정 생성 CoreML 자동 태그 분류
- `ClassifyScheduleUseCase`를 `HomeUseCaseProvider`에 등록 및 DIContainer 주입
- `ScheduleRegistrationViewModel.titleDidChange(to:)` — 제목 변경 시 자동 태그 추천
- 사용자 직접 태그 변경 시 `isTagManuallyOverridden`으로 자동 추천 중단

### 기타
- 공지 작성 시트 스크롤 영역 frame alignment 보정
- `RemoteImage` displayScale 기반 다운샘플링 및 interpolation/antialiased 품질 개선
- 멤버 상세 시트 높이/폰트 조정

## 📋 추후 진행 상황

- CoreML 모델 정확도 개선 및 추가 학습 데이터 확보

## 📌 리뷰 포인트

- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift` — `fetchAuthorProfileIfNeeded` 비동기 프로필 조회 로직
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift` — `displayedAuthorProfileLine`, `displayedAuthorIdentity` 표시 로직
- `Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift` — `authorProfileImage` RemoteImage 로딩 상태 분기
- `Features/Activity/Data/Repositories/MemberRepository.swift` — 본인 프로필 MyPageRouter 폴백 로직
- `Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift` — `canViewPenaltyHistory` 기반 UI 분기
- `Features/MyPage/Data/DTO/MyPageProfileDTO.swift` — email/status 옵셔널 디코딩 및 organizationName
- `Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift` — `titleDidChange(to:)` 자동 태그 추천 로직
- `Utilities/RemoteImage/RemoteImage.swift` — displayScale 기반 다운샘플링

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)