### PR TITLE
🐛 [Fix] 스터디 그룹 생성 버튼 권한 체크 추가 (#506)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
@@ -64,6 +64,11 @@ enum ManagementTeam: String, CaseIterable, Codable, Comparable {
         level >= Self.schoolEtcAdmin.level
     }
 
+    /// 스터디 그룹 생성 가능 여부 (교내 회장/부회장만 가능)
+    var canCreateStudyGroup: Bool {
+        self == .schoolPresident || self == .schoolVicePresident
+    }
+
     // MARK: - Comparable
 
     static func < (lhs: ManagementTeam, rhs: ManagementTeam) -> Bool {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -23,6 +23,13 @@ struct OperatorStudyManagementView: View {
         container.resolve(PathStore.self)
     }
 
+    private var userSession: UserSessionManager {
+        container.resolve(UserSessionManager.self)
+    }
+
+    @AppStorage(AppStorageKey.organizationType)
+    private var organizationType: String = ""
+
     @State private var selectedTab: ManagementTab = .submission
     @State private var showCreateView = false
 
@@ -100,7 +107,7 @@ struct OperatorStudyManagementView: View {
                     selection: $viewModel.selectedStudyGroup,
                     onChange: viewModel.selectStudyGroup
                 )
-            } else {
+            } else if canCreateStudyGroup {
                 ToolBarCollection.AddBtn {
                     showCreateView = true
                 }
@@ -168,6 +175,14 @@ struct OperatorStudyManagementView: View {
             OperatorStudyGroupCreateView(viewModel: viewModel)
         }
         .alertPrompt(item: $viewModel.alertPrompt)
+    }
+
+    // MARK: - Function
+
+    /// 스터디 그룹 생성 권한 확인 (역할 + 조직 타입)
+    private var canCreateStudyGroup: Bool {
+        userSession.currentRole.canCreateStudyGroup
+            && OrganizationType(rawValue: organizationType) == .school
     }
 
     // MARK: - Submission Content View


### PR DESCRIPTION
## ✨ PR 유형

🐛 Bug Fix — 교내 파트장에게 스터디 그룹 생성 화면이 노출되는 권한 분기 누락 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 교내 파트장 계정으로 로그인 시 "+" 버튼이 사라지는 것을 확인해주세요 -->

## 🛠️ 작업내용

- `ManagementTeam`에 `canCreateStudyGroup` computed property 추가 (schoolPresident/schoolVicePresident만 true)
- `OperatorStudyManagementView`에서 AddBtn 노출 조건에 역할 + 조직 타입(SCHOOL) 체크 추가
- 기존 403 에러 핸들링은 defense-in-depth로 유지

## 📋 추후 진행 상황

- 서버 측 superAdmin 권한 허용 시 클라이언트 동기화 필요 (#435)

## 📌 리뷰 포인트

- `Core/Common/Enum/ManagementTeam.swift` — `canCreateStudyGroup` 권한 조건이 서버 로직과 일치하는지 확인
- `Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift` — AddBtn 조건 분기 및 `@AppStorage(organizationType)` 접근 패턴 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #506