### PR TITLE
🐛 [Fix] 일정 수정 시 생성자 본인 참여자 제거 방지

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -315,7 +315,12 @@ class ScheduleRegistrationViewModel {
         submitState = .loading
         var participantMemberIds: [Int]? = nil
         if !participatn.isEmpty {
-            participantMemberIds = Array(Set(participatn.map(\.memberId))).sorted()
+            var memberIds = Array(Set(participatn.map(\.memberId))).sorted()
+            let myMemberId = UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+            if myMemberId != 0, !memberIds.contains(myMemberId) {
+                memberIds.append(myMemberId)
+            }
+            participantMemberIds = memberIds
         }
         let dto = UpdateScheduleRequestDTO(
             name: title,

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/ChallengerFormView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/ChallengerFormView.swift
@@ -31,6 +31,9 @@ struct ChallengerFormView: View {
 
     /// 마지막 아이템이 화면에 나타났을 때 호출 (페이지네이션용)
     let onBottomReached: (() -> Void)?
+
+    /// 삭제 불가능한 멤버 ID 집합 (생성자 보호 등)
+    let nonDeletableMemberIds: Set<Int>
     
     // MARK: - Init
     
@@ -48,7 +51,8 @@ struct ChallengerFormView: View {
         showCheckBox: Bool = false,
         selectedIds: Binding<Set<String>> = .constant([]),
         tap: ((ChallengerInfo) -> Void)? = nil,
-        onBottomReached: (() -> Void)? = nil
+        onBottomReached: (() -> Void)? = nil,
+        nonDeletableMemberIds: Set<Int> = []
     ) {
         self._challenger = challenger
         self.isDeletAction = isDeletAction
@@ -56,6 +60,7 @@ struct ChallengerFormView: View {
         self._selectedIds = selectedIds
         self.tap = tap
         self.onBottomReached = onBottomReached
+        self.nonDeletableMemberIds = nonDeletableMemberIds
     }
     
     // MARK: - Body
@@ -83,6 +88,7 @@ struct ChallengerFormView: View {
                 )
                 .equatable()
                 .contentShape(Rectangle()) // 터치 영역 확장
+                .deleteDisabled(nonDeletableMemberIds.contains(participant.memberId))
                 .onTapGesture {
                     tap?(participant)
                 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift
@@ -26,6 +26,12 @@ struct SelectedChallengerView: View {
 
     /// 챌린저 검색 화면으로의 네비게이션 활성화 여부
     @State var searchNavi: Bool = false
+
+    /// 현재 사용자의 memberId (삭제 방지용)
+    private var myMemberIdSet: Set<Int> {
+        let id = UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+        return id != 0 ? [id] : []
+    }
     
     // MARK: - Body
     
@@ -65,7 +71,11 @@ struct SelectedChallengerView: View {
             unSelectedContent
         } else {
             // 선택된 인원이 있으면 리스트 폼 표시 (삭제 가능 모드)
-            ChallengerFormView(challenger: $challenger, isDeletAction: true)
+            ChallengerFormView(
+                challenger: $challenger,
+                isDeletAction: true,
+                nonDeletableMemberIds: myMemberIdSet
+            )
         }
     }
     


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 일정 수정 시 생성자가 참여자 목록에서 본인을 제거하여 유령 일정이 되는 문제 방지

Closes #533

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 일정 수정 > 참여자 목록에서 본인 스와이프 삭제 불가 확인 필요 -->

## 🛠️ 작업내용

- `updateSchedule()`에 본인 `memberId` 자동 포함 로직 추가 (`submitSchedule`과 동일한 방어 처리)
- `ChallengerFormView`에 `nonDeletableMemberIds` 파라미터 추가하여 특정 멤버 스와이프 삭제 차단 (`.deleteDisabled`)
- `SelectedChallengerView`에서 현재 로그인한 사용자의 `memberId`를 삭제 불가 목록으로 전달

## 📋 추후 진행 상황

- 일정 상세 API 응답에 참여자 목록이 포함되는지 서버팀과 확인 필요 (수정 화면 진입 시 참여자 0명 표시 이슈)
- 서버 측에서도 생성자가 참여자에서 빠지는 케이스에 대한 방어 로직 필요 여부 논의

## 📌 리뷰 포인트

- `Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift` - `updateSchedule()`에 추가된 본인 memberId 자동 포함 로직
- `Features/Home/Presentation/Views/Registration/Challenger/ChallengerFormView.swift` - `nonDeletableMemberIds` 파라미터 및 `.deleteDisabled` 적용
- `Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift` - `myMemberIdSet` 계산 프로퍼티 및 전달

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)