### PR TITLE
💄 [Design] 커뮤니티 및 마이페이지 Admin 파트 표시 개선 (#557)

### DIFF
--- a/AppProduct/AppProduct/Features/Community/Presentation/Components/CommunityPostCard/CommunityPostCard.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/Components/CommunityPostCard/CommunityPostCard.swift
@@ -90,8 +90,13 @@ struct CommunityPostCard: View {
             RemoteImage(urlString: model.profileImage ?? "", size: Constant.profileSize)
 
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
-                Text("\(model.displayUserName) • \(model.part.name)")
-                    .appFont(.subheadlineEmphasis, color: .black)
+                if model.part == .admin {
+                    Text(model.displayUserName)
+                        .appFont(.subheadlineEmphasis, color: .black)
+                } else {
+                    Text("\(model.displayUserName) • \(model.part.name)")
+                        .appFont(.subheadlineEmphasis, color: .black)
+                }
             }
         }
     }

--- a/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
@@ -293,12 +293,40 @@ extension MyPageProfileResponseDTO {
             )
         }
 
-        return (roleLogs + challengerLogs).sorted { lhs, rhs in
+        let allLogs = roleLogs + challengerLogs
+        let merged = mergeAdminLogs(allLogs)
+
+        return merged.sorted { lhs, rhs in
             if lhs.generation == rhs.generation {
                 return lhs.role > rhs.role
             }
             return lhs.generation > rhs.generation
         }
+    }
+
+    /// 같은 기수의 Admin 이력을 하나로 병합합니다.
+    private func mergeAdminLogs(_ logs: [ActivityLog]) -> [ActivityLog] {
+        var adminByGen: [Int: [ManagementTeam]] = [:]
+        var result: [ActivityLog] = []
+
+        for log in logs {
+            if log.part == .admin {
+                adminByGen[log.generation, default: []].append(log.role)
+            } else {
+                result.append(log)
+            }
+        }
+
+        for (gen, adminRoles) in adminByGen {
+            let sortedRoles = adminRoles.sorted(by: >)
+            result.append(ActivityLog(
+                part: .admin,
+                generation: gen,
+                roles: sortedRoles
+            ))
+        }
+
+        return result
     }
 
     /// 서버 응답의 외부 링크 필드를 `SocialLinkType` 기반 `[ProfileLink]` 배열로 변환합니다.

--- a/AppProduct/AppProduct/Features/MyPage/Domain/Models/ProfileData.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Domain/Models/ProfileData.swift
@@ -48,15 +48,44 @@ struct SocialConnection: Identifiable, Equatable, Hashable {
 struct ActivityLog: Identifiable, Equatable, Hashable {
     /// 활동 기록의 고유 식별자
     var id: UUID = .init()
-    
+
     /// 활동 당시의 파트 (기획, 디자인, 서버 등)
     var part: UMCPartType
-    
+
     /// 활동 기수 (예: 11기, 12기)
     var generation: Int
-    
-    /// 맡았던 역할 (회장, 팀원 등)
-    var role: ManagementTeam
+
+    /// 맡았던 역할 목록 (같은 기수/파트에서 여러 역할을 가질 수 있음)
+    var roles: [ManagementTeam]
+
+    /// 가장 높은 우선순위의 역할 (기존 호환용)
+    var role: ManagementTeam {
+        roles.max() ?? .challenger
+    }
+
+    init(
+        id: UUID = .init(),
+        part: UMCPartType,
+        generation: Int,
+        role: ManagementTeam
+    ) {
+        self.id = id
+        self.part = part
+        self.generation = generation
+        self.roles = [role]
+    }
+
+    init(
+        id: UUID = .init(),
+        part: UMCPartType,
+        generation: Int,
+        roles: [ManagementTeam]
+    ) {
+        self.id = id
+        self.part = part
+        self.generation = generation
+        self.roles = roles
+    }
 }
 
 /// 외부 소셜/포트폴리오 링크 정보를 나타내는 모델입니다.

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Row/MyPageRow/ActiveLogRow.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Row/MyPageRow/ActiveLogRow.swift
@@ -68,16 +68,22 @@ struct ActiveLogRow: View, Equatable {
     
     /// 직책(역할)을 표시하는 뱃지 뷰
     /// 역할별 고유 색상을 배경색으로 사용합니다.
+    /// 여러 역할이 있는 경우 (같은 기수 Admin) 모든 역할을 나열합니다.
     @ViewBuilder
     private var role: some View {
-        if row.role != .challenger {
-            Text(row.role.displayName)
-                .appFont(.footnote, weight: .medium, color: row.role.textColor)
-                .padding(Constants.padding)
-                .glassEffect(
-                    .clear.tint(row.role.backgroundColor),
-                    in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius)
-                )
+        let displayRoles = row.roles.filter { $0 != .challenger }
+        if !displayRoles.isEmpty {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                ForEach(displayRoles, id: \.self) { role in
+                    Text(role.displayName)
+                        .appFont(.footnote, weight: .medium, color: role.textColor)
+                        .padding(Constants.padding)
+                        .glassEffect(
+                            .clear.tint(role.backgroundColor),
+                            in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius)
+                        )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Design - 커뮤니티/마이페이지에서 Admin 파트 표시 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 아래 항목을 확인해주세요:
1. 커뮤니티 게시글 카드에서 Admin 파트가 표시되지 않는 것
2. 마이페이지 활동 이력에서 같은 기수 Admin이 한 줄로 병합되어 역할 뱃지가 나열되는 것 -->

## 🛠️ 작업내용

### 커뮤니티 Admin 파트 표시 제외
- `CommunityPostCard` profileSection에서 `part`가 `.admin`인 경우 파트명 생략, 유저 이름만 표시

### 마이페이지 같은 기수 Admin 활동 이력 병합
- `ActivityLog` 모델에 `roles: [ManagementTeam]` 프로퍼티 추가
- `role`은 최고 우선순위 역할을 반환하는 computed property로 변경 (기존 코드 호환)
- `MyPageProfileDTO.activityLogs()`에서 같은 기수 Admin 이력을 `mergeAdminLogs()`로 병합
- `ActiveLogRow`에서 다중 역할 뱃지를 `HStack`으로 나열 표시 (예: 10기 [회장] [부회장])

## 📋 추후 진행 상황

- 커뮤니티 관련 추가 UI 개선 작업

## 📌 리뷰 포인트

- `Features/Community/Presentation/Components/CommunityPostCard/CommunityPostCard.swift` - profileSection에서 admin 분기 처리
- `Features/MyPage/Domain/Models/ProfileData.swift` - ActivityLog에 roles 추가 및 role computed property 호환성
- `Features/MyPage/Data/DTO/MyPageProfileDTO.swift` - mergeAdminLogs() 병합 로직
- `Features/MyPage/Presentation/Components/Row/MyPageRow/ActiveLogRow.swift` - 다중 역할 뱃지 HStack 나열

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)