### PR TITLE
🐛 [Fix] 서버 에러 메시지 Alert 미표시 문제 수정

### DIFF
--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -68,6 +68,7 @@ struct AppProductApp: App {
                 .environment(\.di, container)
                 .environment(\.appFlow, appFlow)
                 .modelContainer(sharedModelContainer)
+                .alertPrompt(item: errorAlertBinding)
                 .onAppear(perform: configureAppDelegateIfNeeded)
                 .onReceive(
                     NotificationCenter.default.publisher(for: .authSessionExpired)
@@ -155,6 +156,31 @@ extension AppProductApp {
         withAnimation {
             appState = state
         }
+    }
+
+    /// ErrorHandler의 currentError를 AlertPrompt 바인딩으로 변환합니다.
+    private var errorAlertBinding: Binding<AlertPrompt?> {
+        Binding(
+            get: {
+                guard let presentable = errorHandler.currentError else {
+                    return nil
+                }
+                return AlertPrompt(
+                    title: presentable.title,
+                    message: presentable.message,
+                    positiveBtnTitle: presentable.showRetry ? "재시도" : "확인",
+                    positiveBtnAction: presentable.showRetry
+                        ? { Task { await presentable.retryAction?() } }
+                        : nil,
+                    negativeBtnTitle: presentable.showRetry ? "닫기" : nil
+                )
+            },
+            set: { newValue in
+                if newValue == nil {
+                    errorHandler.clearError()
+                }
+            }
+        )
     }
 
     /// 루트 화면 전환에 사용하는 공통 트랜지션

--- a/AppProduct/AppProduct/Core/Common/Error/Types/NetworkError.swift
+++ b/AppProduct/AppProduct/Core/Common/Error/Types/NetworkError.swift
@@ -168,7 +168,10 @@ extension NetworkError: LocalizedError {
             return "로그인이 필요합니다."
         case .tokenRefreshFailed, .noRefreshToken, .maxRetryExceeded:
             return "세션이 만료되었습니다. 다시 로그인해주세요."
-        case .requestFailed(let statusCode, _):
+        case .requestFailed(let statusCode, let data):
+            if let serverMessage = Self.parseServerMessage(from: data) {
+                return serverMessage
+            }
             switch statusCode {
             case 400...499:
                 return "요청을 처리할 수 없습니다. 다시 시도해주세요."
@@ -184,6 +187,17 @@ extension NetworkError: LocalizedError {
         case .timeout:
             return "서버 응답이 늦어지고 있어요. 잠시 후 다시 시도해주세요."
         }
+    }
+
+    /// 서버 응답 데이터에서 에러 메시지를 추출합니다.
+    private static func parseServerMessage(from data: Data?) -> String? {
+        guard let data else { return nil }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let message = json["message"] as? String,
+              !message.isEmpty else {
+            return nil
+        }
+        return message
     }
 
     /// 에러 심각도

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/VoteAllVotersSheet.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/VoteAllVotersSheet.swift
@@ -2,7 +2,7 @@
 //  VoteAllVotersSheet.swift
 //  AppProduct
 //
-//  Created by Claude on 3/16/26.
+//  Created by euijjang97 on 3/16/26.
 //
 
 import SwiftUI

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/VoteVoterListSheet.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/VoteVoterListSheet.swift
@@ -2,7 +2,7 @@
 //  VoteVoterListSheet.swift
 //  AppProduct
 //
-//  Created by Claude on 3/16/26.
+//  Created by euijjang97 on 3/16/26.
 //
 
 import SwiftUI


### PR DESCRIPTION
## ✨ PR 유형

서버 API 에러 응답(400 등) 시 에러 메시지가 사용자에게 Alert로 표시되지 않던 문제 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 서버 에러 발생 시 Alert가 정상 표시되는지 확인 필요 -->

## 🛠️ 작업내용

- `NetworkError.userMessage`에서 서버 응답 body의 `message` 필드를 파싱하여 실제 서버 에러 메시지 표시 (예: "모임 시간은 현재 이후여야 합니다.")
- `ErrorHandler.currentError`를 `AlertPrompt`로 변환하는 글로벌 에러 Alert 바인딩 추가
- `AppProductApp`에 `.alertPrompt(item: errorAlertBinding)` 연결하여 앱 전역 에러 Alert 표시
- 기존 `AlertPrompt` 패턴을 재사용하여 일관된 Alert UX 유지

## 📋 추후 진행 상황

- 커뮤니티 글 생성 시 클라이언트 유효성 검증 가이드 추가 (이슈 #553 추가 작업)

## 📌 리뷰 포인트

- `Core/Common/Error/Types/NetworkError.swift` - `parseServerMessage(from:)` 메서드로 서버 응답 JSON에서 message 추출 로직
- `App/AppProductApp.swift` - `errorAlertBinding` computed property에서 `PresentableError` → `AlertPrompt` 변환 로직

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)