### PR TITLE
🐛 [Fix] 서버 출석 상태 매핑 보정, 사유 제출 버튼 재활성화 및 승인 대기 버튼 터치 수정 (#547)

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/project.pbxproj
+++ b/AppProduct/AppProduct.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 71;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8B8B4462NV;
 				ENABLE_PREVIEWS = YES;
@@ -407,7 +407,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.umc.product;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -440,7 +440,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 71;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 8B8B4462NV;
 				ENABLE_PREVIEWS = YES;
@@ -463,7 +463,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.umc.product;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AppProduct/AppProduct/Features/Activity/Domain/Enum/Attendance/AttendanceStatus.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Enum/Attendance/AttendanceStatus.swift
@@ -63,16 +63,19 @@ extension AttendanceStatus {
     ///
     /// - Parameter serverStatus: 서버 응답 status 필드
     ///   (e.g., "PRESENT", "LATE", "ABSENT", "PENDING",
-    ///    "PRESENT_PENDING", "LATE_PENDING")
+    ///    "PRESENT_PENDING", "LATE_PENDING", "EXCUSED",
+    ///    "EXCUSED_PENDING")
     init(serverStatus: String) {
         switch serverStatus {
-        case "PRESENT":
+        case "PRESENT", "EXCUSED":
             self = .present
         case "LATE":
             self = .late
         case "ABSENT":
             self = .absent
         case "PENDING":
+            self = .beforeAttendance
+        case "PRESENT_PENDING", "LATE_PENDING", "EXCUSED_PENDING":
             self = .pendingApproval
         default:
             if serverStatus.hasSuffix("_PENDING") {

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Session/Session.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Session/Session.swift
@@ -75,6 +75,7 @@ final class Session: Identifiable, Equatable {
     func canSubmitReason() -> Bool {
         !isLoading
         && !hasSubmitted
+        && attendanceStatus == .beforeAttendance
     }
 
     init(info: SessionInfo, initialAttendance: Attendance? = nil) {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorSessionCard.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorSessionCard.swift
@@ -150,6 +150,7 @@ struct OperatorSessionCard: View, Equatable {
             }
             .padding(ActivityConstants.statusCardPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .glassEffect(

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Map/BaseMapViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Map/BaseMapViewModel.swift
@@ -56,7 +56,7 @@ final class BaseMapViewModel {
             center: .init(
                 latitude: info.location.latitude,
                 longitude: info.location.longitude),
-            span: .init(latitudeDelta: 0.003, longitudeDelta: 0.003)))
+            span: .init(latitudeDelta: 0.002, longitudeDelta: 0.002)))
     }
     
     /// 출석용 지오펜스 모니터링 시작


### PR DESCRIPTION
## ✨ PR 유형

버그 수정 (Bug Fix)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 여기에 추가해주세요 -->

## 🛠️ 작업내용

- **서버 출석 상태 매핑 보정**: `PENDING` → `.beforeAttendance`, `PRESENT_PENDING`/`LATE_PENDING`/`EXCUSED_PENDING` → `.pendingApproval` 명시적 case 전환 + `EXCUSED` → `.present` 매핑 추가 (#543 회귀 수정)
- **사유 제출 버튼 재활성화 방지**: `canSubmitReason()`에 `attendanceStatus == .beforeAttendance` 가드 추가하여 앱 재시작 후에도 승인 대기 상태에서 버튼 비활성 유지
- **승인 대기 명단 버튼 터치 영역 수정**: `Spacer()` 영역이 터치 불가했던 문제를 `.contentShape(Rectangle())`로 해결
- 지도 줌 레벨 미세 조정 (0.003 → 0.002)
- 변경 파일: 5개

## 📋 추후 진행 상황

- #549 스터디 그룹 권한 판단을 서버 resource-permission API 기반으로 전환

## 📌 리뷰 포인트

- `Features/Activity/Domain/Enum/Attendance/AttendanceStatus.swift` — 서버 상태 매핑 하이브리드 방식 (명시적 case + `hasSuffix("_PENDING")` fallback)
- `Features/Activity/Domain/Models/Session/Session.swift` — `canSubmitReason()` 도메인 규칙 변경
- `Features/Activity/Presentation/Components/Operation/Attendance/OperatorSessionCard.swift` — 버튼 hit area 수정

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)