### PR TITLE
🔧[Chore] 스터디 관리 - 제출 현황 페이지 비활성화

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -33,22 +33,7 @@ struct OperatorStudyManagementView: View {
     @AppStorage(AppStorageKey.challengerId)
     private var currentChallengerId: Int = 0
 
-    @State private var selectedTab: ManagementTab = .submission
     @State private var showCreateView = false
-
-    /// 관리 화면 탭 구분
-    private enum ManagementTab: Int, CaseIterable {
-        case submission
-        case groupManagement
-
-        /// 탭 표시 제목
-        var title: String {
-            switch self {
-            case .submission: "제출 현황"
-            case .groupManagement: "스터디 그룹 관리"
-            }
-        }
-    }
 
     // MARK: - Initializer
 
@@ -73,82 +58,16 @@ struct OperatorStudyManagementView: View {
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: 0) {
-            Picker("관리", selection: $selectedTab) {
-                ForEach(ManagementTab.allCases, id: \.self) { tab in
-                    Text(tab.title).tag(tab)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
-            .padding(.vertical, DefaultSpacing.spacing8)
-
-            switch selectedTab {
-            case .submission:
-                submissionContentView
-
-            case .groupManagement:
-                groupManagementContentView
-            }
-        }
-        .task(id: selectedTab) {
-            if selectedTab == .submission {
-                await viewModel.fetchSubmissionMembers()
-            } else {
-                await viewModel.fetchGroupManagementData()
-            }
+        groupManagementContentView
+        .task {
+            await viewModel.fetchGroupManagementData()
         }
         .toolbar {
-            if selectedTab == .submission {
-                ToolBarCollection.StudyWeekFilter(
-                    weeks: viewModel.weeks,
-                    selection: $viewModel.selectedWeek,
-                    onChange: viewModel.selectWeek
-                )
-                ToolBarCollection.StudyGroupFilter(
-                    studyGroups: viewModel.studyGroups,
-                    selection: $viewModel.selectedStudyGroup,
-                    onChange: viewModel.selectStudyGroup
-                )
-            } else if canCreateStudyGroup {
+            if canCreateStudyGroup {
                 ToolBarCollection.AddBtn {
                     showCreateView = true
                 }
             }
-        }
-        .sheet(
-            item: $viewModel.selectedMemberForReview,
-            onDismiss: { viewModel.presentPendingAlert() }
-        ) { member in
-            OperatorStudyReviewSheet(
-                member: member,
-                onApprove: { feedback in
-                    await viewModel.submitReviewApproval(
-                        member: member,
-                        feedback: feedback
-                    )
-                },
-                onReject: { feedback in
-                    await viewModel.submitReviewRejection(
-                        member: member,
-                        feedback: feedback
-                    )
-                }
-            )
-        }
-        .sheet(
-            item: $viewModel.selectedMemberForBest,
-            onDismiss: { viewModel.presentPendingAlert() }
-        ) { member in
-            OperatorBestWorkbookSheet(
-                member: member,
-                onSelect: { recommendation in
-                    await viewModel.submitBestWorkbookSelection(
-                        member: member,
-                        recommendation: recommendation
-                    )
-                }
-            )
         }
         .sheet(
             item: $viewModel.addMemberGroup,
@@ -185,26 +104,6 @@ struct OperatorStudyManagementView: View {
     /// 스터디 그룹 생성 권한 확인 (보유 역할 중 회장/부회장 포함 여부)
     private var canCreateStudyGroup: Bool {
         userSession.hasAnyRole { $0.canCreateStudyGroup }
-    }
-
-    // MARK: - Submission Content View
-
-    @ViewBuilder
-    private var submissionContentView: some View {
-        switch viewModel.membersState {
-        case .idle, .loading:
-            loadingView(message: "제출 현황 불러오는 중...")
-
-        case .loaded(let members):
-            if members.isEmpty {
-                emptyView
-            } else {
-                memberListView(members: members)
-            }
-
-        case .failed(let error):
-            errorView(error: error)
-        }
     }
 
     // MARK: - Group Management View
@@ -321,13 +220,6 @@ struct OperatorStudyManagementView: View {
 
     // MARK: - Empty View
 
-    private var emptyView: some View {
-        emptyContentView(
-            title: "제출 현황 관리",
-            message: "과제를 제출한 스터디원이 없습니다."
-        )
-    }
-
     private func emptyContentView(
         title: String,
         message: String
@@ -341,56 +233,7 @@ struct OperatorStudyManagementView: View {
         .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
     }
 
-    // MARK: - Member List View
-
-    private func memberListView(members: [StudyMemberItem]) -> some View {
-        List {
-            ForEach(members) { member in
-                OperatorStudyMemberCard(member: member)
-                    .equatable()
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets(
-                        top: DefaultSpacing.spacing4,
-                        leading: DefaultConstant.defaultSafeHorizon,
-                        bottom: DefaultSpacing.spacing4,
-                        trailing: DefaultConstant.defaultSafeHorizon
-                    ))
-                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        Button {
-                            viewModel.openReviewSheet(for: member)
-                        } label: {
-                            Label("검토", systemImage: "checkmark.circle.fill")
-                        }
-                        .tint(.indigo500)
-
-                        Button {
-                            if viewModel.isBestSelectionDisabled(for: member) {
-                                viewModel.showBestSelectionDisabledAlert()
-                            } else {
-                                viewModel.selectedMemberForBest = member
-                            }
-                        } label: {
-                            Label("베스트", systemImage: "trophy")
-                        }
-                        .tint(
-                            viewModel.isBestSelectionDisabled(for: member) ? .gray : .orange
-                        )
-                    }
-            }
-        }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .contentMargins(.bottom, DefaultConstant.defaultContentBottomMargins, for: .scrollContent)
-    }
-
     // MARK: - Error View
-
-    private func errorView(error: AppError) -> some View {
-        errorView(error: error) {
-            await viewModel.fetchSubmissionMembers()
-        }
-    }
 
     private func errorView(
         error: AppError,


### PR DESCRIPTION
## ✨ PR 유형

Chore - 10기 운영 정책에 따른 기능 비활성화

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 스터디 그룹 관리 탭만 단독 표시됩니다. -->

## 🛠️ 작업내용

- `ManagementTab` enum 및 `selectedTab` 상태 제거
- 제출 현황/스터디 그룹 관리 세그먼트 Picker 제거
- 스터디 그룹 관리 화면만 단독 표시하도록 변경
- 제출 현황 관련 뷰 제거 (`submissionContentView`, `emptyView`, `memberListView`)
- 제출 검토 시트 (`OperatorStudyReviewSheet`) 및 베스트 워크북 시트 (`OperatorBestWorkbookSheet`) 제거
- 제출 관련 Toolbar 필터(주차/스터디 그룹) 제거
- 스터디 그룹 관리 및 출석 생성 기능은 그대로 유지

## 📋 추후 진행 상황

<!-- 현재는 비활성화만 진행, 향후 재활성화 시 이전 커밋 참조 가능 -->

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift` - 제출 현황 탭 제거 및 스터디 그룹 관리만 단독 표시 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #583