### PR TITLE
✨ [Feat] 베스트 워크북 스터디 그룹당 1인 제한 및 비활성화 처리 (#416)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/WorkbookSubmissionPageDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/WorkbookSubmissionPageDTO.swift
@@ -84,10 +84,11 @@ struct WorkbookSubmissionItemDTO: Codable, Sendable, Equatable {
 }
 
 extension WorkbookSubmissionItemDTO {
-    func toDomain(week: Int) -> StudyMemberItem {
+    func toDomain(week: Int, studyGroupId: Int?) -> StudyMemberItem {
         StudyMemberItem(
             serverID: String(challengerId),
             challengerWorkbookId: challengerWorkbookId,
+            studyGroupId: studyGroupId,
             name: challengerName,
             nickname: challengerName,
             part: part.toStudyPart,

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
@@ -665,7 +665,8 @@ final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
                 )
             }
 
-            members.append(contentsOf: page.content.map { $0.toDomain(week: week) })
+            members.append(contentsOf: page.content.map {
+                $0.toDomain(week: week, studyGroupId: studyGroupId) })
             hasNext = page.hasNext
             cursor = page.nextCursor
         }

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/StudyMemberItem.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/StudyMemberItem.swift
@@ -50,6 +50,9 @@ struct StudyMemberItem: Identifiable, Equatable, Hashable {
     /// 챌린저 워크북 식별자
     let challengerWorkbookId: Int?
 
+    /// 스터디 그룹 식별자
+    let studyGroupId: Int?
+
     /// 이름
     let name: String
 
@@ -84,6 +87,7 @@ struct StudyMemberItem: Identifiable, Equatable, Hashable {
         id: UUID = UUID(),
         serverID: String,
         challengerWorkbookId: Int? = nil,
+        studyGroupId: Int? = nil,
         name: String,
         nickname: String,
         part: StudyPart,
@@ -97,6 +101,7 @@ struct StudyMemberItem: Identifiable, Equatable, Hashable {
         self.id = id
         self.serverID = serverID
         self.challengerWorkbookId = challengerWorkbookId
+        self.studyGroupId = studyGroupId
         self.name = name
         self.nickname = nickname
         self.part = part

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorStudyManagementViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorStudyManagementViewModel.swift
@@ -785,6 +785,7 @@ final class OperatorStudyManagementViewModel {
                     id: member.id,
                     serverID: member.serverID,
                     challengerWorkbookId: member.challengerWorkbookId,
+                    studyGroupId: member.studyGroupId,
                     name: member.name,
                     nickname: member.nickname,
                     part: member.part,
@@ -843,6 +844,27 @@ final class OperatorStudyManagementViewModel {
         await submitBestWorkbook(
             member: member,
             recommendation: recommendation
+        )
+    }
+
+    /// 해당 멤버의 스터디 그룹에 이미 베스트 워크북이 선정되었는지 확인
+    /// - Parameter member: 확인 대상 멤버
+    /// - Returns: 같은 그룹에 이미 베스트 워크북이 있으면 true
+    func isBestSelectionDisabled(for member: StudyMemberItem) -> Bool {
+        guard let groupId = member.studyGroupId else { return false }
+        return allMembers.contains { other in
+            other.studyGroupId == groupId
+                && other.isBestWorkbook
+                && other.id != member.id
+        }
+    }
+
+    /// 베스트 워크북 선정 불가 안내 AlertPrompt 표시
+    func showBestSelectionDisabledAlert() {
+        alertPrompt = AlertPrompt(
+            title: "베스트 워크북 선정 불가",
+            message: "이 스터디 그룹에는 이미 베스트 워크북이 선정되었습니다.",
+            positiveBtnTitle: "확인"
         )
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -355,11 +355,17 @@ struct OperatorStudyManagementView: View {
                         .tint(.indigo500)
 
                         Button {
-                            viewModel.selectedMemberForBest = member
+                            if viewModel.isBestSelectionDisabled(for: member) {
+                                viewModel.showBestSelectionDisabledAlert()
+                            } else {
+                                viewModel.selectedMemberForBest = member
+                            }
                         } label: {
                             Label("베스트", systemImage: "trophy")
                         }
-                        .tint(.orange)
+                        .tint(
+                            viewModel.isBestSelectionDisabled(for: member) ? .gray : .orange
+                        )
                     }
             }
         }


### PR DESCRIPTION
## ✨ PR 유형

Feature - 베스트 워크북 스터디 그룹당 1인 제한 및 비활성화 처리

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 베스트 버튼 비활성화(회색) 상태 스크린샷 추가 필요 -->

## 🛠️ 작업내용

- `StudyMemberItem`에 `studyGroupId: Int?` 필드 추가
- `WorkbookSubmissionPageDTO.toDomain`에서 `studyGroupId` 전달
- `StudyRepository`에서 매핑 시 `studyGroupId` 주입 (전체/개별 그룹 필터 모두 대응)
- ViewModel에 `isBestSelectionDisabled(for:)` 메서드 추가 (같은 그룹 내 베스트 존재 여부 확인)
- 스와이프 "베스트" 버튼 비활성화 처리 (회색 `.gray` tint)
- 비활성 버튼 탭 시 AlertPrompt 표시 ("이 스터디 그룹에는 이미 베스트 워크북이 선정되었습니다.")
- `openReviewSheet` 멤버 재구성 시 `studyGroupId` 보존
- 변경 파일: 5개

## 📋 추후 진행 상황

- 서버 측 베스트 워크북 1인 제한 검증 추가 시 연동 필요

## 📌 리뷰 포인트

- `Features/Activity/Domain/Models/Study/` — `StudyMemberItem`에 `studyGroupId` 필드 추가 확인
- `Features/Activity/Data/` — DTO, Repository에서 `studyGroupId` 데이터 파이프라인 확인
- `Features/Activity/Presentation/ViewModels/` — `isBestSelectionDisabled` 로직 검증 (같은 그룹 내 베스트 존재 + 자기 자신 제외)
- `Features/Activity/Presentation/Views/` — 스와이프 버튼 조건부 비활성화 UI 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)