### PR TITLE
🐛 [Fix] 마이페이지 회원 관리 섹션 타이틀 수정

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/project.pbxproj
+++ b/AppProduct/AppProduct.xcodeproj/project.pbxproj
@@ -407,7 +407,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.umc.product;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -463,7 +463,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.umc.product;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Enum/MyPageSectionType.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Enum/MyPageSectionType.swift
@@ -24,5 +24,5 @@ enum MyPageSectionType: String, CaseIterable {
     /// Apple, Kakao 등 소셜 계정 연동 상태
     case socialConnect = "소셜계정 연동"
     /// 회원 정보 처리
-    case auth = "회원 탈퇼 및 로그아웃"
+    case auth = "회원 관리"
 }


### PR DESCRIPTION
## ✨ PR 유형

마이페이지 회원 관리 섹션 타이틀 오타 수정 및 문구 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 텍스트 변경이므로 스크린샷을 첨부해주세요 -->

## 🛠️ 작업내용

- MyPageSectionType의 auth 케이스 rawValue "회원 탈퇼 및 로그아웃" → "회원 관리"로 변경 (오타 수정 및 문구 개선)
- Xcode 프로젝트 파일 동기화

## 📋 추후 진행 상황

- 없음

## 📌 리뷰 포인트

- `Features/MyPage/Presentation/Enum/MyPageSectionType.swift` - auth 케이스 rawValue 문구 변경 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)