### PR TITLE
✨ [Feat] 스터디 일정 등록 버튼 리더 권한 체크 추가 (#520)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -30,6 +30,9 @@ struct OperatorStudyManagementView: View {
     @AppStorage(AppStorageKey.organizationType)
     private var organizationType: String = ""
 
+    @AppStorage(AppStorageKey.challengerId)
+    private var currentChallengerId: Int = 0
+
     @State private var selectedTab: ManagementTab = .submission
     @State private var showCreateView = false
 
@@ -252,6 +255,14 @@ struct OperatorStudyManagementView: View {
                             )
                         },
                         onSchedule: {
+                            guard group.leader.challengerID == currentChallengerId else {
+                                viewModel.alertPrompt = AlertPrompt(
+                                    title: "권한 없음",
+                                    message: "그룹 리더만 일정을 등록할 수 있습니다.",
+                                    positiveBtnTitle: "확인"
+                                )
+                                return
+                            }
                             guard let studyGroupId = Int(group.serverID) else {
                                 return
                             }


### PR DESCRIPTION
## ✨ PR 유형

기능 추가 - 스터디 일정 등록 시 리더 권한 검증

## 📷 스크린샷 or 영상(UI 변경 시)

리더가 아닌 경우 "권한 없음" AlertPrompt 표시

## 🛠️ 작업내용

- 스터디 그룹 관리 화면에서 "일정 등록" 버튼 탭 시 리더 권한 체크 추가
- `group.leader.challengerID`와 현재 사용자 `challengerId` 비교
- 리더가 아닌 경우 AlertPrompt로 진입 차단 ("그룹 리더만 일정을 등록할 수 있습니다.")
- 변경 파일: 1개

## 📋 추후 진행 상황

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift` - onSchedule 콜백 내 리더 권한 guard 로직 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)