### PR TITLE
✨[Feat] 지도 POI 선택 기능 강화 및 UX 개선

### DIFF
--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -10,6 +10,7 @@ import KakaoSDKAuth
 import KakaoSDKCommon
 import SwiftData
 import SwiftUI
+import TipKit
 
 /// UMC 동아리 운영 관리 앱의 진입점
 ///
@@ -56,6 +57,7 @@ struct AppProductApp: App {
                 modelContext: sharedModelContainer.mainContext
             )
         )
+        try? Tips.configure()
     }
     
     // MARK: - Body

--- a/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/MapPlacePickerView.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/MapPlacePickerView.swift
@@ -120,7 +120,6 @@ struct MapPlacePickerView: View {
             }
             .overlay(alignment: .top) {
                 TipView(poiTip, arrowEdge: .none)
-                    .padding(.top, DefaultSpacing.spacing12)
                     .padding(.horizontal, DefaultSpacing.spacing16)
             }
             .onChange(of: selectedMapFeature) { _, feature in

--- a/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/MapPlacePickerView.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/MapPlacePickerView.swift
@@ -8,6 +8,7 @@
 import CoreLocation
 import MapKit
 import SwiftUI
+import TipKit
 
 /// Apple 지도에서 핀을 찍어 장소를 선택하는 뷰
 ///
@@ -39,6 +40,11 @@ struct MapPlacePickerView: View {
     @State private var isResolvingPlace: Bool = false
     /// 초기 카메라/선택 상태를 한 번만 구성하기 위한 플래그입니다.
     @State private var hasInitializedState: Bool = false
+    /// 애플 맵 기본 POI 말풍선 표시를 위한 선택된 지도 피처입니다.
+    @State private var selectedMapFeature: MapFeature?
+
+    /// POI 길게 누르기 안내 팁입니다.
+    private let poiTip = POILongPressTip()
 
     /// 레이아웃과 지도 기본값을 모아둔 상수입니다.
     private enum Constants {
@@ -95,8 +101,9 @@ struct MapPlacePickerView: View {
     /// 핀 선택과 사용자 위치를 표시하는 지도 본문입니다.
     private var mapContent: some View {
         MapReader { proxy in
-            Map(position: $cameraPosition) {
-                if let selectedCoordinate {
+            Map(position: $cameraPosition, selection: $selectedMapFeature) {
+                // POI가 선택된 경우 커스텀 핀을 숨기고 애플 맵 기본 말풍선을 표시합니다.
+                if let selectedCoordinate, selectedMapFeature == nil {
                     Annotation(
                         "선택한 위치",
                         coordinate: selectedCoordinate,
@@ -111,10 +118,30 @@ struct MapPlacePickerView: View {
             .mapControls {
                 MapCompass()
             }
+            .overlay(alignment: .top) {
+                TipView(poiTip, arrowEdge: .none)
+                    .padding(.top, DefaultSpacing.spacing12)
+                    .padding(.horizontal, DefaultSpacing.spacing16)
+            }
+            .onChange(of: selectedMapFeature) { _, feature in
+                guard let feature else { return }
+                // POI 탭: 애플 맵 기본 말풍선 유지, 하단 카드 정보만 갱신
+                poiTip.invalidate(reason: .actionPerformed)
+                Task {
+                    await selectPOICoordinate(feature.coordinate)
+                }
+            }
             .simultaneousGesture(
                 SpatialTapGesture()
                     .onEnded { value in
-                        handleMapTap(value, proxy: proxy)
+                        let location = value.location
+                        Task { @MainActor in
+                            // Map의 selectedMapFeature 상태 업데이트를 기다린 후 POI 여부를 판단합니다.
+                            await Task.yield()
+                            guard selectedMapFeature == nil else { return }
+                            guard let coordinate = proxy.convert(location, from: .local) else { return }
+                            Task { await selectCoordinate(coordinate) }
+                        }
                     }
             )
         }
@@ -209,6 +236,20 @@ struct MapPlacePickerView: View {
     private func selectCoordinate(_ coordinate: CLLocationCoordinate2D) async {
         selectedCoordinate = coordinate
         moveCamera(to: coordinate)
+        isResolvingPlace = true
+        selectedPlace = await reverseGeocodePlaceInfo(for: coordinate)
+        isResolvingPlace = false
+    }
+
+    /// POI 탭 시 커스텀 핀 없이 장소 정보만 역지오코딩합니다.
+    ///
+    /// 애플 맵 기본 POI 말풍선을 유지하기 위해 `selectedCoordinate`를 nil로 초기화하며,
+    /// 역지오코딩 결과로 하단 카드의 장소 정보만 갱신합니다.
+    ///
+    /// - Parameter coordinate: POI의 좌표입니다.
+    @MainActor
+    private func selectPOICoordinate(_ coordinate: CLLocationCoordinate2D) async {
+        selectedCoordinate = nil
         isResolvingPlace = true
         selectedPlace = await reverseGeocodePlaceInfo(for: coordinate)
         isResolvingPlace = false
@@ -366,7 +407,7 @@ private struct SelectionCardView: View {
         } else if isResolvingPlace {
             resolvingContent
         } else {
-            Text("지도를 탭해서 위치를 선택하세요.")
+            Text("탭으로 주소를 선택하거나, POI를 길게 눌러 장소를 선택하세요.")
                 .appFont(.subheadline, color: .grey600)
         }
     }

--- a/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/MapPlacePickerView.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/MapPlacePickerView.swift
@@ -120,6 +120,7 @@ struct MapPlacePickerView: View {
             }
             .overlay(alignment: .top) {
                 TipView(poiTip, arrowEdge: .none)
+                    .glassEffect()
                     .padding(.horizontal, DefaultSpacing.spacing16)
             }
             .onChange(of: selectedMapFeature) { _, feature in
@@ -127,7 +128,7 @@ struct MapPlacePickerView: View {
                 // POI 탭: 애플 맵 기본 말풍선 유지, 하단 카드 정보만 갱신
                 poiTip.invalidate(reason: .actionPerformed)
                 Task {
-                    await selectPOICoordinate(feature.coordinate)
+                    await selectPOICoordinate(feature.coordinate, poiName: feature.title)
                 }
             }
             .simultaneousGesture(
@@ -243,14 +244,28 @@ struct MapPlacePickerView: View {
     /// POI 탭 시 커스텀 핀 없이 장소 정보만 역지오코딩합니다.
     ///
     /// 애플 맵 기본 POI 말풍선을 유지하기 위해 `selectedCoordinate`를 nil로 초기화하며,
-    /// 역지오코딩 결과로 하단 카드의 장소 정보만 갱신합니다.
+    /// 역지오코딩 결과로 하단 카드의 장소 정보를 갱신합니다.
+    /// POI 이름이 제공된 경우 역지오코딩 결과의 이름 대신 POI 이름을 우선 사용합니다.
     ///
-    /// - Parameter coordinate: POI의 좌표입니다.
+    /// - Parameters:
+    ///   - coordinate: POI의 좌표입니다.
+    ///   - poiName: 애플 맵에서 제공하는 POI 이름입니다.
     @MainActor
-    private func selectPOICoordinate(_ coordinate: CLLocationCoordinate2D) async {
+    private func selectPOICoordinate(
+        _ coordinate: CLLocationCoordinate2D,
+        poiName: String? = nil
+    ) async {
         selectedCoordinate = nil
         isResolvingPlace = true
-        selectedPlace = await reverseGeocodePlaceInfo(for: coordinate)
+        var place = await reverseGeocodePlaceInfo(for: coordinate)
+        if let poiName {
+            place = PlaceSearchInfo(
+                name: poiName,
+                address: place.address,
+                coordinate: place.coordinate
+            )
+        }
+        selectedPlace = place
         isResolvingPlace = false
     }
 

--- a/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/POILongPressTip.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/POILongPressTip.swift
@@ -13,11 +13,11 @@ import TipKit
 /// POI를 실제로 선택하거나 직접 닫으면 다시 표시되지 않습니다.
 struct POILongPressTip: Tip {
     var title: Text {
-        Text("장소 선택 팁")
+        Text("장소를 더 정확하게 선택하려면")
     }
 
     var message: Text? {
-        Text("POI를 길게 눌러 장소를 선택할 수 있어요")
+        Text("카페, 식당 등 지도 위 아이콘을 길게 누르면 해당 장소를 바로 선택할 수 있어요.")
     }
 
     var image: Image? {

--- a/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/POILongPressTip.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/PlaceSelectView/POILongPressTip.swift
@@ -1,0 +1,26 @@
+//
+//  POILongPressTip.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/1/26.
+//
+
+import TipKit
+
+/// 지도에서 POI를 길게 눌러 장소를 선택하는 방법을 안내하는 팁입니다.
+///
+/// 사용자가 처음 지도 선택 화면에 진입했을 때 표시되며,
+/// POI를 실제로 선택하거나 직접 닫으면 다시 표시되지 않습니다.
+struct POILongPressTip: Tip {
+    var title: Text {
+        Text("장소 선택 팁")
+    }
+
+    var message: Text? {
+        Text("POI를 길게 눌러 장소를 선택할 수 있어요")
+    }
+
+    var image: Image? {
+        Image(systemName: "hand.tap")
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/BaseMapComponent.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/BaseMapComponent.swift
@@ -44,7 +44,6 @@ struct BaseMapComponent: View, Equatable {
         .mapStyle(.standard)
         .mapControls {
             MapCompass()
-            MapUserLocationButton()
         }
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/BaseMapComponent.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/BaseMapComponent.swift
@@ -44,6 +44,7 @@ struct BaseMapComponent: View, Equatable {
         .mapStyle(.standard)
         .mapControls {
             MapCompass()
+            MapUserLocationButton()
         }
     }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Map/SelectedPlaceAnnotation.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Map/SelectedPlaceAnnotation.swift
@@ -52,11 +52,8 @@ struct SelectedPlaceAnnotation: View {
             }
             .padding(.horizontal, DefaultSpacing.spacing12)
             .padding(.vertical, DefaultSpacing.spacing8)
-            .background(
-                Capsule(style: .continuous)
-                    .fill(.white)
-                    .glass()
-            )
+            .clipShape(.capsule)
+            .glassEffect(.clear, in: .capsule)
             .transition(
                 .asymmetric(
                     insertion: .scale(scale: 0.88, anchor: .bottom)

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/InlineMapPickerState.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/InlineMapPickerState.swift
@@ -103,6 +103,20 @@ final class InlineMapPickerState {
         isResolvingPlace = false
     }
 
+    /// POI 탭 시 커스텀 핀 없이 장소 정보만 역지오코딩합니다.
+    ///
+    /// 애플 맵 기본 POI 말풍선을 유지하기 위해 `selectedCoordinate`를 nil로 초기화하며,
+    /// 역지오코딩 결과로 하단 카드의 장소 정보만 갱신합니다.
+    ///
+    /// - Parameter coordinate: POI의 좌표입니다.
+    @MainActor
+    func selectPOICoordinate(_ coordinate: CLLocationCoordinate2D) async {
+        selectedCoordinate = nil
+        isResolvingPlace = true
+        selectedPlace = await reverseGeocodePlaceInfo(for: coordinate)
+        isResolvingPlace = false
+    }
+
     // MARK: - Private Function
 
     @MainActor

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/InlineMapPickerState.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/InlineMapPickerState.swift
@@ -106,14 +106,28 @@ final class InlineMapPickerState {
     /// POI 탭 시 커스텀 핀 없이 장소 정보만 역지오코딩합니다.
     ///
     /// 애플 맵 기본 POI 말풍선을 유지하기 위해 `selectedCoordinate`를 nil로 초기화하며,
-    /// 역지오코딩 결과로 하단 카드의 장소 정보만 갱신합니다.
+    /// 역지오코딩 결과로 하단 카드의 장소 정보를 갱신합니다.
+    /// POI 이름이 제공된 경우 역지오코딩 결과의 이름 대신 POI 이름을 우선 사용합니다.
     ///
-    /// - Parameter coordinate: POI의 좌표입니다.
+    /// - Parameters:
+    ///   - coordinate: POI의 좌표입니다.
+    ///   - poiName: 애플 맵에서 제공하는 POI 이름입니다.
     @MainActor
-    func selectPOICoordinate(_ coordinate: CLLocationCoordinate2D) async {
+    func selectPOICoordinate(
+        _ coordinate: CLLocationCoordinate2D,
+        poiName: String? = nil
+    ) async {
         selectedCoordinate = nil
         isResolvingPlace = true
-        selectedPlace = await reverseGeocodePlaceInfo(for: coordinate)
+        var place = await reverseGeocodePlaceInfo(for: coordinate)
+        if let poiName {
+            place = PlaceSearchInfo(
+                name: poiName,
+                address: place.address,
+                coordinate: place.coordinate
+            )
+        }
+        selectedPlace = place
         isResolvingPlace = false
     }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/InlineMapPickerState.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/InlineMapPickerState.swift
@@ -81,11 +81,12 @@ final class InlineMapPickerState {
         }
     }
 
-    /// 사용자의 현재 위치를 다시 조회해 지도와 선택 핀을 갱신합니다.
+    /// 사용자의 현재 위치를 다시 조회해 카메라를 이동하고 선택 핀을 갱신합니다.
     @MainActor
     func moveToCurrentLocation() async {
         do {
             let coordinate = try await LocationManager.shared.getCurrentLocation()
+            moveCamera(to: coordinate)
             await selectCoordinate(coordinate)
         } catch {
             LocationManager.shared.requestAuthorization()

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/InlineMapPlacePicker.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/InlineMapPlacePicker.swift
@@ -55,7 +55,6 @@ struct InlineMapPlacePicker: View {
             .mapStyle(.standard)
             .mapControls {
                 MapCompass()
-                MapUserLocationButton()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay(alignment: .top) {

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/InlineMapPlacePicker.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/InlineMapPlacePicker.swift
@@ -7,6 +7,7 @@
 
 import MapKit
 import SwiftUI
+import TipKit
 
 /// 일정 등록 시트 안에서 사용하는 인라인 지도 선택 뷰입니다.
 ///
@@ -17,6 +18,12 @@ struct InlineMapPlacePicker: View {
 
     /// 지도 선택 상태입니다.
     @Bindable var state: InlineMapPickerState
+
+    /// 애플 맵 기본 POI 말풍선 표시를 위한 선택된 지도 피처입니다.
+    @State private var selectedMapFeature: MapFeature?
+
+    /// POI 길게 누르기 안내 팁입니다.
+    private let poiTip = POILongPressTip()
 
     // MARK: - Initializer
 
@@ -31,8 +38,10 @@ struct InlineMapPlacePicker: View {
 
     var body: some View {
         MapReader { proxy in
-            Map(position: $state.cameraPosition) {
-                if let selectedCoordinate = state.selectedCoordinate {
+            Map(position: $state.cameraPosition, selection: $selectedMapFeature) {
+                // POI가 선택된 경우 커스텀 핀을 숨기고 애플 맵 기본 말풍선을 표시합니다.
+                if let selectedCoordinate = state.selectedCoordinate,
+                   selectedMapFeature == nil {
                     Annotation(
                         state.selectedPlace?.name ?? "선택한 위치",
                         coordinate: selectedCoordinate,
@@ -48,17 +57,26 @@ struct InlineMapPlacePicker: View {
                 MapCompass()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay(alignment: .top) {
+                TipView(poiTip, arrowEdge: .none)
+                    .padding(.top, DefaultSpacing.spacing12)
+                    .padding(.horizontal, DefaultSpacing.spacing16)
+            }
+            .onChange(of: selectedMapFeature) { _, feature in
+                guard let feature else { return }
+                poiTip.invalidate(reason: .actionPerformed)
+                Task {
+                    await state.selectPOICoordinate(feature.coordinate)
+                }
+            }
             .simultaneousGesture(
                 SpatialTapGesture()
                     .onEnded { value in
-                        guard let coordinate = proxy.convert(
-                            value.location,
-                            from: .local
-                        ) else {
-                            return
-                        }
-
-                        Task {
+                        let location = value.location
+                        Task { @MainActor in
+                            await Task.yield()
+                            guard selectedMapFeature == nil else { return }
+                            guard let coordinate = proxy.convert(location, from: .local) else { return }
                             await state.selectCoordinate(coordinate)
                         }
                     }
@@ -69,3 +87,4 @@ struct InlineMapPlacePicker: View {
         }
     }
 }
+

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/InlineMapPlacePicker.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/InlineMapPlacePicker.swift
@@ -66,7 +66,7 @@ struct InlineMapPlacePicker: View {
                 guard let feature else { return }
                 poiTip.invalidate(reason: .actionPerformed)
                 Task {
-                    await state.selectPOICoordinate(feature.coordinate)
+                    await state.selectPOICoordinate(feature.coordinate, poiName: feature.title)
                 }
             }
             .simultaneousGesture(

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/InlineMapPlacePicker.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/InlineMapPlacePicker.swift
@@ -55,6 +55,7 @@ struct InlineMapPlacePicker: View {
             .mapStyle(.standard)
             .mapControls {
                 MapCompass()
+                MapUserLocationButton()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay(alignment: .top) {


### PR DESCRIPTION
## ✨ PR 유형

Feature + Fix — 지도 장소 선택 기능 전반 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->

## 🛠️ 작업내용

**POI 네이티브 말풍선 지원**
- `Map(selection: $selectedMapFeature)` 적용으로 POI 길게 누르기 시 애플 맵 네이티브 말풍선 표시
- POI 선택 시 커스텀 핀 숨기고 역지오코딩으로 하단 카드 정보만 갱신
- `SpatialTapGesture` + `Task.yield()`로 일반 탭과 POI 탭 구분 처리

**POI 이름 표시 수정**
- `feature.title`을 활용해 역지오코딩 이름 대신 POI 이름 우선 사용
- `poiName`이 nil인 경우 기존 역지오코딩 결과로 fallback

**TipKit 안내 추가**
- `POILongPressTip` 생성 — 카페, 식당 등 아이콘 길게 누르기 안내 (최초 1회 표시)
- POI 선택 시 `tip.invalidate(reason: .actionPerformed)` 자동 무효화
- `InlineMapPlacePicker`, `MapPlacePickerView` 상단에 `TipView` 오버레이 적용
- `AppProductApp.init()`에 `Tips.configure()` 등록

**내 위치 버튼 카메라 이동 수정**
- `moveToCurrentLocation()`에서 `moveCamera()` 호출 누락 수정
- 내 위치 버튼 클릭 시 카메라가 즉시 현재 위치로 이동

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Core/Common/UIComponents/PlaceSelectView/POILongPressTip.swift` — TipKit Tip 정의
- `Features/Home/Presentation/ViewModels/InlineMapPickerState.swift` — `selectPOICoordinate(poiName:)`, `moveToCurrentLocation()` 수정 확인
- `Features/Home/Presentation/Views/Registration/InlineMapPlacePicker.swift` — `selectedMapFeature` onChange / TipView 오버레이
- `Core/Common/UIComponents/PlaceSelectView/MapPlacePickerView.swift` — 동일 패턴 적용 확인
- `App/AppProductApp.swift` — `Tips.configure()` 호출 위치

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)