### PR TITLE
✨ [Feat] 상벌점 제도 전환, 홈 차트 카드 개선, 지오펜싱 조정 및 인증 UI 개선

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/ChallengerPointCreateRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/ChallengerPointCreateRequestDTO.swift
@@ -12,12 +12,106 @@ import Foundation
 /// `POST /api/v1/challenger/{challengerId}/points`
 struct ChallengerPointCreateRequestDTO: Codable, Sendable {
     let pointType: ChallengerPointType
+    let pointValue: Int
     let description: String
 }
 
 /// 챌린저 포인트 유형
-enum ChallengerPointType: String, Codable, Sendable {
+enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identifiable {
     case bestWorkbook = "BEST_WORKBOOK"
     case warning = "WARNING"
     case out = "OUT"
+    case blogChallenge = "BLOG_CHALLENGE"
+    case umcEventReview = "UMC_EVENT_REVIEW"
+    case peerReviewSubmission = "PEER_REVIEW_SUBMISSION"
+    case noWorkbookMission = "NO_WORKBOOK_MISSION"
+    case studyLate = "STUDY_LATE"
+    case studyAbsent = "STUDY_ABSENT"
+    case eventLate = "EVENT_LATE"
+    case eventEarlyLeave = "EVENT_EARLY_LEAVE"
+    case eventLateCancel = "EVENT_LATE_CANCEL"
+    case eventNoShow = "EVENT_NO_SHOW"
+    case partLeadFeedbackLate = "PART_LEAD_FEEDBACK_LATE"
+    case schoolCoreMeetingAbsent = "SCHOOL_CORE_MEETING_ABSENT"
+    case schoolCoreTaskNotCompleted = "SCHOOL_CORE_TASK_NOT_COMPLETED"
+    case custom = "CUSTOM"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .bestWorkbook: return "우수 워크북"
+        case .warning: return "경고"
+        case .out: return "아웃"
+        case .blogChallenge: return "블로그 챌린지"
+        case .umcEventReview: return "UMC 행사 후기"
+        case .peerReviewSubmission: return "동료 평가 제출"
+        case .noWorkbookMission: return "워크북 미제출"
+        case .studyLate: return "스터디 지각"
+        case .studyAbsent: return "스터디 결석"
+        case .eventLate: return "행사 지각"
+        case .eventEarlyLeave: return "행사 조퇴"
+        case .eventLateCancel: return "행사 당일 취소"
+        case .eventNoShow: return "행사 노쇼"
+        case .partLeadFeedbackLate: return "파트장 피드백 지연"
+        case .schoolCoreMeetingAbsent: return "회장단 회의 결석"
+        case .schoolCoreTaskNotCompleted: return "회장단 업무 미완료"
+        case .custom: return "기타"
+        }
+    }
+
+    var defaultPointValue: Int {
+        switch self {
+        case .bestWorkbook: return 2
+        case .warning: return 1
+        case .out: return 1
+        case .blogChallenge: return 3
+        case .umcEventReview: return 1
+        case .peerReviewSubmission: return 1
+        case .noWorkbookMission: return -4
+        case .studyLate: return -2
+        case .studyAbsent: return -4
+        case .eventLate: return -2
+        case .eventEarlyLeave: return -2
+        case .eventLateCancel: return -4
+        case .eventNoShow: return -10
+        case .partLeadFeedbackLate: return -4
+        case .schoolCoreMeetingAbsent: return -4
+        case .schoolCoreTaskNotCompleted: return -4
+        case .custom: return 0
+        }
+    }
+
+    var isReward: Bool {
+        defaultPointValue > 0
+    }
+
+    /// CUSTOM 타입은 사용자가 직접 배점을 입력해야 합니다.
+    var isCustom: Bool {
+        self == .custom
+    }
+
+    var minimumRequiredLevel: Int {
+        switch self {
+        case .bestWorkbook, .blogChallenge, .umcEventReview, .peerReviewSubmission:
+            return 20
+        case .noWorkbookMission, .studyLate, .studyAbsent,
+             .eventLate, .eventEarlyLeave, .eventLateCancel, .eventNoShow:
+            return 20
+        case .partLeadFeedbackLate:
+            return 30
+        case .schoolCoreMeetingAbsent, .schoolCoreTaskNotCompleted:
+            return 50
+        case .warning, .out:
+            return 20
+        case .custom:
+            return 20
+        }
+    }
+
+    static func availableTypes(for level: Int) -> [ChallengerPointType] {
+        allCases.filter { type in
+            type != .warning && type != .out && level >= type.minimumRequiredLevel
+        }
+    }
 }

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -238,6 +238,13 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         let profile = try await fetchMemberProfile(memberId: memberId)
         return allGenerationsText(from: profile, fallback: "")
     }
+
+    func fetchGenerationPointSummaries(
+        memberId: Int
+    ) async throws -> [GenerationPointSummary] {
+        let profile = try await fetchMemberProfile(memberId: memberId)
+        return makeGenerationPointSummaries(from: profile, memberId: memberId)
+    }
 }
 
 // MARK: - Private Helper
@@ -636,6 +643,43 @@ private extension MemberRepository {
             return "\(gisu)기"
         }
         return "-"
+    }
+
+    func makeGenerationPointSummaries(
+        from profile: MemberManagementProfileDTO,
+        memberId: Int
+    ) -> [GenerationPointSummary] {
+        let records = profile.challengerRecords.filter {
+            $0.memberId == memberId || $0.memberId == 0
+        }
+        guard !records.isEmpty else { return [] }
+
+        return records.compactMap { record in
+            guard record.gisu > 0 else { return nil }
+            let allPoints = record.resolvedPoints
+            let reward = allPoints
+                .filter {
+                    let resolved = ChallengerPointType(
+                        rawValue: $0.pointType.uppercased()
+                    )
+                    return resolved?.isReward == true
+                }
+                .reduce(0) { $0 + abs($1.point) }
+            let penalty = allPoints
+                .filter {
+                    let resolved = ChallengerPointType(
+                        rawValue: $0.pointType.uppercased()
+                    )
+                    return resolved == nil || !(resolved!.isReward)
+                }
+                .reduce(0) { $0 + abs($1.point) }
+            return GenerationPointSummary(
+                gisu: record.gisu,
+                reward: reward,
+                penalty: penalty
+            )
+        }
+        .sorted { $0.gisu < $1.gisu }
     }
 
     func makePenaltyHistories(

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -62,20 +62,31 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
                     preferredGisuId: preferredGisuID
                 )
             }
-            let outPoints = record?.resolvedPoints.filter {
-                $0.pointType.uppercased() == ChallengerPointType.out.rawValue
-            } ?? []
+            let allPoints = record?.resolvedPoints ?? []
 
-            let totalOutPenalty: Double
+            let penaltyPoints = allPoints.filter {
+                let typeStr = $0.pointType.uppercased()
+                let resolved = ChallengerPointType(rawValue: typeStr)
+                return resolved == nil || !(resolved!.isReward)
+            }
+            let rewardPointsList = allPoints.filter {
+                let typeStr = $0.pointType.uppercased()
+                let resolved = ChallengerPointType(rawValue: typeStr)
+                return resolved?.isReward == true
+            }
+
+            let totalPenalty: Double
             let penaltyHistories: [OperatorMemberPenaltyHistory]
 
-            if outPoints.isEmpty {
-                totalOutPenalty = descriptor.fallbackPenalty
+            if penaltyPoints.isEmpty {
+                totalPenalty = descriptor.fallbackPenalty
                 penaltyHistories = []
             } else {
-                totalOutPenalty = outPoints.reduce(0) { $0 + abs($1.point) }
-                penaltyHistories = makePenaltyHistories(from: outPoints)
+                totalPenalty = penaltyPoints.reduce(0) { $0 + abs($1.point) }
+                penaltyHistories = makePenaltyHistories(from: penaltyPoints)
             }
+
+            let totalReward = rewardPointsList.reduce(0) { $0 + abs($1.point) }
 
             return MemberManagementItem(
                 memberID: descriptor.memberId,
@@ -93,7 +104,8 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
                 school: profile?.schoolName.nonEmpty ?? descriptor.schoolName,
                 position: descriptor.position,
                 part: descriptor.part,
-                penalty: totalOutPenalty,
+                penalty: totalPenalty,
+                rewardPoints: totalReward,
                 badge: false,
                 managementTeam: resolvedManagementTeam(
                     profile: profile,
@@ -114,21 +126,19 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         }
     }
 
-    /// 챌린저에게 아웃 포인트를 부여합니다.
-    ///
-    /// - Parameters:
-    ///   - challengerId: 포인트를 부여할 챌린저 ID
-    ///   - description: 아웃 사유
-    /// - Throws: 네트워크 오류 또는 서버 에러
-    func grantOutPoint(
+    /// 챌린저에게 포인트를 부여합니다.
+    func grantPoint(
         challengerId: Int,
+        pointType: ChallengerPointType,
+        pointValue: Int,
         description: String
     ) async throws {
         let response = try await adapter.request(
             StudyRouter.createChallengerPoint(
                 challengerId: challengerId,
                 body: ChallengerPointCreateRequestDTO(
-                    pointType: .out,
+                    pointType: pointType,
+                    pointValue: pointValue,
                     description: description
                 )
             )
@@ -145,11 +155,8 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         try apiResponse.validateSuccess()
     }
 
-    /// 챌린저 아웃 포인트를 삭제합니다.
-    ///
-    /// - Parameter challengerPointId: 삭제할 챌린저 포인트 ID
-    /// - Throws: 네트워크 오류 또는 서버 에러
-    func deleteOutPoint(
+    /// 챌린저 포인트를 삭제합니다.
+    func deletePoint(
         challengerPointId: Int
     ) async throws {
         let response = try await adapter.request(
@@ -198,11 +205,8 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         }
     }
 
-    /// 챌린저 상세에서 아웃 히스토리를 조회합니다.
-    ///
-    /// `GET /api/v1/challenger/{challengerId}` 응답의 `challengerPoints`
-    /// 또는 `points` 중 `OUT` 타입만 추려 반환합니다.
-    func fetchOutPenaltyHistory(
+    /// 챌린저 상세에서 전체 포인트 히스토리를 조회합니다.
+    func fetchPointHistory(
         challengerId: Int
     ) async throws -> [OperatorMemberPenaltyHistory] {
         let response = try await adapter.request(
@@ -213,18 +217,21 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
             from: response.data
         )
         let challenger = try apiResponse.unwrap()
-        let outPoints = challenger.challengerPoints.filter { $0.pointType == .out }
 
-        return outPoints.map { point in
-            OperatorMemberPenaltyHistory(
-                challengerPointId: point.id > 0 ? point.id : nil,
-                date: ServerDateTimeConverter.parseUTCDateTimeOrTime(point.createdAt)
-                    ?? Date(),
-                reason: point.description.nonEmpty ?? "아웃",
-                penaltyScore: abs(point.point)
-            )
-        }
-        .sorted { $0.date > $1.date }
+        return challenger.challengerPoints
+            .filter { $0.pointType != .warning }
+            .map { point in
+                let resolvedType = ChallengerPointType(rawValue: point.pointType.rawValue) ?? .out
+                return OperatorMemberPenaltyHistory(
+                    challengerPointId: point.id > 0 ? point.id : nil,
+                    date: ServerDateTimeConverter.parseUTCDateTimeOrTime(point.createdAt)
+                        ?? Date(),
+                    reason: point.description.nonEmpty ?? resolvedType.displayName,
+                    penaltyScore: abs(point.point),
+                    pointType: resolvedType
+                )
+            }
+            .sorted { $0.date > $1.date }
     }
 
     func fetchAllGenerations(memberId: Int) async throws -> String {
@@ -632,15 +639,17 @@ private extension MemberRepository {
     }
 
     func makePenaltyHistories(
-        from outPoints: [MemberManagementPointDTO]
+        from points: [MemberManagementPointDTO]
     ) -> [OperatorMemberPenaltyHistory] {
-        outPoints.map { point in
-            OperatorMemberPenaltyHistory(
+        points.map { point in
+            let resolvedType = ChallengerPointType(rawValue: point.pointType.uppercased()) ?? .out
+            return OperatorMemberPenaltyHistory(
                 challengerPointId: point.id > 0 ? point.id : nil,
                 date: ServerDateTimeConverter.parseUTCDateTimeOrTime(point.createdAt)
                     ?? Date(),
-                reason: point.description.nonEmpty ?? "아웃",
-                penaltyScore: abs(point.point)
+                reason: point.description.nonEmpty ?? resolvedType.displayName,
+                penaltyScore: abs(point.point),
+                pointType: resolvedType
             )
         }
         .sorted { $0.date > $1.date }

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
@@ -142,34 +142,31 @@ final class MockMemberRepository: MemberRepositoryProtocol {
         ]
     }
 
-    func grantOutPoint(
+    func grantPoint(
         challengerId: Int,
+        pointType: ChallengerPointType,
+        pointValue: Int,
         description: String
     ) async throws {
-        _ = challengerId
-        _ = description
         try await Task.sleep(for: .milliseconds(300))
     }
 
-    func deleteOutPoint(
+    func deletePoint(
         challengerPointId: Int
     ) async throws {
-        _ = challengerPointId
         try await Task.sleep(for: .milliseconds(200))
     }
 
     func fetchAttendanceRecords(
         challengerId: Int
     ) async throws -> [MemberAttendanceRecord] {
-        _ = challengerId
         try await Task.sleep(for: .milliseconds(150))
         return MockAttendanceRecords.good
     }
 
-    func fetchOutPenaltyHistory(
+    func fetchPointHistory(
         challengerId: Int
     ) async throws -> [OperatorMemberPenaltyHistory] {
-        _ = challengerId
         try await Task.sleep(for: .milliseconds(150))
         return MockPenaltyHistory.oneOut
     }

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
@@ -174,6 +174,15 @@ final class MockMemberRepository: MemberRepositoryProtocol {
     func fetchAllGenerations(memberId: Int) async throws -> String {
         "8기, 9기"
     }
+
+    func fetchGenerationPointSummaries(
+        memberId: Int
+    ) async throws -> [GenerationPointSummary] {
+        [
+            GenerationPointSummary(gisu: 8, reward: 2, penalty: 1),
+            GenerationPointSummary(gisu: 9, reward: 1, penalty: 0)
+        ]
+    }
 }
 
 // MARK: - Mock Attendance Records

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
@@ -12,14 +12,16 @@ protocol MemberRepositoryProtocol {
     /// 멤버 목록 조회
     func fetchMembers() async throws -> [MemberManagementItem]
 
-    /// 챌린저에게 아웃 포인트를 부여합니다.
-    func grantOutPoint(
+    /// 챌린저에게 포인트를 부여합니다.
+    func grantPoint(
         challengerId: Int,
+        pointType: ChallengerPointType,
+        pointValue: Int,
         description: String
     ) async throws
 
-    /// 챌린저 아웃 포인트를 삭제합니다.
-    func deleteOutPoint(
+    /// 챌린저 포인트를 삭제합니다.
+    func deletePoint(
         challengerPointId: Int
     ) async throws
 
@@ -28,8 +30,8 @@ protocol MemberRepositoryProtocol {
         challengerId: Int
     ) async throws -> [MemberAttendanceRecord]
 
-    /// 특정 챌린저의 아웃 히스토리를 조회합니다.
-    func fetchOutPenaltyHistory(
+    /// 특정 챌린저의 포인트 히스토리를 조회합니다.
+    func fetchPointHistory(
         challengerId: Int
     ) async throws -> [OperatorMemberPenaltyHistory]
 

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
@@ -37,4 +37,9 @@ protocol MemberRepositoryProtocol {
 
     /// 멤버 프로필에서 모든 활동 기수 텍스트를 조회합니다.
     func fetchAllGenerations(memberId: Int) async throws -> String
+
+    /// 멤버의 기수별 상벌점 요약을 조회합니다.
+    func fetchGenerationPointSummaries(
+        memberId: Int
+    ) async throws -> [GenerationPointSummary]
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Attendance/AttendancePolicy.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Attendance/AttendancePolicy.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreLocation
 
 enum AttendancePolicy {
-    static let geofenceRadius: CLLocationDistance = 100.0
+    static let geofenceRadius: CLLocationDistance = 50.0
     static let onTimeThresholdMinutes: Int = 10
     static let lateThresholdMinutes: Int = 30
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberManagementItem.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberManagementItem.swift
@@ -46,9 +46,12 @@ struct MemberManagementItem: Identifiable, Equatable {
     /// 파트 정보 (iOS, Web 등)
     let part: UMCPartType
     
-    /// 현재 누적 패널티 점수
+    /// 현재 누적 벌점
     let penalty: Double
-    
+
+    /// 현재 누적 상점
+    let rewardPoints: Double
+
     /// 뱃지 표시 여부
     let badge: Bool
     
@@ -80,6 +83,7 @@ struct MemberManagementItem: Identifiable, Equatable {
         position: String,
         part: UMCPartType,
         penalty: Double,
+        rewardPoints: Double = 0,
         badge: Bool,
         managementTeam: ManagementTeam,
         attendanceRecords: [MemberAttendanceRecord],
@@ -97,6 +101,7 @@ struct MemberManagementItem: Identifiable, Equatable {
         self.position = position
         self.part = part
         self.penalty = penalty
+        self.rewardPoints = rewardPoints
         self.badge = badge
         self.managementTeam = managementTeam
         self.attendanceRecords = attendanceRecords

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberManagementItem.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberManagementItem.swift
@@ -8,6 +8,16 @@
 import Foundation
 import SwiftUI
 
+// MARK: - GenerationPointSummary
+
+/// 기수별 상벌점 요약 데이터
+struct GenerationPointSummary: Equatable, Identifiable {
+    var id: Int { gisu }
+    let gisu: Int
+    let reward: Double
+    let penalty: Double
+}
+
 // MARK: - MemberManagementItem
 
 /// 멤버 관리 리스트에서 사용되는 데이터 모델입니다.
@@ -71,6 +81,9 @@ struct MemberManagementItem: Identifiable, Equatable {
     /// 아웃 히스토리 열람 가능 여부
     let canViewPenaltyHistory: Bool
 
+    /// 기수별 상벌점 요약 목록
+    let generationPoints: [GenerationPointSummary]
+
     init(
         id: UUID = .init(),
         memberID: Int? = nil,
@@ -88,7 +101,8 @@ struct MemberManagementItem: Identifiable, Equatable {
         managementTeam: ManagementTeam,
         attendanceRecords: [MemberAttendanceRecord],
         penaltyHistory: [OperatorMemberPenaltyHistory],
-        canViewPenaltyHistory: Bool = true
+        canViewPenaltyHistory: Bool = true,
+        generationPoints: [GenerationPointSummary] = []
     ) {
         self.id = id
         self.memberID = memberID
@@ -107,5 +121,6 @@ struct MemberManagementItem: Identifiable, Equatable {
         self.attendanceRecords = attendanceRecords
         self.penaltyHistory = penaltyHistory
         self.canViewPenaltyHistory = canViewPenaltyHistory
+        self.generationPoints = generationPoints
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/OperatorMemberPenaltyHistory.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/OperatorMemberPenaltyHistory.swift
@@ -9,33 +9,38 @@ import Foundation
 
 /// 운영진 멤버 관리 히스토리
 ///
-/// 멤버 아웃 히스토리를 나타내는 모델입니다.
+/// 멤버 상벌점 히스토리를 나타내는 모델입니다.
 struct OperatorMemberPenaltyHistory: Identifiable, Equatable {
     let id: UUID
 
-    /// 서버 아웃 포인트 식별자
+    /// 서버 포인트 식별자
     let challengerPointId: Int?
-    
+
     /// 날짜
     let date: Date
-    
+
     /// 사유
     let reason: String
-    
-    /// 페널티 점수
+
+    /// 포인트 점수 (절대값)
     let penaltyScore: Double
+
+    /// 포인트 유형
+    let pointType: ChallengerPointType
 
     init(
         id: UUID = UUID(),
         challengerPointId: Int? = nil,
         date: Date,
         reason: String,
-        penaltyScore: Double
+        penaltyScore: Double,
+        pointType: ChallengerPointType = .out
     ) {
         self.id = id
         self.challengerPointId = challengerPointId
         self.date = date
         self.reason = reason
         self.penaltyScore = penaltyScore
+        self.pointType = pointType
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
@@ -12,14 +12,16 @@ protocol FetchMembersUseCaseProtocol {
     /// 멤버 목록 조회
     func execute() async throws -> [MemberManagementItem]
 
-    /// 챌린저에게 아웃 포인트를 부여합니다.
-    func grantOutPoint(
+    /// 챌린저에게 포인트를 부여합니다.
+    func grantPoint(
         challengerId: Int,
+        pointType: ChallengerPointType,
+        pointValue: Int,
         description: String
     ) async throws
 
-    /// 챌린저 아웃 포인트를 삭제합니다.
-    func deleteOutPoint(
+    /// 챌린저 포인트를 삭제합니다.
+    func deletePoint(
         challengerPointId: Int
     ) async throws
 
@@ -28,8 +30,8 @@ protocol FetchMembersUseCaseProtocol {
         challengerId: Int
     ) async throws -> [MemberAttendanceRecord]
 
-    /// 특정 챌린저의 아웃 히스토리를 조회합니다.
-    func fetchOutPenaltyHistory(
+    /// 특정 챌린저의 포인트 히스토리를 조회합니다.
+    func fetchPointHistory(
         challengerId: Int
     ) async throws -> [OperatorMemberPenaltyHistory]
 

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
@@ -37,4 +37,9 @@ protocol FetchMembersUseCaseProtocol {
 
     /// 멤버 프로필에서 모든 활동 기수 텍스트를 조회합니다.
     func fetchAllGenerations(memberId: Int) async throws -> String
+
+    /// 멤버의 기수별 상벌점 요약을 조회합니다.
+    func fetchGenerationPointSummaries(
+        memberId: Int
+    ) async throws -> [GenerationPointSummary]
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
@@ -11,31 +11,35 @@ import Foundation
 final class FetchMembersUseCase: FetchMembersUseCaseProtocol {
     // MARK: - Property
     private let repository: MemberRepositoryProtocol
-    
+
     // MARK: - Init
     init(repository: MemberRepositoryProtocol) {
         self.repository = repository
     }
-    
+
     // MARK: - Function
     func execute() async throws -> [MemberManagementItem] {
         try await repository.fetchMembers()
     }
 
-    func grantOutPoint(
+    func grantPoint(
         challengerId: Int,
+        pointType: ChallengerPointType,
+        pointValue: Int,
         description: String
     ) async throws {
-        try await repository.grantOutPoint(
+        try await repository.grantPoint(
             challengerId: challengerId,
+            pointType: pointType,
+            pointValue: pointValue,
             description: description
         )
     }
 
-    func deleteOutPoint(
+    func deletePoint(
         challengerPointId: Int
     ) async throws {
-        try await repository.deleteOutPoint(
+        try await repository.deletePoint(
             challengerPointId: challengerPointId
         )
     }
@@ -48,10 +52,10 @@ final class FetchMembersUseCase: FetchMembersUseCaseProtocol {
         )
     }
 
-    func fetchOutPenaltyHistory(
+    func fetchPointHistory(
         challengerId: Int
     ) async throws -> [OperatorMemberPenaltyHistory] {
-        try await repository.fetchOutPenaltyHistory(
+        try await repository.fetchPointHistory(
             challengerId: challengerId
         )
     }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
@@ -63,4 +63,10 @@ final class FetchMembersUseCase: FetchMembersUseCaseProtocol {
     func fetchAllGenerations(memberId: Int) async throws -> String {
         try await repository.fetchAllGenerations(memberId: memberId)
     }
+
+    func fetchGenerationPointSummaries(
+        memberId: Int
+    ) async throws -> [GenerationPointSummary] {
+        try await repository.fetchGenerationPointSummaries(memberId: memberId)
+    }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
@@ -9,59 +9,57 @@ import SwiftUI
 
 struct ChallengerMemberDetailSheetView: View {
     // MARK: - Property
-    
+
     @Environment(\.dismiss) private var dismiss
     var member: MemberManagementItem
-    
+    @State private var showGenerationPopover: Bool = false
+
     private enum Constants {
         static let tagPadding: EdgeInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
         static let boxPadding: EdgeInsets = .init(top: 12, leading: 0, bottom: 12, trailing: 0)
         static let listPadding: EdgeInsets = .init(top: 12, leading: 12, bottom: 12, trailing: 12)
         static let profileSize: CGSize = .init(width: 60, height: 60)
-        
-        static let baseHeight: CGFloat = 340  // 기본 정보 영역
-        static let emptyRecordHeight: CGFloat = 150 // 빈 상태 뷰 높이
-        static let recordRowHeight: CGFloat = 50  // 각 출석 기록 행의 높이
-        static let maxVisibleRecords: Int = 5  // 스크롤 없이 보이는 최대 기록 수
-        static let minSheetHeight: CGFloat = 420  // 최소 시트 높이
-        static let maxSheetHeight: CGFloat = 700  // 최대 시트 높이
+
+        static let baseHeight: CGFloat = 340
+        static let emptyRecordHeight: CGFloat = 150
+        static let recordRowHeight: CGFloat = 50
+        static let maxVisibleRecords: Int = 5
+        static let minSheetHeight: CGFloat = 420
+        static let maxSheetHeight: CGFloat = 700
     }
-    
-    private enum InfoType {
-        case generation
-        case penalty
-        
-        var title: String {
-            switch self {
-            case .generation: return "활동 기수"
-            case .penalty: return "누적 경고"
-            }
-        }
-    }
-    
+
     // MARK: - Computed Properties
-    
-    /// 출석 기록 개수에 따른 동적 시트 높이
+
+    /// 현재 기수 (마지막 기수만 표시)
+    private var currentGeneration: String {
+        let gens = member.generation
+            .components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        return gens.last ?? member.generation
+    }
+
+    /// 복수 기수 여부
+    private var hasMultipleGenerations: Bool {
+        member.generation.contains(",")
+    }
+
     private var dynamicSheetHeight: CGFloat {
         let recordCount = member.attendanceRecords.count
-        
+
         if recordCount == 0 {
-            // 기록 없을 때: 기본 높이 + 빈 상태 뷰 높이 (150)
             return Constants.baseHeight + Constants.emptyRecordHeight
         }
-        
-        // 표시할 기록 수 (최대 개수까지만 높이 증가, 그 이상은 스크롤)
+
         let visibleRecords = min(recordCount, Constants.maxVisibleRecords)
         let recordsHeight = (CGFloat(visibleRecords) * Constants.recordRowHeight)
         + (CGFloat(max(0, visibleRecords - 1)) * DefaultSpacing.spacing8)
 
         let calculatedHeight = Constants.baseHeight + recordsHeight
 
-        // 최소/최대 높이 제한
         return max(Constants.minSheetHeight, min(calculatedHeight, Constants.maxSheetHeight))
     }
 
-    /// 스크롤뷰 높이 (기록 개수에 따라 동적)
     private var scrollViewHeight: CGFloat {
         let recordCount = member.attendanceRecords.count
 
@@ -75,18 +73,19 @@ struct ChallengerMemberDetailSheetView: View {
 
         return recordsHeight
     }
-    
+
     // MARK: - Body
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
                 memberInfoView
-                
+
                 HStack(spacing: DefaultSpacing.spacing16) {
-                    generationPenaltyView(type: .generation)
-                    generationPenaltyView(type: .penalty)
+                    generationView
+                    infoBox(title: "상점", value: String(format: "%.0f", member.rewardPoints), color: .green)
+                    infoBox(title: "벌점", value: String(format: "%.0f", member.penalty), color: .red)
                 }
-                
+
                 recordView
             }
             .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
@@ -94,10 +93,9 @@ struct ChallengerMemberDetailSheetView: View {
             .presentationDetents([.height(dynamicSheetHeight)])
         }
     }
-    
+
     // MARK: - SubView
-    
-    /// 멤버 기본 정보
+
     private var memberInfoView: some View {
         HStack(spacing: DefaultSpacing.spacing12) {
             RemoteImage(urlString: member.profile ?? "", size: Constants.profileSize)
@@ -125,38 +123,65 @@ struct ChallengerMemberDetailSheetView: View {
             }
         }
     }
-    
-    /// 활동 기수 및 누적 경고
-    private func generationPenaltyView(type: InfoType) -> some View {
+
+    /// 활동 기수 박스 — 탭하면 전체 기수 팝오버
+    private var generationView: some View {
         VStack(spacing: DefaultSpacing.spacing8) {
-            Text(type.title)
+            Text("활동 기수")
                 .appFont(.callout, color: .grey700)
-            Text(type == .generation ? member.generation : member.penalty.description)
-                .appFont(.title3Emphasis, color: type == .generation ? .black : .red)
+            HStack(spacing: 2) {
+                Text(currentGeneration)
+                    .appFont(.title3Emphasis)
+                if hasMultipleGenerations {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.grey500)
+                }
+            }
+        }
+        .padding(Constants.boxPadding)
+        .frame(maxWidth: .infinity)
+        .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
+        .glass()
+        .onTapGesture {
+            if hasMultipleGenerations {
+                showGenerationPopover = true
+            }
+        }
+        .popover(isPresented: $showGenerationPopover, arrowEdge: .bottom) {
+            Text(member.generation)
+                .appFont(.subheadline)
+                .padding()
+                .presentationCompactAdaptation(.popover)
+        }
+    }
+
+    private func infoBox(title: String, value: String, color: Color) -> some View {
+        VStack(spacing: DefaultSpacing.spacing8) {
+            Text(title)
+                .appFont(.callout, color: .grey700)
+            Text(value)
+                .appFont(.title3Emphasis, color: color)
         }
         .padding(Constants.boxPadding)
         .frame(maxWidth: .infinity)
         .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
         .glass()
     }
-    
-    /// 출석/활동 기록
+
     private var recordView: some View {
         VStack(alignment: .leading) {
             Label("출석/활동 기록", systemImage: "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90")
                 .appFont(.title3Emphasis)
-            
+
             if member.attendanceRecords.isEmpty {
-                // 기록 없음
                 emptyRecordView
             } else {
-                // 기록 리스트
                 recordListView
             }
         }
     }
-    
-    /// 기록 없음 뷰
+
     private var emptyRecordView: some View {
         VStack(spacing: DefaultSpacing.spacing8) {
             Image(systemName: "calendar.badge.exclamationmark")
@@ -169,10 +194,9 @@ struct ChallengerMemberDetailSheetView: View {
         .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
         .glass()
     }
-    
-    /// 기록 리스트 뷰
+
     private var recordListView: some View {
-        List(member.attendanceRecords, rowContent:  { record in
+        List(member.attendanceRecords, rowContent: { record in
             attendanceRecordRow(record)
                 .listRowBackground(Color.clear)
         })
@@ -183,21 +207,18 @@ struct ChallengerMemberDetailSheetView: View {
         .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
         .glass()
     }
-    
-    /// 출석 기록 행
+
     private func attendanceRecordRow(_ record: MemberAttendanceRecord) -> some View {
         HStack(spacing: DefaultSpacing.spacing16) {
-            // 출석 상태
             Text(record.status.displayText)
                 .appFont(.subheadlineEmphasis, color: record.status.fontColor)
                 .padding(Constants.tagPadding)
                 .background(record.status.backgroundColor, in: Capsule())
-            
-            // 세션 제목
+
             Text(record.sessionTitle)
                 .appFont(.subheadline)
                 .lineLimit(1)
-            
+
             Spacer()
         }
     }
@@ -216,6 +237,7 @@ struct ChallengerMemberDetailSheetView: View {
                     position: "Challenger",
                     part: .front(type: .ios),
                     penalty: 2,
+                    rewardPoints: 3,
                     badge: false,
                     managementTeam: .schoolPartLeader,
                     attendanceRecords: [
@@ -233,26 +255,6 @@ struct ChallengerMemberDetailSheetView: View {
                             sessionTitle: "네비게이션 & 데이터 플로우",
                             week: 3,
                             status: .late
-                        ),
-                        MemberAttendanceRecord(
-                            sessionTitle: "API 통신 & 네트워킹",
-                            week: 4,
-                            status: .present
-                        ),
-                        MemberAttendanceRecord(
-                            sessionTitle: "상태 관리 & MVVM 패턴",
-                            week: 5,
-                            status: .present
-                        ),
-                        MemberAttendanceRecord(
-                            sessionTitle: "클린 아키텍처 & DI",
-                            week: 6,
-                            status: .present
-                        ),
-                        MemberAttendanceRecord(
-                            sessionTitle: "프로젝트 중간 발표",
-                            week: 7,
-                            status: .present
                         ),
                     ],
                     penaltyHistory: []

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
@@ -12,7 +12,7 @@ struct ChallengerMemberDetailSheetView: View {
 
     @Environment(\.dismiss) private var dismiss
     var member: MemberManagementItem
-    @State private var showGenerationPopover: Bool = false
+    @State private var selectedGisu: Int?
 
     private enum Constants {
         static let tagPadding: EdgeInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
@@ -20,18 +20,27 @@ struct ChallengerMemberDetailSheetView: View {
         static let listPadding: EdgeInsets = .init(top: 12, leading: 12, bottom: 12, trailing: 12)
         static let profileSize: CGSize = .init(width: 60, height: 60)
 
-        static let baseHeight: CGFloat = 340
+        static let baseHeight: CGFloat = 360
         static let emptyRecordHeight: CGFloat = 150
         static let recordRowHeight: CGFloat = 50
         static let maxVisibleRecords: Int = 5
         static let minSheetHeight: CGFloat = 420
         static let maxSheetHeight: CGFloat = 700
+
+        static let summaryRowVerticalPadding: CGFloat = 12
+        static let partTagOpacity: Double = 0.14
+        static let partStrokeOpacity: Double = 0.4
+        static let partStrokeWidth: CGFloat = 1
     }
 
     // MARK: - Computed Properties
 
-    /// 현재 기수 (마지막 기수만 표시)
+    /// 현재 기수 표시 (마지막 기수)
     private var currentGeneration: String {
+        if hasMultipleGenerations,
+           let lastGisu = member.generationPoints.map(\.gisu).max() {
+            return "\(lastGisu)기"
+        }
         let gens = member.generation
             .components(separatedBy: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
@@ -41,7 +50,23 @@ struct ChallengerMemberDetailSheetView: View {
 
     /// 복수 기수 여부
     private var hasMultipleGenerations: Bool {
-        member.generation.contains(",")
+        member.generationPoints.count > 1
+    }
+
+    /// 현재 선택된 기수의 요약 데이터
+    private var selectedSummary: GenerationPointSummary? {
+        guard let gisu = selectedGisu else { return nil }
+        return member.generationPoints.first { $0.gisu == gisu }
+    }
+
+    /// 현재 선택된 기수의 상점
+    private var displayRewardPoints: Double {
+        selectedSummary?.reward ?? member.rewardPoints
+    }
+
+    /// 현재 선택된 기수의 벌점
+    private var displayPenaltyPoints: Double {
+        selectedSummary?.penalty ?? member.penalty
     }
 
     private var dynamicSheetHeight: CGFloat {
@@ -80,11 +105,7 @@ struct ChallengerMemberDetailSheetView: View {
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
                 memberInfoView
 
-                HStack(spacing: DefaultSpacing.spacing16) {
-                    generationView
-                    infoBox(title: "상점", value: String(format: "%.0f", member.rewardPoints), color: .green)
-                    infoBox(title: "벌점", value: String(format: "%.0f", member.penalty), color: .red)
-                }
+                summaryCardView
 
                 recordView
             }
@@ -107,10 +128,16 @@ struct ChallengerMemberDetailSheetView: View {
                     Text(member.part.name)
                         .appFont(.callout, color: member.part.color)
                         .padding(Constants.tagPadding)
-                        .background(member.part.color.opacity(0.14), in: Capsule())
+                        .background(
+                            member.part.color.opacity(Constants.partTagOpacity),
+                            in: Capsule()
+                        )
                         .overlay {
                             Capsule()
-                                .stroke(member.part.color.opacity(0.4), lineWidth: 1)
+                                .stroke(
+                                    member.part.color.opacity(Constants.partStrokeOpacity),
+                                    lineWidth: Constants.partStrokeWidth
+                                )
                         }
                     Text(member.school)
                         .appFont(.callout, color: .black)
@@ -124,49 +151,85 @@ struct ChallengerMemberDetailSheetView: View {
         }
     }
 
-    /// 활동 기수 박스 — 탭하면 전체 기수 팝오버
-    private var generationView: some View {
-        VStack(spacing: DefaultSpacing.spacing8) {
-            Text("활동 기수")
-                .appFont(.callout, color: .grey700)
-            HStack(spacing: 2) {
-                Text(currentGeneration)
-                    .appFont(.title3Emphasis)
+    private var summaryCardView: some View {
+        VStack(spacing: 0) {
+            summaryRow(title: "활동 기수") {
                 if hasMultipleGenerations {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(.grey500)
+                    generationMenu
+                } else {
+                    Text(currentGeneration)
+                        .appFont(.subheadlineEmphasis)
                 }
             }
-        }
-        .padding(Constants.boxPadding)
-        .frame(maxWidth: .infinity)
-        .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
-        .glass()
-        .onTapGesture {
-            if hasMultipleGenerations {
-                showGenerationPopover = true
+
+            Divider()
+
+            summaryRow(title: "상점") {
+                Text(String(format: "%.0f", displayRewardPoints))
+                    .appFont(.subheadlineEmphasis, color: .green)
+            }
+
+            Divider()
+
+            summaryRow(title: "벌점") {
+                Text(String(format: "%.0f", displayPenaltyPoints))
+                    .appFont(.subheadlineEmphasis, color: .red)
             }
         }
-        .popover(isPresented: $showGenerationPopover, arrowEdge: .bottom) {
-            Text(member.generation)
-                .appFont(.subheadline)
-                .padding()
-                .presentationCompactAdaptation(.popover)
+        .padding(.horizontal, Constants.listPadding.leading)
+        .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
+        .glass()
+    }
+
+    private var generationMenu: some View {
+        Group {
+            if selectedGisu != nil {
+                Button {
+                    withAnimation { selectedGisu = nil }
+                } label: {
+                    generationLabel
+                }
+                .buttonStyle(.plain)
+            } else {
+                Menu {
+                    ForEach(member.generationPoints) { summary in
+                        Button {
+                            selectedGisu = summary.gisu
+                        } label: {
+                            Text("\(summary.gisu)기")
+                        }
+                    }
+                } label: {
+                    generationLabel
+                }
+                .foregroundStyle(.primary)
+            }
         }
     }
 
-    private func infoBox(title: String, value: String, color: Color) -> some View {
-        VStack(spacing: DefaultSpacing.spacing8) {
-            Text(title)
-                .appFont(.callout, color: .grey700)
-            Text(value)
-                .appFont(.title3Emphasis, color: color)
+    private var generationLabel: some View {
+        HStack(spacing: DefaultSpacing.spacing4) {
+            Text(selectedGisu.map { "\($0)기" } ?? currentGeneration)
+                .appFont(.subheadlineEmphasis)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.grey500)
         }
-        .padding(Constants.boxPadding)
-        .frame(maxWidth: .infinity)
-        .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
-        .glass()
+    }
+
+    // MARK: - Function
+
+    private func summaryRow<Content: View>(
+        title: String,
+        @ViewBuilder value: () -> Content
+    ) -> some View {
+        HStack {
+            Text(title)
+                .appFont(.subheadline, color: .grey700)
+            Spacer()
+            value()
+        }
+        .padding(.vertical, Constants.summaryRowVerticalPadding)
     }
 
     private var recordView: some View {
@@ -257,7 +320,12 @@ struct ChallengerMemberDetailSheetView: View {
                             status: .late
                         ),
                     ],
-                    penaltyHistory: []
+                    penaltyHistory: [],
+                    generationPoints: [
+                        GenerationPointSummary(gisu: 7, reward: 1, penalty: 0),
+                        GenerationPointSummary(gisu: 8, reward: 2, penalty: 1),
+                        GenerationPointSummary(gisu: 9, reward: 0, penalty: 1)
+                    ]
                 ))
             })
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/CoreMemberManagementList.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/CoreMemberManagementList.swift
@@ -121,20 +121,19 @@ struct ManagementTeamBadgePresenter: View {
 
 // MARK: - PenaltyBadgePresenter
 
-/// 운영진 모드에서 멤버의 페널티 점수를 보여주는 뱃지 뷰입니다.
+/// 운영진 모드에서 멤버의 벌점을 보여주는 뱃지 뷰입니다.
 struct PenaltyBadgePresenter: View {
-    
-    /// 아웃
+
     let penalty: Double
-    
+
     private enum Constants {
         static let verticalPadding: CGFloat = 6
         static let horizontalPadding: CGFloat = 8
         static let bgOpacity: Double = 0.2
     }
-    
+
     var body: some View {
-        Text("아웃 \(String(format: "%.1f", penalty))")
+        Text("벌점 \(String(format: "%.0f", penalty))")
             .font(.app(.footnote, weight: .regular))
             .foregroundStyle(.red)
             .padding(.vertical, Constants.verticalPadding)

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/MemberManagementCard.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/MemberManagementCard.swift
@@ -146,42 +146,64 @@ private struct MemberBottomTextPresenter: View, Equatable {
 
 
 // MARK: - MemberPenaltyPresenter
-/// 아웃 상태
-/// - 0일 때: 아무것도 나타나지않음
-/// - 0이 아닐 때: 경고 + 점수
+/// 상벌점 배지
 private struct MemberPenaltyPresenter: View, Equatable {
-    
+
     // MARK: - Property
     let memberManagementItem: MemberManagementItem
-    
+
     // MARK: - Constants
     fileprivate enum Constants {
-        static let hstackSpacing: CGFloat = 3
+        static let hstackSpacing: CGFloat = 4
         static let horizonSpacing: CGFloat = 8
         static let verticalSpacing: CGFloat = 4
         static let radius: CGFloat = 8
         static let strokeWidth: CGFloat = 0.5
     }
-    
+
     // MARK: - Body
     var body: some View {
-        if memberManagementItem.penalty != 0 {
-            HStack(spacing: Constants.hstackSpacing) {
-                Text("경고")
-                Text(String(format: "%.1f", memberManagementItem.penalty))
+        HStack(spacing: Constants.hstackSpacing) {
+            if memberManagementItem.rewardPoints > 0 {
+                pointBadge(
+                    label: "상점",
+                    value: memberManagementItem.rewardPoints,
+                    fgColor: .green,
+                    bgColor: Color.green.opacity(0.1),
+                    borderColor: Color.green.opacity(0.3)
+                )
             }
-            .appFont(.footnoteEmphasis)
-            .foregroundStyle(Color.red700)
-            .padding(.horizontal, Constants.horizonSpacing)
-            .padding(.vertical, Constants.verticalSpacing)
-            .background {
-                RoundedRectangle(cornerRadius: Constants.radius)
-                    .fill(Color.red100)
-                    .strokeBorder(Color.red300, lineWidth: Constants.strokeWidth)
+            if memberManagementItem.penalty > 0 {
+                pointBadge(
+                    label: "벌점",
+                    value: memberManagementItem.penalty,
+                    fgColor: Color.red700,
+                    bgColor: Color.red100,
+                    borderColor: Color.red300
+                )
             }
         }
-        else {
-            EmptyView()
+    }
+
+    private func pointBadge(
+        label: String,
+        value: Double,
+        fgColor: Color,
+        bgColor: Color,
+        borderColor: Color
+    ) -> some View {
+        HStack(spacing: 3) {
+            Text(label)
+            Text(String(format: "%.0f", value))
+        }
+        .appFont(.footnoteEmphasis)
+        .foregroundStyle(fgColor)
+        .padding(.horizontal, Constants.horizonSpacing)
+        .padding(.vertical, Constants.verticalSpacing)
+        .background {
+            RoundedRectangle(cornerRadius: Constants.radius)
+                .fill(bgColor)
+                .strokeBorder(borderColor, lineWidth: Constants.strokeWidth)
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
@@ -7,35 +7,40 @@
 
 import SwiftUI
 
-/// 운영진 멤버 상세 정보 및 아웃 포인트 관리 시트 뷰
+/// 운영진 멤버 상세 정보 및 상벌점 관리 시트 뷰
 struct OperatorMemberDetailSheetView: View {
-    
+
     // MARK: - Property
-    
+
     @Environment(\.dismiss) private var dismiss
     var member: MemberManagementItem
-    let isSubmittingOutPoint: Bool
-    let isDeletingOutPoint: Bool
-    let onGrantOut: @Sendable (String) async -> Bool
-    let onDeleteOut: @Sendable (OperatorMemberPenaltyHistory) async -> String?
-    @State private var showPenaltyAlert: Bool = false
-    @State private var penaltyReason: String = ""
+    let availablePointTypes: [ChallengerPointType]
+    let isSubmittingPoint: Bool
+    let isDeletingPoint: Bool
+    let onGrantPoint: @Sendable (ChallengerPointType, Int, String) async -> Bool
+    let onDeletePoint: @Sendable (OperatorMemberPenaltyHistory) async -> String?
+    @State private var showPointForm: Bool = false
+    @State private var selectedPointType: ChallengerPointType?
+    @State private var pointValue: Int = 0
+    @State private var customPointValueText: String = ""
+    @State private var pointReason: String = ""
     @State private var penaltyHistory: [OperatorMemberPenaltyHistory] = []
     @State private var totalPenalty: Double = 0
+    @State private var totalReward: Double = 0
+    @State private var showReasonAlert: Bool = false
     @State private var transientHistoryMessage: String?
     @State private var transientHistoryMessageTask: Task<Void, Never>?
-    
+
     // MARK: - Constant
-    
+
     private enum Constants {
         static let tagPadding: EdgeInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
         static let profileSize: CGSize = .init(width: 60, height: 60)
-        static let fixedPenaltyScore: Double = 1.0
         static let contentHorizontalPadding: CGFloat = 16
         static let contentTopPadding: CGFloat = 8
         static let contentBottomPadding: CGFloat = 0
         static let contentSpacing: CGFloat = 24
-        
+
         static let baseHeight: CGFloat = 340
         static let emptyHistoryHeight: CGFloat = 150
         static let historyRowHeight: CGFloat = 50
@@ -47,24 +52,22 @@ struct OperatorMemberDetailSheetView: View {
         static let bgOpacity: Double = 0.2
         static let animation: Animation = .spring(response: 0.34, dampingFraction: 0.86)
     }
-    
+
     // MARK: - Computed Properties
-    
-    /// 사유 입력 유효성 검사
+
     private var isReasonValid: Bool {
-        !penaltyReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !pointReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var partTint: Color {
         member.part.color
     }
-    
-    /// 아웃 기록 개수에 따른 동적 시트 높이
+
     private var dynamicSheetHeight: CGFloat {
         let historyCount = penaltyHistory.count
-        
+
         var calculatedHeight: CGFloat = Constants.baseHeight
-        
+
         if historyCount == 0 {
             calculatedHeight += max(
                 Constants.emptyHistoryHeight,
@@ -79,33 +82,40 @@ struct OperatorMemberDetailSheetView: View {
                 Constants.minimumVisibleHistoryHeight
             )
         }
-        
+
         return max(Constants.minSheetHeight, min(calculatedHeight, Constants.maxSheetHeight))
     }
-    
-    /// 스크롤뷰 높이 (기록 개수에 따라 동적)
+
     private var scrollViewHeight: CGFloat {
         let recordCount = penaltyHistory.count
-        
+
         if recordCount == 0 {
             return max(
                 Constants.emptyHistoryHeight,
                 Constants.minimumVisibleHistoryHeight
             )
         }
-        
+
         let visibleHistory = min(recordCount, Constants.maxVisibleHistory)
         let historyHeight = (CGFloat(visibleHistory) * Constants.historyRowHeight)
             + (CGFloat(max(0, visibleHistory - 1)) * DefaultSpacing.spacing8)
-        
+
         return max(
             historyHeight,
             Constants.minimumVisibleHistoryHeight
         )
     }
-    
+
+    private var rewardTypes: [ChallengerPointType] {
+        availablePointTypes.filter { $0.isReward }
+    }
+
+    private var penaltyTypes: [ChallengerPointType] {
+        availablePointTypes.filter { !$0.isReward }
+    }
+
     // MARK: - Body
-    
+
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading, spacing: Constants.contentSpacing) {
@@ -120,85 +130,183 @@ struct OperatorMemberDetailSheetView: View {
             .presentationDetents([.height(dynamicSheetHeight)])
             .interactiveDismissDisabled()
             .animation(Constants.animation, value: penaltyHistory.count)
-            .alert("아웃 부여", isPresented: $showPenaltyAlert) {
-                outPenaltyInputField
-                outPenaltyCancelButton
-                outPenaltyConfirmButton
-            } message: {
-                outPenaltyMessage
+            .fullScreenCover(isPresented: $showPointForm) {
+                pointFormSheet
             }
         }
         .onChange(of: member) { _, newValue in
             penaltyHistory = newValue.penaltyHistory
             totalPenalty = newValue.penalty
+            totalReward = newValue.rewardPoints
         }
         .task {
             penaltyHistory = member.penaltyHistory
             totalPenalty = member.penalty
+            totalReward = member.rewardPoints
         }
     }
-    
+
     // MARK: - Toolbar
-    
+
     @ToolbarContentBuilder
     private var toolbarItems: some ToolbarContent {
         ToolBarCollection.CancelBtn {
             dismiss()
         }
         ToolbarItem(placement: .topBarTrailing) {
-            outPenaltyTriggerButton
+            pointTriggerButton
         }
     }
-    
-    private var outPenaltyTriggerButton: some View {
+
+    private var pointTriggerButton: some View {
         Button {
-            penaltyReason = ""
-            showPenaltyAlert = true
+            selectedPointType = nil
+            pointValue = 0
+            customPointValueText = ""
+            pointReason = ""
+            showPointForm = true
         } label: {
-            if isSubmittingOutPoint {
+            if isSubmittingPoint {
                 ProgressView()
-                    .tint(.red)
+                    .tint(.blue)
             } else {
-                Image(systemName: "slash.circle.fill")
-                    .foregroundStyle(.red)
+                Image(systemName: "plus.circle.fill")
+                    .foregroundStyle(.blue)
             }
         }
-        .tint(.red)
-        .disabled(isSubmittingOutPoint)
+        .tint(.blue)
+        .disabled(isSubmittingPoint)
     }
-    
-    private var outPenaltyInputField: some View {
-        TextField("아웃 사유를 입력하세요", text: $penaltyReason)
+
+    // MARK: - Point Form Sheet
+
+    /// CUSTOM 타입의 배점 유효성
+    private var isCustomPointValueValid: Bool {
+        guard selectedPointType?.isCustom == true else { return true }
+        guard let value = Int(customPointValueText), value != 0 else { return false }
+        return true
     }
-    
-    private var outPenaltyCancelButton: some View {
-        Button("취소", role: .cancel) {
-            penaltyReason = ""
-        }
+
+    /// 확정 버튼 활성 조건
+    private var isConfirmEnabled: Bool {
+        selectedPointType != nil && isCustomPointValueValid && !isSubmittingPoint
     }
-    
-    private var outPenaltyConfirmButton: some View {
-        Button("확정") {
-            Task {
-                await addPenalty()
+
+    private var pointFormSheet: some View {
+        NavigationStack {
+            Form {
+                if !rewardTypes.isEmpty {
+                    Section {
+                        ForEach(rewardTypes) { type in
+                            pointTypeRow(type: type, tint: .green)
+                        }
+                    } header: {
+                        Text("상점")
+                    }
+                }
+
+                Section {
+                    ForEach(penaltyTypes) { type in
+                        pointTypeRow(type: type, tint: .red)
+                    }
+                } header: {
+                    Text("벌점")
+                }
+
+                if let selected = selectedPointType, selected.isCustom {
+                    Section("배점") {
+                        HStack {
+                            Text("점수 입력")
+                                .appFont(.subheadline)
+                            Spacer()
+                            TextField("예: 3 또는 -2", text: $customPointValueText)
+                                .keyboardType(.numbersAndPunctuation)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: 100)
+                                .onChange(of: customPointValueText) { _, newValue in
+                                    if let parsed = Int(newValue) {
+                                        pointValue = parsed
+                                    }
+                                }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("상벌점 부여")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") {
+                        showPointForm = false
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("확정") {
+                        pointReason = ""
+                        showReasonAlert = true
+                    }
+                    .disabled(!isConfirmEnabled)
+                }
+            }
+            .alert("사유 입력", isPresented: $showReasonAlert) {
+                TextField("사유를 입력하세요", text: $pointReason)
+                Button("취소", role: .cancel) {
+                    pointReason = ""
+                }
+                Button("확인") {
+                    Task {
+                        await addPoint()
+                    }
+                }
+                .disabled(!isReasonValid)
+            } message: {
+                if let selected = selectedPointType {
+                    Text("\(selected.displayName) (\(pointValue > 0 ? "+" : "")\(pointValue)점) 사유를 입력해주세요.")
+                }
             }
         }
-        .disabled(!isReasonValid || isSubmittingOutPoint)
     }
-    
-    private var outPenaltyMessage: some View {
-        Text("사유를 입력하면 아웃 +\(String(format: "%.1f", Constants.fixedPenaltyScore))가 기록됩니다.")
+
+    private func pointTypeRow(
+        type: ChallengerPointType,
+        tint: Color
+    ) -> some View {
+        Button {
+            selectedPointType = type
+            if type.isCustom {
+                customPointValueText = ""
+                pointValue = 0
+            } else {
+                pointValue = type.defaultPointValue
+            }
+        } label: {
+            HStack {
+                Text(type.displayName)
+                    .appFont(.subheadline, color: .primary)
+                Spacer()
+                if !type.isCustom {
+                    Text("\(type.defaultPointValue > 0 ? "+" : "")\(type.defaultPointValue)")
+                        .appFont(.subheadline, color: tint)
+                }
+                if selectedPointType == type {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(tint)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
-    
+
     // MARK: - SubView
-    
+
     private var memberInfoView: some View {
         HStack(spacing: DefaultSpacing.spacing12) {
             RemoteImage(urlString: member.profile ?? "", size: Constants.profileSize)
             memberMetadataView
         }
     }
-    
+
     private var memberMetadataView: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
             Text("\(member.nickname)/\(member.name)")
@@ -212,12 +320,12 @@ struct OperatorMemberDetailSheetView: View {
             }
         }
     }
-    
+
     private enum StatusChipStyle {
         case accent
         case plain
     }
-    
+
     @ViewBuilder
     private func statusChip(title: String, style: StatusChipStyle) -> some View {
         switch style {
@@ -237,7 +345,7 @@ struct OperatorMemberDetailSheetView: View {
                 .background(.white, in: Capsule())
         }
     }
-    
+
     private var historyView: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
             historyHeader
@@ -245,18 +353,32 @@ struct OperatorMemberDetailSheetView: View {
             historyListContainer
         }
     }
-    
+
     private var historyHeader: some View {
         HStack(spacing: DefaultSpacing.spacing8) {
             Label("히스토리", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
                 .appFont(.title3Emphasis)
-            
-            if !penaltyHistory.isEmpty {
-                penaltyBadge
+
+            if totalReward > 0 {
+                pointBadge(label: "상점 \(String(format: "%.0f", totalReward))", color: .green)
+            }
+            if totalPenalty > 0 {
+                pointBadge(label: "벌점 \(String(format: "%.0f", totalPenalty))", color: .red)
             }
         }
     }
-    
+
+    private func pointBadge(label: String, color: Color) -> some View {
+        Text(label)
+            .font(.app(.footnote, weight: .regular))
+            .foregroundStyle(color)
+            .padding(Constants.badgePadding)
+            .background {
+                RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+                    .fill(color.opacity(Constants.bgOpacity))
+            }
+    }
+
     private var historyListContainer: some View {
         Group {
             if penaltyHistory.isEmpty {
@@ -274,25 +396,12 @@ struct OperatorMemberDetailSheetView: View {
                 color: transientHistoryMessage == nil ? .grey500 : .red
             )
     }
-    
-    /// 누적 경고 뱃지
-    private var penaltyBadge: some View {
-        Text("아웃 \(String(format: "%.1f", totalPenalty))")
-            .font(.app(.footnote, weight: .regular))
-            .foregroundStyle(.red)
-            .padding(Constants.badgePadding)
-            .background {
-                RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
-                    .fill(.red.opacity(Constants.bgOpacity))
-            }
-    }
-    
-    /// 기록 없음 뷰
+
     private var emptyHistoryView: some View {
         VStack(spacing: DefaultSpacing.spacing8) {
             Image(systemName: "exclamationmark.bubble.fill")
                 .appFont(.title1, color: .grey500)
-            Text(member.canViewPenaltyHistory ? "아웃 기록이 없습니다" : "타인의 아웃 히스토리를 확인할 수 없습니다")
+            Text(member.canViewPenaltyHistory ? "포인트 기록이 없습니다" : "타인의 포인트 히스토리를 확인할 수 없습니다")
                 .appFont(.subheadline, color: .grey500)
         }
         .frame(maxWidth: .infinity)
@@ -300,8 +409,7 @@ struct OperatorMemberDetailSheetView: View {
         .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
         .glass()
     }
-    
-    /// 히스토리 리스트 뷰
+
     private var historyListView: some View {
         List {
             ForEach(penaltyHistory) { history in
@@ -315,7 +423,7 @@ struct OperatorMemberDetailSheetView: View {
                             Label("삭제", systemImage: "trash")
                         }
                     }
-                    .disabled(isDeletingOutPoint || !member.canViewPenaltyHistory)
+                    .disabled(isDeletingPoint || !member.canViewPenaltyHistory)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                     .listRowInsets(.init())
@@ -327,71 +435,89 @@ struct OperatorMemberDetailSheetView: View {
         .scrollIndicators(.hidden)
         .frame(height: scrollViewHeight)
     }
-    
-    /// 아웃 히스토리 행
+
     private func penaltyHistoryRow(_ history: OperatorMemberPenaltyHistory) -> some View {
-        HStack(spacing: DefaultSpacing.spacing16) {
+        let isReward = history.pointType.isReward
+        let color: Color = isReward ? .green : .red
+        let sign = isReward ? "+" : "-"
+
+        return HStack(spacing: DefaultSpacing.spacing16) {
             Text(history.date.toYearMonthDay())
                 .appFont(.subheadlineEmphasis)
-            
+
             Text(history.reason)
                 .appFont(.subheadline)
                 .lineLimit(1)
-            
+
             Spacer()
-            
-            Text("아웃 +\(String(format: "%.1f", history.penaltyScore))")
-                .appFont(.subheadline, color: .red)
+
+            Text("\(sign)\(String(format: "%.0f", history.penaltyScore))")
+                .appFont(.subheadline, color: color)
         }
         .padding(.horizontal, Constants.contentHorizontalPadding)
         .frame(maxWidth: .infinity)
         .frame(height: Constants.historyRowHeight)
         .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
     }
-    
+
     // MARK: - Function
-    
-    /// 아웃 부여하기
+
     @MainActor
-    private func addPenalty() async {
+    private func addPoint() async {
         guard member.canViewPenaltyHistory else { return }
-        guard !penaltyReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard let selectedType = selectedPointType else { return }
+        guard !pointReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return
         }
 
-        let reason = penaltyReason
-        let isSuccess = await onGrantOut(reason)
+        let reason = pointReason
+        let value = pointValue
+        let isSuccess = await onGrantPoint(selectedType, value, reason)
         guard isSuccess else { return }
-        
-        let newPenalty = OperatorMemberPenaltyHistory(
+
+        let newHistory = OperatorMemberPenaltyHistory(
             date: Date(),
             reason: reason,
-            penaltyScore: Constants.fixedPenaltyScore
+            penaltyScore: Double(abs(value)),
+            pointType: selectedType
         )
-        
+
         withAnimation(Constants.animation) {
-            penaltyHistory.append(newPenalty)
+            penaltyHistory.append(newHistory)
             penaltyHistory.sort { $0.date > $1.date }
         }
-        
-        totalPenalty += Constants.fixedPenaltyScore
-        penaltyReason = ""
+
+        let isRewardPoint = selectedType.isCustom ? value > 0 : selectedType.isReward
+        if isRewardPoint {
+            totalReward += Double(abs(value))
+        } else {
+            totalPenalty += Double(abs(value))
+        }
+
+        showPointForm = false
+        pointReason = ""
+        customPointValueText = ""
+        selectedPointType = nil
     }
-    
-    /// 히스토리 삭제하기
+
     @MainActor
     private func deletePenalty(_ history: OperatorMemberPenaltyHistory) async {
         guard member.canViewPenaltyHistory else { return }
-        if let message = await onDeleteOut(history) {
+        if let message = await onDeletePoint(history) {
             showTransientHistoryMessage(message)
             return
         }
 
         if let index = penaltyHistory.firstIndex(where: { $0.id == history.id }) {
             let deletedScore = penaltyHistory[index].penaltyScore
+            let isReward = penaltyHistory[index].pointType.isReward
             withAnimation(Constants.animation) {
                 penaltyHistory.remove(at: index)
-                totalPenalty -= deletedScore
+                if isReward {
+                    totalReward -= deletedScore
+                } else {
+                    totalPenalty -= deletedScore
+                }
             }
         }
     }
@@ -405,7 +531,7 @@ struct OperatorMemberDetailSheetView: View {
         if member.canViewPenaltyHistory {
             return "히스토리 항목을 왼쪽으로 밀어서 삭제할 수 있습니다."
         }
-        return "본인이 아닌 경우 아웃 히스토리를 확인할 수 없습니다."
+        return "본인이 아닌 경우 포인트 히스토리를 확인할 수 없습니다."
     }
 
     private func showTransientHistoryMessage(_ message: String) {
@@ -427,10 +553,11 @@ struct OperatorMemberDetailSheetView: View {
         .sheet(isPresented: .constant(true), content: {
             OperatorMemberDetailSheetView(
                 member: OperatorMemberDetailSheetView.previewMember,
-                isSubmittingOutPoint: false,
-                isDeletingOutPoint: false,
-                onGrantOut: { _ in true },
-                onDeleteOut: { _ in nil }
+                availablePointTypes: ChallengerPointType.availableTypes(for: 30),
+                isSubmittingPoint: false,
+                isDeletingPoint: false,
+                onGrantPoint: { _, _, _ in true },
+                onDeletePoint: { _ in nil }
             )
         })
 }
@@ -444,20 +571,29 @@ private extension OperatorMemberDetailSheetView {
         school: "덕성여자대학교",
         position: "Challenger",
         part: .front(type: .ios),
-        penalty: 2,
+        penalty: 4,
+        rewardPoints: 3,
         badge: false,
         managementTeam: .schoolPartLeader,
         attendanceRecords: [],
         penaltyHistory: [
             OperatorMemberPenaltyHistory(
                 date: Date().addingTimeInterval(-14 * 24 * 60 * 60),
-                reason: "세션 지각",
-                penaltyScore: 1.0
+                reason: "스터디 지각",
+                penaltyScore: 2.0,
+                pointType: .studyLate
             ),
             OperatorMemberPenaltyHistory(
                 date: Date().addingTimeInterval(-7 * 24 * 60 * 60),
-                reason: "세션 결석 (사유 없음)",
-                penaltyScore: 1.0
+                reason: "우수 워크북",
+                penaltyScore: 2.0,
+                pointType: .bestWorkbook
+            ),
+            OperatorMemberPenaltyHistory(
+                date: Date().addingTimeInterval(-3 * 24 * 60 * 60),
+                reason: "스터디 결석",
+                penaltyScore: 4.0,
+                pointType: .studyAbsent
             )
         ]
     )

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/OperatorMemberDetailSheetView.swift
@@ -271,26 +271,32 @@ struct OperatorMemberDetailSheetView: View {
         type: ChallengerPointType,
         tint: Color
     ) -> some View {
-        Button {
-            selectedPointType = type
-            if type.isCustom {
-                customPointValueText = ""
-                pointValue = 0
-            } else {
-                pointValue = type.defaultPointValue
+        let isSelected = selectedPointType == type
+
+        return Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                selectedPointType = type
+                if type.isCustom {
+                    customPointValueText = ""
+                    pointValue = 0
+                } else {
+                    pointValue = type.defaultPointValue
+                }
             }
         } label: {
             HStack {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? tint : .grey400)
+                    .contentTransition(.symbolEffect(.replace))
+
                 Text(type.displayName)
                     .appFont(.subheadline, color: .primary)
+
                 Spacer()
+
                 if !type.isCustom {
                     Text("\(type.defaultPointValue > 0 ? "+" : "")\(type.defaultPointValue)")
-                        .appFont(.subheadline, color: tint)
-                }
-                if selectedPointType == type {
-                    Image(systemName: "checkmark")
-                        .foregroundStyle(tint)
+                        .appFont(.subheadlineEmphasis, color: isSelected ? tint : .grey500)
                 }
             }
             .contentShape(Rectangle())
@@ -433,7 +439,7 @@ struct OperatorMemberDetailSheetView: View {
         .listRowSpacing(DefaultSpacing.spacing8)
         .scrollContentBackground(.hidden)
         .scrollIndicators(.hidden)
-        .frame(height: scrollViewHeight)
+//        .frame(height: scrollViewHeight)
     }
 
     private func penaltyHistoryRow(_ history: OperatorMemberPenaltyHistory) -> some View {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
@@ -11,47 +11,55 @@ import SwiftUI
 @Observable
 final class MemberListViewModel {
     // MARK: - Dependency
-    
+
     private let fetchMembersUseCase: FetchMembersUseCaseProtocol
     private let errorHandler: ErrorHandler
-    
+    private let userSessionManager: UserSessionManager
+
     // MARK: - Properties
-    
+
     var searchText: String = ""
     var selectedMember: MemberManagementItem?
     private(set) var membersState: Loadable<[MemberManagementItem]> = .idle
     var alertPrompt: AlertPrompt?
-    private(set) var isSubmittingOutPoint: Bool = false
-    private(set) var isDeletingOutPoint: Bool = false
+    private(set) var isSubmittingPoint: Bool = false
+    private(set) var isDeletingPoint: Bool = false
     private(set) var isLoadingMemberDetail: Bool = false
-    
+
     // MARK: - Init
-    
+
     init(
         fetchMembersUseCase: FetchMembersUseCaseProtocol,
-        errorHandler: ErrorHandler
+        errorHandler: ErrorHandler,
+        userSessionManager: UserSessionManager
     ) {
         self.fetchMembersUseCase = fetchMembersUseCase
         self.errorHandler = errorHandler
+        self.userSessionManager = userSessionManager
     }
-    
+
     // MARK: - Computed Properties
-    
+
+    /// 현재 사용자 역할 기반 사용 가능한 포인트 타입
+    var availablePointTypes: [ChallengerPointType] {
+        ChallengerPointType.availableTypes(for: userSessionManager.currentRole.level)
+    }
+
     /// 검색어로 필터링된 멤버 목록
     private var filteredMembers: [MemberManagementItem] {
         guard case .loaded(let items) = membersState else {
             return []
         }
-        
+
         if searchText.isEmpty {
             return items
         }
-        
+
         return items.filter { member in
             member.name.localizedCaseInsensitiveContains(searchText)
         }
     }
-    
+
     /// Part별로 그룹핑된 멤버 목록
     var groupedMembers: [(part: UMCPartType, members: [MemberManagementItem])] {
         let grouped = Dictionary(grouping: filteredMembers, by: { $0.part })
@@ -59,12 +67,12 @@ final class MemberListViewModel {
             .map { (part: $0.key, members: $0.value) }
             .sorted { $0.part.sortOrder < $1.part.sortOrder }
     }
-    
+
     /// 검색 결과가 비어있는지 여부
     var isSearchResultEmpty: Bool {
         !searchText.isEmpty && filteredMembers.isEmpty
     }
-    
+
     // MARK: - Action
 
     /// 멤버 전체 목록을 조회합니다.
@@ -89,24 +97,21 @@ final class MemberListViewModel {
         }
     }
 
-    /// 멤버에게 아웃 포인트를 부여합니다.
-    ///
-    /// - Parameters:
-    ///   - member: 아웃을 부여할 멤버
-    ///   - reason: 아웃 사유
-    /// - Returns: 성공 여부
+    /// 멤버에게 포인트를 부여합니다.
     @MainActor
-    func submitOutPoint(
+    func submitPoint(
         member: MemberManagementItem,
-        reason: String
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
     ) async -> Bool {
-        let trimmedReason = reason.trimmingCharacters(
+        let trimmedDescription = description.trimmingCharacters(
             in: .whitespacesAndNewlines
         )
-        guard !trimmedReason.isEmpty else {
+        guard !trimmedDescription.isEmpty else {
             alertPrompt = AlertPrompt(
-                title: "아웃 부여 실패",
-                message: "아웃 사유를 입력해 주세요.",
+                title: "포인트 부여 실패",
+                message: "사유를 입력해 주세요.",
                 positiveBtnTitle: "확인"
             )
             return false
@@ -114,20 +119,22 @@ final class MemberListViewModel {
 
         guard let challengerId = member.challengerID else {
             alertPrompt = AlertPrompt(
-                title: "아웃 부여 실패",
+                title: "포인트 부여 실패",
                 message: "챌린저 ID를 찾을 수 없습니다.",
                 positiveBtnTitle: "확인"
             )
             return false
         }
 
-        isSubmittingOutPoint = true
-        defer { isSubmittingOutPoint = false }
+        isSubmittingPoint = true
+        defer { isSubmittingPoint = false }
 
         do {
-            try await fetchMembersUseCase.grantOutPoint(
+            try await fetchMembersUseCase.grantPoint(
                 challengerId: challengerId,
-                description: trimmedReason
+                pointType: pointType,
+                pointValue: pointValue,
+                description: trimmedDescription
             )
 
             try await reloadMembersAndReselect(member: member)
@@ -135,7 +142,7 @@ final class MemberListViewModel {
             return true
         } catch let error as DomainError {
             alertPrompt = AlertPrompt(
-                title: "아웃 부여 실패",
+                title: "포인트 부여 실패",
                 message: error.userMessage,
                 positiveBtnTitle: "확인"
             )
@@ -145,7 +152,7 @@ final class MemberListViewModel {
                 error,
                 context: ErrorContext(
                     feature: "Activity",
-                    action: "submitOutPoint"
+                    action: "submitPoint"
                 )
             )
             return false
@@ -153,11 +160,6 @@ final class MemberListViewModel {
     }
 
     /// 챌린저 멤버 상세 시트를 표시합니다.
-    ///
-    /// 출석 기록을 조회한 뒤 `selectedMember`를 설정합니다.
-    /// 조회 실패 시 기존 멤버 데이터 그대로 시트를 표시합니다.
-    ///
-    /// - Parameter member: 상세 정보를 표시할 멤버
     @MainActor
     func openChallengerMemberDetail(
         _ member: MemberManagementItem
@@ -173,7 +175,7 @@ final class MemberListViewModel {
         async let recordsTask = try? fetchMembersUseCase.fetchAttendanceRecords(
             challengerId: challengerId
         )
-        async let penaltyHistoryTask = try? fetchMembersUseCase.fetchOutPenaltyHistory(
+        async let pointHistoryTask = try? fetchMembersUseCase.fetchPointHistory(
             challengerId: challengerId
         )
         async let generationsTask = try? fetchMembersUseCase.fetchAllGenerations(
@@ -181,11 +183,15 @@ final class MemberListViewModel {
         )
 
         let records = await recordsTask ?? member.attendanceRecords
-        let penaltyHistory = await penaltyHistoryTask ?? member.penaltyHistory
+        let pointHistory = await pointHistoryTask ?? member.penaltyHistory
         let generations = await generationsTask ?? member.generation
-        let totalPenalty = penaltyHistory.isEmpty
+
+        let penaltyItems = pointHistory.filter { !$0.pointType.isReward }
+        let rewardItems = pointHistory.filter { $0.pointType.isReward }
+        let totalPenalty = penaltyItems.isEmpty
             ? member.penalty
-            : penaltyHistory.reduce(0) { $0 + $1.penaltyScore }
+            : penaltyItems.reduce(0) { $0 + $1.penaltyScore }
+        let totalReward = rewardItems.reduce(0) { $0 + $1.penaltyScore }
 
         selectedMember = MemberManagementItem(
             id: member.id,
@@ -199,34 +205,30 @@ final class MemberListViewModel {
             position: member.position,
             part: member.part,
             penalty: totalPenalty,
+            rewardPoints: totalReward,
             badge: member.badge,
             managementTeam: member.managementTeam,
             attendanceRecords: records,
-            penaltyHistory: penaltyHistory,
+            penaltyHistory: pointHistory,
             canViewPenaltyHistory: true
         )
     }
 
-    /// 아웃 포인트 기록을 삭제합니다.
-    ///
-    /// - Parameters:
-    ///   - member: 아웃을 삭제할 멤버
-    ///   - history: 삭제할 아웃 이력 항목
-    /// - Returns: 성공 여부
+    /// 포인트 기록을 삭제합니다.
     @MainActor
-    func deleteOutPoint(
+    func deletePoint(
         member: MemberManagementItem,
         history: OperatorMemberPenaltyHistory
     ) async -> String? {
         guard let challengerPointId = history.challengerPointId else {
-            return "삭제할 아웃 포인트 ID를 찾을 수 없습니다."
+            return "삭제할 포인트 ID를 찾을 수 없습니다."
         }
 
-        isDeletingOutPoint = true
-        defer { isDeletingOutPoint = false }
+        isDeletingPoint = true
+        defer { isDeletingPoint = false }
 
         do {
-            try await fetchMembersUseCase.deleteOutPoint(
+            try await fetchMembersUseCase.deletePoint(
                 challengerPointId: challengerPointId
             )
             try await reloadMembersAndReselect(member: member)
@@ -235,18 +237,18 @@ final class MemberListViewModel {
         } catch let error as DomainError {
             return error.userMessage
         } catch let error as RepositoryError {
-            return deleteOutPointFailureMessage(from: error)
+            return deletePointFailureMessage(from: error)
         } catch let error as NetworkError {
-            return deleteOutPointFailureMessage(from: error)
+            return deletePointFailureMessage(from: error)
         } catch {
             errorHandler.handle(
                 error,
                 context: ErrorContext(
                     feature: "Activity",
-                    action: "deleteOutPoint"
+                    action: "deletePoint"
                 )
             )
-            return "아웃 삭제에 실패했습니다. 잠시 후 다시 시도해주세요."
+            return "포인트 삭제에 실패했습니다. 잠시 후 다시 시도해주세요."
         }
     }
 
@@ -291,8 +293,6 @@ final class MemberListViewModel {
         })
     }
 
-    /// `sheet(item:)`는 `id`가 바뀌면 다른 시트로 인식해 닫았다가 다시 엽니다.
-    /// 서버 재조회 후 데이터는 최신 값으로 바꾸되, 시트 식별자는 유지합니다.
     private func memberWithStableSheetIdentity(
         base: MemberManagementItem,
         updated: MemberManagementItem
@@ -309,6 +309,7 @@ final class MemberListViewModel {
             position: updated.position,
             part: updated.part,
             penalty: updated.penalty,
+            rewardPoints: updated.rewardPoints,
             badge: updated.badge,
             managementTeam: updated.managementTeam,
             attendanceRecords: updated.attendanceRecords,
@@ -317,7 +318,7 @@ final class MemberListViewModel {
         )
     }
 
-    private func deleteOutPointFailureMessage(from error: RepositoryError) -> String {
+    private func deletePointFailureMessage(from error: RepositoryError) -> String {
         if case .serverError(_, let message) = error,
            let message,
            !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -326,7 +327,7 @@ final class MemberListViewModel {
         return error.userMessage
     }
 
-    private func deleteOutPointFailureMessage(from error: NetworkError) -> String {
+    private func deletePointFailureMessage(from error: NetworkError) -> String {
         guard case .requestFailed(_, let data) = error else {
             return error.userMessage
         }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
@@ -172,6 +172,8 @@ final class MemberListViewModel {
         isLoadingMemberDetail = true
         defer { isLoadingMemberDetail = false }
 
+        let memberId = member.memberID ?? 0
+
         async let recordsTask = try? fetchMembersUseCase.fetchAttendanceRecords(
             challengerId: challengerId
         )
@@ -179,12 +181,15 @@ final class MemberListViewModel {
             challengerId: challengerId
         )
         async let generationsTask = try? fetchMembersUseCase.fetchAllGenerations(
-            memberId: member.memberID ?? 0
+            memberId: memberId
         )
+        async let genPointsTask = try? fetchMembersUseCase
+            .fetchGenerationPointSummaries(memberId: memberId)
 
         let records = await recordsTask ?? member.attendanceRecords
         let pointHistory = await pointHistoryTask ?? member.penaltyHistory
         let generations = await generationsTask ?? member.generation
+        let generationPoints = await genPointsTask ?? []
 
         let penaltyItems = pointHistory.filter { !$0.pointType.isReward }
         let rewardItems = pointHistory.filter { $0.pointType.isReward }
@@ -210,7 +215,8 @@ final class MemberListViewModel {
             managementTeam: member.managementTeam,
             attendanceRecords: records,
             penaltyHistory: pointHistory,
-            canViewPenaltyHistory: true
+            canViewPenaltyHistory: true,
+            generationPoints: generationPoints
         )
     }
 
@@ -314,7 +320,8 @@ final class MemberListViewModel {
             managementTeam: updated.managementTeam,
             attendanceRecords: updated.attendanceRecords,
             penaltyHistory: updated.penaltyHistory,
-            canViewPenaltyHistory: base.canViewPenaltyHistory || updated.canViewPenaltyHistory
+            canViewPenaltyHistory: base.canViewPenaltyHistory || updated.canViewPenaltyHistory,
+            generationPoints: updated.generationPoints
         )
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/ActivityView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/ActivityView.swift
@@ -107,13 +107,13 @@ struct ActivityView: View {
                 container: di, errorHandler: errorHandler)
         case (.challenger, .members):
             ChallengerMemberListView(
-                container: di, errorHandler: errorHandler)
+                container: di, errorHandler: errorHandler, userSessionManager: userSession)
         case (.admin, .attendanceManage):
             operatorAttendanceContent
         case (.admin, .studyManage):
             OperatorStudyManagementView(container: di, errorHandler: errorHandler)
         case (.admin, .memberManage):
-            OperatorMemberManagementView(container: di, errorHandler: errorHandler)
+            OperatorMemberManagementView(container: di, errorHandler: errorHandler, userSessionManager: userSession)
         default:
             EmptyView()
         }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
@@ -19,12 +19,14 @@ struct ChallengerMemberListView: View {
     
     init(
         container: DIContainer,
-        errorHandler: ErrorHandler
+        errorHandler: ErrorHandler,
+        userSessionManager: UserSessionManager
     ) {
         let useCaseProvider = container.resolve(ActivityUseCaseProviding.self)
         let memberListViewModel = MemberListViewModel(
             fetchMembersUseCase: useCaseProvider.fetchMembersUseCase,
-            errorHandler: errorHandler
+            errorHandler: errorHandler,
+            userSessionManager: userSessionManager
         )
         self._viewModel = .init(wrappedValue: memberListViewModel)
     }
@@ -134,6 +136,7 @@ struct ChallengerMemberListView: View {
 #Preview {
     ChallengerMemberListView(
         container: MissionPreviewData.container,
-        errorHandler: MissionPreviewData.errorHandler)
+        errorHandler: MissionPreviewData.errorHandler,
+        userSessionManager: UserSessionManager())
 }
 #endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorMemberManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorMemberManagementView.swift
@@ -11,31 +11,30 @@ import SwiftUI
 ///
 /// 운영진이 동아리 멤버를 관리하는 화면입니다.
 struct OperatorMemberManagementView: View {
-    
+
     // MARK: - Property
-    
+
     @State private var viewModel: MemberListViewModel
-    
+
     // MARK: - Initializer
-    
+
     init(
         container: DIContainer,
-        errorHandler: ErrorHandler
+        errorHandler: ErrorHandler,
+        userSessionManager: UserSessionManager
     ) {
         let useCaseProvider = container.resolve(ActivityUseCaseProviding.self)
         let memberListViewModel = MemberListViewModel(
             fetchMembersUseCase: useCaseProvider.fetchMembersUseCase,
-            errorHandler: errorHandler
+            errorHandler: errorHandler,
+            userSessionManager: userSessionManager
         )
         self._viewModel = .init(wrappedValue: memberListViewModel)
     }
-    
-    // MARK: - Constant
-    
-    
+
     // MARK: - Body
     var body: some View {
-        
+
         Group {
             switch viewModel.membersState {
             case .idle, .loading:
@@ -69,16 +68,19 @@ struct OperatorMemberManagementView: View {
         .sheet(item: $viewModel.selectedMember) { member in
             OperatorMemberDetailSheetView(
                 member: member,
-                isSubmittingOutPoint: viewModel.isSubmittingOutPoint,
-                isDeletingOutPoint: viewModel.isDeletingOutPoint,
-                onGrantOut: { reason in
-                    await viewModel.submitOutPoint(
+                availablePointTypes: viewModel.availablePointTypes,
+                isSubmittingPoint: viewModel.isSubmittingPoint,
+                isDeletingPoint: viewModel.isDeletingPoint,
+                onGrantPoint: { pointType, pointValue, description in
+                    await viewModel.submitPoint(
                         member: member,
-                        reason: reason
+                        pointType: pointType,
+                        pointValue: pointValue,
+                        description: description
                     )
                 },
-                onDeleteOut: { history in
-                    await viewModel.deleteOutPoint(
+                onDeletePoint: { history in
+                    await viewModel.deletePoint(
                         member: member,
                         history: history
                     )
@@ -87,7 +89,7 @@ struct OperatorMemberManagementView: View {
         }
         .alertPrompt(item: $viewModel.alertPrompt)
     }
-    
+
     // MARK: - SubView
 
     private var loadingView: some View {
@@ -153,7 +155,8 @@ struct OperatorMemberManagementView: View {
 #Preview {
     OperatorMemberManagementView(
         container: MissionPreviewData.container,
-        errorHandler: MissionPreviewData.errorHandler
+        errorHandler: MissionPreviewData.errorHandler,
+        userSessionManager: UserSessionManager()
     )
 }
 #endif

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
@@ -55,8 +55,8 @@ struct FailedVerificationUMC: View {
         /// 서브타이틀 텍스트
         static let subtitle: String = "죄송합니다. 입력하신 정보로 등록된 \nUMC 챌린저 정보를 찾을 수 없습니다."
 
-        /// 상단 텍스트 버튼용 기존 챌린저 인증 문구
-        static let verifyTextButtonTitle: String = "기존 챌린저 인증하기"
+        /// 상단 텍스트 버튼용 UMC 챌린저 인증 문구
+        static let verifyTextButtonTitle: String = "UMC 챌린저 인증하기"
 
         /// 기존 챌린저 코드 입력 얼럿 제목
         static let codeAlertTitle: String = "기존 챌린저 코드 입력"
@@ -139,17 +139,32 @@ struct FailedVerificationUMC: View {
         }
     }
 
-    /// 제목/부제목 하단의 기존 챌린저 인증 텍스트 버튼
+    /// 제목/부제목 하단의 UMC 챌린저 인증 텍스트 버튼
+    @State private var isBouncing = false
+
     private var existingChallengerTextButton: some View {
         Button {
             viewModel.presentCodeAlert()
         } label: {
             Text(Constants.verifyTextButtonTitle)
-                .underline()
-                .appFont(.callout, weight: .semibold, color: .indigo500)
+                .appFont(.callout, weight: .semibold, color: .white)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
         }
+        .buttonStyle(.glassProminent)
+        .scaleEffect(isBouncing ? 1.08 : 1.0)
+        .animation(
+            .spring(duration: 0.4, bounce: 0.6)
+                .repeatCount(3, autoreverses: true),
+            value: isBouncing
+        )
         .padding(.top, Constants.verifyButtonTopPadding)
         .disabled(isInteractionDisabled)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                isBouncing = true
+            }
+        }
     }
 
     /// 하단 툴바 액션 구성을 제공합니다.

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -203,7 +203,7 @@ private struct LoginViewPreviewFetchMyProfileUseCase: FetchMyProfileUseCaseProto
             ],
             roles: [],
             generations: [
-                GenerationData(gisuId: 1, gen: 1, penaltyPoint: 0, penaltyLogs: [])
+                GenerationData(gisuId: 1, gen: 1, penaltyPoint: 0, rewardPoint: 0, pointLogs: [], penaltyLogs: [])
             ]
         )
     }

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
@@ -205,12 +205,32 @@ struct ChallengerPointDTO: Codable {
 
 /// 포인트 유형 열거형
 enum PointType: String, Codable {
-    /// 우수 워크북 포인트
     case bestWorkbook = "BEST_WORKBOOK"
-    /// 경고 패널티
     case warning = "WARNING"
-    /// 퇴출 패널티
     case out = "OUT"
+    case blogChallenge = "BLOG_CHALLENGE"
+    case umcEventReview = "UMC_EVENT_REVIEW"
+    case peerReviewSubmission = "PEER_REVIEW_SUBMISSION"
+    case noWorkbookMission = "NO_WORKBOOK_MISSION"
+    case studyLate = "STUDY_LATE"
+    case studyAbsent = "STUDY_ABSENT"
+    case eventLate = "EVENT_LATE"
+    case eventEarlyLeave = "EVENT_EARLY_LEAVE"
+    case eventLateCancel = "EVENT_LATE_CANCEL"
+    case eventNoShow = "EVENT_NO_SHOW"
+    case partLeadFeedbackLate = "PART_LEAD_FEEDBACK_LATE"
+    case schoolCoreMeetingAbsent = "SCHOOL_CORE_MEETING_ABSENT"
+    case schoolCoreTaskNotCompleted = "SCHOOL_CORE_TASK_NOT_COMPLETED"
+    case custom = "CUSTOM"
+
+    var isPenalty: Bool {
+        switch self {
+        case .bestWorkbook, .blogChallenge, .umcEventReview, .peerReviewSubmission:
+            return false
+        default:
+            return true
+        }
+    }
 }
 
 private extension KeyedDecodingContainer {
@@ -294,9 +314,9 @@ extension ChallengerMemberDTO {
     func toGenerationData(gisuId: Int) -> GenerationData {
         let maxRecentPenaltyLogs = 3
 
-        // 패널티 유형(warning, out)만 필터링
+        // 벌점 유형만 필터링
         let penaltyPoints = challengerPoints.filter {
-            $0.pointType == .warning || $0.pointType == .out
+            $0.pointType.isPenalty
         }
 
         // ISO 8601 파싱 (소수 초 유무 모두 허용)

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
@@ -305,19 +305,12 @@ extension ChallengerMemberDTO {
         )
     }
 
-    /// DTO → GenerationData 변환 (홈 화면 패널티 카드용)
+    /// DTO → GenerationData 변환 (홈 화면 상벌점 카드용)
     ///
     /// - Parameter gisuId: MyProfileDTO의 RoleDTO에서 전달받은 기수 식별 ID
-    /// - Returns: 패널티만 필터링된 `GenerationData`
-    ///
-    /// - Note: `bestWorkbook` 포인트는 제외하고 `warning`, `out`만 포함합니다.
+    /// - Returns: 상점/벌점이 포함된 `GenerationData`
     func toGenerationData(gisuId: Int) -> GenerationData {
-        let maxRecentPenaltyLogs = 3
-
-        // 벌점 유형만 필터링
-        let penaltyPoints = challengerPoints.filter {
-            $0.pointType.isPenalty
-        }
+        let maxRecentLogs = 3
 
         // ISO 8601 파싱 (소수 초 유무 모두 허용)
         let fractionalFormatter = ISO8601DateFormatter()
@@ -331,20 +324,55 @@ extension ChallengerMemberDTO {
         }
 
         let displayFormatter = DateFormatter()
-        displayFormatter.dateFormat = "yyyy.MM.dd"
+        displayFormatter.dateFormat = "MM.dd"
 
+        let penaltyDisplayFormatter = DateFormatter()
+        penaltyDisplayFormatter.dateFormat = "yyyy.MM.dd"
+
+        // 벌점/상점 분리
+        let penaltyPoints = challengerPoints.filter { $0.pointType.isPenalty }
+        let rewardPoints = challengerPoints.filter { !$0.pointType.isPenalty }
+
+        let penaltyTotal = penaltyPoints.reduce(0) { $0 + Int($1.point) }
+        let rewardTotal = rewardPoints.reduce(0) { $0 + Int($1.point) }
+
+        // 상벌점 통합 기록 (최신순 정렬, 전체)
+        let allPointsSorted = challengerPoints
+            .sorted { lhs, rhs in
+                let lhsDate = parseISODate(lhs.createdAt) ?? .distantPast
+                let rhsDate = parseISODate(rhs.createdAt) ?? .distantPast
+                return lhsDate > rhsDate
+            }
+
+        let pointLogs = allPointsSorted.map { point in
+            let dateString: String
+            if let date = parseISODate(point.createdAt) {
+                dateString = displayFormatter.string(from: date)
+            } else {
+                dateString = point.createdAt
+            }
+            let isReward = !point.pointType.isPenalty
+            return PointLogItem(
+                reason: point.description,
+                date: dateString,
+                point: isReward ? Int(point.point) : -Int(point.point),
+                isReward: isReward
+            )
+        }
+
+        // 기존 penaltyLogs 유지 (하위호환)
         let recentPenaltyPoints = penaltyPoints
             .sorted { lhs, rhs in
                 let lhsDate = parseISODate(lhs.createdAt) ?? .distantPast
                 let rhsDate = parseISODate(rhs.createdAt) ?? .distantPast
                 return lhsDate > rhsDate
             }
-            .prefix(maxRecentPenaltyLogs)
+            .prefix(maxRecentLogs)
 
-        let logs = recentPenaltyPoints.map { point in
+        let penaltyLogs = recentPenaltyPoints.map { point in
             let dateString: String
             if let date = parseISODate(point.createdAt) {
-                dateString = displayFormatter.string(from: date)
+                dateString = penaltyDisplayFormatter.string(from: date)
             } else {
                 dateString = point.createdAt
             }
@@ -355,13 +383,13 @@ extension ChallengerMemberDTO {
             )
         }
 
-        let total = penaltyPoints.reduce(0) { $0 + Int($1.point) }
-
         return GenerationData(
             gisuId: gisuId,
             gen: gisu,
-            penaltyPoint: total,
-            penaltyLogs: logs
+            penaltyPoint: penaltyTotal,
+            rewardPoint: rewardTotal,
+            pointLogs: Array(pointLogs),
+            penaltyLogs: penaltyLogs
         )
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Domain/Models/Home/GenerationData.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/Home/GenerationData.swift
@@ -22,9 +22,15 @@ struct GenerationData: Identifiable, Equatable {
     /// 기수 번호 (예: 9, 10, 11)
     let gen: Int
 
-    /// 현재 패널티 포인트 총점
+    /// 현재 벌점 총점
     let penaltyPoint: Int
 
-    /// 패널티 상세 기록 리스트
+    /// 현재 상점 총점
+    let rewardPoint: Int
+
+    /// 상벌점 통합 기록 (최근 3건)
+    let pointLogs: [PointLogItem]
+
+    /// 패널티 상세 기록 리스트 (하위호환)
     let penaltyLogs: [PenaltyInfoItem]
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
@@ -6,48 +6,60 @@
 //
 
 import SwiftUI
+import Charts
 
-/// 홈 화면 패널티 카드
+/// 홈 화면 상벌점 카드
 ///
-/// 사용자의 기수별 패널티 정보와 상세 기록을 카드 형태로 표시합니다.
+/// 사용자의 기수별 상점/벌점 차트와 상세 기록을 카드 형태로 표시합니다.
 struct PenaltyCard: View, Equatable {
-    
+
     // MARK: - Properties
-    
-    /// 기수별 패널티 데이터 리스트
+
+    /// 기수별 상벌점 데이터 리스트
     let generations: [GenerationData]
-    
+
     /// 현재 표시 중인 탭(기수) 인덱스
     @State private var currentIndex: Int = 0
     /// 드래그 오프셋 (손가락 추적용)
     @State private var dragOffset: CGFloat = 0
     /// 수평 드래그 여부 (방향 잠금용)
     @State private var isHorizontalDrag: Bool?
+    /// 팝오버 필터 (nil이면 닫힘)
+    @State private var popoverFilter: PointLogFilter?
+
+    fileprivate enum PointLogFilter {
+        case reward
+        case penalty
+    }
 
     // MARK: - Constants
 
-    enum Constants {
+    fileprivate enum Constants {
         /// 카드 전체 패딩
         static let padding: CGFloat = 20
         /// 스와이프 임계 거리
         static let swipeThreshold: CGFloat = 50
         /// 스와이프 임계 속도
         static let velocityThreshold: CGFloat = 300
+        /// 차트 크기
+        static let chartSize: CGFloat = 120
+        /// 도넛 내부 비율
+        static let innerRadius: CGFloat = 0.6
     }
-    
+
     // MARK: - Equtable
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.generations == rhs.generations
     }
-    
+
     // MARK: - Init
-    
+
     /// PenaltyCard 생성자
-    /// - Parameter generations: 표시할 기수별 패널티 데이터
+    /// - Parameter generations: 표시할 기수별 상벌점 데이터
     init(generations: [GenerationData]) {
         self.generations = generations
     }
-    
+
     // MARK: - Body
     var body: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing24, content: {
@@ -55,7 +67,7 @@ struct PenaltyCard: View, Equatable {
                 generations: generations.map { $0.gen },
                 currentIndex: $currentIndex
             )
-            
+
             cardContent
                 .offset(x: dragOffset)
                 .contentShape(.rect)
@@ -76,16 +88,13 @@ struct PenaltyCard: View, Equatable {
 
     // MARK: - Function
 
-    /// 현재 선택된 기수의 패널티 포인트 및 상세 기록을 표시하는 콘텐츠 영역
+    /// 현재 선택된 기수의 상벌점 차트 및 기록을 표시하는 콘텐츠 영역
     @ViewBuilder
     private var cardContent: some View {
         if generations.indices.contains(currentIndex) {
             let generation = generations[currentIndex]
-            HStack(alignment: .top, spacing: DefaultSpacing.spacing16) {
-                CardInfo(infoType: .penalties(generation.penaltyPoint))
-
-                CardInfo(infoType: .infoText(generation.penaltyLogs))
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+                pointChart(generation: generation)
             }
             .padding(.horizontal, DefaultSpacing.spacing4)
             .id(currentIndex)
@@ -93,15 +102,105 @@ struct PenaltyCard: View, Equatable {
         }
     }
 
+    /// 상점/벌점 도넛 차트
+    private func pointChart(generation: GenerationData) -> some View {
+        let hasData = generation.rewardPoint > 0 || generation.penaltyPoint > 0
+
+        return HStack(spacing: DefaultSpacing.spacing24) {
+            ZStack {
+                Chart {
+                    SectorMark(
+                        angle: .value("상점", hasData ? generation.rewardPoint : 0),
+                        innerRadius: .ratio(Constants.innerRadius),
+                        angularInset: 2
+                    )
+                    .foregroundStyle(.green)
+
+                    SectorMark(
+                        angle: .value("벌점", hasData ? generation.penaltyPoint : 0),
+                        innerRadius: .ratio(Constants.innerRadius),
+                        angularInset: 2
+                    )
+                    .foregroundStyle(.red)
+
+                    if !hasData {
+                        SectorMark(
+                            angle: .value("없음", 1),
+                            innerRadius: .ratio(Constants.innerRadius)
+                        )
+                        .foregroundStyle(.grey200)
+                    }
+                }
+                .chartLegend(.hidden)
+                .frame(width: Constants.chartSize, height: Constants.chartSize)
+                .allowsHitTesting(false)
+
+                VStack(spacing: 2) {
+                    Text("\(generation.rewardPoint + generation.penaltyPoint)")
+                        .appFont(.title2Emphasis, color: .grey900)
+                    Text("총점")
+                        .appFont(.caption2, color: .grey500)
+                }
+                .allowsHitTesting(false)
+
+                // 차트 영역 탭 감지 오버레이
+                Color.clear
+                    .frame(width: Constants.chartSize, height: Constants.chartSize)
+                    .contentShape(Circle())
+                    .onTapGesture { location in
+                        guard hasData else { return }
+                        let size = Constants.chartSize
+                        let center = CGPoint(x: size / 2, y: size / 2)
+                        let dx = location.x - center.x
+                        let dy = location.y - center.y
+                        // 12시 기준 시계방향 각도
+                        var angle = atan2(dx, -dy) * 180.0 / .pi
+                        if angle < 0 { angle += 360.0 }
+                        let total = Double(
+                            generation.rewardPoint + generation.penaltyPoint
+                        )
+                        let rewardDeg = Double(generation.rewardPoint) / total * 360.0
+                        popoverFilter = angle <= rewardDeg ? .reward : .penalty
+                    }
+            }
+            .popover(isPresented: Binding(
+                get: { popoverFilter != nil },
+                set: { if !$0 { popoverFilter = nil } }
+            )) {
+                PointLogPopover(
+                    logs: generation.pointLogs.filter {
+                        popoverFilter == .reward ? $0.isReward : !$0.isReward
+                    }
+                )
+                .presentationCompactAdaptation(.popover)
+            }
+
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+                legendLabel(color: .green, label: "상점", value: generation.rewardPoint)
+                legendLabel(color: .red, label: "벌점", value: generation.penaltyPoint)
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    /// 범례 라벨
+    private func legendLabel(color: Color, label: String, value: Int) -> some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Circle()
+                .fill(color)
+                .frame(width: 10, height: 10)
+            Text(label)
+                .appFont(.subheadline, color: .grey600)
+            Spacer()
+            Text("\(value)")
+                .appFont(.calloutEmphasis, color: .grey900)
+        }
+    }
+
     /// 기수 간 전환을 위한 수평 스와이프 제스처
-    ///
-    /// 방향 잠금, 러버밴드 효과, 속도 기반 전환을 포함합니다.
-    ///
-    /// - Note: 첫 터치 방향으로 수평/수직을 판별하여 세로 스크롤과 충돌을 방지합니다.
     private var swipeGesture: some Gesture {
         DragGesture(minimumDistance: 15)
             .onChanged { value in
-                // 최초 드래그 방향으로 수평/수직 잠금
                 if isHorizontalDrag == nil {
                     isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
                 }
@@ -111,7 +210,6 @@ struct PenaltyCard: View, Equatable {
                 let isAtLeadingEdge = currentIndex == 0 && translation > 0
                 let isAtTrailingEdge = currentIndex == generations.count - 1 && translation < 0
 
-                // 양 끝에서 러버밴드 효과 (저항감 적용)
                 if isAtLeadingEdge || isAtTrailingEdge {
                     dragOffset = translation * 0.3
                 } else {
@@ -125,7 +223,6 @@ struct PenaltyCard: View, Equatable {
                 let translation = value.translation.width
                 let velocity = value.predictedEndTranslation.width
 
-                // 거리 또는 속도 임계값 초과 시 페이지 전환
                 withAnimation(.smooth(duration: 0.3)) {
                     if (translation < -Constants.swipeThreshold || velocity < -Constants.velocityThreshold),
                        currentIndex < generations.count - 1 {
@@ -148,15 +245,62 @@ struct PenaltyCard: View, Equatable {
     }
 }
 
+/// 상벌점 기록 팝오버
+fileprivate struct PointLogPopover: View {
+
+    // MARK: - Property
+
+    let logs: [PointLogItem]
+
+    private enum Constants {
+        static let circleDiameter: CGFloat = 8
+        static let popoverPadding: CGFloat = 16
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text("상세 기록")
+                .appFont(.footnoteEmphasis, color: .grey900)
+
+            ForEach(logs) { log in
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Circle()
+                        .fill(log.isReward ? Color.green : Color.red)
+                        .frame(
+                            width: Constants.circleDiameter,
+                            height: Constants.circleDiameter
+                        )
+
+                    Text(log.reason)
+                        .appFont(.subheadline, color: .grey900)
+
+                    Spacer()
+
+                    Text(log.isReward ? "+\(log.point)" : "\(log.point)")
+                        .appFont(.subheadline, color: log.isReward ? .green : .red)
+
+                    Text(log.date)
+                        .appFont(.footnote, color: .grey500)
+                }
+            }
+        }
+        .padding(Constants.popoverPadding)
+        .glassEffect(.clear, in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius))
+    }
+}
+
 /// 기수 선택 탭 바
 fileprivate struct GenTabBar: View {
+
     // MARK: - Properties
-    
+
     /// 표시할 기수 목록
     let generations: [Int]
     /// 현재 선택된 인덱스 바인딩
     @Binding var currentIndex: Int
-    
+
     private enum Constants {
         /// 탭 텍스트 패딩
         static let textPadding: EdgeInsets = .init(top: 8, leading: 16, bottom: 8, trailing: 16)
@@ -165,7 +309,7 @@ fileprivate struct GenTabBar: View {
         /// 인디케이터 지름
         static let indicatorDiameter: CGFloat = 8
     }
-    
+
     // MARK: - Body
     var body: some View {
         let titleText = generations.indices.contains(currentIndex)
@@ -177,9 +321,9 @@ fileprivate struct GenTabBar: View {
                 .appFont(.footnoteEmphasis, color: .indigo600)
                 .padding(Constants.textPadding)
                 .background(.indigo100, in: .capsule)
-            
+
             Spacer()
-            
+
             HStack(spacing: Constants.indicatorSpacing) {
                 ForEach(generations.indices, id: \.self) { index in
                     Circle()
@@ -196,191 +340,18 @@ fileprivate struct GenTabBar: View {
     }
 }
 
-// MARK: - CardInfo
-/// 카드 경고 포인트 및 설명
-fileprivate struct CardInfo: View {
-    
-    // MARK:  - Properties
-    /// 표시할 정보 타입 (점수 또는 상세 기록)
-    var infoType: InfoType
-    
-    // MARK: - Constants
-    
-    private enum Constants {
-        static let desCardPadding: CGFloat = 4
-        /// 프로그레스 바 높이
-        static let progressHeight: CGFloat = 20
-    }
-    
-    // MARK: - Init
-    init(infoType: InfoType) {
-        self.infoType = infoType
-    }
-    
-    // MARK: - Body
-    var body: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing16, content: {
-            title
-            content
-        })
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-    
-    // MARK: - Top
-    /// 카드 타이틀
-    private var title: some View {
-        Text(infoType.text)
-            .font(.subheadline)
-            .foregroundStyle(.grey600)
-            .fontWeight(.semibold)
-    }
-    
-    /// 카드 컨텐츠
-    @ViewBuilder
-    private var content: some View {
-        if let point = infoType.point {
-            pointContent(point: point)
-        } else if let items = infoType.infoItems {
-            descripContent(items: items)
-        }
-    }
-    
-    // MARK: - Point
-    /// 포인트 컨텐츠
-    /// - Parameter point: 포인트 점수
-    /// - Returns: 포인트 뷰 반환
-    private func pointContent(point: Int) -> some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8, content: {
-            pointTitle(point: point)
-            progressBar(point: point)
-        })
-    }
-    
-    private func pointTitle(point: Int) -> some View {
-        HStack(alignment: .lastTextBaseline, spacing: DefaultSpacing.spacing12, content: {
-            Text("\(point)")
-                .appFont(.title1Emphasis, color: .grey900)
-            
-            Group {
-                Text("/")
-                Text("3")
-            }
-            .appFont(.title2Emphasis, color: .grey400)
-        })
-    }
-    
-    // MARK: - Descrip
-    /// 패널티 사유 카드 리스트
-    /// - Parameter items: 패널티 사유
-    /// - Returns: 패널티 사유 뷰
-    @ViewBuilder
-    private func descripContent(items: [PenaltyInfoItem]) -> some View {
-        if items.isEmpty {
-            emptyPenaltyState
-        } else {
-            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
-                ForEach(items.indices, id: \.self) { index in
-                    descripCard(item: items[index])
-                }
-            }
-        }
-    }
-
-    private var emptyPenaltyState: some View {
-        VStack(alignment: .leading) {
-            Image(systemName: "checkmark.shield.fill")
-                .font(.system(size: 28, weight: .semibold))
-                .foregroundStyle(.green500)
-            
-            Spacer()
-
-            Text("등록된 패널티가 없습니다.")
-                .appFont(.footnoteEmphasis, color: .grey900)
-                .multilineTextAlignment(.leading)
-                .padding(.bottom, DefaultSpacing.spacing4)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-    
-    /// 패널티 사유 뷰 카드
-    /// - Parameter item: 패널티 사유 데이터
-    /// - Returns: 패널티 사유 뷰
-    private func descripCard(item: PenaltyInfoItem) -> some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4, content: {
-            HStack(spacing: DefaultSpacing.spacing8) {
-                Text(item.reason)
-                    .appFont(.calloutEmphasis, color: .grey900)
-                Spacer()
-                Text("\(item.penaltyPoint)점")
-                    .appFont(.calloutEmphasis, color: .red)
-            }
-            
-            Text(item.date)
-                .appFont(.footnote, color: .grey500)
-        })
-    }
-    
-    // MARK: - Method
-    private func progressBar(point: Int) -> some View {
-        Gauge(value: Double(point), in: 0...3) {
-            EmptyView()
-        }
-        .gaugeStyle(.linearCapacity)
-        .tint(progressGradient(point))
-        .frame(height: Constants.progressHeight)
-    }
-    
-    /// 프로그레스 바 그라데이션 색상 결정
-    private func progressGradient(_ point: Int) -> LinearGradient {
-        switch point {
-        case 0...1:
-            return LinearGradient(
-                colors: [.green300, .green500, .green700],
-                startPoint: .leading,
-                endPoint: .trailing
-            )
-        case 2:
-            return LinearGradient(
-                colors: [.orange400, .orange500, .orange600],
-                startPoint: .leading,
-                endPoint: .trailing
-            )
-        case 3:
-            return LinearGradient(
-                colors: [.red300, .red500, .red700],
-                startPoint: .leading,
-                endPoint: .trailing
-            )
-        default:
-            return LinearGradient(
-                colors: [.grey400, .grey500, .grey600],
-                startPoint: .leading,
-                endPoint: .trailing
-            )
-        }
-    }
-    
-    /// 프로그레스 바 배경 색상 결정
-    private func progressBackgroundColor(_ point: Int) -> Color {
-        switch point {
-        case 0...1:
-            return .green100
-        case 2:
-            return .orange100
-        case 3:
-            return .red100
-        default:
-            return .grey100
-        }
-    }
-}
-
 #Preview(traits: .sizeThatFitsLayout) {
     PenaltyCard(generations: [
         GenerationData(
             gisuId: 0,
             gen: 11,
-            penaltyPoint: 3,
+            penaltyPoint: 6,
+            rewardPoint: 5,
+            pointLogs: [
+                .init(reason: "스터디 지각", date: "03.26", point: -2, isReward: false),
+                .init(reason: "워크북 미제출", date: "03.27", point: -4, isReward: false),
+                .init(reason: "우수 워크북", date: "03.28", point: 2, isReward: true)
+            ],
             penaltyLogs: [
                 .init(reason: "지각", date: "03.26", penaltyPoint: 1),
                 .init(reason: "과제 미제출", date: "03.27", penaltyPoint: 1),
@@ -391,6 +362,10 @@ fileprivate struct CardInfo: View {
             gisuId: 0,
             gen: 12,
             penaltyPoint: 1,
+            rewardPoint: 3,
+            pointLogs: [
+                .init(reason: "지각", date: "03.14", point: -1, isReward: false),
+            ],
             penaltyLogs: [
                 .init(reason: "지각", date: "03.14", penaltyPoint: 1),
             ]
@@ -399,6 +374,8 @@ fileprivate struct CardInfo: View {
             gisuId: 0,
             gen: 13,
             penaltyPoint: 0,
+            rewardPoint: 0,
+            pointLogs: [],
             penaltyLogs: []
         )
     ])

--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
@@ -114,14 +114,26 @@ struct PenaltyCard: View, Equatable {
                         innerRadius: .ratio(Constants.innerRadius),
                         angularInset: 2
                     )
-                    .foregroundStyle(.green)
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [.indigo400, .indigo600],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
 
                     SectorMark(
                         angle: .value("벌점", hasData ? generation.penaltyPoint : 0),
                         innerRadius: .ratio(Constants.innerRadius),
                         angularInset: 2
                     )
-                    .foregroundStyle(.red)
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [.indigo100, .indigo300],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
 
                     if !hasData {
                         SectorMark(
@@ -176,8 +188,8 @@ struct PenaltyCard: View, Equatable {
             }
 
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
-                legendLabel(color: .green, label: "상점", value: generation.rewardPoint)
-                legendLabel(color: .red, label: "벌점", value: generation.penaltyPoint)
+                legendLabel(color: .indigo500, label: "상점", value: generation.rewardPoint)
+                legendLabel(color: .indigo200, label: "벌점", value: generation.penaltyPoint)
             }
             .frame(maxWidth: .infinity)
         }
@@ -267,7 +279,7 @@ fileprivate struct PointLogPopover: View {
             ForEach(logs) { log in
                 HStack(spacing: DefaultSpacing.spacing8) {
                     Circle()
-                        .fill(log.isReward ? Color.green : Color.red)
+                        .fill(log.isReward ? Color.indigo500 : Color.indigo200)
                         .frame(
                             width: Constants.circleDiameter,
                             height: Constants.circleDiameter
@@ -279,7 +291,7 @@ fileprivate struct PointLogPopover: View {
                     Spacer()
 
                     Text(log.isReward ? "+\(log.point)" : "\(log.point)")
-                        .appFont(.subheadline, color: log.isReward ? .green : .red)
+                        .appFont(.subheadline, color: log.isReward ? .indigo500 : .indigo300)
 
                     Text(log.date)
                         .appFont(.footnote, color: .grey500)

--- a/AppProduct/AppProduct/Features/Home/Presentation/Enum/PenalyInfoType.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Enum/PenalyInfoType.swift
@@ -17,6 +17,19 @@ struct PenaltyInfoItem: Equatable, Codable {
     let penaltyPoint: Int
 }
 
+/// 상벌점 통합 기록 아이템
+struct PointLogItem: Equatable, Identifiable {
+    let id = UUID()
+    /// 사유 (예: 지각, 우수 워크북 등)
+    let reason: String
+    /// 발생 날짜 (MM.dd 형식)
+    let date: String
+    /// 포인트 값 (양수=상점, 음수=벌점)
+    let point: Int
+    /// 상점 여부
+    let isReward: Bool
+}
+
 /// 패널티 정보 표시 타입
 ///
 /// 패널티 점수 요약 또는 상세 기록 표시에 사용됩니다.

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -303,6 +303,8 @@ extension HomeViewModel {
                 gisuId: 1,
                 gen: 6,
                 penaltyPoint: 0,
+                rewardPoint: 0,
+                pointLogs: [],
                 penaltyLogs: []
             )
         ])


### PR DESCRIPTION
## ✨ PR 유형

상벌점 제도 전환에 따른 멤버 관리 + 홈 화면 상벌점 차트 카드 신규 구현 + 기타 UX 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경이 포함되어 있습니다. 스크린샷/영상을 첨부해주세요 -->

## 🛠️ 작업내용

### 상벌점 제도 전환
- 아웃 제도에서 상벌점 제도로 전환 (멤버 관리 전반)
- `MemberRepository`, `FetchMembersUseCase` 상벌점 관련 로직 추가
- `ChallengerMemberDetailSheetView`, `OperatorMemberDetailSheetView` 상벌점 UI 반영
- `MemberListViewModel` 상벌점 데이터 처리 로직 추가

### 홈 상벌점 차트 카드
- `PointLogItem` 구조체 추가 (상벌점 통합 기록 아이템)
- `GenerationData`에 `rewardPoint`, `pointLogs` 필드 추가
- `ChallengerMemberDTO.toGenerationData()`에서 상점/벌점 분리 합산 및 전체 기록 생성
- `PenaltyCard`를 SectorMark 도넛 차트로 변경 (indigo 그라데이션)
- 차트 섹터 탭 시 해당 유형 기록 팝오버 표시 (`glassEffect(.clear)`)

### 기타 개선
- 지오펜싱 반경 100m → 50m로 변경
- `FailedVerificationUMC` 버튼 텍스트 "UMC 챌린저 인증하기"로 변경
- 인증 버튼 `glassProminent` 스타일 + 바운스 애니메이션 적용

## 📋 추후 진행 상황

- 상벌점 기록 상세 화면 연결
- 홈 카드 애니메이션 추가 검토

## 📌 리뷰 포인트

- `Features/Home/Presentation/Components/Card/PenaltyCard.swift` - SectorMark 도넛 차트 + 탭 감지 오버레이 로직
- `Features/Home/Data/DTO/ChallengerMemeberDTO.swift` - 상점/벌점 분리 합산 및 pointLogs 생성 로직
- `Features/Home/Domain/Models/Home/GenerationData.swift` - rewardPoint, pointLogs 필드 추가
- `Features/Activity/Domain/Models/Attendance/AttendancePolicy.swift` - 지오펜싱 반경 50m 변경
- `Features/Auth/Presentation/Views/FailedVerificationUMC.swift` - glassProminent 버튼 + 바운스 애니메이션

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)