### PR TITLE
🐛[Fix] 일정 삭제 후 홈 화면에 삭제된 일정 표시되는 문제 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
@@ -33,6 +33,8 @@ class ScheduleDetailViewModel {
     var canEditSchedule: Bool = false
     /// 일정 삭제 가능 여부 (DELETE/MANAGE)
     var canDeleteSchedule: Bool = false
+    /// 일정 삭제 진행 중 여부
+    var isDeleting: Bool = false
 
     // MARK: - Init
     init(scheduleId: Int) {

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
@@ -119,16 +119,23 @@ struct ScheduleDetailView: View {
                 }
 
                 if viewModel.canDeleteSchedule {
-                    Button(role: .destructive, action: {
-                        viewModel.deleteAlertAction {
-                            dismiss()
-                            Task { @MainActor in
-                                await deleteSchedule(scheduleId: loadedData.scheduleId)
+                    if viewModel.isDeleting {
+                        ProgressView()
+                            .tint(.red)
+                    } else {
+                        Button(role: .destructive, action: {
+                            viewModel.deleteAlertAction {
+                                Task { @MainActor in
+                                    let success = await deleteSchedule(
+                                        scheduleId: loadedData.scheduleId
+                                    )
+                                    if success { dismiss() }
+                                }
                             }
+                        }) {
+                            Image(systemName: "trash")
+                                .foregroundStyle(.red)
                         }
-                    }) {
-                        Image(systemName: "trash")
-                            .foregroundStyle(.red)
                     }
                 }
             }
@@ -180,13 +187,19 @@ struct ScheduleDetailView: View {
 
     /// 일정과 출석부를 함께 삭제합니다.
     /// - Parameter scheduleId: 삭제할 일정 ID
+    /// - Returns: 삭제 성공 여부
     @MainActor
-    private func deleteSchedule(scheduleId: Int) async {
+    @discardableResult
+    private func deleteSchedule(scheduleId: Int) async -> Bool {
+        viewModel.isDeleting = true
+        defer { viewModel.isDeleting = false }
+
         do {
             let provider = di.resolve(HomeUseCaseProviding.self)
             try await provider.deleteScheduleUseCase.execute(
                 scheduleId: scheduleId
             )
+            return true
         } catch {
             errorHandler.handle(error, context: ErrorContext(
                 feature: "Home",
@@ -199,6 +212,7 @@ struct ScheduleDetailView: View {
                     )
                 }
             ))
+            return false
         }
     }
 


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 일정 삭제 시 dismiss이 삭제 API 완료 전에 호출되어 홈 화면에 삭제된 일정이 그대로 표시되는 문제 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 삭제 버튼 클릭 → 로딩 스피너 → dismiss 흐름 영상 첨부 필요 -->

## 🛠️ 작업내용

- `deleteSchedule()` 반환 타입을 `Bool`로 변경하여 삭제 성공/실패 구분
- Alert 확인 시 `dismiss()` → `deleteSchedule()` 순서를 `deleteSchedule()` → `dismiss()`로 변경
- 삭제 성공 시에만 `dismiss()` 호출하여 홈 화면에서 최신 데이터 fetch 보장
- 삭제 실패 시 상세 화면 유지 + ErrorHandler Alert 표시로 재시도 가능
- ViewModel에 `isDeleting` 상태 추가, 삭제 진행 중 툴바에 `ProgressView` 로딩 표시

## 📋 추후 진행 상황

- 삭제 완료 후 홈 화면 복귀 시 삭제된 일정이 사라지는 애니메이션 개선 검토

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift` - 삭제 순서 변경 로직 및 ProgressView 전환
- `Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift` - `isDeleting` 상태 추가

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)