### PR TITLE
💄 [Design] 마이페이지 활동 이력에서 Admin 파트명 표시 제외

### DIFF
--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Row/MyPageRow/ActiveLogRow.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Row/MyPageRow/ActiveLogRow.swift
@@ -57,9 +57,13 @@ struct ActiveLogRow: View, Equatable {
     }
     
     /// 파트 이름을 표시하는 텍스트 뷰
+    /// Admin 파트는 표시하지 않습니다.
+    @ViewBuilder
     private var part: some View {
-        Text(row.part.name)
-            .appFont(.subheadline, color: .black)
+        if row.part != .admin {
+            Text(row.part.name)
+                .appFont(.subheadline, color: .black)
+        }
     }
     
     /// 직책(역할)을 표시하는 뱃지 뷰


### PR DESCRIPTION
## ✨ PR 유형

UI 개선 - 마이페이지 활동 이력 Admin 표시 제거

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 활동 이력에서 "Admin" 텍스트가 사라지고 기수 + 역할 뱃지만 표시되는지 확인 필요 -->

## 🛠️ 작업내용

- `ActiveLogRow`에서 `part == .admin`일 때 파트 이름 텍스트 숨김 처리
- 활동 이력 자체는 유지하고 "Admin" 텍스트만 비표시
- 기존: `8기 Admin 🏛️ 지부장` → 변경: `8기 🏛️ 지부장`

## 📋 추후 진행 상황

- Admin만 가진 사용자의 활동 이력 표시 확인

## 📌 리뷰 포인트

- `Features/MyPage/Presentation/Components/Row/MyPageRow/ActiveLogRow.swift` - `part` 뷰에서 `.admin` 파트 필터링 로직

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)