### PR TITLE
🐛 [Fix] 앱 재시작 시 출석체크 승인 대기 상태 초기화 버그 수정 (#543)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/ActivityRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/ActivityRepository.swift
@@ -126,8 +126,19 @@ final class ActivityRepository: ActivityRepositoryProtocol, @unchecked Sendable 
         schedule: AvailableAttendanceSchedule
     ) -> Attendance? {
         switch schedule.status {
-        case .beforeAttendance, .pendingApproval:
+        case .beforeAttendance:
             return nil
+        case .pendingApproval:
+            return Attendance(
+                sessionId: SessionID(
+                    value: String(schedule.scheduleId)
+                ),
+                userId: UserID(value: ""),
+                type: schedule.locationVerified ? .gps : .reason,
+                status: .pendingApproval,
+                locationVerification: nil,
+                reason: nil
+            )
         case .present, .late, .absent:
             return Attendance(
                 sessionId: SessionID(

--- a/AppProduct/AppProduct/Features/Activity/Domain/Enum/Attendance/AttendanceStatus.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Enum/Attendance/AttendanceStatus.swift
@@ -73,7 +73,7 @@ extension AttendanceStatus {
         case "ABSENT":
             self = .absent
         case "PENDING":
-            self = .beforeAttendance
+            self = .pendingApproval
         default:
             if serverStatus.hasSuffix("_PENDING") {
                 self = .pendingApproval


### PR DESCRIPTION
## ✨ PR 유형

🐛 Bug Fix

## 🛠️ 작업내용

- `AttendanceStatus.init(serverStatus:)`에서 서버 `"PENDING"` 상태를 `.beforeAttendance`(출석 전) 대신 `.pendingApproval`(승인 대기)로 올바르게 매핑
- `ActivityRepository.mapAttendance()`에서 `.pendingApproval` 상태일 때 `nil` 대신 `Attendance` 객체를 반환하여 Session에 초기 출석 정보 전달

### 원인

1. 서버가 GPS 출석 제출 후 반환하는 `"PENDING"` 상태를 `.beforeAttendance`로 잘못 매핑 → 앱 재시작 시 "출석 전" UI 표시
2. `mapAttendance()`가 `.pendingApproval`에서도 `nil`을 반환 → `Session.initialAttendance`가 없어 `attendanceLoadable = .idle`로 초기화
3. `hasSubmitted`가 메모리 전용 플래그라 앱 재시작 시 `false`로 리셋 (위 두 수정으로 자동 해결)

### 수정 후 데이터 흐름

```
서버 "PENDING" → .pendingApproval → mapAttendance → Attendance(status: .pendingApproval)
→ Session(initialAttendance: ✅) → attendanceStatus = .pendingApproval
→ ChallengerPendingApprovalView 표시 ✅
```

## 📌 리뷰 포인트

- `Features/Activity/Domain/` — `AttendanceStatus` 서버 매핑 변경 확인
- `Features/Activity/Data/` — `mapAttendance` case 분리 및 Attendance 객체 생성 확인

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

closes #543