### PR TITLE
♻️ [Refactor] ProjectDescriptionHelpers 도입으로 Tuist Project.swift 보일러플레이트 제거

### DIFF
--- a/UMCApp/Core/DI/Project.swift
+++ b/UMCApp/Core/DI/Project.swift
@@ -1,18 +1,10 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
+let project = coreProject(
     name: "CoreDI",
-    targets: [
-        .target(
-            name: "CoreDI",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.core.di",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Sources/**"],
-            dependencies: [
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        )
+    bundleIdSuffix: "di",
+    dependencies: [
+        .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
     ]
 )

--- a/UMCApp/Core/DesignSystem/Project.swift
+++ b/UMCApp/Core/DesignSystem/Project.swift
@@ -1,15 +1,7 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
+let project = coreProject(
     name: "CoreDesignSystem",
-    targets: [
-        .target(
-            name: "CoreDesignSystem",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.core.designsystem",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Sources/**"]
-        )
-    ]
+    bundleIdSuffix: "designsystem"
 )

--- a/UMCApp/Core/Foundation/Project.swift
+++ b/UMCApp/Core/Foundation/Project.swift
@@ -1,15 +1,7 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
+let project = coreProject(
     name: "UMCFoundation",
-    targets: [
-        .target(
-            name: "UMCFoundation",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.core.foundation",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Sources/**"]
-        )
-    ]
+    bundleIdSuffix: "foundation"
 )

--- a/UMCApp/Core/Network/Project.swift
+++ b/UMCApp/Core/Network/Project.swift
@@ -1,19 +1,11 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
+let project = coreProject(
     name: "CoreNetwork",
-    targets: [
-        .target(
-            name: "CoreNetwork",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.core.network",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Sources/**"],
-            dependencies: [
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-                .external(name: "Moya"),
-            ]
-        )
+    bundleIdSuffix: "network",
+    dependencies: [
+        .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+        .external(name: "Moya"),
     ]
 )

--- a/UMCApp/Core/UIComponents/Project.swift
+++ b/UMCApp/Core/UIComponents/Project.swift
@@ -1,19 +1,11 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
+let project = coreProject(
     name: "CoreUIComponents",
-    targets: [
-        .target(
-            name: "CoreUIComponents",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.core.uicomponents",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Sources/**"],
-            dependencies: [
-                .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
-                .external(name: "Kingfisher"),
-            ]
-        )
+    bundleIdSuffix: "uicomponents",
+    dependencies: [
+        .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
+        .external(name: "Kingfisher"),
     ]
 )

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -1,45 +1,4 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
-    name: "Activity",
-    targets: [
-        .target(
-            name: "ActivityDomain",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.activity.domain",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Domain/Sources/**"],
-            dependencies: [
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "ActivityData",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.activity.data",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Data/Sources/**"],
-            dependencies: [
-                .target(name: "ActivityDomain"),
-                .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "ActivityPresentation",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.activity.presentation",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Presentation/Sources/**"],
-            dependencies: [
-                .target(name: "ActivityDomain"),
-                .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
-                .project(target: "CoreUIComponents", path: .relativeToRoot("Core/UIComponents")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-    ]
-)
+let project = featureProject(name: "Activity")

--- a/UMCApp/Features/Auth/Project.swift
+++ b/UMCApp/Features/Auth/Project.swift
@@ -1,45 +1,4 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
-    name: "Auth",
-    targets: [
-        .target(
-            name: "AuthDomain",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.auth.domain",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Domain/Sources/**"],
-            dependencies: [
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "AuthData",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.auth.data",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Data/Sources/**"],
-            dependencies: [
-                .target(name: "AuthDomain"),
-                .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "AuthPresentation",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.auth.presentation",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Presentation/Sources/**"],
-            dependencies: [
-                .target(name: "AuthDomain"),
-                .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
-                .project(target: "CoreUIComponents", path: .relativeToRoot("Core/UIComponents")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-    ]
-)
+let project = featureProject(name: "Auth")

--- a/UMCApp/Features/Community/Project.swift
+++ b/UMCApp/Features/Community/Project.swift
@@ -1,45 +1,4 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
-    name: "Community",
-    targets: [
-        .target(
-            name: "CommunityDomain",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.community.domain",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Domain/Sources/**"],
-            dependencies: [
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "CommunityData",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.community.data",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Data/Sources/**"],
-            dependencies: [
-                .target(name: "CommunityDomain"),
-                .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "CommunityPresentation",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.community.presentation",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Presentation/Sources/**"],
-            dependencies: [
-                .target(name: "CommunityDomain"),
-                .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
-                .project(target: "CoreUIComponents", path: .relativeToRoot("Core/UIComponents")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-    ]
-)
+let project = featureProject(name: "Community")

--- a/UMCApp/Features/Home/Project.swift
+++ b/UMCApp/Features/Home/Project.swift
@@ -1,45 +1,4 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
-    name: "Home",
-    targets: [
-        .target(
-            name: "HomeDomain",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.home.domain",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Domain/Sources/**"],
-            dependencies: [
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "HomeData",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.home.data",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Data/Sources/**"],
-            dependencies: [
-                .target(name: "HomeDomain"),
-                .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "HomePresentation",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.home.presentation",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Presentation/Sources/**"],
-            dependencies: [
-                .target(name: "HomeDomain"),
-                .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
-                .project(target: "CoreUIComponents", path: .relativeToRoot("Core/UIComponents")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-    ]
-)
+let project = featureProject(name: "Home")

--- a/UMCApp/Features/MyPage/Project.swift
+++ b/UMCApp/Features/MyPage/Project.swift
@@ -1,45 +1,4 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
-    name: "MyPage",
-    targets: [
-        .target(
-            name: "MyPageDomain",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.mypage.domain",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Domain/Sources/**"],
-            dependencies: [
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "MyPageData",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.mypage.data",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Data/Sources/**"],
-            dependencies: [
-                .target(name: "MyPageDomain"),
-                .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "MyPagePresentation",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.mypage.presentation",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Presentation/Sources/**"],
-            dependencies: [
-                .target(name: "MyPageDomain"),
-                .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
-                .project(target: "CoreUIComponents", path: .relativeToRoot("Core/UIComponents")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-    ]
-)
+let project = featureProject(name: "MyPage")

--- a/UMCApp/Features/Notice/Project.swift
+++ b/UMCApp/Features/Notice/Project.swift
@@ -1,45 +1,4 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
-let project = Project(
-    name: "Notice",
-    targets: [
-        .target(
-            name: "NoticeDomain",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.notice.domain",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Domain/Sources/**"],
-            dependencies: [
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "NoticeData",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.notice.data",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Data/Sources/**"],
-            dependencies: [
-                .target(name: "NoticeDomain"),
-                .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-        .target(
-            name: "NoticePresentation",
-            destinations: .iOS,
-            product: .staticFramework,
-            bundleId: "dev.umc.feature.notice.presentation",
-            deploymentTargets: .iOS("26.0"),
-            sources: ["Presentation/Sources/**"],
-            dependencies: [
-                .target(name: "NoticeDomain"),
-                .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
-                .project(target: "CoreUIComponents", path: .relativeToRoot("Core/UIComponents")),
-                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-            ]
-        ),
-    ]
-)
+let project = featureProject(name: "Notice")

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
@@ -1,0 +1,34 @@
+import ProjectDescription
+
+private let deploymentTargets: DeploymentTargets = .iOS("26.0")
+private let destinations: Destinations = .iOS
+private let bundleIdBase = "dev.umc.core"
+
+/// Core 모듈용 Project 생성 헬퍼
+///
+/// Core 모듈은 단일 staticFramework 타겟으로 구성됩니다.
+///
+/// - Parameters:
+///   - name: 타겟 이름 (예: "CoreNetwork", "UMCFoundation")
+///   - bundleIdSuffix: bundleId 접미사 (예: "network", "foundation")
+///   - dependencies: 의존성 목록
+public func coreProject(
+    name: String,
+    bundleIdSuffix: String,
+    dependencies: [TargetDependency] = []
+) -> Project {
+    Project(
+        name: name,
+        targets: [
+            .target(
+                name: name,
+                destinations: destinations,
+                product: .staticFramework,
+                bundleId: "\(bundleIdBase).\(bundleIdSuffix)",
+                deploymentTargets: deploymentTargets,
+                sources: ["Sources/**"],
+                dependencies: dependencies
+            )
+        ]
+    )
+}

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
@@ -1,0 +1,70 @@
+import ProjectDescription
+
+private let deploymentTargets: DeploymentTargets = .iOS("26.0")
+private let destinations: Destinations = .iOS
+private let bundleIdBase = "dev.umc.feature"
+
+/// Feature 모듈용 Project 생성 헬퍼
+///
+/// 각 Feature는 Domain / Data / Presentation 세 개의 staticFramework 타겟으로 구성됩니다.
+/// - Domain: UMCFoundation 의존
+/// - Data: {Name}Domain + CoreNetwork + UMCFoundation 의존
+/// - Presentation: {Name}Domain + CoreDesignSystem + CoreUIComponents + UMCFoundation 의존
+///
+/// - Parameters:
+///   - name: Feature 이름 (예: "Auth", "Home"). 타겟명 및 bundleId 생성에 사용됩니다.
+///   - domainExtraDependencies: Domain 타겟에 추가할 의존성
+///   - dataExtraDependencies: Data 타겟에 추가할 의존성
+///   - presentationExtraDependencies: Presentation 타겟에 추가할 의존성
+public func featureProject(
+    name: String,
+    domainExtraDependencies: [TargetDependency] = [],
+    dataExtraDependencies: [TargetDependency] = [],
+    presentationExtraDependencies: [TargetDependency] = []
+) -> Project {
+    let nameLowered = name.lowercased()
+
+    return Project(
+        name: name,
+        targets: [
+            .target(
+                name: "\(name)Domain",
+                destinations: destinations,
+                product: .staticFramework,
+                bundleId: "\(bundleIdBase).\(nameLowered).domain",
+                deploymentTargets: deploymentTargets,
+                sources: ["Domain/Sources/**"],
+                dependencies: [
+                    .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+                ] + domainExtraDependencies
+            ),
+            .target(
+                name: "\(name)Data",
+                destinations: destinations,
+                product: .staticFramework,
+                bundleId: "\(bundleIdBase).\(nameLowered).data",
+                deploymentTargets: deploymentTargets,
+                sources: ["Data/Sources/**"],
+                dependencies: [
+                    .target(name: "\(name)Domain"),
+                    .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
+                    .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+                ] + dataExtraDependencies
+            ),
+            .target(
+                name: "\(name)Presentation",
+                destinations: destinations,
+                product: .staticFramework,
+                bundleId: "\(bundleIdBase).\(nameLowered).presentation",
+                deploymentTargets: deploymentTargets,
+                sources: ["Presentation/Sources/**"],
+                dependencies: [
+                    .target(name: "\(name)Domain"),
+                    .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
+                    .project(target: "CoreUIComponents", path: .relativeToRoot("Core/UIComponents")),
+                    .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+                ] + presentationExtraDependencies
+            ),
+        ]
+    )
+}


### PR DESCRIPTION
## ✨ PR 유형

Refactor — Tuist ProjectDescriptionHelpers 헬퍼 함수 도입을 통한 Project.swift 보일러플레이트 제거

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음

## 🛠️ 작업내용

- `Tuist/ProjectDescriptionHelpers/Project+Feature.swift` 추가
  - `featureProject(name:domainExtraDependencies:dataExtraDependencies:presentationExtraDependencies:)` 헬퍼 함수 정의
  - Feature당 Domain / Data / Presentation 3개의 staticFramework 타겟을 이름 하나로 자동 생성
  - 각 레이어별 추가 의존성 파라미터로 확장 가능
- `Tuist/ProjectDescriptionHelpers/Project+Core.swift` 추가
  - `coreProject(name:bundleIdSuffix:dependencies:)` 헬퍼 함수 정의
  - Core 단일 타겟 모듈을 간결하게 정의
- Features 6개(Auth / Home / Notice / Activity / Community / MyPage) `Project.swift` 간소화
  - 기존 40줄 → 4줄로 축소
- Core 5개(Foundation / DesignSystem / Network / UIComponents / DI) `Project.swift` 간소화
  - `deploymentTargets`, `destinations`, `bundleIdBase` 등 공통 설정을 헬퍼로 일원화

## 📋 추후 진행 상황

- 새 Feature 추가 시 `featureProject(name: "{Name}")` 4줄만 작성하면 됨
- `deploymentTargets` iOS 버전 변경 시 헬퍼 파일 2곳만 수정하면 전체 반영
- 향후 `tuist scaffold` 템플릿과 연계하여 Feature 폴더 자동 생성으로 확장 가능

## 📌 리뷰 포인트

- `UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift` - `featureProject` 헬퍼 함수 설계 및 기본 의존성 확인
- `UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift` - `coreProject` 헬퍼 함수 설계 확인
- `UMCApp/Features/*/Project.swift` - 기존 boilerplate 대비 동일한 타겟/bundleId/의존성이 유지되는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)