### PR TITLE
🐛[Fix] 커리큘럼 미션 상태 판별 간소화 및 잠금 해제 기준 완화 (#515)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/CurriculumProgressDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/CurriculumProgressDTO.swift
@@ -154,40 +154,25 @@ private extension ChallengerWorkbookProgressDTO {
             return .pendingApproval
         case "IN_PROGRESS", "PROGRESS":
             return .inProgress
+        case "NOT_STARTED", "NOT_STARTED_YET", "READY":
+            return releasedStatusFallback
         case "LOCKED":
-            return .locked
+            return releasedStatusFallback
         case "PENDING":
-            return pendingStatus(schedule: schedule, now: now)
+            return releasedStatusFallback
         case nil:
             // status가 내려오지 않으면 기존 플래그 기준으로 보정
             if isInProgress {
                 return .inProgress
             }
-            return pendingStatus(schedule: schedule, now: now)
+            return releasedStatusFallback
         default:
-            return .locked
+            return releasedStatusFallback
         }
     }
 
-    private func pendingStatus(
-        schedule: WorkbookSchedule?,
-        now: Date
-    ) -> MissionStatus {
-        guard let schedule else {
-            return isInProgress ? .inProgress : .locked
-        }
-        if let startDate = schedule.startDate, now < startDate {
-            return .locked
-        }
-        if let startDate = schedule.startDate,
-           let endDate = schedule.endDate,
-           now >= startDate && now <= endDate {
-            return .inProgress
-        }
-        if let startDate = schedule.startDate, now >= startDate {
-            return .inProgress
-        }
-        return .locked
+    var releasedStatusFallback: MissionStatus {
+        .inProgress
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix — 커리큘럼 미션 상태 분기 로직 간소화로 불필요한 잠금 해제

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 커리큘럼 미션 목록에서 잠금 해제된 상태 확인 스크린샷 필요 -->

## 🛠️ 작업내용

- `LOCKED`, `PENDING`, `NOT_STARTED`, `NOT_STARTED_YET`, `READY` 등 서버 미배정 상태를 `releasedStatusFallback(.inProgress)`으로 통일
- 날짜 기반 `pendingStatus(schedule:now:)` 분기 로직 제거하여 미션 접근 불필요 차단 해소
- `status`가 nil일 때 `isInProgress` 플래그 폴백 유지

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Activity/Data/DTOs/CurriculumProgressDTO.swift` — `resolvedMissionStatus` switch 분기 및 `releasedStatusFallback` 통일 로직

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)