### PR TITLE
✨ [Feat] 마이페이지 앱 평가 및 리뷰, 커뮤니티 권한 개선, 명예의 전당 레이아웃 수정

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/project.pbxproj
+++ b/AppProduct/AppProduct.xcodeproj/project.pbxproj
@@ -407,7 +407,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.umc.product;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -463,7 +463,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.umc.product;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AppProduct/AppProduct/Core/Common/Authorization/Models/ResourcePermission.swift
+++ b/AppProduct/AppProduct/Core/Common/Authorization/Models/ResourcePermission.swift
@@ -16,6 +16,7 @@ enum AuthorizationResourceType: String, CaseIterable, Hashable {
     case workbookSubmission = "WORKBOOK_SUBMISSION"
     case attendanceSheet = "ATTENDANCE_SHEET"
     case attendanceRecord = "ATTENDANCE_RECORD"
+    case communityPost = "COMMUNITY_POST"
     case comment = "COMMUNITY_COMMENT"
 }
 

--- a/AppProduct/AppProduct/Core/Manager/User/UserSessionManager.swift
+++ b/AppProduct/AppProduct/Core/Manager/User/UserSessionManager.swift
@@ -24,6 +24,9 @@ final class UserSessionManager {
     /// 현재 사용자의 역할 (서버에서 받아온 실제 권한)
     private(set) var currentRole: ManagementTeam = .challenger
 
+    /// 사용자가 보유한 전체 역할 목록
+    private(set) var allRoles: [ManagementTeam] = []
+
     /// Admin 모드 활성화 여부
     private(set) var isAdminModeEnabled: Bool = false
 
@@ -48,17 +51,24 @@ final class UserSessionManager {
     }
 
     /// 사용자 역할 업데이트 (로그인/세션 복원 시 호출)
-    func updateRole(_ role: ManagementTeam) {
+    func updateRole(_ role: ManagementTeam, allRoles: [ManagementTeam] = []) {
         currentRole = role
+        self.allRoles = allRoles.isEmpty ? [role] : allRoles
         // Admin 모드 접근 불가 역할로 변경되면 Admin 모드 비활성화
         if !role.canAccessAdminMode {
             isAdminModeEnabled = false
         }
     }
 
+    /// 보유 역할 중 특정 권한이 있는지 확인
+    func hasAnyRole(where predicate: (ManagementTeam) -> Bool) -> Bool {
+        allRoles.contains(where: predicate)
+    }
+
     /// 세션 초기화 (로그아웃 시 호출)
     func reset() {
         currentRole = .challenger
+        allRoles = []
         isAdminModeEnabled = false
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -182,10 +182,9 @@ struct OperatorStudyManagementView: View {
 
     // MARK: - Function
 
-    /// 스터디 그룹 생성 권한 확인 (역할 + 조직 타입)
+    /// 스터디 그룹 생성 권한 확인 (보유 역할 중 회장/부회장 포함 여부)
     private var canCreateStudyGroup: Bool {
-        userSession.currentRole.canCreateStudyGroup
-            && OrganizationType(rawValue: organizationType) == .school
+        userSession.hasAnyRole { $0.canCreateStudyGroup }
     }
 
     // MARK: - Submission Content View

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/FailedVerificationUMCViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/FailedVerificationUMCViewModel.swift
@@ -343,7 +343,10 @@ final class FailedVerificationUMCViewModel {
         )
         defaults.set(isApprovedProfile(profile), forKey: AppStorageKey.canAutoLogin)
 
-        container.resolve(UserSessionManager.self).updateRole(resolvedRole)
+        container.resolve(UserSessionManager.self).updateRole(
+            resolvedRole,
+            allRoles: profile.roles.map(\.roleType)
+        )
         NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
     }
 

--- a/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityDetailViewModel.swift
@@ -32,6 +32,7 @@ class CommunityDetailViewModel {
     private(set) var isPostingComment: Bool = false
     private(set) var commentDeletePermissions: [Int: Bool] = [:]
     private(set) var isPermissionsLoaded: Bool = false
+    private(set) var postPermission: ResourcePermission?
 
     var commentText: String = ""
     var alertPrompt: AlertPrompt?
@@ -70,6 +71,29 @@ class CommunityDetailViewModel {
         } catch {
             postDetailState = .failed(.unknown(message: error.localizedDescription))
         }
+    }
+
+    /// 게시글 권한 조회
+    @MainActor
+    func fetchPostPermission() async {
+        do {
+            postPermission = try await authorizationUseCase.getResourcePermission(
+                resourceType: .communityPost,
+                resourceId: postId
+            )
+        } catch {
+            postPermission = nil
+        }
+    }
+
+    /// 게시글 수정 권한 여부
+    var canEditPost: Bool {
+        postPermission?.has(.edit) ?? false
+    }
+
+    /// 게시글 삭제 권한 여부
+    var canDeletePost: Bool {
+        postPermission?.has(.delete) ?? false
     }
 
     /// 댓글 목록 조회

--- a/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityDetailView.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityDetailView.swift
@@ -98,6 +98,7 @@ struct CommunityDetailView: View {
         .navigation(naviTitle: .communityDetail, displayMode: .inline)
         .task {
             await vm.fetchPostDetail()
+            await vm.fetchPostPermission()
             await vm.fetchComments()
         }
         .onChange(of: pathStore.communityPath.count) { oldCount, newCount in
@@ -105,6 +106,7 @@ struct CommunityDetailView: View {
                 Task {
                     try? await Task.sleep(nanoseconds: 300_000_000) // 0.3초
                     await vm.fetchPostDetail()
+                    await vm.fetchPostPermission()
                     await vm.fetchComments()
                 }
             }
@@ -162,24 +164,27 @@ struct CommunityDetailView: View {
     /// - Parameter postItem: 현재 상세 화면에 표시 중인 게시글 모델입니다.
     /// - Returns: 작성자 본인일 때는 수정/삭제, 타인일 때는 신고 액션 목록입니다.
     private func toolbarActions(for postItem: CommunityItemModel) -> [ToolBarCollection.ToolbarTrailingMenu.ActionItem] {
-        if postItem.isAuthor {
-            // 본인 게시글: 수정/삭제
-            return [
-                .init(title: "수정하기", icon: "pencil") {
-                    pathStore.communityPath.append(.community(.post(editItem: postItem)))
-                },
-                .init(title: "삭제하기", icon: "trash", role: .destructive) {
-                    showDeletePostAlert()
-                }
-            ]
-        } else {
-            // 타인 게시글: 신고
-            return [
-                .init(title: "신고하기", icon: "light.beacon.max.fill", role: .destructive) {
-                    showReportPostAlert()
-                }
-            ]
+        var actions: [ToolBarCollection.ToolbarTrailingMenu.ActionItem] = []
+
+        if vm.canEditPost {
+            actions.append(.init(title: "수정하기", icon: "pencil") {
+                pathStore.communityPath.append(.community(.post(editItem: postItem)))
+            })
         }
+
+        if vm.canDeletePost {
+            actions.append(.init(title: "삭제하기", icon: "trash", role: .destructive) {
+                showDeletePostAlert()
+            })
+        }
+
+        if !vm.canEditPost && !vm.canDeletePost {
+            actions.append(.init(title: "신고하기", icon: "light.beacon.max.fill", role: .destructive) {
+                showReportPostAlert()
+            })
+        }
+
+        return actions
     }
 
     // MARK: - Alert Functions

--- a/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityFameView.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityFameView.swift
@@ -70,12 +70,10 @@ struct CommunityFameView: View {
                 weeks: vm.availableWeeks,
                 selection: $vm.selectedWeek
             )
-            
-            ToolBarCollection.CommunityUnivFilter(
+
+            ToolBarCollection.CommunityFameFilter(
                 selectedUniversity: $vm.selectedUniversity,
-                universities: vm.availableUniversities
-            )
-            ToolBarCollection.CommunityPartFilter(
+                universities: vm.availableUniversities,
                 selectedPart: $vm.selectedPart,
                 parts: UMCPartType.allCases
             )

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -140,7 +140,10 @@ final class HomeViewModel {
             forKey: AppStorageKey.generationOrganizations
         )
         defaults.set(isApproved, forKey: AppStorageKey.canAutoLogin)
-        container.resolve(UserSessionManager.self).updateRole(resolvedRole)
+        container.resolve(UserSessionManager.self).updateRole(
+            resolvedRole,
+            allRoles: result.roles.map(\.roleType)
+        )
         NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
     }
 
@@ -170,7 +173,7 @@ final class HomeViewModel {
     @MainActor
     private func applyGenerationsFromProfile(_ generations: [GenerationData]) {
         generationData = .loading
-        generationData = .loaded(generations.sorted { $0.gen < $1.gen })
+        generationData = .loaded(generations.sorted { $0.gen > $1.gen })
     }
 
     /// 챌린저 이력 기반 (gen, gisuId) 매핑을 SwiftData(CloudKit)에 동기화합니다.

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/AppBundleSection.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/AppBundleSection.swift
@@ -5,6 +5,7 @@
 //  Created by euijjang97 on 1/28/26.
 //
 
+import StoreKit
 import SwiftUI
 
 /// MyPage에서 앱 정보(버전 등)를 표시하는 Section 컴포넌트
@@ -14,6 +15,7 @@ struct InfoSection: View {
     // MARK: - Property
 
     @Environment(\.di) private var di
+    @Environment(\.requestReview) private var requestReview
 
     private enum Constants {
         static let appStoreURLString = "https://apps.apple.com/us/app/umc/id6759412446"
@@ -57,31 +59,46 @@ struct InfoSection: View {
     // MARK: - Body
 
     var body: some View {
-        Section(content: {
-            MyPageSectionRow(systemIcon: "info.circle", title: "버전", rightText: appVersion, iconBackgroundColor: .cyan)
-            Button(action: {
-                pathStore.mypagePath.append(.myPage(.productTeamIntroduction))
-            }, label: {
-                MyPageSectionRow(
-                    systemIcon: "person.3.fill",
-                    title: "UMC PRODUCT 소개",
-                    rightImage: "chevron.right",
-                    iconBackgroundColor: .orange
-                )
-            })
-            .buttonStyle(.plain)
-            ShareLink(
-                item: shareContent,
-                preview: SharePreview(Constants.appName)
-            ) {
-                MyPageSectionRow(
-                    systemIcon: "square.and.arrow.up",
-                    title: "앱 공유하기",
-                    rightImage: "arrow.up.right",
-                    iconBackgroundColor: .yellow
-                )
-            }
-        }, header: {
+        Section(
+            content: {
+                
+                MyPageSectionRow(systemIcon: "info.circle", title: "버전", rightText: appVersion, iconBackgroundColor: .cyan)
+               
+                Button {
+                    requestReview()
+                } label: {
+                    MyPageSectionRow(
+                        systemIcon: "star.fill",
+                        title: "앱 평가 및 리뷰",
+                        rightImage: "arrow.up.right",
+                        iconBackgroundColor: .pink
+                    )
+                }
+                .buttonStyle(.plain)
+                ShareLink(
+                    item: shareContent,
+                    preview: SharePreview(Constants.appName)
+                ) {
+                    MyPageSectionRow(
+                        systemIcon: "square.and.arrow.up",
+                        title: "앱 공유하기",
+                        rightImage: "arrow.up.right",
+                        iconBackgroundColor: .yellow
+                    )
+                }
+                Button(action: {
+                    pathStore.mypagePath.append(.myPage(.productTeamIntroduction))
+                }, label: {
+                    MyPageSectionRow(
+                        systemIcon: "person.3.fill",
+                        title: "UMC PRODUCT 소개",
+                        rightImage: "chevron.right",
+                        iconBackgroundColor: .orange
+                    )
+                })
+                .buttonStyle(.plain)
+            },
+            header: {
             SectionHeaderView(title: sectionType.rawValue)
         })
     }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
@@ -235,7 +235,10 @@ struct MyPageProfileView: View {
         defaults.set(isApprovedProfile(profile), forKey: AppStorageKey.canAutoLogin)
         syncGenerationMappings(profile.generations)
 
-        di.resolve(UserSessionManager.self).updateRole(resolvedRole)
+        di.resolve(UserSessionManager.self).updateRole(
+            resolvedRole,
+            allRoles: profile.roles.map(\.roleType)
+        )
         NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
     }
 

--- a/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
+++ b/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
@@ -338,7 +338,7 @@ struct ToolBarCollection {
             .pickerStyle(.inline)
         }
     }
-    
+
     /// 커뮤니티 목록을 파트 기준으로 좁혀보는 필터 툴바입니다.
     struct CommunityPartFilter: ToolbarContent {
         @Binding var selectedPart: UMCPartType?
@@ -367,6 +367,53 @@ struct ToolBarCollection {
                 }
             }
             .pickerStyle(.inline)
+        }
+    }
+
+    /// 커뮤니티 명예의 전당에서 학교/파트 필터를 하나의 메뉴로 통합한 툴바입니다.
+    struct CommunityFameFilter: ToolbarContent {
+        @Binding var selectedUniversity: String
+        let universities: [String]
+        @Binding var selectedPart: UMCPartType?
+        let parts: [UMCPartType]
+
+        var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Menu {
+                        Picker("학교 선택", selection: $selectedUniversity) {
+                            Text("전체")
+                                .tag("전체")
+
+                            ForEach(universities.filter { $0 != "전체" }, id: \.self) { university in
+                                Text(university)
+                                    .tag(university)
+                            }
+                        }
+                        .pickerStyle(.inline)
+                    } label: {
+                        Label("\(selectedUniversity)", systemImage: "graduationcap.fill")
+                    }
+
+                    Menu {
+                        Picker("파트 선택", selection: $selectedPart) {
+                            Label("전체", systemImage: "person.2.fill")
+                                .tag(nil as UMCPartType?)
+
+                            ForEach(parts, id: \.self) { part in
+                                Label(part.name, systemImage: part.icon)
+                                    .tag(part)
+                            }
+                        }
+                        .pickerStyle(.inline)
+                    } label: {
+                        Label("\(selectedPart?.name ?? "전체")", systemImage: "building.columns.fill")
+                    }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle.fill")
+                        .appFont(.subheadline)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## ✨ PR 유형

Feature 추가 / Bug Fix / Refactor 복합 PR

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이 포함되어 있습니다. 스크린샷 또는 영상을 첨부해주세요. -->

## 🛠️ 작업내용

### ✨ 새로운 기능
- 마이페이지 Info 섹션에 **앱 평가 및 리뷰** 버튼 추가 (StoreKit `requestReview`)
- 마이페이지 회원 관리 섹션 타이틀 수정

### 🐛 버그 수정
- **명예의 전당 타이틀 레이아웃 깨짐 해결**: 학교/파트 필터를 `CommunityFameFilter`로 통합 (아이콘 2개 → 1개), 서브메뉴에 선택값 표시
- **커뮤니티 게시글 수정/삭제 권한 오류 해결**: `isAuthor` 대신 `resource-permission` API(`COMMUNITY_POST`) 기반으로 권한 판단
- **듀얼 롤 계정 스터디 그룹 생성 불가 해결**: `UserSessionManager`에 `allRoles` 추가, 보유 역할 전체에서 회장/부회장 여부 확인

### ♻️ 리팩토링
- `AuthorizationResourceType`에 `communityPost` 타입 추가
- `UserSessionManager.updateRole`에 전체 역할 목록 전달 (Home, MyPage, Auth)

## 📋 추후 진행 상황

- 홈 화면 패널티 카드 최신 기수 우선 정렬 반영 확인

## 📌 리뷰 포인트

- `Core/Manager/User/UserSessionManager.swift` - `allRoles` 프로퍼티 및 `hasAnyRole(where:)` 메서드 추가
- `Features/Community/Presentation/ViewModels/CommunityDetailViewModel.swift` - `fetchPostPermission()` 및 `canEditPost`/`canDeletePost` 권한 체크 로직
- `Features/Community/Presentation/Views/CommunityDetailView.swift` - 툴바 메뉴를 권한 기반으로 동적 구성
- `Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift` - `canCreateStudyGroup` 조건 변경
- `Utilities/ToolBar/ToolBarCollection.swift` - `CommunityFameFilter` 통합 필터 컴포넌트
- `Features/MyPage/Presentation/Components/Section/MypageSection/AppBundleSection.swift` - StoreKit 인앱 리뷰 연동

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)