### PR TITLE
:bug: [Fix] 하루종일 일정(isAllDay) 출석 로직 변경 및 UI 애니메이션 개선

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/ActivityRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/ActivityRepository.swift
@@ -113,7 +113,8 @@ final class ActivityRepository: ActivityRepositoryProtocol, @unchecked Sendable 
                 location: Coordinate(
                     latitude: detail.latitude,
                     longitude: detail.longitude
-                )
+                ),
+                isAllDay: detail.isAllDay
             ),
             initialAttendance: mapAttendance(
                 schedule: schedule

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Session/SessionInfo.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Session/SessionInfo.swift
@@ -22,6 +22,7 @@ struct SessionInfo: Identifiable, Equatable {
     let startTime: Date
     let endTime: Date
     let location: Coordinate
+    var isAllDay: Bool = false
 }
 
 import CoreLocation

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/ChallengerAttendanceUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/ChallengerAttendanceUseCase.swift
@@ -158,23 +158,33 @@ final class ChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProtocol {
         let lateThreshold = TimeInterval(AttendancePolicy.lateThresholdMinutes * 60)
         let startTime = info.startTime
 
-        // 세션 시작 - threshold 이전이면 너무 이름
-        if now < startTime.addingTimeInterval(-onTimeThreshold) {
-            return .tooEarly
-        }
+        if info.isAllDay {
+            if now < startTime.addingTimeInterval(-onTimeThreshold) {
+                return .tooEarly
+            }
+            if now <= info.endTime {
+                return .onTime
+            }
+            return .expired
+        } else {
+            // 세션 시작 - threshold 이전이면 너무 이름
+            if now < startTime.addingTimeInterval(-onTimeThreshold) {
+                return .tooEarly
+            }
 
-        // 세션 시작 ± threshold 내이면 정시 출석 가능
-        if now <= startTime.addingTimeInterval(onTimeThreshold) {
-            return .onTime
-        }
+            // 세션 시작 ± threshold 내이면 정시 출석 가능
+            if now <= startTime.addingTimeInterval(onTimeThreshold) {
+                return .onTime
+            }
 
-        // 세션 시작 + lateThreshold 내이면 지각 시간대
-        if now <= startTime.addingTimeInterval(lateThreshold) {
-            return .lateWindow
-        }
+            // 세션 시작 + lateThreshold 내이면 지각 시간대
+            if now <= startTime.addingTimeInterval(lateThreshold) {
+                return .lateWindow
+            }
 
-        // 그 이후는 마감
-        return .expired
+            // 그 이후는 마감
+            return .expired
+        }
     }
 
     /// 지오코딩

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerAttendanceView.swift
@@ -67,7 +67,7 @@ struct ChallengerAttendanceView: View, Equatable {
                 lateReasonButton
             }
         }
-        .animation(.smooth, value: session.attendanceStatus)
+        .animation(.spring(response: 0.4, dampingFraction: 0.75), value: session.attendanceStatus)
         .animation(.easeInOut(duration: 0.2), value: isMapReady)
         .task {
             try? await Task.sleep(for: Constants.mapLoadDelay)
@@ -101,16 +101,28 @@ struct ChallengerAttendanceView: View, Equatable {
                         in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true))
                     .glassEffectID(
                         Constants.attendanceActionId, in: attendanceNamespace)
+                    .transition(.asymmetric(
+                        insertion: .scale(scale: 0.95).combined(with: .opacity),
+                        removal: .scale(scale: 0.95).combined(with: .opacity)
+                    ))
 
             case .beforeAttendance:
                 // 출석 버튼
                 attendanceButton
                     .glassEffectID(
                         Constants.attendanceActionId, in: attendanceNamespace)
+                    .transition(.asymmetric(
+                        insertion: .scale(scale: 0.95).combined(with: .opacity),
+                        removal: .scale(scale: 0.95).combined(with: .opacity)
+                    ))
 
             case .present, .late, .absent:
                 // 확정 상태 - 버튼 비활성화
                 attendanceButton
+                    .transition(.asymmetric(
+                        insertion: .scale(scale: 0.95).combined(with: .opacity),
+                        removal: .scale(scale: 0.95).combined(with: .opacity)
+                    ))
             }
         }
     }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerPendingApprovalView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerPendingApprovalView.swift
@@ -21,6 +21,8 @@ struct ChallengerPendingApprovalView: View {
         static let backgroundOpacity: CGFloat = 0.1
     }
 
+    @State private var isRotating = false
+
     // MARK: - Body
 
     var body: some View {
@@ -39,9 +41,14 @@ struct ChallengerPendingApprovalView: View {
 
     private var iconView: some View {
         Image(systemName: "arrow.trianglehead.2.counterclockwise")
-            .symbolEffect(.pulse.wholeSymbol)
             .font(.system(size: Constant.iconSize))
             .foregroundStyle(.yellow)
+            .rotationEffect(.degrees(isRotating ? 360 : 0))
+            .onAppear {
+                withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+                    isRotating = true
+                }
+            }
     }
 
     private var titleText: some View {


### PR DESCRIPTION
## ✨ PR 유형

- [x] 버그 수정
- [x] 새로운 기능 추가 (UI 애니메이션 개선)

## 📷 스크린샷 or 영상(UI 변경 시)
출석 승인 대기 화면 전환 트랜지션 및 심볼 애니메이션 추가 진행 (별도 영상 생략)

## 🛠️ 작업내용
1. **하루종일 일정 출석 시간 검증 로직 변경 (이슈 #559)**
   - `SessionInfo` 구조체에 `isAllDay` 속성을 추가하였습니다.
   - 하루종일 일정의 경우, 출석 마감 기준을 기존 `startTime + 30분`이 아닌 `endsAt` 기반으로 변경하여 하루종일 정시 출석(on time)이 가능하도록 수정하였습니다 (`ChallengerAttendanceUseCase`).
   
2. **출석 승인 대기 화면 애니메이션 개선**
   - 현 위치 출석 체크 시 `ChallengerPendingApprovalView`로 모핑될 때의 트랜지션을 `.scale.combined(with: .opacity)` 비대칭 효과와 스프링 등속 전환으로 적용하여 부드럽게 나타나도록 개선했습니다.
   - 승인 대기 뷰 내부의 대기 아이콘이 항상 빙글빙글 시계 방향으로 돌아가도록 뷰 로테이션 애니메이션(rotationEffect)을 추가했습니다.

## 📋 추후 진행 상황
- 다른 운영진 및 참여자의 출석 내역 동기화/지오펜싱 관련 추가 이슈 및 엣지 케이스 지속 점검

## 📌 리뷰 포인트
- `ActivityRepository`에서 `isAllDay` 속성을 `detail` 정보로부터 주입하는 부분이 의도대로 안전한지 확인 부탁드립니다.
- `ChallengerAttendanceUseCase` 내 `isAllDay == true` 분기에서 `lateWindow` 개념이 배제된 채로 로직이 처리된 점이 정상적인지 확인해주세요.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
