### PR TITLE
🐛[Fix] 홈 상벌점 도넛 차트 탭 감지 및 팝오버 표시 버그 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
@@ -26,6 +26,8 @@ struct PenaltyCard: View, Equatable {
     @State private var isHorizontalDrag: Bool?
     /// 팝오버 필터 (nil이면 닫힘)
     @State private var popoverFilter: PointLogFilter?
+    /// chartAngleSelection 선택 값
+    @State private var selectedChartAngle: Int?
 
     fileprivate enum PointLogFilter {
         case reward
@@ -104,13 +106,16 @@ struct PenaltyCard: View, Equatable {
 
     /// 상점/벌점 도넛 차트
     private func pointChart(generation: GenerationData) -> some View {
-        let hasData = generation.rewardPoint > 0 || generation.penaltyPoint > 0
+        let hasData = generation.rewardPoint != 0 || generation.penaltyPoint != 0
+        let selectedFilter: PointLogFilter? = selectedChartAngle.map {
+            $0 <= abs(generation.rewardPoint) ? .reward : .penalty
+        }
 
         return HStack(spacing: DefaultSpacing.spacing24) {
             ZStack {
                 Chart {
                     SectorMark(
-                        angle: .value("상점", hasData ? generation.rewardPoint : 0),
+                        angle: .value("상점", hasData ? abs(generation.rewardPoint) : 0),
                         innerRadius: .ratio(Constants.innerRadius),
                         angularInset: 2
                     )
@@ -121,9 +126,10 @@ struct PenaltyCard: View, Equatable {
                             endPoint: .trailing
                         )
                     )
+                    .opacity(selectedFilter == nil || selectedFilter == .reward ? 1.0 : 0.3)
 
                     SectorMark(
-                        angle: .value("벌점", hasData ? generation.penaltyPoint : 0),
+                        angle: .value("벌점", hasData ? abs(generation.penaltyPoint) : 0),
                         innerRadius: .ratio(Constants.innerRadius),
                         angularInset: 2
                     )
@@ -134,6 +140,7 @@ struct PenaltyCard: View, Equatable {
                             endPoint: .trailing
                         )
                     )
+                    .opacity(selectedFilter == nil || selectedFilter == .penalty ? 1.0 : 0.3)
 
                     if !hasData {
                         SectorMark(
@@ -145,7 +152,11 @@ struct PenaltyCard: View, Equatable {
                 }
                 .chartLegend(.hidden)
                 .frame(width: Constants.chartSize, height: Constants.chartSize)
-                .allowsHitTesting(false)
+                .chartAngleSelection(value: $selectedChartAngle)
+                .onChange(of: selectedChartAngle) { _, newAngle in
+                    guard hasData, let value = newAngle else { return }
+                    popoverFilter = value <= abs(generation.rewardPoint) ? .reward : .penalty
+                }
 
                 VStack(spacing: 2) {
                     Text("\(generation.rewardPoint + generation.penaltyPoint)")
@@ -154,30 +165,13 @@ struct PenaltyCard: View, Equatable {
                         .appFont(.caption2, color: .grey500)
                 }
                 .allowsHitTesting(false)
-
-                // 차트 영역 탭 감지 오버레이
-                Color.clear
-                    .frame(width: Constants.chartSize, height: Constants.chartSize)
-                    .contentShape(Circle())
-                    .onTapGesture { location in
-                        guard hasData else { return }
-                        let size = Constants.chartSize
-                        let center = CGPoint(x: size / 2, y: size / 2)
-                        let dx = location.x - center.x
-                        let dy = location.y - center.y
-                        // 12시 기준 시계방향 각도
-                        var angle = atan2(dx, -dy) * 180.0 / .pi
-                        if angle < 0 { angle += 360.0 }
-                        let total = Double(
-                            generation.rewardPoint + generation.penaltyPoint
-                        )
-                        let rewardDeg = Double(generation.rewardPoint) / total * 360.0
-                        popoverFilter = angle <= rewardDeg ? .reward : .penalty
-                    }
             }
             .popover(isPresented: Binding(
                 get: { popoverFilter != nil },
-                set: { if !$0 { popoverFilter = nil } }
+                set: { if !$0 {
+                    popoverFilter = nil
+                    selectedChartAngle = nil
+                }}
             )) {
                 PointLogPopover(
                     logs: generation.pointLogs.filter {
@@ -290,7 +284,7 @@ fileprivate struct PointLogPopover: View {
 
                     Spacer()
 
-                    Text(log.isReward ? "+\(log.point)" : "\(log.point)")
+                    Text(log.isReward ? "+\(abs(log.point))" : "-\(abs(log.point))")
                         .appFont(.subheadline, color: log.isReward ? .indigo500 : .indigo300)
 
                     Text(log.date)


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 홈 화면 상벌점 도넛 차트에서 벌점 영역 탭 시 상점 기록이 표시되는 문제 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요
그 외에는 스크린샷으로 올려도 무방합니다.
어떤 작업을 하였는지 시각적으로 바로 확인 가능하게 해주세요! -->

## 🛠️ 작업내용

- `PenaltyCard.swift` - 수동 각도 계산(`atan2`) 방식을 `chartAngleSelection`으로 교체
  - 기존 방식은 계산된 각도가 `SectorMark` 실제 렌더링 좌표와 불일치하여 잘못된 섹터 판별
- `PenaltyCard.swift` - `SectorMark` 값에 `abs()` 적용
  - API가 벌점을 음수로 내려주는 경우 차트가 역방향 렌더링되던 문제 수정
- `PenaltyCard.swift` - `hasData` 조건 수정 (`> 0` → `!= 0`)
  - `penaltyPoint`가 음수일 때 데이터가 있음에도 회색 차트가 표시되던 잠재 버그 수정
- `PenaltyCard.swift` - 팝오버 dismiss 시 `selectedChartAngle` 리셋 추가
  - 동일 섹터 재탭 시 `onChange`가 발생하지 않는 문제 해결
- `PenaltyCard.swift` - 탭 시 선택 섹터 opacity 피드백 추가
  - 선택된 섹터: `opacity 1.0` / 비선택 섹터: `opacity 0.3`
- `PenaltyCard.swift` - 벌점 팝오버 점수 표시 수정
  - 기존: `"\(point)"` (양수로 표시) → 수정: `"-\(abs(point))"` (음수 명시)

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Home/Presentation/Components/Card/PenaltyCard.swift` - `chartAngleSelection` 기반 섹터 탭 감지 로직 및 `selectedFilter` opacity 계산 확인
- `Features/Home/Presentation/Components/Card/PenaltyCard.swift` - 팝오버 dismiss 시 `selectedChartAngle = nil` 리셋 처리 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)