### PR TITLE
🐛 [Fix] 지도 검색 시 MKErrorDomain 오류 Alert 반복 노출 수정 (#569)

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchPlaceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/SearchPlaceViewModel.swift
@@ -15,7 +15,7 @@ class SearchPlaceViewModel {
     /// 검색어 입력값
     var searchPlace: String = ""
     /// 검색 결과 리스트
-    var searchResult: [PlaceSearchResult] = .init()
+    var searchResult: Loadable<[PlaceSearchResult]> = .idle
     /// 최근 검색 장소 리스트
     var recentPlaces: [RecentPlace] = .init()
     
@@ -100,7 +100,7 @@ class SearchPlaceViewModel {
     
     /// 검색 데이터 초기화(결과 및 쿼리)
     func clear() async {
-        searchResult.removeAll()
+        searchResult = .idle
         searchPlace.removeAll()
     }
     
@@ -108,10 +108,23 @@ class SearchPlaceViewModel {
     /// 검색 쿼리로 장소 검색 수행
     /// - Parameter query: 검색어
     public func search(query: String) async {
+        guard !query.isEmpty else {
+            searchResult = .loaded([])
+            return
+        }
+
+        searchResult = .loading
         do {
-            self.searchResult =  try await self.performSearch(query: query)
+            let results = try await performSearch(query: query)
+            searchResult = .loaded(results)
+        } catch is MKError {
+            searchResult = .failed(.unknown(message: "검색 결과를 찾을 수 없습니다"))
         } catch {
-            errorHandler.handle(error, context: .init(feature: "MapSearchError", action: "MapSearchError"))
+            searchResult = .idle
+            errorHandler.handle(
+                error,
+                context: .init(feature: "MapSearchError", action: "MapSearchError")
+            )
         }
     }
     

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/SearchPlaceView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/SearchPlaceView.swift
@@ -259,29 +259,56 @@ struct SearchMapView: View {
         }
     }
 
-    /// 검색 결과가 있을 때만 검색 위치 섹션을 노출합니다.
+    /// 검색 결과 상태에 따라 검색 위치 섹션을 노출합니다.
     @ViewBuilder
     private var mapSearchResult: some View {
-        if !viewModel.searchResult.isEmpty {
-            Section(content: {
-                List(viewModel.searchResult, rowContent: { place in
-                    SearchContent(place: place) {
-                        Task {
-                            await viewModel.addRecentPlace(place)
-                            await viewModel.clear()
-                            placeSelected(.init(
-                                name: place.name,
-                                address: place.address ?? "도로명 주소 없음",
-                                coordinate: place.coordinate
-                            ))
-                            dismiss()
+        switch viewModel.searchResult {
+        case .idle:
+            EmptyView()
+
+        case .loading:
+            Section(header: generateHeader(.search)) {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+
+        case .loaded(let results):
+            if !results.isEmpty {
+                Section(header: generateHeader(.search)) {
+                    List(results, rowContent: { place in
+                        SearchContent(place: place) {
+                            Task {
+                                await viewModel.addRecentPlace(place)
+                                await viewModel.clear()
+                                placeSelected(.init(
+                                    name: place.name,
+                                    address: place.address ?? "도로명 주소 없음",
+                                    coordinate: place.coordinate
+                                ))
+                                dismiss()
+                            }
                         }
-                    }
-                    .equatable()
-                })
-            }, header: {
-                generateHeader(.search)
-            })
+                        .equatable()
+                    })
+                }
+            } else {
+                Section(header: generateHeader(.search)) {
+                    ContentUnavailableView(
+                        "검색 결과가 없습니다",
+                        systemImage: "magnifyingglass",
+                        description: Text("다른 검색어로 다시 시도해보세요.")
+                    )
+                }
+            }
+
+        case .failed(let error):
+            Section(header: generateHeader(.search)) {
+                ContentUnavailableView(
+                    error.errorDescription ?? "검색에 실패했습니다",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text("다른 검색어로 다시 시도해보세요.")
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 지도 검색 시 MKErrorDomain 에러가 모두 Alert으로 처리되어 반복 노출되는 문제 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 검색 결과 없음 → 인라인 메시지 표시 확인 필요 -->

## 🛠️ 작업내용

- `SearchPlaceViewModel.searchResult` 타입을 `[PlaceSearchResult]` → `Loadable<[PlaceSearchResult]>`로 변경
- `search(query:)` 에러 처리 분기:
  - `MKError` → `Loadable.failed`로 인라인 처리 (Alert 대신 화면 내 표시)
  - 기타 에러(네트워크 등) → 기존 `ErrorHandler` Alert 유지
- `SearchPlaceView.mapSearchResult`에 상태별 UI 분기 추가:
  - `.idle` → 빈 뷰
  - `.loading` → ProgressView
  - `.loaded([])` → ContentUnavailableView("검색 결과가 없습니다")
  - `.loaded(results)` → 기존 검색 결과 List
  - `.failed(error)` → ContentUnavailableView(에러 메시지)
- `clear()` 메서드: `searchResult = .idle`로 초기화

## 📋 추후 진행 상황

- 없음

## 📌 리뷰 포인트

- `Features/Home/Presentation/ViewModels/SearchPlaceViewModel.swift` - `search(query:)` 에러 분기 로직 (`MKError` vs 기타 에러)
- `Features/Home/Presentation/Views/Registration/SearchPlaceView.swift` - `mapSearchResult` Loadable 상태별 UI 분기

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)