### PR TITLE
🐛[Fix] 커리큘럼 과제 링크 텍스트 필드 포커스 시 사이즈 변동 버그 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Curriculum/ChallengerCurriculumView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Curriculum/ChallengerCurriculumView.swift
@@ -58,7 +58,7 @@ struct ChallengerCurriculumView: View {
             for: .scrollContent
         )
         .background(.white)
-        .keyboardDismissToolbar(focusedID: $focusedMissionID)
+        .scrollDismissesKeyboard(.immediately)
     }
 
     // MARK: - View Components

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift
@@ -215,25 +215,29 @@ fileprivate struct MissionSubmissionView: View, Equatable {
     }
 
     private var linkInput: some View {
-        TextField("https://...", text: Binding(
+        TextField("", text: Binding(
             get: { linkText },
-            set: { onLinkTextChanged($0) }
-        ))
+            set: { onLinkTextChanged($0) }),
+                  prompt: textfieldPlaceholder)
         .focused(focusedMissionID, equals: missionID)
-        .appFont(.footnote, weight: .regular, color: .grey500)
         .padding(DefaultConstant.defaultTextFieldPadding)
-        .background(
-            RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius)
-                .strokeBorder(
-                    hasError ? Color.red : Color.grey300,
-                    lineWidth: Constants.borderWidth)
-        )
+        .overlay(content: {
+            RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+                .fill(.clear)
+                .strokeBorder(.grey300, style: .init())
+        })
         .transition(
             .asymmetric(
                 insertion: .scale(scale: 0.95).combined(with: .opacity),
                 removal: .scale(scale: 0.95).combined(with: .opacity)
             )
         )
+    }
+    
+    private var textfieldPlaceholder: Text {
+        Text("https://...")
+            .font(.app(.footnote))
+            .foregroundStyle(Color(.placeholderText))
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 커리큘럼 화면에서 과제 링크 입력 텍스트 필드 포커스 시 사이즈가 줄어드는 문제 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요
그 외에는 스크린샷으로 올려도 무방합니다.
어떤 작업을 하였는지 시각적으로 바로 확인 가능하게 해주세요! -->

## 🛠️ 작업내용

- `ChallengerMissionCardContent.swift` - `linkInput` border를 `.background` → `.overlay`로 교체
  - `.background`는 레이아웃 크기에 영향을 주기 때문에 포커스 시 레이아웃 재계산 과정에서 `.scale(0.95)` transition이 재적용되는 문제 유발
  - `.overlay`는 레이아웃에 영향을 주지 않아 사이즈 변동 없음
- `ChallengerMissionCardContent.swift` - TextField placeholder를 `prompt:` 파라미터 방식으로 변경
  - `.appFont()` 제거로 포커스 전환 시 폰트 재적용에 따른 레이아웃 재계산 방지
  - `prompt: Text(...)` 방식으로 placeholder 스타일 분리
- `ChallengerCurriculumView.swift` - `.keyboardDismissToolbar` → `.scrollDismissesKeyboard(.immediately)` 교체
  - 키보드 위 툴바 대신 스크롤 시 즉시 키보드가 내려가는 방식으로 UX 개선

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift` - `.overlay` 방식 border 및 `prompt:` placeholder 적용 확인
- `Features/Activity/Presentation/Components/Challenger/Curriculum/ChallengerCurriculumView.swift` - `scrollDismissesKeyboard` 동작 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)