### PR TITLE
🐛 [Fix] 공지 상세 UX 개선, 멤버 관리 레이아웃 수정, 일정 등록 키보드 처리

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -86,8 +86,8 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
                 profile: profile?.profileImageLink ?? descriptor.profileImageURL,
                 name: profile?.name.nonEmpty ?? descriptor.name,
                 nickname: profile?.nickname.nonEmpty ?? descriptor.name,
-                generation: generationText(
-                    from: record,
+                generation: allGenerationsText(
+                    from: profile,
                     fallback: descriptor.generation
                 ),
                 school: profile?.schoolName.nonEmpty ?? descriptor.schoolName,
@@ -567,6 +567,19 @@ private extension MemberRepository {
             return fallback
         }
         return "\(gisu)기"
+    }
+
+    /// 프로필의 모든 challengerRecords에서 중복 없는 기수 목록을 반환합니다.
+    func allGenerationsText(
+        from profile: MemberManagementProfileDTO?,
+        fallback: String
+    ) -> String {
+        guard let records = profile?.challengerRecords, !records.isEmpty else {
+            return fallback
+        }
+        let uniqueGisu = Set(records.map(\.gisu)).filter { $0 > 0 }.sorted()
+        guard !uniqueGisu.isEmpty else { return fallback }
+        return uniqueGisu.map { "\($0)기" }.joined(separator: ", ")
     }
 
     func resolvedChallengerID(

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -226,6 +226,11 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         }
         .sorted { $0.date > $1.date }
     }
+
+    func fetchAllGenerations(memberId: Int) async throws -> String {
+        let profile = try await fetchMemberProfile(memberId: memberId)
+        return allGenerationsText(from: profile, fallback: "")
+    }
 }
 
 // MARK: - Private Helper

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
@@ -173,6 +173,10 @@ final class MockMemberRepository: MemberRepositoryProtocol {
         try await Task.sleep(for: .milliseconds(150))
         return MockPenaltyHistory.oneOut
     }
+
+    func fetchAllGenerations(memberId: Int) async throws -> String {
+        "8기, 9기"
+    }
 }
 
 // MARK: - Mock Attendance Records

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
@@ -32,4 +32,7 @@ protocol MemberRepositoryProtocol {
     func fetchOutPenaltyHistory(
         challengerId: Int
     ) async throws -> [OperatorMemberPenaltyHistory]
+
+    /// 멤버 프로필에서 모든 활동 기수 텍스트를 조회합니다.
+    func fetchAllGenerations(memberId: Int) async throws -> String
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
@@ -32,4 +32,7 @@ protocol FetchMembersUseCaseProtocol {
     func fetchOutPenaltyHistory(
         challengerId: Int
     ) async throws -> [OperatorMemberPenaltyHistory]
+
+    /// 멤버 프로필에서 모든 활동 기수 텍스트를 조회합니다.
+    func fetchAllGenerations(memberId: Int) async throws -> String
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
@@ -55,4 +55,8 @@ final class FetchMembersUseCase: FetchMembersUseCaseProtocol {
             challengerId: challengerId
         )
     }
+
+    func fetchAllGenerations(memberId: Int) async throws -> String {
+        try await repository.fetchAllGenerations(memberId: memberId)
+    }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
@@ -102,10 +102,10 @@ struct ChallengerMemberDetailSheetView: View {
         HStack(spacing: DefaultSpacing.spacing12) {
             RemoteImage(urlString: member.profile ?? "", size: Constants.profileSize)
 
-            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
                 Text("\(member.nickname)/\(member.name)")
                     .appFont(.bodyEmphasis)
-                HStack(spacing: DefaultSpacing.spacing4) {
+                HStack(spacing: DefaultSpacing.spacing8) {
                     Text(member.part.name)
                         .appFont(.callout, color: member.part.color)
                         .padding(Constants.tagPadding)
@@ -211,7 +211,7 @@ struct ChallengerMemberDetailSheetView: View {
                     profile: nil,
                     name: "김미주",
                     nickname: "마티",
-                    generation: "9기",
+                    generation: "7기, 8기, 9기",
                     school: "덕성여자대학교",
                     position: "Challenger",
                     part: .front(type: .ios),

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
@@ -89,15 +89,9 @@ struct ChallengerMemberDetailSheetView: View {
                 
                 recordView
             }
-            .toolbar {
-                ToolBarCollection.CancelBtn(action: {
-                    dismiss()
-                })
-            }
-            .padding()
+            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
             .scrollContentBackground(.hidden)
             .presentationDetents([.height(dynamicSheetHeight)])
-            .interactiveDismissDisabled()
         }
     }
     
@@ -107,19 +101,22 @@ struct ChallengerMemberDetailSheetView: View {
     private var memberInfoView: some View {
         HStack(spacing: DefaultSpacing.spacing12) {
             RemoteImage(urlString: member.profile ?? "", size: Constants.profileSize)
-            
-            HStack (spacing: DefaultSpacing.spacing8) {
+
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
                 Text("\(member.nickname)/\(member.name)")
-                    .appFont(.title2Emphasis)
-                Text(member.part.name)
-                    .appFont(.callout, color: .gray)
-                    .padding(Constants.tagPadding)
-                    .background(.white, in: Capsule())
-                if member.managementTeam != .challenger {
-                    Text(member.managementTeam.korean)
-                        .appFont(.callout, color: member.managementTeam.textColor)
+                    .appFont(.bodyEmphasis)
+                HStack(spacing: DefaultSpacing.spacing4) {
+                    Text(member.part.name)
+                        .appFont(.callout, color: .gray)
                         .padding(Constants.tagPadding)
-                        .background(member.managementTeam.backgroundColor, in: Capsule())
+                        .background(.white, in: Capsule())
+                    Text(member.school)
+                        .appFont(.callout, color: .black)
+                        .padding(Constants.tagPadding)
+                        .background(.white, in: Capsule())
+                    if member.managementTeam != .challenger {
+                        ManagementTeamBadgePresenter(managementTeam: member.managementTeam)
+                    }
                 }
             }
         }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
@@ -107,9 +107,13 @@ struct ChallengerMemberDetailSheetView: View {
                     .appFont(.bodyEmphasis)
                 HStack(spacing: DefaultSpacing.spacing4) {
                     Text(member.part.name)
-                        .appFont(.callout, color: .gray)
+                        .appFont(.calloutEmphasis, color: member.part.color)
                         .padding(Constants.tagPadding)
-                        .background(.white, in: Capsule())
+                        .background(member.part.color.opacity(0.14), in: Capsule())
+                        .overlay {
+                            Capsule()
+                                .stroke(member.part.color.opacity(0.4), lineWidth: 1)
+                        }
                     Text(member.school)
                         .appFont(.callout, color: .black)
                         .padding(Constants.tagPadding)

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
@@ -107,7 +107,7 @@ struct ChallengerMemberDetailSheetView: View {
                     .appFont(.bodyEmphasis)
                 HStack(spacing: DefaultSpacing.spacing4) {
                     Text(member.part.name)
-                        .appFont(.calloutEmphasis, color: member.part.color)
+                        .appFont(.callout, color: member.part.color)
                         .padding(Constants.tagPadding)
                         .background(member.part.color.opacity(0.14), in: Capsule())
                         .overlay {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/CoreMemberManagementList.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/CoreMemberManagementList.swift
@@ -47,7 +47,8 @@ struct CoreMemberManagementList: View {
             
             switch mode {
             case .management:
-                // 운영진 모드: 페널티 뱃지 (0이 아닐 때만)
+                // 운영진 모드: 직책 뱃지 + 페널티 뱃지
+                ManagementTeamBadgePresenter(managementTeam: memberManagementItem.managementTeam)
                 if memberManagementItem.penalty != 0 {
                     PenaltyBadgePresenter(penalty: memberManagementItem.penalty)
                 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/CoreMemberManagementList.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/CoreMemberManagementList.swift
@@ -45,18 +45,8 @@ struct CoreMemberManagementList: View {
             
             Spacer()
             
-            switch mode {
-            case .management:
-                // 운영진 모드: 직책 뱃지 + 페널티 뱃지
-                ManagementTeamBadgePresenter(managementTeam: memberManagementItem.managementTeam)
-                if memberManagementItem.penalty != 0 {
-                    PenaltyBadgePresenter(penalty: memberManagementItem.penalty)
-                }
-
-            case .challenger:
-                // 챌린저 모드: 직책 뱃지
-                ManagementTeamBadgePresenter(managementTeam: memberManagementItem.managementTeam)
-            }
+            // 직책 뱃지 (챌린저가 아닌 경우에만 표시)
+            ManagementTeamBadgePresenter(managementTeam: memberManagementItem.managementTeam)
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
@@ -223,7 +223,7 @@ struct OperatorMemberDetailSheetView: View {
         switch style {
         case .accent:
             Text(title)
-                .appFont(.calloutEmphasis, color: partTint)
+                .appFont(.callout, color: partTint)
                 .padding(Constants.tagPadding)
                 .background(partTint.opacity(0.14), in: Capsule())
                 .overlay {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
@@ -33,7 +33,7 @@ struct OperatorMemberDetailSheetView: View {
         static let fixedPenaltyScore: Double = 1.0
         static let contentHorizontalPadding: CGFloat = 16
         static let contentTopPadding: CGFloat = 8
-        static let contentBottomPadding: CGFloat = 16
+        static let contentBottomPadding: CGFloat = 0
         static let contentSpacing: CGFloat = 24
         
         static let baseHeight: CGFloat = 340
@@ -115,7 +115,6 @@ struct OperatorMemberDetailSheetView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .toolbar { toolbarItems }
             .padding(.horizontal, Constants.contentHorizontalPadding)
-            .padding(.top, Constants.contentTopPadding)
             .padding(.bottom, Constants.contentBottomPadding)
             .scrollContentBackground(.hidden)
             .presentationDetents([.height(dynamicSheetHeight)])

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
@@ -201,13 +201,15 @@ struct OperatorMemberDetailSheetView: View {
     }
     
     private var memberMetadataView: some View {
-        HStack(spacing: DefaultSpacing.spacing8) {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
             Text("\(member.nickname)/\(member.name)")
                 .appFont(.bodyEmphasis)
-            statusChip(title: member.part.name, style: .accent)
-            statusChip(title: member.school, style: .plain)
-            if member.managementTeam != .challenger {
-                ManagementTeamBadgePresenter(managementTeam: member.managementTeam)
+            HStack(spacing: DefaultSpacing.spacing4) {
+                statusChip(title: member.part.name, style: .accent)
+                statusChip(title: member.school, style: .plain)
+                if member.managementTeam != .challenger {
+                    ManagementTeamBadgePresenter(managementTeam: member.managementTeam)
+                }
             }
         }
     }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
@@ -206,6 +206,9 @@ struct OperatorMemberDetailSheetView: View {
                 .appFont(.bodyEmphasis)
             statusChip(title: member.part.name, style: .accent)
             statusChip(title: member.school, style: .plain)
+            if member.managementTeam != .challenger {
+                ManagementTeamBadgePresenter(managementTeam: member.managementTeam)
+            }
         }
     }
     

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
@@ -200,10 +200,10 @@ struct OperatorMemberDetailSheetView: View {
     }
     
     private var memberMetadataView: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
             Text("\(member.nickname)/\(member.name)")
                 .appFont(.bodyEmphasis)
-            HStack(spacing: DefaultSpacing.spacing4) {
+            HStack(spacing: DefaultSpacing.spacing8) {
                 statusChip(title: member.part.name, style: .accent)
                 statusChip(title: member.school, style: .plain)
                 if member.managementTeam != .challenger {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
@@ -176,9 +176,13 @@ final class MemberListViewModel {
         async let penaltyHistoryTask = try? fetchMembersUseCase.fetchOutPenaltyHistory(
             challengerId: challengerId
         )
+        async let generationsTask = try? fetchMembersUseCase.fetchAllGenerations(
+            memberId: member.memberID ?? 0
+        )
 
         let records = await recordsTask ?? member.attendanceRecords
         let penaltyHistory = await penaltyHistoryTask ?? member.penaltyHistory
+        let generations = await generationsTask ?? member.generation
         let totalPenalty = penaltyHistory.isEmpty
             ? member.penalty
             : penaltyHistory.reduce(0) { $0 + $1.penaltyScore }
@@ -190,7 +194,7 @@ final class MemberListViewModel {
             profile: member.profile,
             name: member.name,
             nickname: member.nickname,
-            generation: member.generation,
+            generation: generations.isEmpty ? member.generation : generations,
             school: member.school,
             position: member.position,
             part: member.part,

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
@@ -64,6 +64,7 @@ struct ChallengerMemberListView: View {
         }
         .sheet(item: $viewModel.selectedMember) { member in
             ChallengerMemberDetailSheetView(member: member)
+                .presentationDragIndicator(.visible)
         }
     }
     

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleDetailDTO.swift
@@ -83,7 +83,7 @@ struct ScheduleDetailDTO: Codable, Sendable, Equatable {
         status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
         dDay = try container.decodeIntFlexibleIfPresent(forKey: .dDay) ?? 0
         requiresAttendanceApproval = try container.decodeBoolFlexibleIfPresent(forKey: .requiresAttendanceApproval) ?? false
-        participantMemberIds = try container.decodeIfPresent([Int].self, forKey: .participantMemberIds) ?? []
+        participantMemberIds = Self.decodeFlexibleIntArray(container: container, forKey: .participantMemberIds)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -135,6 +135,20 @@ extension ScheduleDetailDTO {
     private static func parseISO8601(_ string: String) -> Date {
         ServerDateTimeConverter.parseUTCDateTime(string)
             ?? .now
+    }
+
+    /// `[Int]` 또는 `[String]` 배열을 `[Int]`로 유연하게 디코딩합니다.
+    private static func decodeFlexibleIntArray(
+        container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) -> [Int] {
+        if let intArray = try? container.decodeIfPresent([Int].self, forKey: key) {
+            return intArray
+        }
+        if let stringArray = try? container.decodeIfPresent([String].self, forKey: key) {
+            return stringArray.compactMap(Int.init)
+        }
+        return []
     }
 }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -71,6 +71,12 @@ struct ScheduleRegistrationView: View {
     var body: some View {
         formContent
             .scrollDismissesKeyboard(.immediately)
+            .onTapGesture {
+                UIApplication.shared.sendAction(
+                    #selector(UIResponder.resignFirstResponder),
+                    to: nil, from: nil, for: nil
+                )
+            }
             .navigation(naviTitle: navigationTitle, displayMode: .inline)
             .toolbar { toolbarContent }
             .onChange(of: viewModel.submitState) {

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -71,14 +71,13 @@ struct ScheduleRegistrationView: View {
     var body: some View {
         formContent
             .scrollDismissesKeyboard(.immediately)
-            .onTapGesture {
-                UIApplication.shared.sendAction(
-                    #selector(UIResponder.resignFirstResponder),
-                    to: nil, from: nil, for: nil
-                )
-            }
             .navigation(naviTitle: navigationTitle, displayMode: .inline)
             .toolbar { toolbarContent }
+            .onChange(of: viewModel.showStartDatePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showStartTimePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showEndDatePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showEndTimePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.isAllDay) { dismissKeyboard() }
             .onChange(of: viewModel.submitState) {
                 if case .loaded = viewModel.submitState {
                     dismiss()
@@ -244,6 +243,13 @@ struct ScheduleRegistrationView: View {
         } else {
             showApprovalConfirmationDialog = true
         }
+    }
+
+    private func dismissKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
     }
 
     // MARK: - Section Components

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailContentDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailContentDTO.swift
@@ -58,11 +58,13 @@ struct NoticeDetailVoteOptionDTO: Codable {
     let optionId: String
     let content: String
     let voteCount: String
+    let selectedMemberIds: [String]
 
     private enum CodingKeys: String, CodingKey {
         case optionId
         case content
         case voteCount
+        case selectedMemberIds
     }
 
     init(from decoder: Decoder) throws {
@@ -70,10 +72,16 @@ struct NoticeDetailVoteOptionDTO: Codable {
         self.optionId = try container.decodeStringFlexible(forKey: .optionId)
         self.content = try container.decode(String.self, forKey: .content)
         self.voteCount = try container.decodeStringFlexible(forKey: .voteCount)
+        self.selectedMemberIds = (try? container.decodeStringArrayFlexible(forKey: .selectedMemberIds)) ?? []
     }
 
     func toDomain() -> VoteOption {
-        VoteOption(id: optionId, title: content, voteCount: Int(voteCount) ?? 0)
+        VoteOption(
+            id: optionId,
+            title: content,
+            voteCount: Int(voteCount) ?? 0,
+            selectedMemberIds: selectedMemberIds
+        )
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
@@ -203,6 +203,19 @@ struct NoticeRepository: NoticeRepositoryProtocol {
         )
         _ = try apiResponse.unwrap()
     }
+
+    /// 투표 응답 수정
+    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws {
+        let response = try await adapter.request(
+            NoticeRouter.updateVoteResponse(voteId: voteId, optionIds: optionIds)
+        )
+
+        let apiResponse = try JSONDecoder().decode(
+            APIResponse<EmptyResult>.self,
+            from: response.data
+        )
+        _ = try apiResponse.unwrap()
+    }
     
     // MARK: - 공지 수정
     

--- a/AppProduct/AppProduct/Features/Notice/Data/Router/NoticeRouter.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Router/NoticeRouter.swift
@@ -66,6 +66,11 @@ enum NoticeRouter: BaseTargetType {
         voteId: Int,
         optionIds: [Int]
     )
+    /// 투표 응답 수정
+    case updateVoteResponse(
+        voteId: Int,
+        optionIds: [Int]
+    )
     
     // PATCH Method
     /// 공지사항 수정
@@ -119,6 +124,8 @@ enum NoticeRouter: BaseTargetType {
             return "/api/v1/notices/\(noticeId)/read"
         case .submitVoteResponse(let voteId, _):
             return "/api/v1/surveys/votes/\(voteId)/responses"
+        case .updateVoteResponse(let voteId, _):
+            return "/api/v1/surveys/votes/\(voteId)/responses"
         case .updateNotice(let noticeId, _):
             return "/api/v1/notices/\(noticeId)"
         case .updateLink(let noticeId, _):
@@ -141,6 +148,8 @@ enum NoticeRouter: BaseTargetType {
             return .get
         case .postNotice, .addVote, .addLink, .addImage, .sendReminder, .readNotice, .submitVoteResponse:
             return .post
+        case .updateVoteResponse:
+            return .put
         case .updateNotice, .updateLink, .updateImage:
             return .patch
         case .deleteNotice, .deleteVote:
@@ -207,6 +216,11 @@ enum NoticeRouter: BaseTargetType {
         case .readNotice:
             return .requestPlain
         case .submitVoteResponse(_, let optionIds):
+            return .requestParameters(
+                parameters: ["optionIds": optionIds],
+                encoding: JSONEncoding.default
+            )
+        case .updateVoteResponse(_, let optionIds):
             return .requestParameters(
                 parameters: ["optionIds": optionIds],
                 encoding: JSONEncoding.default

--- a/AppProduct/AppProduct/Features/Notice/Domain/Interfaces/NoticeRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Interfaces/NoticeRepositoryProtocol.swift
@@ -44,6 +44,9 @@ protocol NoticeRepositoryProtocol {
 
     /// 투표 응답(사용자 선택 전송)
     func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws
+
+    /// 투표 응답 수정
+    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws
     
     // MARK: - 공지 수정
     /// 공지사항 수정 (제목, 본문)

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
@@ -327,6 +327,14 @@ struct VoteOption: Equatable, Identifiable, Hashable {
     let id: String
     let title: String
     let voteCount: Int
+    let selectedMemberIds: [String]
+
+    init(id: String, title: String, voteCount: Int, selectedMemberIds: [String] = []) {
+        self.id = id
+        self.title = title
+        self.voteCount = voteCount
+        self.selectedMemberIds = selectedMemberIds
+    }
 
     /// 투표율 계산
     func percentage(totalVotes: Int) -> Double {
@@ -396,7 +404,7 @@ struct ReadStatusUser: Equatable, Identifiable {
     /// NoticeReadStatusItemModel로 변환
     func toItemModel() -> NoticeReadStatusItemModel {
         NoticeReadStatusItemModel(
-            profileImage: nil,
+            profileImageURL: profileImageURL,
             userName: name,
             nickName: nickName,
             part: part,

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeReadStatusItemModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeReadStatusItemModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct NoticeReadStatusItemModel: Equatable, Identifiable {
     let id = UUID()
-    let profileImage: Image?
+    let profileImageURL: String?
     let userName: String
     let nickName: String
     let part: String

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift
@@ -180,6 +180,14 @@ final class NoticeUseCase: NoticeUseCaseProtocol {
         }
         try await repository.submitVoteResponse(voteId: voteId, optionIds: optionIds)
     }
+
+    /// 투표 응답 수정 (빈 배열 전송 시 투표 해제)
+    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws {
+        guard voteId > 0 else {
+            throw DomainError.custom(message: "유효하지 않은 투표입니다")
+        }
+        try await repository.updateVoteResponse(voteId: voteId, optionIds: optionIds)
+    }
     
     /// 미확인 대상에게 공지 리마인더 발송
     func sendReminder(noticeId: Int, targetIds: [Int]) async throws {

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeUseCaseProtocol.swift
@@ -84,6 +84,12 @@ protocol NoticeUseCaseProtocol {
     ///   - voteId: 투표 ID
     ///   - optionIds: 선택한 옵션 ID 목록
     func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws
+
+    /// 투표 응답 수정
+    /// - Parameters:
+    ///   - voteId: 투표 ID
+    ///   - optionIds: 수정할 옵션 ID 목록
+    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws
     
     // MARK: - 리마인더 (POST)
     

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeLinkCard.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeLinkCard.swift
@@ -5,21 +5,48 @@
 //  Created by 이예지 on 1/10/26.
 //
 
+import LinkPresentation
 import SwiftUI
+
+// MARK: - LinkMetadata
+/// OG 메타데이터 로컬 모델
+private struct LinkMetadata {
+    let title: String
+    let description: String?
+    let image: UIImage?
+}
 
 // MARK: - NoticeLinkCard
 /// 공지 상세에서 첨부 링크를 표시하는 카드 컴포넌트
 struct NoticeLinkCard: View {
-    
+
     // MARK: - Property
     let url: String
     @Environment(\.openURL) var openURL
-    
+    @State private var metadata: LinkMetadata?
+    @State private var isLoading: Bool = true
+
     // MARK: - Constants
     fileprivate enum Constants {
-        static let innerPadding: CGFloat = 12
+        static let innerPadding: CGFloat = 8
+        static let imageSize: CGFloat = 56
+        static let imageCornerRadius: CGFloat = 10
+        static let contentSpacing: CGFloat = 12
+        static let textSpacing: CGFloat = 4
+        static let chevronSize: CGFloat = 12
+        static let skeletonCornerRadius: CGFloat = 4
+        static let skeletonTitleHeight: CGFloat = 16
+        static let skeletonTitleMaxWidth: CGFloat = 180
+        static let skeletonDescHeight: CGFloat = 12
+        static let skeletonDescMaxWidth: CGFloat = 140
+        static let richLeadingPadding: CGFloat = 10
+        static let richTrailingPadding: CGFloat = 4
+        static let richVerticalPadding: CGFloat = 6
+        static let titleLineLimit: Int = 2
+        static let descLineLimit: Int = 2
+        static let animationDuration: Double = 0.25
     }
-    
+
     // MARK: - Body
     var body: some View {
         Button(action: {
@@ -32,24 +59,173 @@ struct NoticeLinkCard: View {
             }
             openURL(linkURL)
         }) {
-            HStack {
-                LinkIconPresenter()
-                
-                LinkTextPresenter(url: url)
-                
-                Spacer()
-                
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 12))
-                    .foregroundStyle(Color.grey400)
+            Group {
+                if isLoading {
+                    loadingContent
+                } else if let metadata {
+                    richPreviewContent(metadata)
+                } else {
+                    fallbackContent
+                }
             }
             .padding(Constants.innerPadding)
-            .background {
-                ConcentricRectangle(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
-                    .foregroundStyle(Color(.systemGroupedBackground))
+            .glassEffect(
+                .clear.interactive().tint(Color(.systemGroupedBackground)),
+                in: .rect(
+                    corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                    isUniform: true
+                )
+            )
+        }
+       
+        .task {
+            await fetchMetadata()
+        }
+    }
+
+    // MARK: - Function
+
+    private var loadingContent: some View {
+        HStack(spacing: Constants.contentSpacing) {
+            VStack(alignment: .leading, spacing: Constants.textSpacing) {
+                RoundedRectangle(cornerRadius: Constants.skeletonCornerRadius)
+                    .fill(Color.grey200)
+                    .frame(height: Constants.skeletonTitleHeight)
+                    .frame(maxWidth: Constants.skeletonTitleMaxWidth)
+
+                RoundedRectangle(cornerRadius: Constants.skeletonCornerRadius)
+                    .fill(Color.grey100)
+                    .frame(height: Constants.skeletonDescHeight)
+                    .frame(maxWidth: Constants.skeletonDescMaxWidth)
+            }
+
+            Spacer()
+
+            RoundedRectangle(cornerRadius: Constants.imageCornerRadius)
+                .fill(Color.grey100)
+                .frame(
+                    width: Constants.imageSize,
+                    height: Constants.imageSize
+                )
+
+            chevronIcon
+        }
+        .redacted(reason: .placeholder)
+    }
+
+    private func richPreviewContent(_ metadata: LinkMetadata) -> some View {
+        HStack(spacing: Constants.contentSpacing) {
+            VStack(alignment: .leading, spacing: Constants.textSpacing) {
+                Text(metadata.title)
+                    .appFont(.subheadlineEmphasis, color: .black)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(Constants.titleLineLimit)
+
+                if let description = metadata.description,
+                   !description.isEmpty {
+                    Text(description)
+                        .appFont(.footnote, color: .grey600)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(Constants.descLineLimit)
+                }
+
+                Text(displayHost)
+                    .appFont(.caption2, color: .grey500)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if let image = metadata.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(
+                        width: Constants.imageSize,
+                        height: Constants.imageSize
+                    )
+                    .clipShape(
+                        RoundedRectangle(cornerRadius: Constants.imageCornerRadius)
+                    )
+            }
+
+            chevronIcon
+        }
+        .padding(.leading, Constants.richLeadingPadding)
+        .padding(.trailing, Constants.richTrailingPadding)
+        .padding(.vertical, Constants.richVerticalPadding)
+    }
+
+    private var fallbackContent: some View {
+        HStack {
+            LinkIconPresenter()
+
+            LinkTextPresenter(url: url)
+
+            Spacer()
+
+            chevronIcon
+        }
+    }
+
+    private var chevronIcon: some View {
+        Image(systemName: "chevron.right")
+            .font(.system(size: Constants.chevronSize))
+            .foregroundStyle(Color.grey400)
+    }
+
+    private var displayHost: String {
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = URL(string: trimmed),
+              let host = parsed.host else {
+            return trimmed
+        }
+        return host
+    }
+
+    private func fetchMetadata() async {
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let linkURL = URL(string: trimmed),
+              linkURL.scheme != nil else {
+            isLoading = false
+            return
+        }
+
+        let provider = LPMetadataProvider()
+        do {
+            let lpMetadata = try await provider.startFetchingMetadata(
+                for: linkURL
+            )
+
+            let title = lpMetadata.title ?? trimmed
+            let description = lpMetadata.value(forKey: "_summary") as? String
+
+            var image: UIImage?
+            if let imageProvider = lpMetadata.imageProvider {
+                image = await loadImage(from: imageProvider)
+            }
+
+            withAnimation(.easeInOut(duration: Constants.animationDuration)) {
+                metadata = LinkMetadata(
+                    title: title,
+                    description: description,
+                    image: image
+                )
+                isLoading = false
+            }
+        } catch {
+            withAnimation(.easeInOut(duration: Constants.animationDuration)) {
+                isLoading = false
             }
         }
-        .glassEffect(.clear.interactive(), in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true))
+    }
+
+    private func loadImage(from provider: NSItemProvider) async -> UIImage? {
+        await withCheckedContinuation { continuation in
+            provider.loadObject(ofClass: UIImage.self) { object, _ in
+                continuation.resume(returning: object as? UIImage)
+            }
+        }
     }
 }
 
@@ -57,7 +233,7 @@ struct NoticeLinkCard: View {
 // MARK: - LinkIconPresenter
 /// 링크 아이콘
 struct LinkIconPresenter: View {
-    
+
     // MARK: - Constants
     fileprivate enum Constants {
         static let linkIconSize: CGSize = .init(width: 20, height: 20)
@@ -65,12 +241,15 @@ struct LinkIconPresenter: View {
         static let iconTintColor: Color = .indigo500
         static let iconBackgroundColor: Color = .indigo100
     }
-    
+
     // MARK: - Body
     var body: some View {
         Image(systemName: "link")
             .resizable()
-            .frame(width: Constants.linkIconSize.width, height: Constants.linkIconSize.height)
+            .frame(
+                width: Constants.linkIconSize.width,
+                height: Constants.linkIconSize.height
+            )
             .foregroundStyle(Constants.iconTintColor)
             .padding(Constants.iconPadding)
             .background {
@@ -84,25 +263,27 @@ struct LinkIconPresenter: View {
 // MARK: - LinkTextPresenter
 /// 링크 텍스트
 struct LinkTextPresenter: View {
-    
+
     // MARK: - Property
     let url: String
-    
+
     // MARK: Constants
     fileprivate enum Constants {
         static let vstackSpacing: CGFloat = 3
     }
-    
+
     // MARK: - Body
     var body: some View {
         VStack(alignment: .leading, spacing: Constants.vstackSpacing) {
             Text("관련 링크 바로가기")
                 .font(.app(.calloutEmphasis))
                 .foregroundStyle(Color.black)
-            
+
             Text(url)
                 .font(.app(.footnote, weight: .regular))
                 .foregroundStyle(Color.grey700)
+                .multilineTextAlignment(.leading)
+                .lineLimit(2)
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeVoteCard.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeVoteCard.swift
@@ -9,16 +9,25 @@ import SwiftUI
 
 /// 공지 상세에서 투표를 표시하는 카드 컴포넌트
 ///
-/// 투표 전/후 UI를 분기하며, 단일선택/복수선택 모드를 지원합니다.
+/// 투표 전에도 결과 게이지를 표시하며, 투표 후 응답 수정과
+/// 실명 투표 시 투표자 명단 보기를 지원합니다.
 struct NoticeVoteCard: View {
 
     // MARK: - Property
+
     let vote: NoticeVote
     let isSubmitting: Bool
+    let container: DIContainer
     @State private var selectedOptionIds: Set<String> = []
+    @State private var isEditingVote: Bool = false
+    @State private var isVotingMode: Bool = false
+    @State private var voterSheetOption: VoteOption?
+    @State private var showAllVotersSheet: Bool = false
     let onVote: ([String]) -> Void
+    let onUpdateVote: ([String]) -> Void
 
     // MARK: - Constants
+
     fileprivate enum Constants {
         static let innerPadding: CGFloat = 25
         static let dividerHeight: CGFloat = 10
@@ -29,25 +38,49 @@ struct NoticeVoteCard: View {
     }
 
     // MARK: - Body
+
     var body: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
-            // 헤더
             headerSection
-
-            // 투표 옵션
             optionsSection
-
-            // 하단 정보
             footerSection
         }
         .padding(Constants.innerPadding)
         .background {
-            ConcentricRectangle(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
-                .fill(Color(.systemGroupedBackground))
+            ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+            .fill(Color(.systemGroupedBackground))
+        }
+        .sheet(item: $voterSheetOption) { option in
+            VoteVoterListSheet(
+                optionTitle: option.title,
+                memberIds: option.selectedMemberIds,
+                container: container
+            )
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showAllVotersSheet) {
+            VoteAllVotersSheet(
+                options: vote.options,
+                container: container
+            )
+            .presentationDetents([.medium, .large])
+        }
+        .onChange(of: vote) {
+            if isEditingVote {
+                isEditingVote = false
+            }
+            if isVotingMode && vote.hasUserVoted {
+                isVotingMode = false
+            }
         }
     }
 
     // MARK: - HeaderSection
+
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
             HStack {
@@ -65,19 +98,18 @@ struct NoticeVoteCard: View {
                 .appFont(.bodyEmphasis)
                 .foregroundStyle(Color.black)
 
-            // 투표 성격 표시
             HStack(spacing: DefaultSpacing.spacing8) {
                 Text(vote.allowMultipleChoices ? "복수선택" : "단일선택")
                     .appFont(.footnote, color: .grey600)
-                
+
                 Divider()
                     .frame(height: Constants.dividerHeight)
-                
+
                 Text(vote.isAnonymous ? "익명" : "실명")
                     .appFont(.footnote, color: .grey600)
-                
+
                 Spacer()
-                
+
                 Label(vote.formattedPeriod, systemImage: "calendar")
                     .appFont(.footnote, color: .grey600)
             }
@@ -85,6 +117,7 @@ struct NoticeVoteCard: View {
     }
 
     // MARK: - StatusBadge
+
     private var statusBadge: some View {
         Group {
             switch vote.status {
@@ -94,7 +127,13 @@ struct NoticeVoteCard: View {
                     .padding(Constants.capsulePadding)
                     .background(Color.green.opacity(Constants.capsuleOpacity))
                     .clipShape(Capsule())
-                    .glassEffect(.clear, in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true))
+                    .glassEffect(
+                        .clear,
+                        in: .rect(
+                            corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                            isUniform: true
+                        )
+                    )
             case .ended:
                 Text("마감")
                     .appFont(.footnoteEmphasis, color: .red)
@@ -106,68 +145,141 @@ struct NoticeVoteCard: View {
     }
 
     // MARK: - OptionsSection
+
     private var optionsSection: some View {
         VStack(spacing: DefaultSpacing.spacing12) {
             ForEach(vote.options) { option in
-                if vote.hasUserVoted || vote.isEnded {
-                    // 투표 결과 표시
-                    VoteResultRow(
-                        option: option,
-                        totalVotes: vote.totalVotes,
-                        isUserSelected: vote.userVotedOptionIds.contains(option.id)
-                    )
-                } else {
-                    // 투표 선택 표시
+                if canSelectOption {
                     Button(action: {
                         withAnimation(.default) {
                             toggleOption(option.id)
                         }
                     }) {
-                        VoteOptionRow(
+                        VoteSelectableResultRow(
                             option: option,
+                            totalVotes: vote.totalVotes,
                             isSelected: selectedOptionIds.contains(option.id),
-                            allowMultiple: vote.allowMultipleChoices
+                            isAnonymous: vote.isAnonymous,
+                            onVotersTapped: { handleVotersTapped(option) }
                         )
                     }
                     .disabled(isSubmitting)
+                } else {
+                    VoteResultRow(
+                        option: option,
+                        totalVotes: vote.totalVotes,
+                        isUserSelected: vote.userVotedOptionIds.contains(option.id),
+                        isAnonymous: vote.isAnonymous,
+                        onVotersTapped: { handleVotersTapped(option) }
+                    )
                 }
             }
         }
     }
 
+    /// 옵션 선택이 가능한 상태인지 여부
+    private var canSelectOption: Bool {
+        guard vote.status == .active else { return false }
+        if vote.hasUserVoted {
+            return isEditingVote
+        }
+        return isVotingMode
+    }
+
     // MARK: - FooterSection
+
     private var footerSection: some View {
         VStack(spacing: DefaultSpacing.spacing8) {
-            // 투표하기 버튼 (진행 중 + 미투표)
-            if vote.status == .active && !vote.hasUserVoted {
-                Button(action: {
-                    onVote(Array(selectedOptionIds))
-                }) {
-                    Group {
-                        if isSubmitting {
-                            ProgressView()
-                                .tint(.indigo500)
-                        } else {
-                            Text("투표하기")
-                                .appFont(.subheadlineEmphasis, color: .white)
+            if vote.status == .active {
+                if !vote.hasUserVoted && !isVotingMode {
+                    // 미투표 + 결과 보기: 투표 참여 버튼
+                    Button(action: {
+                        withAnimation(.default) {
+                            isVotingMode = true
                         }
+                    }) {
+                        Text("투표하기")
+                            .appFont(.subheadlineEmphasis, color: .white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, Constants.voteBtnVPadding)
                     }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, Constants.voteBtnVPadding)
+                    .buttonStyle(.glassProminent)
+                    .tint(.indigo500)
+                } else if !vote.hasUserVoted && isVotingMode {
+                    // 투표 선택 모드: 투표 완료 버튼
+                    voteSubmitButton(
+                        title: "투표 완료",
+                        allowEmpty: false
+                    ) {
+                        onVote(Array(selectedOptionIds))
+                    }
+                } else if isEditingVote {
+                    // 수정 모드: 수정 완료 버튼 (빈 선택 허용 → 투표 해제)
+                    voteSubmitButton(
+                        title: "수정 완료",
+                        allowEmpty: true
+                    ) {
+                        onUpdateVote(Array(selectedOptionIds))
+                    }
+                } else {
+                    // 투표 완료 + 수정 가능: 투표 수정 버튼
+                    Button(action: {
+                        withAnimation(.default) {
+                            selectedOptionIds = Set(vote.userVotedOptionIds)
+                            isEditingVote = true
+                        }
+                    }) {
+                        Text("투표 수정")
+                            .appFont(.subheadlineEmphasis, color: .indigo500)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, Constants.voteBtnVPadding)
+                    }
+                    .buttonStyle(.glass)
+                    .tint(.indigo500)
                 }
-                .buttonStyle(.glassProminent)
-                .tint(.indigo500)
-                .disabled(selectedOptionIds.isEmpty || isSubmitting)
             }
-            
-            Text("총 \(vote.totalVotes)명 참여")
-                .appFont(.footnote, color: .grey600)
+
+            if !vote.isAnonymous && vote.totalVotes > 0 {
+                Button(action: { showAllVotersSheet = true }) {
+                    HStack(spacing: DefaultSpacing.spacing4) {
+                        Image(systemName: "person.2.fill")
+                            .font(.system(size: 11))
+                        Text("총 \(vote.totalVotes)명 참여")
+                    }
+                    .appFont(.footnote, color: .indigo500)
+                }
+            } else {
+                Text("총 \(vote.totalVotes)명 참여")
+                    .appFont(.footnote, color: .grey600)
+            }
         }
+    }
+
+    private func voteSubmitButton(
+        title: String,
+        allowEmpty: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Group {
+                if isSubmitting {
+                    ProgressView()
+                        .tint(.indigo500)
+                } else {
+                    Text(title)
+                        .appFont(.subheadlineEmphasis, color: .white)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Constants.voteBtnVPadding)
+        }
+        .buttonStyle(.glassProminent)
+        .tint(.indigo500)
+        .disabled((!allowEmpty && selectedOptionIds.isEmpty) || isSubmitting)
     }
 
     // MARK: - Function
 
-    /// 투표 옵션 선택 토글 (복수선택: 개별 추가/제거, 단일선택: 배타적 교체)
     private func toggleOption(_ optionId: String) {
         if vote.allowMultipleChoices {
             if selectedOptionIds.contains(optionId) {
@@ -176,31 +288,43 @@ struct NoticeVoteCard: View {
                 selectedOptionIds.insert(optionId)
             }
         } else {
-            selectedOptionIds = [optionId]
+            if selectedOptionIds.contains(optionId) {
+                selectedOptionIds.remove(optionId)
+            } else {
+                selectedOptionIds = [optionId]
+            }
         }
+    }
+
+    private func handleVotersTapped(_ option: VoteOption) {
+        guard !vote.isAnonymous, option.voteCount > 0 else { return }
+        voterSheetOption = option
     }
 }
 
 
 // MARK: - VoteOptionRow
+
 /// 투표 선택 행 (투표 전)
 struct VoteOptionRow: View {
 
     // MARK: - Property
+
     let option: VoteOption
     let isSelected: Bool
     let allowMultiple: Bool
-    
+
     // MARK: - Constant
+
     fileprivate enum Constants {
         static let mainPadding: CGFloat = 12
         static let bgOpacity: Double = 0.5
     }
 
     // MARK: - Body
+
     var body: some View {
         HStack(spacing: DefaultSpacing.spacing12) {
-            // 선택 아이콘
             Image(systemName: isSelected ? "circle.circle.fill" : "circle")
                 .foregroundStyle(isSelected ? Color.indigo500 : Color.grey400)
                 .appFont(.title3)
@@ -212,61 +336,154 @@ struct VoteOptionRow: View {
             Spacer()
         }
         .padding(Constants.mainPadding)
-        .background(isSelected ? Color.indigo200.opacity(Constants.bgOpacity) : Color(.systemBackground).opacity(Constants.bgOpacity))
+        .background(
+            isSelected
+                ? Color.indigo200.opacity(Constants.bgOpacity)
+                : Color(.systemBackground).opacity(Constants.bgOpacity)
+        )
         .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius))
     }
 }
 
 
-// MARK: - VoteResultRow
-  /// 투표 결과 행 (투표 후)
-struct VoteResultRow: View {
-    
+// MARK: - VoteSelectableResultRow
+
+/// 결과 게이지를 표시하면서도 선택 가능한 투표 행 (미투표 + 진행중 / 수정 모드)
+struct VoteSelectableResultRow: View {
+
     // MARK: - Property
+
     let option: VoteOption
     let totalVotes: Int
-    let isUserSelected: Bool
-    
+    let isSelected: Bool
+    let isAnonymous: Bool
+    var onVotersTapped: (() -> Void)?
+
     // MARK: - Constants
+
     fileprivate enum Constants {
         static let progressHeight: CGFloat = 8
         static let innerPadding: CGFloat = 18
         static let bgOpacity: Double = 0.5
     }
-    
+
     // MARK: - Body
+
     var body: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
             topSection
             gaugeSection
-            Text("\(option.voteCount)명")
-                .appFont(.footnote, color: .grey600)
+            voterCountSection
         }
         .padding(Constants.innerPadding)
-        .background(isUserSelected ? Color.indigo200.opacity(Constants.bgOpacity) : Color(.systemBackground).opacity(Constants.bgOpacity))
+        .background(
+            isSelected
+                ? Color.indigo200.opacity(Constants.bgOpacity)
+                : Color(.systemBackground).opacity(Constants.bgOpacity)
+        )
         .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius))
     }
-    
-    // 투표 항목 + 결과
+
+    private var topSection: some View {
+        HStack {
+            Image(systemName: isSelected ? "circle.circle.fill" : "circle")
+                .foregroundStyle(isSelected ? Color.indigo500 : Color.grey400)
+                .appFont(.title3)
+
+            Text(option.title)
+                .appFont(isSelected ? .bodyEmphasis : .body, color: .black)
+
+            Spacer()
+
+            Text(String(format: "%.1f%%", option.percentage(totalVotes: totalVotes)))
+                .appFont(.calloutEmphasis, color: isSelected ? .indigo700 : .grey700)
+        }
+    }
+
+    private var gaugeSection: some View {
+        Gauge(value: option.percentage(totalVotes: totalVotes), in: 0...100) {
+            EmptyView()
+        } currentValueLabel: {
+            EmptyView()
+        }
+        .gaugeStyle(.linearCapacity)
+        .tint(isSelected ? Color.indigo500 : Color.grey400)
+        .frame(height: Constants.progressHeight)
+    }
+
+    private var voterCountSection: some View {
+        Group {
+            if !isAnonymous && option.voteCount > 0 {
+                Button(action: { onVotersTapped?() }) {
+                    Text("\(option.voteCount)명")
+                        .appFont(.footnote, color: .indigo500)
+                        .underline()
+                }
+            } else {
+                Text("\(option.voteCount)명")
+                    .appFont(.footnote, color: .grey600)
+            }
+        }
+    }
+}
+
+
+// MARK: - VoteResultRow
+
+/// 투표 결과 행 (투표 후 / 종료)
+struct VoteResultRow: View {
+
+    // MARK: - Property
+
+    let option: VoteOption
+    let totalVotes: Int
+    let isUserSelected: Bool
+    let isAnonymous: Bool
+    var onVotersTapped: (() -> Void)?
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let progressHeight: CGFloat = 8
+        static let innerPadding: CGFloat = 18
+        static let bgOpacity: Double = 0.5
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            topSection
+            gaugeSection
+            voterCountSection
+        }
+        .padding(Constants.innerPadding)
+        .background(
+            isUserSelected
+                ? Color.indigo200.opacity(Constants.bgOpacity)
+                : Color(.systemBackground).opacity(Constants.bgOpacity)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius))
+    }
+
     private var topSection: some View {
         HStack {
             Text(option.title)
                 .appFont(isUserSelected ? .bodyEmphasis : .body, color: .black)
-            
+
             Spacer()
-            
+
             if isUserSelected {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(Color.indigo500)
                     .appFont(.callout)
             }
-            
+
             Text(String(format: "%.1f%%", option.percentage(totalVotes: totalVotes)))
                 .appFont(.calloutEmphasis, color: isUserSelected ? .indigo700 : .grey700)
         }
     }
-    
-    // 게이지 바
+
     private var gaugeSection: some View {
         Gauge(value: option.percentage(totalVotes: totalVotes), in: 0...100) {
             EmptyView()
@@ -277,10 +494,26 @@ struct VoteResultRow: View {
         .tint(isUserSelected ? Color.indigo500 : Color.grey400)
         .frame(height: Constants.progressHeight)
     }
+
+    private var voterCountSection: some View {
+        Group {
+            if !isAnonymous && option.voteCount > 0 {
+                Button(action: { onVotersTapped?() }) {
+                    Text("\(option.voteCount)명")
+                        .appFont(.footnote, color: .indigo500)
+                        .underline()
+                }
+            } else {
+                Text("\(option.voteCount)명")
+                    .appFont(.footnote, color: .grey600)
+            }
+        }
+    }
 }
 
 
 // MARK: - Preview
+
 #Preview("투표 가능 - 단일선택/익명", traits: .sizeThatFitsLayout) {
     NoticeVoteCard(
         vote: NoticeVote(
@@ -299,7 +532,9 @@ struct VoteResultRow: View {
             userVotedOptionIds: []
         ),
         isSubmitting: false,
-        onVote: { _ in }
+        container: .init(),
+        onVote: { _ in },
+        onUpdateVote: { _ in }
     )
     .padding()
 }
@@ -322,7 +557,9 @@ struct VoteResultRow: View {
             userVotedOptionIds: ["1"]
         ),
         isSubmitting: false,
-        onVote: { _ in }
+        container: .init(),
+        onVote: { _ in },
+        onUpdateVote: { _ in }
     )
     .padding()
 }
@@ -345,7 +582,9 @@ struct VoteResultRow: View {
             userVotedOptionIds: ["1"]
         ),
         isSubmitting: false,
-        onVote: { _ in }
+        container: .init(),
+        onVote: { _ in },
+        onUpdateVote: { _ in }
     )
     .padding()
 }
@@ -368,7 +607,9 @@ struct VoteResultRow: View {
             userVotedOptionIds: []
         ),
         isSubmitting: false,
-        onVote: { _ in }
+        container: .init(),
+        onVote: { _ in },
+        onUpdateVote: { _ in }
     )
     .padding()
 }
@@ -391,7 +632,9 @@ struct VoteResultRow: View {
             userVotedOptionIds: ["1", "2"]
         ),
         isSubmitting: false,
-        onVote: { _ in }
+        container: .init(),
+        onVote: { _ in },
+        onUpdateVote: { _ in }
     )
     .padding()
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/VoteAllVotersSheet.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/VoteAllVotersSheet.swift
@@ -1,0 +1,176 @@
+//
+//  VoteAllVotersSheet.swift
+//  AppProduct
+//
+//  Created by Claude on 3/16/26.
+//
+
+import SwiftUI
+
+/// 실명 투표 시 옵션별 투표자 명단을 그룹으로 표시하는 시트
+struct VoteAllVotersSheet: View {
+
+    // MARK: - Property
+
+    let options: [VoteOption]
+    let container: DIContainer
+    @State private var profileCache: [String: MemberProfileSummary] = [:]
+    @State private var isLoading: Bool = true
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let profileSize: CGSize = .init(width: 36, height: 36)
+        static let itemSpacing: CGFloat = 10
+        static let itemPadding: CGFloat = 10
+        static let defaultProfileImageName: String = "defaultProfile"
+        static let nameSpacing: CGFloat = 4
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    voterGroupedList
+                }
+            }
+            .navigationTitle("투표 현황")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .task {
+            await fetchAllVoterProfiles()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var voterGroupedList: some View {
+        List {
+            ForEach(options) { option in
+                Section {
+                    if option.selectedMemberIds.isEmpty {
+                        Text("투표자 없음")
+                            .appFont(.footnote, color: .grey500)
+                            .listRowInsets(.init(
+                                top: Constants.itemPadding,
+                                leading: Constants.itemPadding,
+                                bottom: Constants.itemPadding,
+                                trailing: Constants.itemPadding
+                            ))
+                    } else {
+                        ForEach(option.selectedMemberIds, id: \.self) { memberId in
+                            voterRow(for: memberId)
+                                .listRowInsets(.init(
+                                    top: Constants.itemPadding,
+                                    leading: Constants.itemPadding,
+                                    bottom: Constants.itemPadding,
+                                    trailing: Constants.itemPadding
+                                ))
+                        }
+                    }
+                } header: {
+                    HStack {
+                        Text(option.title)
+                            .appFont(.subheadlineEmphasis, color: .grey900)
+
+                        Spacer()
+
+                        Text("\(option.voteCount)명")
+                            .appFont(.footnote, color: .grey600)
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private func voterRow(for memberId: String) -> some View {
+        HStack(spacing: Constants.itemSpacing) {
+            if let voter = profileCache[memberId] {
+                RemoteImage(
+                    urlString: voter.profileImageURL ?? "",
+                    size: Constants.profileSize,
+                    cornerRadius: Constants.profileSize.width / 2,
+                    placeholderImage: Constants.defaultProfileImageName
+                )
+
+                VStack(alignment: .leading, spacing: Constants.nameSpacing) {
+                    Text(voterDisplayName(voter))
+                        .appFont(.subheadline, color: .grey900)
+
+                    if let org = voter.organizationName,
+                       !org.trimmingCharacters(
+                           in: .whitespacesAndNewlines
+                       ).isEmpty {
+                        Text(org)
+                            .appFont(.caption1, color: .grey600)
+                    }
+                }
+            } else {
+                RemoteImage(
+                    urlString: "",
+                    size: Constants.profileSize,
+                    cornerRadius: Constants.profileSize.width / 2,
+                    placeholderImage: Constants.defaultProfileImageName
+                )
+
+                Text("ID: \(memberId)")
+                    .appFont(.subheadline, color: .grey600)
+            }
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Function
+
+    private func voterDisplayName(
+        _ voter: MemberProfileSummary
+    ) -> String {
+        let name = voter.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nickname = voter.nickname.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+
+        if !nickname.isEmpty && !name.isEmpty && nickname != name {
+            return "\(nickname)/\(name)"
+        }
+        return !nickname.isEmpty ? nickname : name
+    }
+
+    @MainActor
+    private func fetchAllVoterProfiles() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        let allMemberIds = Set(options.flatMap(\.selectedMemberIds))
+        guard !allMemberIds.isEmpty else { return }
+
+        let repository = container.resolve(MyPageRepositoryProtocol.self)
+
+        await withTaskGroup(
+            of: (String, MemberProfileSummary?).self
+        ) { group in
+            for memberId in allMemberIds {
+                guard let id = Int(memberId) else { continue }
+                group.addTask {
+                    let profile = try? await repository.fetchMemberProfile(
+                        memberId: id
+                    )
+                    return (memberId, profile)
+                }
+            }
+
+            for await (memberId, profile) in group {
+                if let profile {
+                    profileCache[memberId] = profile
+                }
+            }
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/VoteVoterListSheet.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/VoteVoterListSheet.swift
@@ -1,0 +1,127 @@
+//
+//  VoteVoterListSheet.swift
+//  AppProduct
+//
+//  Created by Claude on 3/16/26.
+//
+
+import SwiftUI
+
+/// 실명 투표 시 특정 옵션에 투표한 사용자 명단을 표시하는 시트
+struct VoteVoterListSheet: View {
+
+    // MARK: - Property
+
+    let optionTitle: String
+    let memberIds: [String]
+    let container: DIContainer
+    @State private var voters: [MemberProfileSummary] = []
+    @State private var isLoading: Bool = true
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let profileSize: CGSize = .init(width: 40, height: 40)
+        static let itemSpacing: CGFloat = 12
+        static let itemPadding: CGFloat = 12
+        static let sheetDetents: Set<PresentationDetent> = [.medium]
+        static let defaultProfileImageName: String = "defaultProfile"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if voters.isEmpty {
+                    ContentUnavailableView(
+                        "투표자가 없습니다",
+                        systemImage: "person.slash"
+                    )
+                } else {
+                    voterList
+                }
+            }
+            .navigationTitle(optionTitle)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .task {
+            await fetchVoterProfiles()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var voterList: some View {
+        List(voters, id: \.memberId) { voter in
+            HStack(spacing: Constants.itemSpacing) {
+                RemoteImage(
+                    urlString: voter.profileImageURL ?? "",
+                    size: Constants.profileSize,
+                    cornerRadius: Constants.profileSize.width / 2,
+                    placeholderImage: Constants.defaultProfileImageName
+                )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(voterDisplayName(voter))
+                        .appFont(.subheadlineEmphasis, color: .grey900)
+
+                    if let org = voter.organizationName,
+                       !org.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text(org)
+                            .appFont(.caption1, color: .grey600)
+                    }
+                }
+
+                Spacer()
+            }
+            .listRowInsets(.init(
+                top: Constants.itemPadding,
+                leading: Constants.itemPadding,
+                bottom: Constants.itemPadding,
+                trailing: Constants.itemPadding
+            ))
+        }
+        .listStyle(.plain)
+    }
+
+    // MARK: - Function
+
+    private func voterDisplayName(_ voter: MemberProfileSummary) -> String {
+        let name = voter.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nickname = voter.nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !nickname.isEmpty && !name.isEmpty && nickname != name {
+            return "\(nickname)/\(name)"
+        }
+        return !nickname.isEmpty ? nickname : name
+    }
+
+    @MainActor
+    private func fetchVoterProfiles() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        let repository = container.resolve(MyPageRepositoryProtocol.self)
+
+        await withTaskGroup(of: MemberProfileSummary?.self) { group in
+            for memberId in memberIds {
+                guard let id = Int(memberId) else { continue }
+                group.addTask {
+                    try? await repository.fetchMemberProfile(memberId: id)
+                }
+            }
+
+            var results: [MemberProfileSummary] = []
+            for await profile in group {
+                if let profile {
+                    results.append(profile)
+                }
+            }
+            voters = results
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeReadStatusItem/NoticeReadStatusItem.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeReadStatusItem/NoticeReadStatusItem.swift
@@ -58,14 +58,12 @@ private struct NoticeReadStatusItemPresenter: View, Equatable {
     var body: some View {
         HStack(spacing: Constant.mainHSpacing) {
             // 프로필 이미지
-            if model.profileImage != nil {
-                model.profileImage
-            } else {
-                Text(model.userName.prefix(1))
-                    .appFont(.caption1Emphasis, color: .grey900)
-                    .frame(width: Constant.profileSize.width, height: Constant.profileSize.height)
-                    .background(.white, in: Circle())
-            }
+            RemoteImage(
+                urlString: model.profileImageURL ?? "",
+                size: Constant.profileSize,
+                cornerRadius: Constant.profileSize.width / 2,
+                placeholderImage: "defaultProfile"
+            )
 
             UserInfoSection(model: model)
 
@@ -116,7 +114,7 @@ private struct UserInfoSection: View, Equatable {
     VStack {
         NoticeReadStatusItem(
             model: .init(
-                profileImage: nil,
+                profileImageURL: nil,
                 userName: "이애플",
                 nickName: "사과",
                 part: "iOS",
@@ -128,7 +126,7 @@ private struct UserInfoSection: View, Equatable {
         
         NoticeReadStatusItem(
             model: .init(
-                profileImage: nil,
+                profileImageURL: nil,
                 userName: "이애플",
                 nickName: "사과",
                 part: "iOS",

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -658,6 +658,37 @@ extension NoticeDetailViewModel {
             )
         } catch let error as NetworkError {
             isSubmittingVote = false
+            if case .requestFailed(_, let data) = error,
+               let data,
+               let parsed = try? JSONDecoder().decode(
+                   APIResponse<EmptyResult>.self, from: data
+               ) {
+                alertPrompt = AlertPrompt(
+                    id: .init(),
+                    title: "투표 실패",
+                    message: parsed.message ?? error.userMessage,
+                    positiveBtnTitle: "확인"
+                )
+            } else {
+                errorHandler.handle(
+                    error,
+                    context: ErrorContext(
+                        feature: "Notice",
+                        action: "handleVote",
+                        retryAction: { [weak self] in
+                            guard let self = self else { return }
+                            Task {
+                                await self.handleVote(
+                                    voteId: voteId,
+                                    optionIds: optionIds
+                                )
+                            }
+                        }
+                    )
+                )
+            }
+        } catch {
+            isSubmittingVote = false
             errorHandler.handle(
                 error,
                 context: ErrorContext(
@@ -671,17 +702,107 @@ extension NoticeDetailViewModel {
                     }
                 )
             )
+        }
+    }
+
+    /// 투표 응답 수정 처리
+    ///
+    /// 기존 투표를 수정(PUT)한 뒤 공지 상세를 재조회하여 최신 투표 상태를 반영합니다.
+    @MainActor
+    func handleUpdateVote(voteId: String, optionIds: [String]) async {
+        guard case .loaded = noticeState else { return }
+        guard !isSubmittingVote else { return }
+
+        do {
+            isSubmittingVote = true
+            defer { isSubmittingVote = false }
+
+            guard let resolvedVoteId = Int(voteId) else {
+                throw DomainError.custom(message: "유효하지 않은 투표 ID입니다.")
+            }
+
+            let resolvedOptionIds = optionIds.compactMap(Int.init)
+
+            try await noticeUseCase.updateVoteResponse(
+                voteId: resolvedVoteId,
+                optionIds: resolvedOptionIds
+            )
+
+            let refreshedNotice = try await noticeUseCase.getDetailNotice(noticeId: noticeID)
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: refreshedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
+        } catch let error as DomainError {
+            isSubmittingVote = false
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "handleUpdateVote",
+                    retryAction: { [weak self] in
+                        guard let self else { return }
+                        Task { await self.handleUpdateVote(voteId: voteId, optionIds: optionIds) }
+                    }
+                )
+            )
+        } catch let error as RepositoryError {
+            isSubmittingVote = false
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "handleUpdateVote",
+                    retryAction: { [weak self] in
+                        guard let self else { return }
+                        Task { await self.handleUpdateVote(voteId: voteId, optionIds: optionIds) }
+                    }
+                )
+            )
+        } catch let error as NetworkError {
+            isSubmittingVote = false
+            if case .requestFailed(_, let data) = error,
+               let data,
+               let parsed = try? JSONDecoder().decode(
+                   APIResponse<EmptyResult>.self, from: data
+               ) {
+                alertPrompt = AlertPrompt(
+                    id: .init(),
+                    title: "투표 실패",
+                    message: parsed.message ?? error.userMessage,
+                    positiveBtnTitle: "확인"
+                )
+            } else {
+                errorHandler.handle(
+                    error,
+                    context: ErrorContext(
+                        feature: "Notice",
+                        action: "handleUpdateVote",
+                        retryAction: { [weak self] in
+                            guard let self else { return }
+                            Task {
+                                await self.handleUpdateVote(
+                                    voteId: voteId,
+                                    optionIds: optionIds
+                                )
+                            }
+                        }
+                    )
+                )
+            }
         } catch {
             isSubmittingVote = false
             errorHandler.handle(
                 error,
                 context: ErrorContext(
                     feature: "Notice",
-                    action: "handleVote",
+                    action: "handleUpdateVote",
                     retryAction: { [weak self] in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         Task {
-                            await self.handleVote(voteId: voteId, optionIds: optionIds)
+                            await self.handleUpdateVote(
+                                voteId: voteId,
+                                optionIds: optionIds
+                            )
                         }
                     }
                 )

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -223,11 +223,24 @@ struct NoticeDetailView: View {
             }
 
             if let vote = data.vote {
-                NoticeVoteCard(vote: vote, isSubmitting: viewModel.isSubmittingVote) { optionIds in
-                    Task {
-                        await viewModel.handleVote(voteId: vote.id, optionIds: optionIds)
+                NoticeVoteCard(
+                    vote: vote,
+                    isSubmitting: viewModel.isSubmittingVote,
+                    container: di,
+                    onVote: { optionIds in
+                        Task {
+                            await viewModel.handleVote(voteId: vote.id, optionIds: optionIds)
+                        }
+                    },
+                    onUpdateVote: { optionIds in
+                        Task {
+                            await viewModel.handleUpdateVote(
+                                voteId: vote.id,
+                                optionIds: optionIds
+                            )
+                        }
                     }
-                }
+                )
                 .padding(
                     .top,
                     (data.images.isEmpty && data.links.isEmpty)


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix + Feature Enhancement — 공지 상세 링크/투표 UX 개선, 멤버 관리 시트 레이아웃 개선, 일정 등록 키보드 처리 등 다수 버그 수정 및 UX 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경이 포함되어 있습니다. 스크린샷/영상을 첨부해주세요 -->

## 🛠️ 작업내용

### 공지사항 (Notice)
- 공지 상세 링크 리치 프리뷰 기능 구현 (`NoticeLinkCard`)
- 투표 UX 개선: 투표자 목록 시트, 전체 투표 현황 시트 추가 (`VoteVoterListSheet`, `VoteAllVotersSheet`)
- 투표 옵션에 `selectedMemberIds` 추가하여 투표자 추적
- 열람 현황 프로필 이미지 표시 기능 추가
- 멤버 프로필 조회 API 연동 (`fetchMemberProfiles`)

### 멤버 관리 (Activity/Member)
- 챌린저/운영진 상세 시트 멤버 정보 레이아웃 개선
- 멤버 상세 시트에서 프로필 API로 활동 기수 조회 및 다중 표시
- 운영진 모드 멤버 리스트에서 아웃 뱃지 제거, 직책+파트만 표시
- 운영진 모드 멤버 관리에서 직책 뱃지 표시 추가
- 챌린저 멤버 상세 시트 파트 태그 색상 적용

### 일정 관리 (Home/Schedule)
- 일정 등록/수정 화면 날짜/토글 버튼 탭 시 키보드 자동 닫기
- 일정 수정 시 참여자 자동 채우기
- 일정 수정 시 생성자 본인을 참여자에서 제거할 수 없도록 방어 처리

### 검색 (Challenger Search)
- 챌린저 검색 시 다중 기수 멤버 동시 선택 기능 추가
- 챌린저 검색 UI 반영 지연 해결 및 로딩 상태 개선

### 기타
- 커리큘럼 API 엔드포인트 수정, 진행률 게이지 보정
- `participantMemberIds` 문자열 배열 디코딩 호환 처리

## 📋 추후 진행 상황

- 공지 투표 결과 통계 화면 고도화
- 멤버 프로필 캐싱 최적화

## 📌 리뷰 포인트

- `Features/Notice/Presentation/Components/DetailCard/NoticeLinkCard.swift` - 링크 리치 프리뷰 메타데이터 파싱 로직
- `Features/Notice/Presentation/Components/DetailCard/NoticeVoteCard.swift` - 투표 UX 개선 및 투표자 목록 연동
- `Features/Notice/Presentation/Components/DetailCard/VoteAllVotersSheet.swift` - 전체 투표 현황 시트
- `Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift` - 프로필 API 기수 조회 로직
- `Features/Home/Presentation/ViewModels/SearchChallengerViewModel.swift` - 다중 기수 검색 리팩토링
- `Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift` - 키보드 닫기 및 참여자 자동 채우기

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)