### PR TITLE
🐛[Fix] 구성원 상세 시트 기수 선택 버그 수정 및 summaryCardView UX 개선

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -243,7 +243,62 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         memberId: Int
     ) async throws -> [GenerationPointSummary] {
         let profile = try await fetchMemberProfile(memberId: memberId)
-        return makeGenerationPointSummaries(from: profile, memberId: memberId)
+        let records = profile.challengerRecords.filter {
+            $0.memberId == memberId || $0.memberId == 0
+        }
+        guard !records.isEmpty else { return [] }
+
+        return await withTaskGroup(
+            of: GenerationPointSummary?.self
+        ) { group in
+            for record in records where record.gisu > 0 {
+                group.addTask { [adapter, decoder] in
+                    guard let response = try? await adapter.request(
+                        MyPageRouter.getChallengerProfile(
+                            challengerId: record.challengerId
+                        )
+                    ),
+                    let apiResponse = try? decoder.decode(
+                        APIResponse<ChallengerMemberDTO>.self,
+                        from: response.data
+                    ),
+                    let challenger = try? apiResponse.unwrap() else {
+                        return GenerationPointSummary(
+                            gisu: record.gisu, reward: 0, penalty: 0
+                        )
+                    }
+
+                    let reward = challenger.challengerPoints
+                        .filter {
+                            let resolved = ChallengerPointType(
+                                rawValue: $0.pointType.rawValue
+                            )
+                            return resolved?.isReward == true
+                        }
+                        .reduce(0.0) { $0 + abs($1.point) }
+                    let penalty = challenger.challengerPoints
+                        .filter {
+                            let resolved = ChallengerPointType(
+                                rawValue: $0.pointType.rawValue
+                            )
+                            return resolved == nil || !(resolved!.isReward)
+                        }
+                        .reduce(0.0) { $0 + abs($1.point) }
+
+                    return GenerationPointSummary(
+                        gisu: record.gisu,
+                        reward: reward,
+                        penalty: penalty
+                    )
+                }
+            }
+
+            var summaries: [GenerationPointSummary] = []
+            for await summary in group {
+                if let summary { summaries.append(summary) }
+            }
+            return summaries.sorted { $0.gisu < $1.gisu }
+        }
     }
 }
 

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -252,7 +252,7 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
             of: GenerationPointSummary?.self
         ) { group in
             for record in records where record.gisu > 0 {
-                group.addTask { [adapter, decoder] in
+                group.addTask { @MainActor [adapter, decoder] in
                     guard let response = try? await adapter.request(
                         MyPageRouter.getChallengerProfile(
                             challengerId: record.challengerId

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
@@ -12,7 +12,14 @@ struct ChallengerMemberDetailSheetView: View {
 
     @Environment(\.dismiss) private var dismiss
     var member: MemberManagementItem
-    @State private var selectedGisu: Int?
+    @State private var selectedGisu: Int
+
+    init(member: MemberManagementItem) {
+        self.member = member
+        _selectedGisu = State(
+            initialValue: member.generationPoints.map(\.gisu).max() ?? 0
+        )
+    }
 
     private enum Constants {
         static let tagPadding: EdgeInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
@@ -55,8 +62,7 @@ struct ChallengerMemberDetailSheetView: View {
 
     /// 현재 선택된 기수의 요약 데이터
     private var selectedSummary: GenerationPointSummary? {
-        guard let gisu = selectedGisu else { return nil }
-        return member.generationPoints.first { $0.gisu == gisu }
+        member.generationPoints.first { $0.gisu == selectedGisu }
     }
 
     /// 현재 선택된 기수의 상점
@@ -152,7 +158,7 @@ struct ChallengerMemberDetailSheetView: View {
     }
 
     private var summaryCardView: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: .zero) {
             summaryRow(title: "활동 기수") {
                 if hasMultipleGenerations {
                     generationMenu
@@ -182,39 +188,23 @@ struct ChallengerMemberDetailSheetView: View {
     }
 
     private var generationMenu: some View {
-        Group {
-            if selectedGisu != nil {
-                Button {
-                    withAnimation { selectedGisu = nil }
-                } label: {
-                    generationLabel
+        Menu {
+            Picker("기수 선택", selection: $selectedGisu) {
+                ForEach(member.generationPoints) { summary in
+                    Text("\(summary.gisu)기")
+                        .tag(summary.gisu)
                 }
-                .buttonStyle(.plain)
-            } else {
-                Menu {
-                    ForEach(member.generationPoints) { summary in
-                        Button {
-                            selectedGisu = summary.gisu
-                        } label: {
-                            Text("\(summary.gisu)기")
-                        }
-                    }
-                } label: {
-                    generationLabel
-                }
-                .foregroundStyle(.primary)
+            }
+        } label: {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Text("\(selectedGisu)기")
+                    .appFont(.subheadlineEmphasis)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.grey500)
             }
         }
-    }
-
-    private var generationLabel: some View {
-        HStack(spacing: DefaultSpacing.spacing4) {
-            Text(selectedGisu.map { "\($0)기" } ?? currentGeneration)
-                .appFont(.subheadlineEmphasis)
-            Image(systemName: "chevron.up.chevron.down")
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(.grey500)
-        }
+        .foregroundStyle(.primary)
     }
 
     // MARK: - Function

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift
@@ -7,7 +7,12 @@
 
 import SwiftUI
 
+/// 챌린저 멤버 상세 정보를 표시하는 바텀 시트 뷰
+///
+/// 프로필, 기수별 상벌점 요약, 출석/활동 기록을 표시합니다.
+/// 복수 기수 사용자의 경우 `Picker`를 통해 기수를 전환할 수 있습니다.
 struct ChallengerMemberDetailSheetView: View {
+
     // MARK: - Property
 
     @Environment(\.dismiss) private var dismiss
@@ -38,11 +43,12 @@ struct ChallengerMemberDetailSheetView: View {
         static let partTagOpacity: Double = 0.14
         static let partStrokeOpacity: Double = 0.4
         static let partStrokeWidth: CGFloat = 1
+        static let pointIconSize: CGFloat = 14
     }
 
-    // MARK: - Computed Properties
+    // MARK: - Computed Property
 
-    /// 현재 기수 표시 (마지막 기수)
+    /// 단일 기수 사용자의 기수 텍스트 (예: "9기")
     private var currentGeneration: String {
         if hasMultipleGenerations,
            let lastGisu = member.generationPoints.map(\.gisu).max() {
@@ -55,26 +61,27 @@ struct ChallengerMemberDetailSheetView: View {
         return gens.last ?? member.generation
     }
 
-    /// 복수 기수 여부
+    /// 복수 기수 보유 여부
     private var hasMultipleGenerations: Bool {
         member.generationPoints.count > 1
     }
 
-    /// 현재 선택된 기수의 요약 데이터
+    /// 현재 선택된 기수의 포인트 요약 데이터
     private var selectedSummary: GenerationPointSummary? {
         member.generationPoints.first { $0.gisu == selectedGisu }
     }
 
-    /// 현재 선택된 기수의 상점
+    /// 표시할 상점 (선택된 기수 우선, 없으면 전체 합산)
     private var displayRewardPoints: Double {
         selectedSummary?.reward ?? member.rewardPoints
     }
 
-    /// 현재 선택된 기수의 벌점
+    /// 표시할 벌점 (선택된 기수 우선, 없으면 전체 합산)
     private var displayPenaltyPoints: Double {
         selectedSummary?.penalty ?? member.penalty
     }
 
+    /// 출석 기록 수에 따라 동적으로 계산된 시트 높이
     private var dynamicSheetHeight: CGFloat {
         let recordCount = member.attendanceRecords.count
 
@@ -83,36 +90,30 @@ struct ChallengerMemberDetailSheetView: View {
         }
 
         let visibleRecords = min(recordCount, Constants.maxVisibleRecords)
-        let recordsHeight = (CGFloat(visibleRecords) * Constants.recordRowHeight)
-        + (CGFloat(max(0, visibleRecords - 1)) * DefaultSpacing.spacing8)
-
+        let recordsHeight = CGFloat(visibleRecords) * Constants.recordRowHeight
+            + CGFloat(max(0, visibleRecords - 1)) * DefaultSpacing.spacing8
         let calculatedHeight = Constants.baseHeight + recordsHeight
 
         return max(Constants.minSheetHeight, min(calculatedHeight, Constants.maxSheetHeight))
     }
 
+    /// 출석 기록 리스트 영역의 높이
     private var scrollViewHeight: CGFloat {
         let recordCount = member.attendanceRecords.count
-
-        if recordCount == 0 {
-            return Constants.emptyRecordHeight
-        }
+        guard recordCount > 0 else { return Constants.emptyRecordHeight }
 
         let visibleRecords = min(recordCount, Constants.maxVisibleRecords)
-        let recordsHeight = (CGFloat(visibleRecords) * Constants.recordRowHeight)
-        + (CGFloat(max(0, visibleRecords - 1)) * DefaultSpacing.spacing8)
-
-        return recordsHeight
+        return CGFloat(visibleRecords) * Constants.recordRowHeight
+            + CGFloat(max(0, visibleRecords - 1)) * DefaultSpacing.spacing8
     }
 
     // MARK: - Body
+
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
                 memberInfoView
-
                 summaryCardView
-
                 recordView
             }
             .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
@@ -123,6 +124,7 @@ struct ChallengerMemberDetailSheetView: View {
 
     // MARK: - SubView
 
+    /// 프로필 이미지, 닉네임/이름, 파트·학교·운영진 배지를 표시
     private var memberInfoView: some View {
         HStack(spacing: DefaultSpacing.spacing12) {
             RemoteImage(urlString: member.profile ?? "", size: Constants.profileSize)
@@ -130,25 +132,10 @@ struct ChallengerMemberDetailSheetView: View {
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
                 Text("\(member.nickname)/\(member.name)")
                     .appFont(.bodyEmphasis)
+
                 HStack(spacing: DefaultSpacing.spacing8) {
-                    Text(member.part.name)
-                        .appFont(.callout, color: member.part.color)
-                        .padding(Constants.tagPadding)
-                        .background(
-                            member.part.color.opacity(Constants.partTagOpacity),
-                            in: Capsule()
-                        )
-                        .overlay {
-                            Capsule()
-                                .stroke(
-                                    member.part.color.opacity(Constants.partStrokeOpacity),
-                                    lineWidth: Constants.partStrokeWidth
-                                )
-                        }
-                    Text(member.school)
-                        .appFont(.callout, color: .black)
-                        .padding(Constants.tagPadding)
-                        .background(.white, in: Capsule())
+                    partTag
+                    schoolTag
                     if member.managementTeam != .challenger {
                         ManagementTeamBadgePresenter(managementTeam: member.managementTeam)
                     }
@@ -157,75 +144,109 @@ struct ChallengerMemberDetailSheetView: View {
         }
     }
 
+    /// 파트 태그 (색상 배경 + 테두리)
+    private var partTag: some View {
+        Text(member.part.name)
+            .appFont(.callout, color: member.part.color)
+            .padding(Constants.tagPadding)
+            .background(
+                member.part.color.opacity(Constants.partTagOpacity),
+                in: Capsule()
+            )
+            .overlay {
+                Capsule()
+                    .stroke(
+                        member.part.color.opacity(Constants.partStrokeOpacity),
+                        lineWidth: Constants.partStrokeWidth
+                    )
+            }
+    }
+
+    /// 학교 태그
+    private var schoolTag: some View {
+        Text(member.school)
+            .appFont(.callout, color: .black)
+            .padding(Constants.tagPadding)
+            .background(.white, in: Capsule())
+    }
+
+    /// 활동 기수 · 상점 · 벌점 요약 카드
     private var summaryCardView: some View {
         VStack(spacing: .zero) {
             summaryRow(title: "활동 기수") {
                 if hasMultipleGenerations {
-                    generationMenu
+                    generationChips
                 } else {
                     Text(currentGeneration)
                         .appFont(.subheadlineEmphasis)
+                        .contentTransition(.numericText())
                 }
             }
 
             Divider()
 
-            summaryRow(title: "상점") {
-                Text(String(format: "%.0f", displayRewardPoints))
-                    .appFont(.subheadlineEmphasis, color: .green)
-            }
+            HStack(spacing: .zero) {
+                pointColumn(
+                    icon: "plus.circle.fill",
+                    iconColor: .green,
+                    label: "상점",
+                    value: displayRewardPoints,
+                    valueColor: .green
+                )
 
-            Divider()
+                Divider()
+                    .frame(height: 48)
 
-            summaryRow(title: "벌점") {
-                Text(String(format: "%.0f", displayPenaltyPoints))
-                    .appFont(.subheadlineEmphasis, color: .red)
+                pointColumn(
+                    icon: "minus.circle.fill",
+                    iconColor: .red,
+                    label: "벌점",
+                    value: displayPenaltyPoints,
+                    valueColor: .red
+                )
             }
+            .padding(.vertical, Constants.summaryRowVerticalPadding)
         }
         .padding(.horizontal, Constants.listPadding.leading)
         .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
         .glass()
+        .animation(.smooth(duration: 0.3), value: selectedGisu)
     }
 
-    private var generationMenu: some View {
-        Menu {
-            Picker("기수 선택", selection: $selectedGisu) {
-                ForEach(member.generationPoints) { summary in
-                    Text("\(summary.gisu)기")
-                        .tag(summary.gisu)
-                }
-            }
-        } label: {
-            HStack(spacing: DefaultSpacing.spacing4) {
-                Text("\(selectedGisu)기")
-                    .appFont(.subheadlineEmphasis)
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.grey500)
+    /// 복수 기수 전환 인라인 칩 셀렉터
+    private var generationChips: some View {
+        HStack(spacing: DefaultSpacing.spacing4) {
+            ForEach(member.generationPoints) { summary in
+                Text("\(summary.gisu)기")
+                    .appFont(
+                        selectedGisu == summary.gisu
+                            ? .subheadlineEmphasis : .subheadline,
+                        color: selectedGisu == summary.gisu
+                            ? .white : .grey700
+                    )
+                    .padding(Constants.tagPadding)
+                    .background(
+                        selectedGisu == summary.gisu
+                            ? Color.accentColor : Color.grey200,
+                        in: Capsule()
+                    )
+                    .onTapGesture {
+                        withAnimation(.smooth(duration: 0.3)) {
+                            selectedGisu = summary.gisu
+                        }
+                    }
             }
         }
-        .foregroundStyle(.primary)
     }
 
-    // MARK: - Function
-
-    private func summaryRow<Content: View>(
-        title: String,
-        @ViewBuilder value: () -> Content
-    ) -> some View {
-        HStack {
-            Text(title)
-                .appFont(.subheadline, color: .grey700)
-            Spacer()
-            value()
-        }
-        .padding(.vertical, Constants.summaryRowVerticalPadding)
-    }
-
+    /// 출석/활동 기록 섹션
     private var recordView: some View {
         VStack(alignment: .leading) {
-            Label("출석/활동 기록", systemImage: "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90")
-                .appFont(.title3Emphasis)
+            Label(
+                "출석/활동 기록",
+                systemImage: "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90"
+            )
+            .appFont(.title3Emphasis)
 
             if member.attendanceRecords.isEmpty {
                 emptyRecordView
@@ -235,6 +256,7 @@ struct ChallengerMemberDetailSheetView: View {
         }
     }
 
+    /// 출석 기록이 없을 때 표시되는 빈 상태 뷰
     private var emptyRecordView: some View {
         VStack(spacing: DefaultSpacing.spacing8) {
             Image(systemName: "calendar.badge.exclamationmark")
@@ -248,11 +270,12 @@ struct ChallengerMemberDetailSheetView: View {
         .glass()
     }
 
+    /// 출석 기록 리스트 뷰
     private var recordListView: some View {
-        List(member.attendanceRecords, rowContent: { record in
+        List(member.attendanceRecords) { record in
             attendanceRecordRow(record)
                 .listRowBackground(Color.clear)
-        })
+        }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .scrollIndicators(.hidden)
@@ -261,6 +284,47 @@ struct ChallengerMemberDetailSheetView: View {
         .glass()
     }
 
+    // MARK: - Function
+
+    /// 상벌점 2열 레이아웃의 개별 컬럼
+    private func pointColumn(
+        icon: String,
+        iconColor: Color,
+        label: String,
+        value: Double,
+        valueColor: Color
+    ) -> some View {
+        VStack(spacing: DefaultSpacing.spacing4) {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Image(systemName: icon)
+                    .font(.system(size: Constants.pointIconSize))
+                    .foregroundStyle(iconColor)
+                Text(label)
+                    .appFont(.footnote, color: .grey700)
+            }
+
+            Text(String(format: "%.0f", value))
+                .appFont(.calloutEmphasis, color: valueColor)
+                .contentTransition(.numericText())
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// 요약 카드의 개별 행 (타이틀 + 우측 값)
+    private func summaryRow<Content: View>(
+        title: String,
+        @ViewBuilder value: () -> Content
+    ) -> some View {
+        HStack {
+            Text(title)
+                .appFont(.subheadline, color: .grey700)
+            Spacer()
+            value()
+        }
+        .padding(.vertical, Constants.summaryRowVerticalPadding)
+    }
+
+    /// 출석 기록 개별 행 (상태 태그 + 세션 제목)
     private func attendanceRecordRow(_ record: MemberAttendanceRecord) -> some View {
         HStack(spacing: DefaultSpacing.spacing16) {
             Text(record.status.displayText)
@@ -277,9 +341,11 @@ struct ChallengerMemberDetailSheetView: View {
     }
 }
 
+// MARK: - Preview
+
 #Preview {
     Text("Preview")
-        .sheet(isPresented: .constant(true), content: {
+        .sheet(isPresented: .constant(true)) {
             ChallengerMemberDetailSheetView(
                 member: .init(
                     profile: nil,
@@ -316,6 +382,7 @@ struct ChallengerMemberDetailSheetView: View {
                         GenerationPointSummary(gisu: 8, reward: 2, penalty: 1),
                         GenerationPointSummary(gisu: 9, reward: 0, penalty: 1)
                     ]
-                ))
-            })
+                )
+            )
+        }
 }


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix + Design 개선 — 구성원 상세 바텀 시트의 기수 선택 버그 수정 및 summaryCardView UX 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경사항이 있으므로 영상으로 올려주세요 -->

## 🛠️ 작업내용

### 기수 선택 버그 수정
- `selectedGisu`를 `Int?` → `Int`로 변경하여 항상 유효한 기수가 선택되도록 수정
- `init`에서 최대 기수를 초기값으로 설정
- `generationMenu`를 `Menu` + `Picker` 조합으로 단순화하여 기수 전환 안정성 확보
- 기수별 상벌점 데이터를 `TaskGroup`으로 병렬 조회하도록 Repository 개선

### summaryCardView UX 개선
- 상벌점 레이아웃을 세로 3행 → 가로 2열로 변경하여 수직 공간 절약
- SF Symbol 아이콘(`plus.circle.fill`, `minus.circle.fill`) 추가로 시각적 구분 강화
- 포인트 숫자 폰트를 `.calloutEmphasis`로 상향, 라벨은 `.footnote` + `.grey700`으로 위계 구분
- 기수 선택을 Menu에서 인라인 칩 셀렉터로 변경하여 시트 내에서 바로 전환 가능
- `contentTransition(.numericText())` 적용으로 기수 전환 시 숫자 롤링 애니메이션 추가

### 코드 정리
- `partTag`, `schoolTag` 서브뷰 분리
- View/Function MARK 구분 및 주석 보강
- 기수별 상벌점 조회 TaskGroup에 `@MainActor` 어노테이션 추가

## 📋 추후 진행 상황

- 구성원 상세 시트 추가 UX 개선 (출석 기록 섹션 등)

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Components/Member/ChallengerMemberDetailSheetView.swift` - summaryCardView 레이아웃 변경, generationChips 인라인 칩 셀렉터, contentTransition 애니메이션
- `Features/Activity/Data/Repositories/MemberRepository.swift` - TaskGroup 기수별 상벌점 병렬 조회 로직, @MainActor 어노테이션

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)