### PR TITLE
🐛 [Fix] 챌린저 검색 UI 반영 지연 해결 및 로딩 상태 개선

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import UniformTypeIdentifiers
 
 /// 챌린저 검색 화면의 비즈니스 로직을 담당하는 뷰 모델입니다.
 ///
@@ -28,9 +27,6 @@ final class SearchChallengerViewModel {
     /// 선택된 챌린저 정보를 별도 보관 (검색 결과 교체 시에도 유지)
     var selectedChallengersMap: [String: ChallengerInfo] = [:]
 
-    /// 검색창 입력 텍스트
-    var searchText: String = ""
-
     /// CSV 파일 가져오기 문서 피커 표시 여부
     var showCSVImporter: Bool = false
 
@@ -49,20 +45,11 @@ final class SearchChallengerViewModel {
     /// 현재 검색 컨텍스트의 키워드
     private var currentKeyword: String = ""
 
-    /// 디바운스용 검색 태스크
-    private var debounceTask: Task<Void, Never>?
-
-    /// 진행 중인 검색 요청 태스크
-    private var searchTask: Task<Void, Never>?
-
     /// 최신 검색 요청 식별자
     private var latestRequestID: UUID = UUID()
 
     /// 다음 페이지 중복 호출 방지 플래그
     private var isFetchingNextPage: Bool = false
-
-    private let debounceNanoseconds: UInt64
-    private let sleep: @Sendable (UInt64) async throws -> Void
 
     // MARK: - Init
 
@@ -70,73 +57,42 @@ final class SearchChallengerViewModel {
     init(container: DIContainer) {
         let provider = container.resolve(HomeUseCaseProviding.self)
         self.searchChallengersUseCase = provider.searchChallengersUseCase
-        self.debounceNanoseconds = 1_000_000_000
-        self.sleep = { nanoseconds in
-            try await Task.sleep(nanoseconds: nanoseconds)
-        }
     }
 
-    init(
-        searchChallengersUseCase: SearchChallengersUseCaseProtocol,
-        debounceNanoseconds: UInt64 = 1_000_000_000,
-        sleep: @escaping @Sendable (UInt64) async throws -> Void = { nanoseconds in
-            try await Task.sleep(nanoseconds: nanoseconds)
-        }
-    ) {
+    init(searchChallengersUseCase: SearchChallengersUseCaseProtocol) {
         self.searchChallengersUseCase = searchChallengersUseCase
-        self.debounceNanoseconds = debounceNanoseconds
-        self.sleep = sleep
     }
 
     // MARK: - Function
 
-    /// 화면 진입 또는 검색어 초기화 시 현재 검색 조건으로 첫 페이지를 로드합니다.
+    /// 현재 검색 키워드로 재검색합니다 (재시도 용도).
     @MainActor
-    func loadInitialChallengers() async {
-        let keyword = normalizedSearchText
-        guard !keyword.isEmpty else {
+    func retrySearch() async {
+        guard !currentKeyword.isEmpty else {
             resetSearchState()
             return
         }
+        let requestID = prepareSearch(keyword: currentKeyword)
+        await fetchChallengers(keyword: currentKeyword, requestID: requestID)
+    }
 
+    /// 키워드로 챌린저를 검색합니다.
+    @MainActor
+    func performSearch(keyword: String) async {
         let requestID = prepareSearch(keyword: keyword)
         await fetchChallengers(keyword: keyword, requestID: requestID)
     }
 
-    /// 검색어 변경 시 디바운스를 적용해 챌린저 목록을 다시 조회합니다.
+    /// 검색 상태를 초기화합니다.
     @MainActor
-    func scheduleSearch() {
-        debounceTask?.cancel()
-        let keyword = normalizedSearchText
-        guard !keyword.isEmpty else {
-            searchTask?.cancel()
-            latestRequestID = UUID()
-            resetSearchState()
-            return
-        }
-
-        let requestID = prepareSearch(keyword: keyword)
-
-        debounceTask = Task { [weak self] in
-            guard let self else { return }
-            do {
-                try await sleep(debounceNanoseconds)
-            } catch {
-                return
-            }
-
-            guard !Task.isCancelled else { return }
-            await MainActor.run {
-                self.startSearchTask(keyword: keyword, requestID: requestID)
-            }
-        }
+    func clearSearch() {
+        resetSearchState()
     }
 
-    /// 더 이상 필요 없는 검색 태스크를 정리합니다.
+    /// 로딩 상태로 전환합니다.
     @MainActor
-    func cancelSearch() {
-        debounceTask?.cancel()
-        searchTask?.cancel()
+    func showLoading() {
+        loadState = .loading
     }
 
     /// 현재 검색 키워드 기준으로 첫 페이지를 조회합니다.
@@ -153,6 +109,7 @@ final class SearchChallengerViewModel {
             self.nextCursor = nextCursor
             loadState = .loaded(true)
         } catch {
+            guard !Task.isCancelled else { return }
             guard latestRequestID == requestID else { return }
             allChallengers = []
             nextCursor = nil
@@ -183,14 +140,6 @@ final class SearchChallengerViewModel {
 // MARK: - Helpers
 private extension SearchChallengerViewModel {
     @MainActor
-    func startSearchTask(keyword: String, requestID: UUID) {
-        searchTask = Task { [weak self] in
-            guard let self else { return }
-            await self.fetchChallengers(keyword: keyword, requestID: requestID)
-        }
-    }
-
-    @MainActor
     func prepareSearch(keyword: String) -> UUID {
         let requestID = UUID()
         latestRequestID = requestID
@@ -199,10 +148,6 @@ private extension SearchChallengerViewModel {
         nextCursor = nil
         hasNext = false
         return requestID
-    }
-
-    var normalizedSearchText: String {
-        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     @MainActor

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
@@ -17,12 +17,18 @@ struct SearchChallengerView: View {
     // MARK: - Properties
 
     @Environment(\.dismiss) private var dismiss
-    
+
     /// 상위 뷰와 공유되는 선택된 챌린저 리스트 바인딩
     @Binding var selectedChallengers: [ChallengerInfo]
-    
+
     /// 검색 화면의 상태 및 로직을 관리하는 뷰 모델
     @State var viewModel: SearchChallengerViewModel
+
+    /// 검색창 입력 텍스트 (로컬 상태로 관리하여 바인딩 지연 방지)
+    @State private var searchText = ""
+
+    /// 디바운스용 검색 Task
+    @State private var searchTask: Task<Void, Never>?
 
     private enum Constants {
         static let loadingMessage: String = "챌린저 목록을 불러오는 중입니다."
@@ -49,7 +55,7 @@ struct SearchChallengerView: View {
     
     var body: some View {
         stateContent
-        .searchable(text: $viewModel.searchText, prompt: "이름 또는 닉네임으로 검색해보세요")
+        .searchable(text: $searchText, prompt: "이름 또는 닉네임으로 검색해보세요")
         .searchPresentationToolbarBehavior(.avoidHidingContent)
         .navigation(naviTitle: .searchChallenger, displayMode: .inline)
         .toolbar(content: {
@@ -73,11 +79,11 @@ struct SearchChallengerView: View {
         .task {
             initializeSelectedIds()
         }
-        .onChange(of: viewModel.searchText) {
-            viewModel.scheduleSearch()
+        .onChange(of: searchText) { _, newValue in
+            handleSearchChanged(newValue)
         }
         .onDisappear {
-            viewModel.cancelSearch()
+            searchTask?.cancel()
         }
     }
     
@@ -114,7 +120,7 @@ struct SearchChallengerView: View {
                 retryTitle: Constants.failedRetryTitle,
                 isRetrying: viewModel.loadState.isLoading
             ) {
-                await viewModel.loadInitialChallengers()
+                await viewModel.retrySearch()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
@@ -133,7 +139,7 @@ struct SearchChallengerView: View {
         ContentUnavailableView(
             "검색 결과가 없습니다",
             systemImage: "magnifyingglass",
-            description: Text("'\(viewModel.searchText)'에 대한 검색 결과를 찾을 수 없습니다.\n다른 검색어를 입력해보세요.")
+            description: Text("'\(searchText)'에 대한 검색 결과를 찾을 수 없습니다.\n다른 검색어를 입력해보세요.")
         )
     }
     
@@ -193,6 +199,22 @@ struct SearchChallengerView: View {
         viewModel.selectedChallengersMap = selectionMap
     }
     
+    /// 검색어 변경 시 디바운스 적용 후 검색 실행
+    private func handleSearchChanged(_ newValue: String) {
+        searchTask?.cancel()
+        let keyword = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !keyword.isEmpty else {
+            viewModel.clearSearch()
+            return
+        }
+        viewModel.showLoading()
+        searchTask = Task {
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            await viewModel.performSearch(keyword: keyword)
+        }
+    }
+
     /// CSV 파일 가져오기 완료 후 처리 액션
     private func csvImportAction(result: Result<[URL], Error>) {
         switch result {


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 챌린저 검색 시 입력 후 ~6초 지연 발생 문제 해결 및 검색 UX 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 검색 입력 후 즉시 로딩 → 결과 표시 확인 필요 -->

## 🛠️ 작업내용

- `.searchable` 바인딩을 `@Observable` ViewModel 프로퍼티에서 `@State` 로컬 변수로 전환하여 검색 입력 지연 해소
- 디바운스 로직을 View의 `.onChange` + `Task`로 이동 (NoticeView 패턴과 통일)
- 검색어 입력 시 즉시 로딩 UI 표시되도록 `showLoading()` 추가
- `Task` 취소 시 에러 UI 표시 방지 (`Task.isCancelled` 체크)
- ViewModel에서 미사용 `debounceTask`/`searchTask`/`sleep` 프로퍼티 제거
- `loadInitialChallengers` → `retrySearch`로 재시도 전용 메서드 분리

## 📋 추후 진행 상황

- #529 일정 챌린저 검색 시 다중 기수 멤버 동시 선택 안됨 이슈 해결

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift` - `@State` 기반 `.searchable` 바인딩 및 `handleSearchChanged` 디바운스 로직
- `Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift` - `performSearch`/`clearSearch`/`showLoading`/`retrySearch` 메서드 구성

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)