### PR TITLE
✨ [Feat] 출석 상태 실시간 동기화 Smart Polling (#544)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Session/Session.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Session/Session.swift
@@ -96,6 +96,53 @@ final class Session: Identifiable, Equatable {
         hasSubmitted = true
     }
 
+    /// Polling 응답 기반 출석 상태 동기화
+    ///
+    /// 서버에서 받은 최신 상태가 현재와 다를 때만 업데이트합니다.
+    /// - 기존 Attendance가 있으면 status만 교체한 복사본으로 갱신
+    /// - 기존 Attendance가 없으면 최소 Attendance 생성
+    /// - 서버가 최종 확정(출석/지각/결석)하면 hasSubmitted 초기화
+    func updateStatusFromPolling(
+        _ serverStatus: AttendanceStatus,
+        userId: UserID
+    ) {
+        // raw status로 비교
+        // (computed attendanceStatus는 hasSubmitted 기반 pendingApproval 매핑이 있어 불필요한 mutation 발생)
+        if let existing = attendance {
+            guard existing.status != serverStatus else { return }
+        } else {
+            guard serverStatus != .beforeAttendance else { return }
+        }
+
+        if let existing = attendance {
+            let updated = Attendance(
+                sessionId: existing.sessionId,
+                userId: existing.userId,
+                type: existing.type,
+                status: serverStatus,
+                locationVerification: existing.locationVerification,
+                reason: existing.reason
+            )
+            attendanceLoadable = .loaded(updated)
+        } else {
+            let minimal = Attendance(
+                sessionId: id,
+                userId: userId,
+                type: .gps,
+                status: serverStatus,
+                locationVerification: nil,
+                reason: nil
+            )
+            attendanceLoadable = .loaded(minimal)
+        }
+
+        // 서버가 최종 상태 확정 시 hasSubmitted 리셋
+        if serverStatus != .beforeAttendance
+            && serverStatus != .pendingApproval {
+            hasSubmitted = false
+        }
+    }
+
     /// 출석 버튼에 표시할 텍스트
     ///
     /// 위치 권한, 지오펜스 상태, 시간대에 따라 적절한 메시지를 반환합니다.

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
@@ -25,6 +25,18 @@ final class ChallengerAttendanceViewModel {
 
     private var statusObserver: (any NSObjectProtocol)?
 
+    /// 폴링 설정
+    private enum PollingConfig {
+        static let intervalSeconds: Int = 30
+    }
+
+    /// 출석 가능한 세션이 있는지 확인
+    private var hasActiveSession: Bool {
+        guard case .loaded(let schedules) = availableSchedules
+        else { return false }
+        return !schedules.isEmpty
+    }
+
     // MARK: - Init
 
     init(
@@ -68,6 +80,48 @@ final class ChallengerAttendanceViewModel {
             myHistory = .loaded(history)
         } catch {
             // 배경 갱신 실패는 무시
+        }
+    }
+
+    /// 출석 가능 일정 갱신 (로딩 상태 변경 없이)
+    @MainActor
+    private func refreshAvailableSchedules() async {
+        guard !availableSchedules.isLoading else { return }
+        do {
+            let schedules = try await challengeAttendanceUseCase.fetchAvailableSchedules()
+            availableSchedules = .loaded(schedules)
+        } catch {
+            // 배경 갱신 실패는 무시
+        }
+    }
+
+    /// 앱 foreground 복귀 시 전체 갱신 (두 API 병렬 호출)
+    @MainActor
+    func refreshAfterForeground() async {
+        async let schedules: Void = refreshAvailableSchedules()
+        async let history: Void = refreshMyHistory()
+        _ = await (schedules, history)
+    }
+
+    /// 출석 가능 세션이 있을 때 주기적으로 상태를 갱신합니다.
+    ///
+    /// `.task` 모디파이어에서 호출하면 뷰 사라질 때
+    /// 자동 취소됩니다.
+    @MainActor
+    func startPollingIfNeeded() async {
+        // isComplete는 .loaded 또는 .failed 모두 true.
+        // .failed 시 hasActiveSession이 false이므로
+        // 폴링 미시작.
+        guard availableSchedules.isComplete, myHistory.isComplete else { return }
+
+        while !Task.isCancelled {
+            guard hasActiveSession else { return }
+            try? await Task.sleep(for: .seconds(
+                PollingConfig.intervalSeconds
+            ))
+            guard !Task.isCancelled else { break }
+            await refreshAvailableSchedules()
+            await refreshMyHistory()
         }
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
@@ -25,16 +25,26 @@ final class ChallengerAttendanceViewModel {
 
     private var statusObserver: (any NSObjectProtocol)?
 
+    /// 폴링 대상 세션 (View에서 주입)
+    private var pollingSessions: [Session] = []
+
+    /// 폴링 시 Session 상태 업데이트용 userId
+    private var pollingUserId: UserID?
+
     /// 폴링 설정
     private enum PollingConfig {
         static let intervalSeconds: Int = 30
     }
 
-    /// 출석 가능한 세션이 있는지 확인
-    private var hasActiveSession: Bool {
-        guard case .loaded(let schedules) = availableSchedules
-        else { return false }
-        return !schedules.isEmpty
+    /// 진행 중인 세션이 하나라도 있는지 확인
+    private func hasActiveSession(in sessions: [Session]) -> Bool {
+        sessions.contains { session in
+            let status = OperatorSessionStatus.from(
+                startTime: session.info.startTime,
+                endTime: session.info.endTime
+            )
+            return status == .inProgress
+        }
     }
 
     // MARK: - Init
@@ -90,8 +100,34 @@ final class ChallengerAttendanceViewModel {
         do {
             let schedules = try await challengeAttendanceUseCase.fetchAvailableSchedules()
             availableSchedules = .loaded(schedules)
+            syncSessionStates()
         } catch {
             // 배경 갱신 실패는 무시
+        }
+    }
+
+    /// 폴링으로 받은 서버 상태를 Session 객체에 동기화
+    ///
+    /// `AvailableAttendanceSchedule.scheduleId`와
+    /// `Session.id`를 매칭하여 상태를 전파합니다.
+    @MainActor
+    private func syncSessionStates() {
+        guard case .loaded(let schedules) = availableSchedules,
+              let userId = pollingUserId else { return }
+
+        let scheduleMap: [String: AttendanceStatus] = Dictionary(
+            uniqueKeysWithValues: schedules.map {
+                (String($0.scheduleId), $0.status)
+            }
+        )
+
+        for session in pollingSessions {
+            if let serverStatus = scheduleMap[session.id.value] {
+                session.updateStatusFromPolling(
+                    serverStatus,
+                    userId: userId
+                )
+            }
         }
     }
 
@@ -103,19 +139,27 @@ final class ChallengerAttendanceViewModel {
         _ = await (schedules, history)
     }
 
-    /// 출석 가능 세션이 있을 때 주기적으로 상태를 갱신합니다.
+    /// 폴링에 필요한 세션 및 userId를 설정합니다.
+    ///
+    /// View 초기화 시 한 번 호출합니다.
+    @MainActor
+    func configurePollingSessions(
+        _ sessions: [Session],
+        userId: UserID
+    ) {
+        self.pollingSessions = sessions
+        self.pollingUserId = userId
+    }
+
+    /// 세션 진행 중일 때 주기적으로 상태를 갱신합니다.
     ///
     /// `.task` 모디파이어에서 호출하면 뷰 사라질 때
     /// 자동 취소됩니다.
+    /// 세션 시간 기반으로 진행 중 여부를 판단합니다.
     @MainActor
-    func startPollingIfNeeded() async {
-        // isComplete는 .loaded 또는 .failed 모두 true.
-        // .failed 시 hasActiveSession이 false이므로
-        // 폴링 미시작.
-        guard availableSchedules.isComplete, myHistory.isComplete else { return }
-
+    func startPollingIfNeeded(sessions: [Session]) async {
         while !Task.isCancelled {
-            guard hasActiveSession else { return }
+            guard hasActiveSession(in: sessions) else { return }
             try? await Task.sleep(for: .seconds(
                 PollingConfig.intervalSeconds
             ))
@@ -134,6 +178,7 @@ final class ChallengerAttendanceViewModel {
         do {
             let schedules = try await challengeAttendanceUseCase.fetchAvailableSchedules()
             availableSchedules = .loaded(schedules)
+            syncSessionStates()
         } catch {
             availableSchedules = .failed(.unknown(
                 message: error.localizedDescription

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
@@ -23,6 +23,11 @@ final class OperatorAttendanceViewModel {
         case failed    // API 에러 또는 내부 상태 오류
     }
 
+    /// 폴링 설정
+    private enum PollingConfig {
+        static let intervalSeconds: Int = 15
+    }
+
     private var container: DIContainer
     private var errorHandler: ErrorHandler
     private var useCase: OperatorAttendanceUseCaseProtocol
@@ -41,6 +46,19 @@ final class OperatorAttendanceViewModel {
 
     /// 현재 처리 중인 멤버 ID (해당 버튼만 ProgressView 표시)
     private(set) var processingMemberIds: Set<UUID> = []
+
+    /// 진행 중인 세션이 하나라도 있는지 확인
+    private var hasActiveSession: Bool {
+        guard case .loaded(let sessions) = sessionsState
+        else { return false }
+        return sessions.contains { session in
+            let status = OperatorSessionStatus.from(
+                startTime: session.session.info.startTime,
+                endTime: session.session.info.endTime
+            )
+            return status == .inProgress
+        }
+    }
 
     // MARK: - Init
 
@@ -358,6 +376,74 @@ final class OperatorAttendanceViewModel {
     func rejectDirectly(member: OperatorPendingMember, sessionId: UUID) {
         Task {
             await rejectAttendance(memberId: member.id, sessionId: sessionId)
+        }
+    }
+
+    // MARK: - Polling
+
+    /// 세션 목록 배경 갱신 (로딩 상태 변경 없이)
+    ///
+    /// 폴링 시 UI 깜빡임을 방지하기 위해
+    /// Loadable.loading 전환 없이 데이터를 갱신합니다.
+    @MainActor
+    func refreshSessions() async {
+        guard !sessionsState.isLoading else { return }
+
+        // 기존 pending members 보존용
+        let existingMembers: [String: [OperatorPendingMember]]
+        if case .loaded(let current) = sessionsState {
+            existingMembers = Dictionary(
+                uniqueKeysWithValues: current.compactMap {
+                    guard let id = $0.serverID else { return nil }
+                    return (id, $0.pendingMembers)
+                }
+            )
+        } else {
+            existingMembers = [:]
+        }
+
+        do {
+            let statsList = try await useCase
+                .fetchScheduleStats()
+            var updated: [OperatorSessionAttendance] = []
+            for stats in statsList {
+                let session = Self.makeSession(from: stats)
+                let key = String(stats.scheduleId)
+                updated.append(OperatorSessionAttendance(
+                    serverID: key,
+                    session: session,
+                    attendanceRate: stats.attendanceRate,
+                    attendedCount: stats.presentCount,
+                    totalCount: stats.totalCount,
+                    pendingCount: stats.pendingCount,
+                    pendingMembers: existingMembers[key] ?? []
+                ))
+            }
+            sessionsState = .loaded(updated)
+        } catch {
+            // 백그라운드 갱신 실패는 무시 (기존 데이터 유지)
+        }
+    }
+
+    /// 세션 진행 중일 때 주기적으로 데이터를 갱신합니다.
+    ///
+    /// `.task` 모디파이어에서 호출하면 뷰 사라질 때
+    /// 자동 취소됩니다.
+    /// 진행 중인 세션이 없으면 폴링을 중단합니다.
+    @MainActor
+    func startPollingIfNeeded() async {
+        // isComplete는 .loaded 또는 .failed 모두 true.
+        // .failed 시 hasActiveSession이 false이므로
+        // 아래 guard에서 즉시 return 되어 폴링 미시작.
+        guard sessionsState.isComplete else { return }
+
+        while !Task.isCancelled {
+            guard hasActiveSession else { return }
+            try? await Task.sleep(for: .seconds(
+                PollingConfig.intervalSeconds
+            ))
+            guard !Task.isCancelled else { break }
+            await refreshSessions()
         }
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -105,12 +105,19 @@ struct ChallengerAttendanceSessionView: View {
             DefaultConstant.defaultContentBottomMargins,
             for: .scrollContent)
         .task {
+            // configurePollingSessions는 반드시 fetch보다 먼저 호출
+            // syncSessionStates()가 pollingSessions에 의존
+            attendanceViewModel.configurePollingSessions(
+                sessions,
+                userId: userId
+            )
             await attendanceViewModel.fetchAvailableSchedules()
             await attendanceViewModel.fetchMyHistory()
         }
-        .task(id: attendanceViewModel.availableSchedules.isComplete) {
-            guard attendanceViewModel.availableSchedules.isComplete else { return }
-            await attendanceViewModel.startPollingIfNeeded()
+        .task {
+            await attendanceViewModel.startPollingIfNeeded(
+                sessions: sessions
+            )
         }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -24,6 +24,7 @@ private final class MapViewModelCache {
 
 struct ChallengerAttendanceSessionView: View {
     @State private var expandedSessionId: Session.ID?
+    @Environment(\.scenePhase) private var scenePhase
     @State private var attendanceViewModel: ChallengerAttendanceViewModel
     @State private var mapViewModelCache = MapViewModelCache()
 
@@ -106,6 +107,17 @@ struct ChallengerAttendanceSessionView: View {
         .task {
             await attendanceViewModel.fetchAvailableSchedules()
             await attendanceViewModel.fetchMyHistory()
+        }
+        .task(id: attendanceViewModel.availableSchedules.isComplete) {
+            guard attendanceViewModel.availableSchedules.isComplete else { return }
+            await attendanceViewModel.startPollingIfNeeded()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                Task {
+                    await attendanceViewModel.refreshAfterForeground()
+                }
+            }
         }
         .onDisappear {
             Task {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
@@ -17,6 +17,7 @@ struct OperatorAttendanceSectionView: View {
 
     @State private var viewModel: OperatorAttendanceViewModel
     @State private var selectedPendingSessionId: UUID?
+    @Environment(\.scenePhase) private var scenePhase
 
     private let container: DIContainer
     private let errorHandler: ErrorHandler
@@ -57,6 +58,17 @@ struct OperatorAttendanceSectionView: View {
             // 상위 컨테이너에서 한 번만 호출 (View 교체로 인한 Task 취소 방지)
             if viewModel.sessionsState.isIdle {
                 await viewModel.fetchSessions()
+            }
+        }
+        .task(id: viewModel.sessionsState.isComplete) {
+            guard viewModel.sessionsState.isComplete else { return }
+            await viewModel.startPollingIfNeeded()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                Task {
+                    await viewModel.refreshSessions()
+                }
             }
         }
         .alertPrompt(item: $viewModel.alertPrompt)


### PR DESCRIPTION
## ✨ PR 유형

새로운 기능 추가 (Feature) + 버그 수정 (Fix)

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (로직 변경만)

## 🛠️ 작업내용

### Smart Polling 구현
- 운영진 뷰: 세션 진행 중 15초 간격으로 출석 현황 자동 갱신 (Silent Refresh)
- 챌린저 뷰: 세션 진행 중 30초 간격으로 출석 상태 자동 갱신
- 앱 foreground 복귀 시 scenePhase 감지하여 출석 데이터 즉시 재로딩
- 뷰 이탈 시 `.task` 구조적 동시성으로 폴링 자동 중단
- 폴링 중 UI 깜빡임 없음 (Loadable.loading 전환 없이 데이터 교체)
- 진행 중인 세션이 없으면 폴링 비활성화

### Session 상태 동기화 수정
- 폴링 후 서버 응답 상태를 Session 객체에 전파 (`updateStatusFromPolling`)
- 운영진이 다른 디바이스에서 승인 시 챌린저 화면에 실시간 반영 (승인 대기 → 출석)
- `hasActiveSession`을 시간 기반으로 전환하여 출석 제출 후에도 폴링 지속
- raw status 비교로 불필요한 @Observable mutation 방지
- 변경된 파일: 5개

## 📋 추후 진행 상황

- #549 스터디 그룹 권한 판단 서버 resource-permission API 전환

## 📌 리뷰 포인트

- `Features/Activity/Domain/Models/Session/` 변경됨 - `updateStatusFromPolling` 메서드의 raw status guard 로직 확인 필요
- `Features/Activity/Presentation/ViewModels/` 변경됨 - 폴링 루프 및 `syncSessionStates` 매칭 로직 확인 필요
- `Features/Activity/Presentation/Views/` 변경됨 - `.task(id:)` / `.task` 및 `scenePhase` 연동 확인 필요

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)