### PR TITLE
🐛 [Fix] 챌린저 검색 시 다중 기수 멤버 동시 선택 기능 추가

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift
@@ -211,11 +211,14 @@ extension SearchChallengerViewModel {
             let searchName = columns[0]
             let searchNickname = columns.count > 1 ? columns[1] : ""
 
-            // 이름 또는 닉네임으로 챌린저 찾기
+            // 이름 또는 닉네임으로 챌린저 찾기 (동일 memberId 전체 선택)
             if let matched = findChallenger(name: searchName, nickname: searchNickname) {
-                let key = matched.selectionKey
-                selectedKeys.insert(key)
-                selectedChallengersMap[key] = matched
+                let siblings = allChallengers.filter { $0.memberId == matched.memberId }
+                for sibling in siblings {
+                    let key = sibling.selectionKey
+                    selectedKeys.insert(key)
+                    selectedChallengersMap[key] = sibling
+                }
                 matchedCount += 1
             } else {
                 unmatchedNames.append("\(searchName)/\(searchNickname)")

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift
@@ -145,17 +145,25 @@ struct SearchChallengerView: View {
     
     // MARK: - Actions
     
-    /// 챌린저 선택/해제 토글 (행 식별 키 기반)
+    /// 챌린저 선택/해제 토글 (memberId 기준 동시 선택)
     ///
+    /// 동일 memberId를 가진 모든 기수 챌린저를 함께 선택/해제합니다.
     /// 선택 시 `selectedChallengersMap`에 보관하여 검색 결과가 바뀌어도 선택 정보 유지
     private func toggleSelection(participant: ChallengerInfo) {
         let key = participant.selectionKey
-        if viewModel.selectedKeys.contains(key) {
-            viewModel.selectedKeys.remove(key)
-            viewModel.selectedChallengersMap.removeValue(forKey: key)
-        } else {
-            viewModel.selectedKeys.insert(key)
-            viewModel.selectedChallengersMap[key] = participant
+        let isSelected = viewModel.selectedKeys.contains(key)
+        let siblings = viewModel.allChallengers.filter {
+            $0.memberId == participant.memberId
+        }
+        for sibling in siblings {
+            let siblingKey = sibling.selectionKey
+            if isSelected {
+                viewModel.selectedKeys.remove(siblingKey)
+                viewModel.selectedChallengersMap.removeValue(forKey: siblingKey)
+            } else {
+                viewModel.selectedKeys.insert(siblingKey)
+                viewModel.selectedChallengersMap[siblingKey] = sibling
+            }
         }
     }
 


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 다중 기수에 걸쳐 활동한 멤버 선택 시 동일 `memberId`의 모든 기수 기록이 동시에 체크되지 않는 문제 해결

Closes #529

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 다중 기수 멤버(예: 박경운/하늘) 선택 시 모든 기수 기록이 동시 체크되는지 확인 필요 -->

## 🛠️ 작업내용

- `toggleSelection`에서 동일 `memberId`를 가진 모든 챌린저를 `allChallengers`에서 찾아 함께 선택/해제하도록 변경
- CSV 임포트 시에도 매칭된 챌린저의 `memberId` 기준으로 형제 레코드 전체 선택하도록 수정

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/Registration/Challenger/SearchChallengerView.swift` - `toggleSelection` 메서드의 `memberId` 기준 형제 챌린저 동시 토글 로직
- `Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift` - CSV 임포트 시 `memberId` 기준 형제 레코드 전체 선택 로직

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)