### PR TITLE
🐛 [Fix] 승인 권한 없는 운영진의 빈 승인 대기 시트 문제 수정 (#546)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorPendingSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorPendingSheetView.swift
@@ -42,24 +42,36 @@ struct OperatorPendingSheetView: View {
     
     var body: some View {
         NavigationStack {
-            List {
-                ForEach(sessionAttendance.pendingMembers, id: \.id) { member in
-                    OperatorPendingMemberRow(
-                        member: member,
-                        isSelecting: isSelecting,
-                        isSelected: selectedMemberIDs.contains(member.id),
-                        onToggleSelection: {
-                            toggleSelection(for: member.id)
-                        }
+            Group {
+                if sessionAttendance.pendingMembers.isEmpty {
+                    ContentUnavailableView(
+                        "승인 대기 멤버 없음",
+                        systemImage: "person.crop.circle.badge.checkmark",
+                        description: Text(
+                            "현재 승인 대기 중인 멤버가 없습니다."
+                        )
                     )
-                    .equatable()
-                    .listRowSeparator(.hidden)
-                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        swipeActionBtn(member: member)
+                } else {
+                    List {
+                        ForEach(sessionAttendance.pendingMembers, id: \.id) { member in
+                            OperatorPendingMemberRow(
+                                member: member,
+                                isSelecting: isSelecting,
+                                isSelected: selectedMemberIDs.contains(member.id),
+                                onToggleSelection: {
+                                    toggleSelection(for: member.id)
+                                }
+                            )
+                            .equatable()
+                            .listRowSeparator(.hidden)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                swipeActionBtn(member: member)
+                            }
+                        }
                     }
+                    .listRowSpacing(DefaultSpacing.spacing12)
                 }
             }
-            .listRowSpacing(DefaultSpacing.spacing12)
             .navigationTitle("승인 대기 명단")
             .navigationBarTitleDisplayMode(.inline)
             .presentationDetents([.medium, .large])

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
@@ -16,6 +16,13 @@ final class OperatorAttendanceViewModel {
 
     // MARK: - Property
 
+    /// 승인 대기 명단 로드 결과
+    enum PendingLoadResult {
+        case loaded    // 멤버 1명 이상
+        case empty     // 성공이지만 빈 배열
+        case failed    // API 에러 또는 내부 상태 오류
+    }
+
     private var container: DIContainer
     private var errorHandler: ErrorHandler
     private var useCase: OperatorAttendanceUseCaseProtocol
@@ -119,11 +126,11 @@ final class OperatorAttendanceViewModel {
     ///
     /// `/api/v1/attendances/pending/{scheduleId}` 호출 후 해당 세션에 멤버 목록을 채웁니다.
     @MainActor
-    func loadPendingMembers(for sessionId: UUID) async {
+    func loadPendingMembers(for sessionId: UUID) async -> PendingLoadResult {
         guard case .loaded(var sessions) = sessionsState,
               let index = sessions.firstIndex(where: { $0.id == sessionId }),
               let scheduleId = Int(sessions[index].serverID ?? "")
-        else { return }
+        else { return .failed }
 
         do {
             let records = try await useCase.fetchPendingAttendances(
@@ -134,11 +141,13 @@ final class OperatorAttendanceViewModel {
                 pendingMembers: members
             )
             sessionsState = .loaded(sessions)
+            return members.isEmpty ? .empty : .loaded
         } catch {
             errorHandler.handle(error, context: .init(
                 feature: "Activity",
                 action: "loadPendingMembers"
             ))
+            return .failed
         }
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
@@ -214,8 +214,21 @@ struct OperatorAttendanceSectionView: View {
             onLocationTap: { viewModel.locationButtonTapped(session: sessionAttendance.session) },
             onPendingListTap: {
                 Task {
-                    await viewModel.loadPendingMembers(for: sessionAttendance.id)
-                    selectedPendingSessionId = sessionAttendance.id
+                    let result = await viewModel.loadPendingMembers(
+                        for: sessionAttendance.id
+                    )
+                    switch result {
+                    case .loaded:
+                        selectedPendingSessionId = sessionAttendance.id
+                    case .empty:
+                        viewModel.alertPrompt = AlertPrompt(
+                            title: "승인 대기 명단",
+                            message: "승인 대기 중인 멤버가 없습니다.",
+                            positiveBtnTitle: "확인"
+                        )
+                    case .failed:
+                        break
+                    }
                 }
             },
             onReasonTap: { viewModel.reasonButtonTapped(member: $0) },


### PR DESCRIPTION
## 🚑 PR 유형

Hotfix - 승인 권한이 없는 운영진이 승인 대기 명단 시트를 열면 빈 화면이 표시되는 버그 수정

## 🛠️ 작업내용

- `OperatorAttendanceViewModel`에 `PendingLoadResult` enum 추가 (`.loaded`, `.empty`, `.failed`)
- `loadPendingMembers` 반환 타입을 `Void` → `PendingLoadResult`로 변경
- `OperatorAttendanceSectionView`에서 결과에 따라 시트 열기/AlertPrompt/무시 분기 처리
- `OperatorPendingSheetView`에 방어적 Empty State (`ContentUnavailableView`) 추가
- 변경된 파일: 3개

## 📌 리뷰 포인트

- `Features/Activity/Presentation/ViewModels/` 변경됨 - `PendingLoadResult` enum 및 반환 타입 변경 확인 필요
- `Features/Activity/Presentation/Views/` 변경됨 - 시트 열기 조건 분기 로직 확인 필요

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

Closes #546