### PR TITLE
🐛 [Fix] 커뮤니티 명예의 전당 학교 정보 Optional 처리

### DIFF
--- a/AppProduct/AppProduct/Features/Community/DTO/CommunityTrophyResponseDTO.swift
+++ b/AppProduct/AppProduct/Features/Community/DTO/CommunityTrophyResponseDTO.swift
@@ -17,7 +17,7 @@ struct TrophyListResponse: Codable {
     let week: String
     let challengerName: String
     let challengerProfileImage: String?
-    let school: String
+    let school: String?
     let part: String
     let title: String
     let content: String
@@ -28,7 +28,7 @@ extension TrophyListResponse {
     func toFameItem() -> CommunityFameItemModel {
         CommunityFameItemModel(
             week: Int(week) ?? 0,
-            university: school,
+            university: school ?? "알 수 없음",
             profileImage: challengerProfileImage,
             userName: challengerName,
             part: UMCPartType(apiValue: part) ?? .pm,


### PR DESCRIPTION
## ✨ PR 유형

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 리팩토링

## 📷 스크린샷 or 영상(UI 변경 시)
N/A

## 🛠️ 작업내용
- `CommunityTrophyResponseDTO`에서 `school` 속성을 Optional(`String?`)로 변경
- 모델 매핑(`toFameItem()`) 시 `school` 필드가 `nil`일 경우 `"알 수 없음"`으로 기본값 설정
- API 응답 내 `school` 필드 누락으로 인한 디코딩 에러(방어 로직) 방지

## 📋 추후 진행 상황
- 다른 응답 DTO 중 Optional 처리 누락된 필드가 있는지 추가 점검

## 📌 리뷰 포인트
- 백엔드 응답에서 스펙이 달라지거나 값이 없는 케이스에 대비하여 크래시를 방지한 부분입니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
