### PR TITLE
🐛[Fix] 공지/커뮤니티 작성자 프로필 조회, 마이페이지 유연 디코딩, 멤버 패널티 권한 및 자동 태그 분류

### DIFF
--- a/AppProduct/AppProduct/App/AppDelegate.swift
+++ b/AppProduct/AppProduct/App/AppDelegate.swift
@@ -135,6 +135,8 @@ extension Notification.Name {
     static let fcmTokenReceived = Notification.Name("fcmTokenReceived")
     /// 멤버 프로필 업데이트 알림 (FCM 토큰 재동기화 트리거)
     static let memberProfileUpdated = Notification.Name("memberProfileUpdated")
+    /// 멤버 패널티/포인트 업데이트 알림
+    static let memberPenaltyUpdated = Notification.Name("memberPenaltyUpdated")
     /// 기수 매핑 로컬 저장소 갱신 알림
     static let generationMappingsUpdated = Notification.Name("generationMappingsUpdated")
 }

--- a/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
+++ b/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
@@ -279,6 +279,9 @@ extension DIContainer {
                 scheduleRepository: container.resolve(
                     ScheduleRepositoryProtocol.self
                 ),
+                classifierRepository: container.resolve(
+                    ScheduleClassifierRepository.self
+                ),
                 challengerSearchRepository: container.resolve(
                     ChallengerSearchRepositoryProtocol.self
                 )

--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/MemberManagementProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/MemberManagementProfileDTO.swift
@@ -66,6 +66,11 @@ struct MemberManagementRoleDTO: Codable, Sendable {
             forKey: .roleType
         ) ?? .challenger
     }
+
+    init(challengerId: Int?, roleType: ManagementTeam) {
+        self.challengerId = challengerId
+        self.roleType = roleType
+    }
 }
 
 struct MemberManagementChallengerRecordDTO: Codable, Sendable {
@@ -107,6 +112,24 @@ struct MemberManagementChallengerRecordDTO: Codable, Sendable {
     var resolvedPoints: [MemberManagementPointDTO] {
         challengerPoints.isEmpty ? fallbackPoints : challengerPoints
     }
+
+    init(
+        challengerId: Int,
+        memberId: Int,
+        gisu: Int,
+        gisuId: Int,
+        part: String,
+        challengerPoints: [MemberManagementPointDTO],
+        fallbackPoints: [MemberManagementPointDTO]
+    ) {
+        self.challengerId = challengerId
+        self.memberId = memberId
+        self.gisu = gisu
+        self.gisuId = gisuId
+        self.part = part
+        self.challengerPoints = challengerPoints
+        self.fallbackPoints = fallbackPoints
+    }
 }
 
 struct MemberManagementPointDTO: Codable, Sendable {
@@ -131,6 +154,55 @@ struct MemberManagementPointDTO: Codable, Sendable {
         point = try container.decodeDoubleFlexibleIfPresent(forKey: .point) ?? 0
         description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
         createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt) ?? ""
+    }
+
+    init(
+        id: Int,
+        pointType: String,
+        point: Double,
+        description: String,
+        createdAt: String
+    ) {
+        self.id = id
+        self.pointType = pointType
+        self.point = point
+        self.description = description
+        self.createdAt = createdAt
+    }
+}
+
+extension MemberManagementProfileDTO {
+    init(myProfileDTO: MyPageProfileResponseDTO) {
+        id = Int(myProfileDTO.id) ?? 0
+        name = myProfileDTO.name
+        nickname = myProfileDTO.nickname
+        schoolName = myProfileDTO.schoolName
+        profileImageLink = myProfileDTO.profileImageLink
+        roles = myProfileDTO.roles.map {
+            MemberManagementRoleDTO(
+                challengerId: Int($0.challengerId),
+                roleType: $0.roleType
+            )
+        }
+        challengerRecords = (myProfileDTO.challengerRecords ?? []).map { record in
+            MemberManagementChallengerRecordDTO(
+                challengerId: Int(record.challengerId) ?? 0,
+                memberId: Int(record.memberId) ?? 0,
+                gisu: Int(record.gisu) ?? 0,
+                gisuId: 0,
+                part: record.part,
+                challengerPoints: record.challengerPoints.map {
+                    MemberManagementPointDTO(
+                        id: Int($0.id) ?? 0,
+                        pointType: $0.pointType,
+                        point: $0.point,
+                        description: $0.description,
+                        createdAt: $0.createdAt
+                    )
+                },
+                fallbackPoints: []
+            )
+        }
     }
 }
 

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -29,6 +29,10 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         self.studyRepository = studyRepository
     }
 
+    private var currentMemberID: Int {
+        UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+    }
+
     // MARK: - Function
 
     /// 학교 단위 멤버 전체 목록을 조회합니다.
@@ -97,7 +101,8 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
                     fallback: descriptor.managementTeam
                 ),
                 attendanceRecords: [],
-                penaltyHistory: penaltyHistories
+                penaltyHistory: penaltyHistories,
+                canViewPenaltyHistory: descriptor.memberId == currentMemberID
             )
         }
 
@@ -472,6 +477,15 @@ private extension MemberRepository {
     func fetchMemberProfile(
         memberId: Int
     ) async throws -> MemberManagementProfileDTO {
+        if memberId == currentMemberID, currentMemberID > 0 {
+            let response = try await adapter.request(MyPageRouter.getMyProfile)
+            let apiResponse = try decoder.decode(
+                APIResponse<MyPageProfileResponseDTO>.self,
+                from: response.data
+            )
+            return MemberManagementProfileDTO(myProfileDTO: try apiResponse.unwrap())
+        }
+
         let response = try await adapter.request(
             StudyRouter.getMemberProfile(memberId: memberId)
         )

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberManagementItem.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberManagementItem.swift
@@ -64,6 +64,9 @@ struct MemberManagementItem: Identifiable, Equatable {
     
     /// 경고 히스토리
     let penaltyHistory: [OperatorMemberPenaltyHistory]
+    
+    /// 아웃 히스토리 열람 가능 여부
+    let canViewPenaltyHistory: Bool
 
     init(
         id: UUID = .init(),
@@ -80,7 +83,8 @@ struct MemberManagementItem: Identifiable, Equatable {
         badge: Bool,
         managementTeam: ManagementTeam,
         attendanceRecords: [MemberAttendanceRecord],
-        penaltyHistory: [OperatorMemberPenaltyHistory]
+        penaltyHistory: [OperatorMemberPenaltyHistory],
+        canViewPenaltyHistory: Bool = true
     ) {
         self.id = id
         self.memberID = memberID
@@ -97,5 +101,6 @@ struct MemberManagementItem: Identifiable, Equatable {
         self.managementTeam = managementTeam
         self.attendanceRecords = attendanceRecords
         self.penaltyHistory = penaltyHistory
+        self.canViewPenaltyHistory = canViewPenaltyHistory
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
@@ -37,9 +37,9 @@ struct OperatorMemberDetailSheetView: View {
         static let baseHeight: CGFloat = 340
         static let emptyHistoryHeight: CGFloat = 150
         static let historyRowHeight: CGFloat = 50
-        static let maxVisibleHistory: Int = 5
+        static let maxVisibleHistory: Int = 7
         static let minSheetHeight: CGFloat = 420
-        static let maxSheetHeight: CGFloat = 700
+        static let maxSheetHeight: CGFloat = 820
         static let badgePadding: EdgeInsets = .init(top: 6, leading: 8, bottom: 6, trailing: 8)
         static let bgOpacity: Double = 0.2
         static let animation: Animation = .spring(response: 0.34, dampingFraction: 0.86)
@@ -188,7 +188,7 @@ struct OperatorMemberDetailSheetView: View {
     private var memberMetadataView: some View {
         HStack(spacing: DefaultSpacing.spacing8) {
             Text("\(member.name)/\(member.nickname)")
-                .appFont(.title2Emphasis)
+                .appFont(.bodyEmphasis)
             statusChip(title: member.part.name, style: .accent)
             statusChip(title: member.school, style: .plain)
         }
@@ -249,7 +249,9 @@ struct OperatorMemberDetailSheetView: View {
     }
     
     private var historyDeleteHint: some View {
-        Text("히스토리 항목을 왼쪽으로 밀어서 삭제할 수 있습니다.")
+        Text(member.canViewPenaltyHistory
+             ? "히스토리 항목을 왼쪽으로 밀어서 삭제할 수 있습니다."
+             : "본인이 아닌 경우 아웃 히스토리를 확인할 수 없습니다.")
             .appFont(.footnote, color: .grey500)
             .padding(.top, DefaultSpacing.spacing8)
     }
@@ -271,7 +273,7 @@ struct OperatorMemberDetailSheetView: View {
         VStack(spacing: DefaultSpacing.spacing8) {
             Image(systemName: "exclamationmark.bubble.fill")
                 .appFont(.title1, color: .grey500)
-            Text("아웃 기록이 없습니다")
+            Text(member.canViewPenaltyHistory ? "아웃 기록이 없습니다" : "타인의 아웃 히스토리를 확인할 수 없습니다")
                 .appFont(.subheadline, color: .grey500)
         }
         .frame(maxWidth: .infinity)
@@ -294,7 +296,7 @@ struct OperatorMemberDetailSheetView: View {
                             Label("삭제", systemImage: "trash")
                         }
                     }
-                    .disabled(isDeletingOutPoint)
+                    .disabled(isDeletingOutPoint || !member.canViewPenaltyHistory)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                     .listRowInsets(.init())
@@ -333,6 +335,7 @@ struct OperatorMemberDetailSheetView: View {
     /// 아웃 부여하기
     @MainActor
     private func addPenalty() async {
+        guard member.canViewPenaltyHistory else { return }
         guard !penaltyReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return
         }
@@ -359,6 +362,7 @@ struct OperatorMemberDetailSheetView: View {
     /// 히스토리 삭제하기
     @MainActor
     private func deletePenalty(_ history: OperatorMemberPenaltyHistory) async {
+        guard member.canViewPenaltyHistory else { return }
         let isSuccess = await onDeleteOut(history)
         guard isSuccess else { return }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
@@ -131,6 +131,7 @@ final class MemberListViewModel {
             )
 
             try await reloadMembersAndReselect(member: member)
+            NotificationCenter.default.post(name: .memberPenaltyUpdated, object: nil)
             return true
         } catch let error as DomainError {
             alertPrompt = AlertPrompt(
@@ -188,7 +189,8 @@ final class MemberListViewModel {
                 badge: member.badge,
                 managementTeam: member.managementTeam,
                 attendanceRecords: records,
-                penaltyHistory: member.penaltyHistory
+                penaltyHistory: member.penaltyHistory,
+                canViewPenaltyHistory: member.canViewPenaltyHistory
             )
         } catch {
             selectedMember = member
@@ -223,6 +225,7 @@ final class MemberListViewModel {
                 challengerPointId: challengerPointId
             )
             try await reloadMembersAndReselect(member: member)
+            NotificationCenter.default.post(name: .memberPenaltyUpdated, object: nil)
             return true
         } catch let error as DomainError {
             alertPrompt = AlertPrompt(
@@ -305,7 +308,8 @@ final class MemberListViewModel {
             badge: updated.badge,
             managementTeam: updated.managementTeam,
             attendanceRecords: updated.attendanceRecords,
-            penaltyHistory: updated.penaltyHistory
+            penaltyHistory: updated.penaltyHistory,
+            canViewPenaltyHistory: updated.canViewPenaltyHistory
         )
     }
 

--- a/AppProduct/AppProduct/Features/Community/Domain/Models/CommunityCommentModel.swift
+++ b/AppProduct/AppProduct/Features/Community/Domain/Models/CommunityCommentModel.swift
@@ -22,6 +22,6 @@ struct CommunityCommentModel: Equatable, Identifiable {
         let trimmedNickname = userNickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let trimmedName = userName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty, trimmedName != "알 수 없음" else { return "알 수 없음" }
-        return trimmedNickname.isEmpty ? trimmedName : "\(trimmedName)/\(trimmedNickname)"
+        return trimmedNickname.isEmpty ? trimmedName : "\(trimmedNickname)/\(trimmedName)"
     }
 }

--- a/AppProduct/AppProduct/Features/Community/Domain/Models/CommunityItemModel.swift
+++ b/AppProduct/AppProduct/Features/Community/Domain/Models/CommunityItemModel.swift
@@ -31,6 +31,6 @@ struct CommunityItemModel: Equatable, Identifiable, Hashable {
         let trimmedNickname = userNickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let trimmedName = userName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty, trimmedName != "알 수 없음" else { return "알 수 없음" }
-        return trimmedNickname.isEmpty ? trimmedName : "\(trimmedName)/\(trimmedNickname)"
+        return trimmedNickname.isEmpty ? trimmedName : "\(trimmedNickname)/\(trimmedName)"
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
@@ -279,6 +279,7 @@ extension ChallengerMemberDTO {
             name: name,
             nickname: nickname,
             generation: gisu,
+            organizationName: chapterName ?? schoolName,
             roleName: resolvedRoleName,
             profileImageURL: profileImageLink
         )

--- a/AppProduct/AppProduct/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
@@ -25,6 +25,8 @@ protocol HomeUseCaseProviding {
     var updateScheduleUseCase: UpdateScheduleUseCaseProtocol { get }
     /// 일정 + 출석부 통합 삭제 UseCase
     var deleteScheduleUseCase: DeleteScheduleUseCaseProtocol { get }
+    /// 일정 제목 기반 태그 분류 UseCase
+    var classifyScheduleUseCase: ClassifyScheduleUseCase { get }
     /// 챌린저 검색 UseCase
     var searchChallengersUseCase: SearchChallengersUseCaseProtocol { get }
 }
@@ -45,6 +47,7 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
     let generateScheduleUseCase: GenerateScheduleUseCaseProtocol
     let updateScheduleUseCase: UpdateScheduleUseCaseProtocol
     let deleteScheduleUseCase: DeleteScheduleUseCaseProtocol
+    let classifyScheduleUseCase: ClassifyScheduleUseCase
     let searchChallengersUseCase: SearchChallengersUseCaseProtocol
 
     // MARK: - Init
@@ -52,6 +55,7 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
     init(
         homeRepository: HomeRepositoryProtocol,
         scheduleRepository: ScheduleRepositoryProtocol,
+        classifierRepository: ScheduleClassifierRepository,
         challengerSearchRepository: ChallengerSearchRepositoryProtocol
     ) {
         self.fetchMyProfileUseCase = FetchMyProfileUseCase(
@@ -77,6 +81,9 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
         )
         self.deleteScheduleUseCase = DeleteScheduleUseCase(
             repository: scheduleRepository
+        )
+        self.classifyScheduleUseCase = ClassifyScheduleUseCaseImpl(
+            repository: classifierRepository
         )
         self.searchChallengersUseCase = SearchChallengersUseCase(
             repository: challengerSearchRepository

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -18,6 +18,8 @@ class ScheduleRegistrationViewModel {
     private let generateScheduleUseCase: GenerateScheduleUseCaseProtocol
     /// 일정 수정 UseCase
     private let updateScheduleUseCase: UpdateScheduleUseCaseProtocol
+    /// 일정 제목 기반 태그 자동 추천 UseCase
+    private let classifyScheduleUseCase: ClassifyScheduleUseCase
 
     /// 전역 에러 핸들러 (실패 시 Alert 표시용)
     private let errorHandler: ErrorHandler
@@ -69,13 +71,30 @@ class ScheduleRegistrationViewModel {
     private(set) var editingScheduleId: Int?
     /// 수정 모드 초기값 스냅샷
     private var initialEditSnapshot: EditFormSnapshot?
+    /// 사용자가 태그를 직접 조정했는지 여부
+    private var isTagManuallyOverridden: Bool = false
 
     // MARK: - Init
 
-    init(container: DIContainer, errorHandler: ErrorHandler) {
+    convenience init(container: DIContainer, errorHandler: ErrorHandler) {
         let provider = container.resolve(HomeUseCaseProviding.self)
-        self.generateScheduleUseCase = provider.generateScheduleUseCase
-        self.updateScheduleUseCase = provider.updateScheduleUseCase
+        self.init(
+            generateScheduleUseCase: provider.generateScheduleUseCase,
+            updateScheduleUseCase: provider.updateScheduleUseCase,
+            classifyScheduleUseCase: provider.classifyScheduleUseCase,
+            errorHandler: errorHandler
+        )
+    }
+
+    init(
+        generateScheduleUseCase: GenerateScheduleUseCaseProtocol,
+        updateScheduleUseCase: UpdateScheduleUseCaseProtocol,
+        classifyScheduleUseCase: ClassifyScheduleUseCase,
+        errorHandler: ErrorHandler
+    ) {
+        self.generateScheduleUseCase = generateScheduleUseCase
+        self.updateScheduleUseCase = updateScheduleUseCase
+        self.classifyScheduleUseCase = classifyScheduleUseCase
         self.errorHandler = errorHandler
     }
 
@@ -99,6 +118,7 @@ class ScheduleRegistrationViewModel {
         tag = detail.tags
             .compactMap(Self.mapScheduleTag)
             .filter { !$0.isDeprecated }
+        isTagManuallyOverridden = !tag.isEmpty
         initialEditSnapshot = currentEditSnapshot
     }
 
@@ -133,6 +153,54 @@ class ScheduleRegistrationViewModel {
     }
 
     // MARK: - Function
+
+    /// 제목 변경 시 자동 태그 추천을 반영합니다.
+    ///
+    /// 사용자가 태그를 직접 변경한 이후에는 자동 추천이 기존 선택을 덮어쓰지 않습니다.
+    @MainActor
+    func titleDidChange(to newTitle: String) async {
+        title = newTitle
+
+        let trimmedTitle = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            if !isTagManuallyOverridden {
+                tag.removeAll()
+            }
+            return
+        }
+
+        guard !isTagManuallyOverridden else {
+            return
+        }
+
+        let suggestedTag = await classifyScheduleUseCase.execute(title: trimmedTitle)
+        let latestTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard latestTitle == trimmedTitle else {
+            return
+        }
+        guard !isTagManuallyOverridden else {
+            return
+        }
+
+        tag = [suggestedTag]
+    }
+
+    /// 태그 선택을 사용자 입력으로 반영합니다.
+    ///
+    /// 사용자가 태그를 비우면 이후 제목 변경 시 자동 추천이 다시 동작합니다.
+    func updateTagsFromUser(_ tags: [ScheduleIconCategory]) {
+        let sanitized = Array(Set(tags.filter { !$0.isDeprecated })).sorted {
+            $0.rawValue < $1.rawValue
+        }
+
+        if tag == sanitized {
+            return
+        }
+
+        tag = sanitized
+        isTagManuallyOverridden = !sanitized.isEmpty
+    }
 
     /// 일정을 서버에 생성합니다.
     ///

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/HomeView.swift
@@ -119,6 +119,12 @@ struct HomeView: View {
                 guard pathStore.homePath.isEmpty else { return }
                 await reloadVisibleScheduleMonth()
             }
+            .onReceive(NotificationCenter.default.publisher(for: .memberPenaltyUpdated)) { _ in
+                guard shouldFetchOnTask else { return }
+                Task {
+                    await viewModel.fetchProfile()
+                }
+            }
         }
     }
     

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -244,7 +244,17 @@ struct ScheduleRegistrationView: View {
     private func sectionView(_ type: ScheduleGenerationType) -> some View {
         switch type {
         case .title:
-            TitleView(text: $viewModel.title)
+            TitleView(
+                text: Binding(
+                    get: { viewModel.title },
+                    set: { newValue in
+                        viewModel.title = newValue
+                        Task { @MainActor in
+                            await viewModel.titleDidChange(to: newValue)
+                        }
+                    }
+                )
+            )
                 .equatable()
         case .place:
             PlaceSelectView(place: $viewModel.place)
@@ -266,7 +276,14 @@ struct ScheduleRegistrationView: View {
         case .participation:
             ParticipantSection(challenger: $viewModel.participatn)
         case .tag:
-            TagSection(tag: $viewModel.tag)
+            TagSection(
+                tag: Binding(
+                    get: { viewModel.tag },
+                    set: { newValue in
+                        viewModel.updateTagsFromUser(newValue)
+                    }
+                )
+            )
         }
     }
 

--- a/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
@@ -40,7 +40,7 @@ struct MyPageProfileResponseDTO: Codable {
         id = try container.decodeMyPageFlexibleString(forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         nickname = try container.decode(String.self, forKey: .nickname)
-        email = try container.decodeMyPageFlexibleString(forKey: .email)
+        email = try container.decodeMyPageFlexibleStringIfPresent(forKey: .email) ?? ""
         schoolId = try container.decodeMyPageFlexibleString(forKey: .schoolId)
         schoolName = try container.decode(String.self, forKey: .schoolName)
         profileImageLink = try container.decodeIfPresent(String.self, forKey: .profileImageLink)
@@ -48,7 +48,7 @@ struct MyPageProfileResponseDTO: Codable {
             MyPageProfileExternalLinksDTO.self,
             forKey: .profile
         )
-        status = try container.decode(MemberStatus.self, forKey: .status)
+        status = try container.decodeIfPresent(MemberStatus.self, forKey: .status) ?? .active
         roles = try container.decodeIfPresent([MyPageRoleDTO].self, forKey: .roles) ?? []
         challengerRecords = try container.decodeIfPresent(
             [MyPageChallengerRecordDTO].self,
@@ -63,6 +63,7 @@ struct MemberProfileSummary {
     let name: String
     let nickname: String
     let generation: Int
+    let organizationName: String?
     let roleName: String
     let profileImageURL: String?
 }
@@ -134,6 +135,7 @@ struct MyPageChallengerRecordDTO: Codable {
     let challengerId: String
     let memberId: String
     let gisu: String
+    let chapterName: String?
     let part: String
     let challengerPoints: [MyPageChallengerPointDTO]
     let name: String
@@ -148,6 +150,7 @@ struct MyPageChallengerRecordDTO: Codable {
         case challengerId
         case memberId
         case gisu
+        case chapterName
         case part
         case challengerPoints
         case name
@@ -168,6 +171,7 @@ struct MyPageChallengerRecordDTO: Codable {
         challengerId = try container.decodeMyPageFlexibleString(forKey: .challengerId)
         memberId = try container.decodeMyPageFlexibleString(forKey: .memberId)
         gisu = try container.decodeMyPageFlexibleString(forKey: .gisu)
+        chapterName = try container.decodeIfPresent(String.self, forKey: .chapterName)
         part = try container.decode(String.self, forKey: .part)
         challengerPoints = try container.decodeIfPresent([MyPageChallengerPointDTO].self, forKey: .challengerPoints)
             ?? decoder.decodeMyPagePointsArrayFallback()
@@ -180,7 +184,8 @@ struct MyPageChallengerRecordDTO: Codable {
         profileImageLink = try container.decodeIfPresent(String.self, forKey: .profileImageLink)
         let fallbackContainer = try decoder.container(keyedBy: FallbackCodingKeys.self)
         status = try container.decodeIfPresent(MemberStatus.self, forKey: .status)
-            ?? fallbackContainer.decode(MemberStatus.self, forKey: .memberStatus)
+            ?? fallbackContainer.decodeIfPresent(MemberStatus.self, forKey: .memberStatus)
+            ?? .active
     }
 }
 
@@ -330,14 +335,19 @@ extension MyPageProfileResponseDTO {
         let latestRecordGeneration = challengerRecords?
             .compactMap { Int($0.gisu) }
             .max() ?? 0
+        let latestRecord = (challengerRecords ?? [])
+            .sorted { Int($0.gisu) ?? 0 > Int($1.gisu) ?? 0 }
+            .first
         let generation = selectedRole?.generation ?? latestRecordGeneration
         let roleName = selectedRole?.role.roleType.korean ?? "챌린저"
+        let organizationName = latestRecord?.chapterName?.nonEmpty ?? latestRecord?.schoolName.nonEmpty
 
         return MemberProfileSummary(
             memberId: id,
             name: latestRecordName(),
             nickname: latestRecordNickname(),
             generation: generation,
+            organizationName: organizationName,
             roleName: roleName,
             profileImageURL: profileImageLink
         )

--- a/AppProduct/AppProduct/Features/MyPage/Data/Repository/Mock/MockMyPageRepository.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Repository/Mock/MockMyPageRepository.swift
@@ -23,6 +23,7 @@ final class MockMyPageRepository: MyPageRepositoryProtocol {
             name: profile.challangerInfo.name,
             nickname: profile.challangerInfo.nickname,
             generation: profile.challangerInfo.gen,
+            organizationName: nil,
             roleName: latestRole?.role.korean ?? "챌린저",
             profileImageURL: profile.challangerInfo.profileImage
         )
@@ -38,6 +39,7 @@ final class MockMyPageRepository: MyPageRepositoryProtocol {
             name: profile.challangerInfo.name,
             nickname: profile.challangerInfo.nickname,
             generation: profile.challangerInfo.gen,
+            organizationName: nil,
             roleName: latestRole?.role.korean ?? "챌린저",
             profileImageURL: profile.challangerInfo.profileImage
         )

--- a/AppProduct/AppProduct/Features/MyPage/Data/Repository/MyPageRepository.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Repository/MyPageRepository.swift
@@ -46,11 +46,19 @@ final class MyPageRepository: MyPageRepositoryProtocol, @unchecked Sendable {
         let response = try await adapter.request(
             MyPageRouter.getMemberProfile(memberId: memberId)
         )
-        let apiResponse = try decoder.decode(
+        if let apiResponse = try? decoder.decode(
             APIResponse<MyPageProfileResponseDTO>.self,
             from: response.data
+        ),
+           let wrapped = try? apiResponse.unwrap() {
+            return wrapped.toMemberProfileSummary()
+        }
+
+        let profile = try decoder.decode(
+            MyPageProfileResponseDTO.self,
+            from: response.data
         )
-        return try apiResponse.unwrap().toMemberProfileSummary()
+        return profile.toMemberProfileSummary()
     }
 
     /// 특정 챌린저 프로필 조회

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/ActiveLogs.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/ActiveLogs.swift
@@ -26,6 +26,8 @@ struct ActiveLogs: View {
 
     /// 활동 이력 추가 처리 중 여부
     let isAdding: Bool
+    /// 활동 이력 추가 성공 직후 여부
+    let didRecentlyAdd: Bool
 
     // MARK: - Init
 
@@ -33,12 +35,14 @@ struct ActiveLogs: View {
         rows: [ActivityLog],
         header: String,
         onAddTap: (() -> Void)? = nil,
-        isAdding: Bool = false
+        isAdding: Bool = false,
+        didRecentlyAdd: Bool = false
     ) {
         self.rows = rows
         self.header = header
         self.onAddTap = onAddTap
         self.isAdding = isAdding
+        self.didRecentlyAdd = didRecentlyAdd
     }
 
     // MARK: - Body
@@ -61,10 +65,13 @@ struct ActiveLogs: View {
                             ProgressView()
                                 .controlSize(.small)
                         } else {
-                            Label("기록 추가", systemImage: "plus.circle")
+                            Label(
+                                didRecentlyAdd ? "추가되었습니다" : "기록 추가",
+                                systemImage: didRecentlyAdd ? "checkmark.circle.fill" : "plus.circle"
+                            )
                                 .labelStyle(.titleAndIcon)
                                 .labelIconToTitleSpacing(DefaultSpacing.spacing8)
-                                .appFont(.footnote, color: .indigo500)
+                                .appFont(.footnote, color: didRecentlyAdd ? .green : .indigo500)
                         }
                     }
                     .buttonStyle(.plain)

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/NameAndNickname.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/NameAndNickname.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// 이름 및 닉네임 정보를 표시하는 읽기 전용 섹션
 ///
-/// 실명과 닉네임을 "이름/닉네임" 형식으로 함께 표시합니다.
+/// 실명과 닉네임을 각각 별도 섹션으로 표시합니다.
 struct NameAndNickname: View, Equatable {
 
     // MARK: - Property
@@ -20,15 +20,18 @@ struct NameAndNickname: View, Equatable {
     /// 사용자 닉네임
     let nickaname: String
 
-    /// 섹션 헤더 타이틀
-    let header: String
-
     // MARK: - Body
 
     var body: some View {
-        ReadOnlyTextField(
-            placeholder: "\(name)/\(nickaname)",
-            header: header
-        )
+        Group {
+            ReadOnlyTextField(
+                placeholder: name,
+                header: "이름"
+            )
+            ReadOnlyTextField(
+                placeholder: nickaname,
+                header: "닉네임"
+            )
+        }
     }
 }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/AuthSection.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/AuthSection.swift
@@ -24,6 +24,8 @@ struct AuthSection: View {
     var body: some View {
         Section(content: {
             sectionContent
+        }, header: {
+            SectionHeaderView(title: sectionType.rawValue)
         })
     }
 

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageProfileViewModel.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/ViewModels/MyPageProfileViewModel.swift
@@ -38,12 +38,16 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
 
     /// 활동 이력 추가 API 진행 상태
     var isAddingActivityLog: Bool = false
+    /// 활동 이력 추가 성공 후 버튼 성공 문구 노출 상태
+    var didRecentlyAddActivityLog: Bool = false
 
     /// 소셜 연동 해제 API 진행 상태
     var disconnectingSocialType: SocialType?
 
     /// 최초 조회/수정 화면 진입 시 링크 스냅샷
     private var initialProfileLinkState: [SocialLinkType: String]
+    /// 활동 이력 추가 성공 문구 자동 복귀 제어 태스크
+    private var activityLogAddedResetTask: Task<Void, Never>?
     
     init(
         profileData: ProfileData,
@@ -143,6 +147,7 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
         profileData = try await useCaseProvider.fetchMyPageProfileUseCase.execute()
         profileData.socialConnections = currentSocialConnections
         initialProfileLinkState = Self.makeProfileLinkState(from: profileData.profileLink)
+        showRecentActivityLogAddedState()
     }
 
     /// 특정 소셜 연동을 해제하고 최신 연동 목록으로 갱신합니다.
@@ -230,5 +235,18 @@ class MyPageProfileViewModel: SinglePhotoPickerManageable {
             memberOAuthId: memberOAuth.memberOAuthId,
             socialType: socialType
         )
+    }
+
+    /// 활동 이력 추가 성공 문구를 잠시 노출한 뒤 기본 상태로 복귀합니다.
+    @MainActor
+    private func showRecentActivityLogAddedState() {
+        activityLogAddedResetTask?.cancel()
+        didRecentlyAddActivityLog = true
+
+        activityLogAddedResetTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            self?.didRecentlyAddActivityLog = false
+        }
     }
 }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
@@ -75,7 +75,10 @@ struct MyPageProfileView: View {
             onDisconnect: presentDisconnectPrompt
         )
         // 이름 및 닉네임 (읽기 전용)
-        NameAndNickname(name: profile.challangerInfo.wrappedValue.name, nickaname: profile.challangerInfo.wrappedValue.nickname, header: "이름/닉네임")
+        NameAndNickname(
+            name: profile.challangerInfo.wrappedValue.name,
+            nickaname: profile.challangerInfo.wrappedValue.nickname
+        )
         // 학교 (읽기 전용)
         SchoolSection(univ: profile.challangerInfo.wrappedValue.schoolName, header: "학교")
         // 활동 이력 목록
@@ -83,7 +86,8 @@ struct MyPageProfileView: View {
             rows: profile.activityLogs.wrappedValue,
             header: "활동 이력",
             onAddTap: { showAddActivityLogAlert = true },
-            isAdding: viewModel.isAddingActivityLog
+            isAdding: viewModel.isAddingActivityLog,
+            didRecentlyAdd: viewModel.didRecentlyAddActivityLog
         )
         // 외부 프로필 링크 수정
         ProfileLinkSection(profileLink: profile.profileLink, header: "외부 프로링크")

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
@@ -414,6 +414,8 @@ private extension NoticeDetail {
             title: title,
             content: content,
             writer: authorName,
+            authorNickname: authorNickname,
+            authorName: authorName,
             links: links,
             images: images,
             vote: vote,

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
@@ -99,6 +99,21 @@ struct NoticeItemModel: Equatable, Identifiable {
     
     var hasLink: Bool { !links.isEmpty }
     var hasVote: Bool { vote != nil }
+    var displayWriter: String {
+        let trimmedName = (authorName ?? writer).trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNickname = authorNickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if !trimmedName.isEmpty && !trimmedNickname.isEmpty {
+            return "\(trimmedName)/\(trimmedNickname)"
+        }
+        if !trimmedName.isEmpty {
+            return trimmedName
+        }
+        if !trimmedNickname.isEmpty {
+            return trimmedNickname
+        }
+        return writer
+    }
 }
 
 private extension NoticeItemModel {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeItem/NoticeItem.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeItem/NoticeItem.swift
@@ -134,7 +134,7 @@ private struct BottomSection: View, Equatable {
 
     var body: some View {
         HStack(spacing: 8) {
-            Text(model.writer)
+            Text(model.displayWriter)
 
             Spacer()
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -27,6 +27,7 @@ extension NoticeDetailViewModel {
             let normalizedDetail = normalizeTargetGenerationIfNeeded(in: mergedDetail)
             noticeState = .loaded(normalizedDetail)
             refreshAuthorDisplayName(for: normalizedDetail)
+            await fetchAuthorProfileIfNeeded(for: normalizedDetail)
             isDetailPreparedForEdit = true
         } catch let error as RepositoryError {
             noticeState = .failed(.repository(error))
@@ -77,6 +78,34 @@ extension NoticeDetailViewModel {
                     }
                 )
             )
+        }
+    }
+
+    /// 공지 작성자의 멤버 프로필을 조회해 이름/닉네임/기수/역할 표시용 상태를 갱신합니다.
+    @MainActor
+    func fetchAuthorProfileIfNeeded(for detail: NoticeDetail) async {
+        hasResolvedAuthorProfile = false
+
+        guard let rawMemberId = detail.authorMemberId,
+              let memberId = Int(rawMemberId) else {
+            isAuthorProfileLoading = false
+            authorProfileSummary = nil
+            hasResolvedAuthorProfile = true
+            return
+        }
+
+        isAuthorProfileLoading = true
+        defer {
+            isAuthorProfileLoading = false
+            hasResolvedAuthorProfile = true
+        }
+
+        do {
+            authorProfileSummary = try await container
+                .resolve(MyPageRepositoryProtocol.self)
+                .fetchMemberProfile(memberId: memberId)
+        } catch {
+            authorProfileSummary = nil
         }
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -50,6 +50,12 @@ final class NoticeDetailViewModel {
 
     /// 작성자 표시 텍스트 (닉네임/이름-기수TH UMC 직책)
     var authorDisplayName: String = ""
+    /// 작성자 상세 프로필 요약 정보
+    var authorProfileSummary: MemberProfileSummary?
+    /// 작성자 프로필 추가 조회 진행 상태
+    var isAuthorProfileLoading: Bool = false
+    /// 작성자 프로필 추가 조회 완료 여부
+    var hasResolvedAuthorProfile: Bool = false
 
     /// 액션 메뉴 표시 여부
     var showingActionMenu: Bool = false
@@ -241,6 +247,76 @@ final class NoticeDetailViewModel {
     /// 화면에 즉시 노출할 작성자명을 반환합니다.
     func displayedAuthorName(for detail: NoticeDetail) -> String {
         authorDisplayName.isEmpty ? detail.defaultAuthorDisplayName : authorDisplayName
+    }
+
+    /// 화면에 노출할 작성자 이름/닉네임 텍스트를 반환합니다.
+    func displayedAuthorIdentity(for detail: NoticeDetail) -> String {
+        if let authorProfileSummary {
+            let name = authorProfileSummary.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let nickname = authorProfileSummary.nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if !name.isEmpty && !nickname.isEmpty {
+                return "\(nickname)/\(name)"
+            }
+            return !nickname.isEmpty ? nickname : name
+        }
+
+        let fallbackName = detail.authorName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallbackNickname = detail.authorNickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if !fallbackName.isEmpty && !fallbackNickname.isEmpty {
+            return "\(fallbackNickname)/\(fallbackName)"
+        }
+        return displayedAuthorName(for: detail)
+    }
+
+    /// 화면에 노출할 작성자 프로필 한 줄 텍스트를 반환합니다.
+    func displayedAuthorProfileLine(for detail: NoticeDetail) -> String {
+        let identity = displayedAuthorIdentity(for: detail)
+        let generation: Int
+        let roleName: String
+
+        if let authorProfileSummary {
+            generation = authorProfileSummary.generation
+            roleName = authorProfileSummary.roleName.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            generation = detail.generation
+            roleName = ""
+        }
+
+        var components: [String] = []
+        if generation > 0 {
+            components.append("\(generation)\(ordinalSuffix(for: generation))")
+        }
+        if !roleName.isEmpty && roleName != ManagementTeam.challenger.korean {
+            components.append(roleName)
+        }
+        components.append(identity)
+
+        return components.joined(separator: " ")
+    }
+
+    /// 화면에 노출할 작성자 프로필 이미지 URL을 반환합니다.
+    func displayedAuthorImageURL(for detail: NoticeDetail) -> String? {
+        authorProfileSummary?.profileImageURL ?? detail.authorImageURL
+    }
+
+    private func ordinalSuffix(for generation: Int) -> String {
+        let suffixBase = generation % 100
+        if (11...13).contains(suffixBase) {
+            return "th"
+        }
+
+        switch generation % 10 {
+        case 1:
+            return "st"
+        case 2:
+            return "nd"
+        case 3:
+            return "rd"
+        default:
+            return "th"
+        }
     }
 
     // MARK: - Generation Helper

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -150,10 +150,9 @@ struct NoticeDetailView: View {
         VStack(alignment: .leading, spacing: Constants.subInfoSpacing) {
             HStack {
                 HStack {
-                    Image(data.authorImageURL ?? Constants.defaultProfileImageName)
-                        .resizable()
-                        .frame(width: Constants.profileSize.width, height: Constants.profileSize.height)
-                    Text(viewModel.displayedAuthorName(for: data))
+                    authorProfileImage(data)
+                    Text(viewModel.displayedAuthorProfileLine(for: data))
+                        .lineLimit(1)
                 }
                 Spacer()
                 Text(data.createdAt.toYearMonthDay())
@@ -165,6 +164,33 @@ struct NoticeDetailView: View {
                     detailTag(tag)
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private func authorProfileImage(_ data: NoticeDetail) -> some View {
+        if let imageURL = viewModel.displayedAuthorImageURL(for: data),
+           !imageURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            RemoteImage(
+                urlString: imageURL,
+                size: Constants.profileSize,
+                cornerRadius: Constants.profileSize.width / 2,
+                placeholderImage: Constants.defaultProfileImageName
+            )
+        } else if !viewModel.hasResolvedAuthorProfile || viewModel.isAuthorProfileLoading {
+            Circle()
+                .fill(.grey100)
+                .frame(width: Constants.profileSize.width, height: Constants.profileSize.height)
+                .overlay {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .tint(.grey500)
+                }
+        } else {
+            Image(.defaultProfile)
+                .resizable()
+                .frame(width: Constants.profileSize.width, height: Constants.profileSize.height)
+                .clipShape(.circle)
         }
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/TargetSheetView.swift
@@ -110,14 +110,17 @@ struct TargetSheetView: View {
 
     @ViewBuilder
     private var sheetContent: some View {
-        switch sheetType {
-        case .part:
-            partFilterSection
-        case .branch:
-            branchFilterSection
-        case .school:
-            schoolFilterSection
+        Group {
+            switch sheetType {
+            case .part:
+                partFilterSection
+            case .branch:
+                branchFilterSection
+            case .school:
+                schoolFilterSection
+            }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     // MARK: - Retry
@@ -192,6 +195,6 @@ struct TargetSheetView: View {
         VStack(alignment: .leading, spacing: Constants.sectionSpacing) {
             content()
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }

--- a/AppProduct/AppProduct/Utilities/RemoteImage/RemoteImage.swift
+++ b/AppProduct/AppProduct/Utilities/RemoteImage/RemoteImage.swift
@@ -25,6 +25,8 @@ struct RemoteImage: View {
     typealias ContentMode = SwiftUI.ContentMode
     
     // MARK: - Properties
+
+    @Environment(\.displayScale) private var displayScale
     
     /// 이미지 로드 실패 상태 (true일 경우 실패)
     @State private var isError: Bool = false
@@ -81,7 +83,11 @@ struct RemoteImage: View {
         Group {
             if let url = URL(string: urlString), !isError {
                 KFImage(url)
-                    .setProcessor(DownsamplingImageProcessor(size: size))
+                    .downsampling(size: CGSize(
+                        width: size.width * displayScale,
+                        height: size.height * displayScale
+                    ))
+                    .scaleFactor(displayScale)
                     .fade(duration: 0.25)
                     .onSuccess { _ in
                         isLoading = false
@@ -91,6 +97,8 @@ struct RemoteImage: View {
                         isError = true // 실패 시 상태 변경
                     }
                     .resizable()
+                    .interpolation(.high)
+                    .antialiased(true)
                     .onAppear {
                         isLoading = true
                     }

--- a/AppProduct/AppProductTests/HomeTest/ScheduleRegistrationViewModelTests.swift
+++ b/AppProduct/AppProductTests/HomeTest/ScheduleRegistrationViewModelTests.swift
@@ -1,0 +1,73 @@
+//
+//  ScheduleRegistrationViewModelTests.swift
+//  AppProductTests
+//
+//  Created by euijjang97 on 3/13/26.
+//
+
+@testable import AppProduct
+import Testing
+
+@MainActor
+struct ScheduleRegistrationViewModelTests {
+
+    @Test("제목 입력 시 자동 추천 태그를 반영한다")
+    func appliesSuggestedTagWhenTitleChanges() async {
+        let viewModel = makeViewModel(suggestedTag: .project)
+
+        await viewModel.titleDidChange(to: "UMC 앱 프로젝트 발표")
+
+        #expect(viewModel.tag == [.project])
+    }
+
+    @Test("사용자가 태그를 직접 변경한 뒤에는 자동 추천이 덮어쓰지 않는다")
+    func preservesManualOverrideAfterUserSelection() async {
+        let viewModel = makeViewModel(suggestedTag: .project)
+
+        await viewModel.titleDidChange(to: "UMC 앱 프로젝트 발표")
+        viewModel.updateTagsFromUser([.meeting])
+        await viewModel.titleDidChange(to: "운영진 회의")
+
+        #expect(viewModel.tag == [.meeting])
+    }
+
+    @Test("사용자가 태그를 모두 비우면 자동 추천을 다시 허용한다")
+    func reEnablesSuggestionAfterClearingManualTags() async {
+        let viewModel = makeViewModel(suggestedTag: .study)
+
+        viewModel.updateTagsFromUser([.meeting])
+        viewModel.updateTagsFromUser([])
+        await viewModel.titleDidChange(to: "알고리즘 스터디")
+
+        #expect(viewModel.tag == [.study])
+    }
+
+    private func makeViewModel(
+        suggestedTag: ScheduleIconCategory
+    ) -> ScheduleRegistrationViewModel {
+        ScheduleRegistrationViewModel(
+            generateScheduleUseCase: MockGenerateScheduleUseCase(),
+            updateScheduleUseCase: MockUpdateScheduleUseCase(),
+            classifyScheduleUseCase: MockClassifyScheduleUseCase(
+                suggestedTag: suggestedTag
+            ),
+            errorHandler: ErrorHandler()
+        )
+    }
+}
+
+private struct MockGenerateScheduleUseCase: GenerateScheduleUseCaseProtocol {
+    func execute(schedule: GenerateScheduleRequetDTO) async throws { }
+}
+
+private struct MockUpdateScheduleUseCase: UpdateScheduleUseCaseProtocol {
+    func execute(scheduleId: Int, schedule: UpdateScheduleRequestDTO) async throws { }
+}
+
+private struct MockClassifyScheduleUseCase: ClassifyScheduleUseCase {
+    let suggestedTag: ScheduleIconCategory
+
+    func execute(title: String) async -> ScheduleIconCategory {
+        suggestedTag
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Fix + Feature — 공지/커뮤니티 작성자 프로필 조회 개선, 마이페이지 DTO 유연 디코딩, 멤버 패널티 권한 분리, CoreML 자동 태그 분류

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 사항 스크린샷/영상 첨부 필요 -->

## 🛠️ 작업내용

### 공지사항 작성자 프로필 개선
- 공지 상세 작성자 프로필을 MyPage API로 추가 조회 (`fetchAuthorProfileIfNeeded`)
- 작성자 영역에 `RemoteImage` 적용 및 로딩 플레이스홀더 표시
- `displayedAuthorProfileLine` — 기수·역할·닉네임/이름 한 줄 표시
- 공지 리스트 `displayWriter`에 이름/닉네임 병합 표시 추가

### 커뮤니티 작성자 표기
- `displayUserName` 순서를 **닉네임/이름**으로 변경 (CommentModel, ItemModel)

### 멤버 관리 패널티 권한 분리
- `MemberManagementItem`에 `canViewPenaltyHistory` 플래그 추가
- 본인이 아닌 멤버의 아웃 히스토리 열람/추가/삭제 차단 UI 분기
- 본인 멤버 프로필 조회 시 `MyPageRouter`로 폴백하여 권한 에러 방지
- `MemberManagementProfileDTO`에 `MyPageProfileResponseDTO` 변환 이니셜라이저 추가
- `memberPenaltyUpdated` 알림으로 홈 프로필 즉시 갱신

### 마이페이지 DTO 유연 디코딩
- `MyPageProfileResponseDTO` email/status 옵셔널 디코딩 및 `.active` 폴백
- `MyPageChallengerRecordDTO`에 `chapterName` 필드 추가
- `MemberProfileSummary`에 `organizationName` 추가
- `MyPageRepository.fetchMemberProfile` API 응답 래핑/비래핑 폴백 디코딩

### 마이페이지 UI 개선
- 이름/닉네임을 별도 `ReadOnlyTextField` 섹션으로 분리
- `AuthSection`에 섹션 헤더 추가
- 활동 이력 추가 성공 시 "추가되었습니다" 피드백 (2초 후 자동 복귀)

### 일정 생성 CoreML 자동 태그 분류
- `ClassifyScheduleUseCase`를 `HomeUseCaseProvider`에 등록 및 DIContainer 주입
- `ScheduleRegistrationViewModel.titleDidChange(to:)` — 제목 변경 시 자동 태그 추천
- 사용자 직접 태그 변경 시 `isTagManuallyOverridden`으로 자동 추천 중단

### 기타
- 공지 작성 시트 스크롤 영역 frame alignment 보정
- `RemoteImage` displayScale 기반 다운샘플링 및 interpolation/antialiased 품질 개선
- 멤버 상세 시트 높이/폰트 조정

## 📌 리뷰 포인트

- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift` — `fetchAuthorProfileIfNeeded` 비동기 프로필 조회
- `Features/Activity/Data/Repositories/MemberRepository.swift` — 본인 프로필 MyPageRouter 폴백
- `Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift` — `canViewPenaltyHistory` 기반 UI 분기
- `Features/MyPage/Data/DTO/MyPageProfileDTO.swift` — email/status 옵셔널 디코딩 및 organizationName
- `Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift` — `titleDidChange(to:)` 자동 태그 추천
- `Utilities/RemoteImage/RemoteImage.swift` — displayScale 기반 다운샘플링

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)