### PR TITLE
🐛 [Fix] 커리큘럼 API 수정, 진행률 게이지 보정, 일정 수정 참여자 자동 채우기

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/CurriculumProgressDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/CurriculumProgressDTO.swift
@@ -86,7 +86,9 @@ extension ChallengerCurriculumProgressDTO {
         let missions = workbooks
             .map { $0.toDomain(platform: part, scheduleByWeek: scheduleByWeek, now: now) }
             .sorted { $0.week < $1.week }
-        let completed = Int(completedCount) ?? missions.filter { $0.status == .pass }.count
+        let serverCompleted = Int(completedCount) ?? 0
+        let localCompleted = missions.filter { $0.status == .pass }.count
+        let completed = max(serverCompleted, localCompleted)
         let total = Int(totalCount) ?? workbooks.count
         let currentTitle = currentCurriculumTitle
 

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
@@ -51,22 +51,7 @@ final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
             throw Self.parseCurriculumProgressError(from: error) ?? error
         }
 
-        let scheduleByWeek: [Int: WorkbookSchedule]
-        do {
-            let curriculumResponse = try await adapter.request(
-                StudyRouter.getCurriculum(part: progressDTO.part)
-            )
-            let curriculumAPIResponse = try decoder.decode(
-                APIResponse<CurriculumDTO>.self,
-                from: curriculumResponse.data
-            )
-            scheduleByWeek = try curriculumAPIResponse.unwrap().scheduleByWeek
-        } catch {
-            // 진행 상황 API만으로도 화면은 구성 가능하도록 보조 API 실패는 폴백 처리
-            scheduleByWeek = [:]
-        }
-
-        return progressDTO.toDomain(scheduleByWeek: scheduleByWeek)
+        return progressDTO.toDomain()
     }
 
     func fetchCurriculumProgress() async throws -> CurriculumProgressModel {

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleDetailDTO.swift
@@ -40,6 +40,8 @@ struct ScheduleDetailDTO: Codable, Sendable, Equatable {
     let dDay: Int
     /// 출석 승인 필요 여부
     let requiresAttendanceApproval: Bool
+    /// 참여자 멤버 ID 목록
+    let participantMemberIds: [Int]
 
     private enum CodingKeys: String, CodingKey {
         case scheduleId
@@ -57,6 +59,7 @@ struct ScheduleDetailDTO: Codable, Sendable, Equatable {
         case status
         case dDay
         case requiresAttendanceApproval
+        case participantMemberIds
     }
 
     init(from decoder: Decoder) throws {
@@ -80,6 +83,7 @@ struct ScheduleDetailDTO: Codable, Sendable, Equatable {
         status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
         dDay = try container.decodeIntFlexibleIfPresent(forKey: .dDay) ?? 0
         requiresAttendanceApproval = try container.decodeBoolFlexibleIfPresent(forKey: .requiresAttendanceApproval) ?? false
+        participantMemberIds = try container.decodeIfPresent([Int].self, forKey: .participantMemberIds) ?? []
     }
 
     func encode(to encoder: Encoder) throws {
@@ -97,6 +101,7 @@ struct ScheduleDetailDTO: Codable, Sendable, Equatable {
         try container.encode(status, forKey: .status)
         try container.encode(dDay, forKey: .dDay)
         try container.encode(requiresAttendanceApproval, forKey: .requiresAttendanceApproval)
+        try container.encode(participantMemberIds, forKey: .participantMemberIds)
     }
 }
 
@@ -121,7 +126,8 @@ extension ScheduleDetailDTO {
             longitude: longitude,
             status: status,
             dDay: dDay,
-            requiresAttendanceApproval: requiresAttendanceApproval
+            requiresAttendanceApproval: requiresAttendanceApproval,
+            participantMemberIds: participantMemberIds
         )
     }
 

--- a/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ScheduleDetailData.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ScheduleDetailData.swift
@@ -26,4 +26,6 @@ struct ScheduleDetailData: Equatable, Identifiable, ScheduleDDayDisplayable {
     /// D-Day 값 (양수: 미래, 음수: 과거)
     let dDay: Int
     let requiresAttendanceApproval: Bool
+    /// 참여자 멤버 ID 목록
+    let participantMemberIds: [Int]
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -20,6 +20,8 @@ class ScheduleRegistrationViewModel {
     private let updateScheduleUseCase: UpdateScheduleUseCaseProtocol
     /// 일정 제목 기반 태그 자동 추천 UseCase
     private let classifyScheduleUseCase: ClassifyScheduleUseCase
+    /// 챌린저 검색 UseCase (수정 모드 참여자 조회용)
+    private let searchChallengersUseCase: SearchChallengersUseCaseProtocol
 
     /// 전역 에러 핸들러 (실패 시 Alert 표시용)
     private let errorHandler: ErrorHandler
@@ -73,6 +75,8 @@ class ScheduleRegistrationViewModel {
     private var initialEditSnapshot: EditFormSnapshot?
     /// 사용자가 태그를 직접 조정했는지 여부
     private var isTagManuallyOverridden: Bool = false
+    /// 수정 모드 프리필 시 서버에서 받은 참여자 멤버 ID 목록
+    private var prefillMemberIds: Set<Int> = []
 
     // MARK: - Init
 
@@ -82,6 +86,7 @@ class ScheduleRegistrationViewModel {
             generateScheduleUseCase: provider.generateScheduleUseCase,
             updateScheduleUseCase: provider.updateScheduleUseCase,
             classifyScheduleUseCase: provider.classifyScheduleUseCase,
+            searchChallengersUseCase: provider.searchChallengersUseCase,
             errorHandler: errorHandler
         )
     }
@@ -90,11 +95,13 @@ class ScheduleRegistrationViewModel {
         generateScheduleUseCase: GenerateScheduleUseCaseProtocol,
         updateScheduleUseCase: UpdateScheduleUseCaseProtocol,
         classifyScheduleUseCase: ClassifyScheduleUseCase,
+        searchChallengersUseCase: SearchChallengersUseCaseProtocol,
         errorHandler: ErrorHandler
     ) {
         self.generateScheduleUseCase = generateScheduleUseCase
         self.updateScheduleUseCase = updateScheduleUseCase
         self.classifyScheduleUseCase = classifyScheduleUseCase
+        self.searchChallengersUseCase = searchChallengersUseCase
         self.errorHandler = errorHandler
     }
 
@@ -119,6 +126,33 @@ class ScheduleRegistrationViewModel {
             .compactMap(Self.mapScheduleTag)
             .filter { !$0.isDeprecated }
         isTagManuallyOverridden = !tag.isEmpty
+        prefillMemberIds = Set(detail.participantMemberIds)
+        initialEditSnapshot = currentEditSnapshot
+    }
+
+    /// 수정 모드에서 서버의 참여자 멤버 ID를 기반으로 챌린저 정보를 조회하여 참여자 목록을 채웁니다.
+    @MainActor
+    func fetchPrefillParticipants() async {
+        guard !prefillMemberIds.isEmpty else { return }
+        var remainingIds = prefillMemberIds
+        var matched: [ChallengerInfo] = []
+        var cursor: Int? = nil
+        var hasNext = true
+
+        while hasNext, !remainingIds.isEmpty {
+            let query = ChallengerSearchRequestDTO(cursor: cursor)
+            guard let (challengers, nextHasNext, nextCursor) = try? await searchChallengersUseCase.execute(query: query) else {
+                break
+            }
+            for challenger in challengers where remainingIds.contains(challenger.memberId) {
+                matched.append(challenger)
+                remainingIds.remove(challenger.memberId)
+            }
+            hasNext = nextHasNext
+            cursor = nextCursor
+        }
+
+        participatn = matched
         initialEditSnapshot = currentEditSnapshot
     }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -78,6 +78,11 @@ struct ScheduleRegistrationView: View {
                     dismiss()
                 }
             }
+            .task {
+                if mode == .edit {
+                    await viewModel.fetchPrefillParticipants()
+                }
+            }
     }
 
     // MARK: - Private Function


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 커리큘럼 API 엔드포인트 불일치 수정, 진행률 게이지 버그 수정, 일정 수정 시 참여자 자동 프리필 기능 추가

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 커리큘럼 진행률 게이지가 정상적으로 반영되는지 확인 필요 -->
<!-- 일정 수정 화면 진입 시 참여자 목록이 자동으로 채워지는지 확인 필요 -->

## 🛠️ 작업내용

### 커리큘럼 API 엔드포인트 수정 (#536)
- `StudyRepository.fetchCurriculumData()`에서 불필요한 `/api/v1/curriculums?part={PART}` 보조 호출 제거
- Android와 동일하게 `/api/v1/curriculums/challengers/me/progress` API만 사용하도록 변경

### 커리큘럼 진행률 게이지 버그 수정
- 서버 `completedCount`가 `"0"`을 반환해도 로컬에서 `BEST`/`PASS` 상태 미션을 감지하여 진행률에 반영
- `max(serverCompleted, localCompleted)`로 보정 로직 적용

### 일정 수정 참여자 자동 채우기
- `ScheduleDetailDTO`/`ScheduleDetailData`에 `participantMemberIds: [Int]` 필드 추가
- `ScheduleRegistrationViewModel`에 `SearchChallengersUseCase` 주입
- `fetchPrefillParticipants()` 메서드 추가: 멤버 ID 기반으로 챌린저 정보를 페이지네이션 조회하여 참여자 목록 프리필
- `ScheduleRegistrationView`에서 edit 모드 진입 시 `.task`로 자동 호출

## 📋 추후 진행 상황

- 운영진 모드 구성원 관리 직책 미표시 이슈 (#535)

## 📌 리뷰 포인트

- `Features/Activity/Data/Repositories/StudyRepository.swift` - `fetchCurriculumData()` 보조 API 호출 제거 확인
- `Features/Activity/Data/DTOs/CurriculumProgressDTO.swift` - `max(serverCompleted, localCompleted)` 진행률 보정 로직
- `Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift` - `fetchPrefillParticipants()` 페이지네이션 기반 멤버 조회 로직
- `Features/Home/Data/DTO/ScheduleDetailDTO.swift` - `participantMemberIds` 디코딩/인코딩 처리

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)