### PR TITLE
🔧[Chore] 커리큘럼 과제 제출란 UI 비활성화

### DIFF
--- a/AppProduct/AppProduct/Core/Mock/ActivityStudyTestView.swift
+++ b/AppProduct/AppProduct/Core/Mock/ActivityStudyTestView.swift
@@ -18,9 +18,7 @@ struct ActivityStudyTestView: View {
                 totalCount: 8
             ),
             missions: MissionPreviewData.iosMissions
-        ) { mission, type, link in
-            print("제출: \(mission.title) - \(type) - \(link ?? "없음")")
-        }
+        )
     }
 }
 

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/CurriculumProgressModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/CurriculumProgressModel.swift
@@ -20,23 +20,24 @@ struct CurriculumProgressModel: Equatable, Identifiable {
     let curriculumTitle: String
     let completedCount: Int
     let totalCount: Int
+    let openedCount: Int
 
     // MARK: - Computed Property
 
-    /// 달성률 (0.0 ~ 1.0)
+    /// 열린 미션 비율 (0.0 ~ 1.0)
     var progress: Double {
         guard totalCount > 0 else { return 0 }
-        return Double(completedCount) / Double(totalCount)
+        return Double(openedCount) / Double(totalCount)
     }
 
-    /// 달성률 퍼센트 (0 ~ 100)
+    /// 열린 미션 퍼센트 (0 ~ 100)
     var progressPercentage: Int {
         Int(progress * 100)
     }
 
-    /// 완료 텍스트 (예: "2/8 완료")
+    /// 열림 텍스트 (예: "2/8 열림")
     var completionText: String {
-        "\(completedCount)/\(totalCount) 완료"
+        "\(openedCount)/\(totalCount) 열림"
     }
 
     /// 파트 메인 컬러
@@ -88,7 +89,8 @@ struct CurriculumProgressModel: Equatable, Identifiable {
         partName: String,
         curriculumTitle: String,
         completedCount: Int,
-        totalCount: Int
+        totalCount: Int,
+        openedCount: Int = 0
     ) {
         self.id = id
         self.partType = partType
@@ -96,5 +98,6 @@ struct CurriculumProgressModel: Equatable, Identifiable {
         self.curriculumTitle = curriculumTitle
         self.completedCount = completedCount
         self.totalCount = totalCount
+        self.openedCount = openedCount
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Curriculum/ChallengerCurriculumView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Curriculum/ChallengerCurriculumView.swift
@@ -16,19 +16,11 @@ import SwiftUI
 struct ChallengerCurriculumView: View {
 
     // MARK: - Property
-    @FocusState private var focusedMissionID: UUID?
 
     /// 커리큘럼 진행률 정보 (파트명, 완료 수, 전체 수)
     let curriculumModel: CurriculumProgressModel
     /// 미션 카드 목록 (주차별 미션 정보)
     let missions: [MissionCardModel]
-    
-    /// 미션 제출 시 호출되는 콜백
-    /// - Parameters:
-    ///   - mission: 제출 대상 미션
-    ///   - type: 제출 타입 (링크 또는 완료만)
-    ///   - link: 링크 URL (링크 타입일 경우)
-    var onMissionSubmit: (MissionCardModel, MissionSubmissionType, String?) -> Void
     
     // MARK: - Constants
 
@@ -78,12 +70,7 @@ struct ChallengerCurriculumView: View {
                     .equatable()
 
                     // Right: MissionCard
-                    ChallengerMissionCard(
-                        model: mission,
-                        focusedMissionID: $focusedMissionID
-                    ) { submissionType, link in
-                        onMissionSubmit(mission, submissionType, link)
-                    }
+                    ChallengerMissionCard(model: mission)
                     .padding(.bottom, isLast ? 0 : Constants.bottomPadding)
                 }
                 .overlay(alignment: .topLeading) {
@@ -106,59 +93,38 @@ struct ChallengerCurriculumView: View {
 
 #if DEBUG
 #Preview("ChallengerCurriculumView - iOS") {
-    struct PreviewWrapper: View {
-        var body: some View {
-            ChallengerCurriculumView(
-                curriculumModel: CurriculumProgressModel(
-                    partName: "iOS PART CURRICULUM",
-                    curriculumTitle: "Swift 기초 문법",
-                    completedCount: 2,
-                    totalCount: 8
-                ),
-                missions: MissionPreviewData.iosMissions
-            ) { mission, type, link in
-                print("제출: \(mission.title) - \(type) - \(link ?? "없음")")
-            }
-        }
-    }
-    return PreviewWrapper()
+    ChallengerCurriculumView(
+        curriculumModel: CurriculumProgressModel(
+            partName: "iOS PART CURRICULUM",
+            curriculumTitle: "Swift 기초 문법",
+            completedCount: 2,
+            totalCount: 8
+        ),
+        missions: MissionPreviewData.iosMissions
+    )
 }
 
 #Preview("ChallengerCurriculumView - Web") {
-    struct PreviewWrapper: View {
-        var body: some View {
-            ChallengerCurriculumView(
-                curriculumModel: CurriculumProgressModel(
-                    partName: "WEB PART CURRICULUM",
-                    curriculumTitle: "웹 프론트엔드 기초",
-                    completedCount: 5,
-                    totalCount: 10
-                ),
-                missions: MissionPreviewData.webMissions
-            ) { mission, type, link in
-                print("제출: \(mission.title) - \(type) - \(link ?? "없음")")
-            }
-        }
-    }
-    return PreviewWrapper()
+    ChallengerCurriculumView(
+        curriculumModel: CurriculumProgressModel(
+            partName: "WEB PART CURRICULUM",
+            curriculumTitle: "웹 프론트엔드 기초",
+            completedCount: 5,
+            totalCount: 10
+        ),
+        missions: MissionPreviewData.webMissions
+    )
 }
 
 #Preview("ChallengerCurriculumView - All Status") {
-    struct PreviewWrapper: View {
-        var body: some View {
-            ChallengerCurriculumView(
-                curriculumModel: CurriculumProgressModel(
-                    partName: "SERVER PART CURRICULUM",
-                    curriculumTitle: "SpringBoot 실습",
-                    completedCount: 3,
-                    totalCount: 6
-                ),
-                missions: MissionPreviewData.allStatusMissions
-            ) { mission, type, link in
-                print("제출: \(mission.title) - \(type) - \(link ?? "없음")")
-            }
-        }
-    }
-    return PreviewWrapper()
+    ChallengerCurriculumView(
+        curriculumModel: CurriculumProgressModel(
+            partName: "SERVER PART CURRICULUM",
+            curriculumTitle: "SpringBoot 실습",
+            completedCount: 3,
+            totalCount: 6
+        ),
+        missions: MissionPreviewData.allStatusMissions
+    )
 }
 #endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Curriculum/ChallengerCurriculumView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Curriculum/ChallengerCurriculumView.swift
@@ -30,13 +30,31 @@ struct ChallengerCurriculumView: View {
         static let bottomPadding: CGFloat = 12
     }
 
+    // MARK: - Computed Property
+
+    /// 잠금 해제된(열린) 미션 수 (.locked, .notStarted 제외)
+    private var openedProgressModel: CurriculumProgressModel {
+        let openedCount = missions.filter {
+            $0.status != .locked && $0.status != .notStarted
+        }.count
+        return CurriculumProgressModel(
+            id: curriculumModel.id,
+            partType: curriculumModel.partType,
+            partName: curriculumModel.partName,
+            curriculumTitle: curriculumModel.curriculumTitle,
+            completedCount: curriculumModel.completedCount,
+            totalCount: curriculumModel.totalCount,
+            openedCount: openedCount
+        )
+    }
+
     // MARK: - Body
 
     var body: some View {
         ScrollView {
             VStack(spacing: DefaultSpacing.spacing24) {
                 // Header
-                ChallengerCurriculumProgressCard(model: curriculumModel)
+                ChallengerCurriculumProgressCard(model: openedProgressModel)
                     .equatable()
                 // Mission List
                 missionListSection

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCard.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCard.swift
@@ -15,24 +15,13 @@ struct ChallengerMissionCard: View {
     // MARK: - Property
 
     private let model: MissionCardModel
-    private var focusedMissionID: FocusState<UUID?>.Binding
-    private var onSubmit: (MissionSubmissionType, String?) -> Void
 
     @State private var isExpanded: Bool = false
-    @State private var submissionType: MissionSubmissionType = .link
-    @State private var linkText: String = ""
 
     // MARK: - Initializer
 
-    init(
-        model: MissionCardModel,
-        focusedMissionID: FocusState<UUID?>.Binding,
-        onSubmit: @escaping (MissionSubmissionType, String?) -> Void
-    ) {
+    init(model: MissionCardModel) {
         self.model = model
-        self.focusedMissionID = focusedMissionID
-        self.onSubmit = onSubmit
-        self._submissionType = State(initialValue: model.missionType.defaultSubmissionType)
     }
 
     // MARK: - Body
@@ -41,21 +30,11 @@ struct ChallengerMissionCard: View {
         ChallengerMissionCardPresenter(
             model: model,
             isExpanded: isExpanded,
-            submissionType: submissionType,
-            linkText: linkText,
-            focusedMissionID: focusedMissionID,
             onToggleExpanded: {
                 withAnimation(.easeInOut(duration: DefaultConstant.animationTime)) {
                     isExpanded.toggle()
                 }
-            },
-            onSubmissionTypeChanged: { newType in
-                submissionType = newType
-            },
-            onLinkTextChanged: { newText in
-                linkText = newText
-            },
-            onSubmit: onSubmit
+            }
         )
         .equatable()
     }
@@ -69,21 +48,13 @@ fileprivate struct ChallengerMissionCardPresenter: View, Equatable {
 
     let model: MissionCardModel
     let isExpanded: Bool
-    let submissionType: MissionSubmissionType
-    let linkText: String
-    var focusedMissionID: FocusState<UUID?>.Binding
     let onToggleExpanded: () -> Void
-    let onSubmissionTypeChanged: (MissionSubmissionType) -> Void
-    let onLinkTextChanged: (String) -> Void
-    let onSubmit: (MissionSubmissionType, String?) -> Void
 
     // MARK: - Equatable
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.model == rhs.model &&
-        lhs.isExpanded == rhs.isExpanded &&
-        lhs.submissionType == rhs.submissionType &&
-        lhs.linkText == rhs.linkText
+        lhs.isExpanded == rhs.isExpanded
     }
 
     // MARK: - Body
@@ -97,15 +68,7 @@ fileprivate struct ChallengerMissionCardPresenter: View, Equatable {
             )
 
             if isExpanded {
-                ChallengerMissionCardContent(
-                    model: model,
-                    submissionType: submissionType,
-                    linkText: linkText,
-                    focusedMissionID: focusedMissionID,
-                    onSubmissionTypeChanged: onSubmissionTypeChanged,
-                    onLinkTextChanged: onLinkTextChanged,
-                    onSubmit: onSubmit
-                )
+                ChallengerMissionCardContent(model: model)
                 .transition(.asymmetric(
                     insertion: .scale(scale: DefaultConstant.transitionScale).combined(with: .opacity),
                     removal: .scale(scale: DefaultConstant.transitionScale).combined(with: .opacity)))
@@ -127,67 +90,31 @@ fileprivate struct ChallengerMissionCardPresenter: View, Equatable {
 
 #if DEBUG
 #Preview("ChallengerMissionCard - All Status") {
-    struct PreviewWrapper: View {
-        @FocusState private var focusedMissionID: UUID?
-
-        var body: some View {
-            ScrollView {
-                VStack(spacing: 20) {
-                    ForEach(MissionPreviewData.allStatusMissions) { mission in
-                        ChallengerMissionCard(
-                            model: mission,
-                            focusedMissionID: $focusedMissionID
-                        ) { type, link in
-                            print("제출: \(type) - \(link ?? "없음")")
-                        }
-                    }
-                }
-                .padding()
+    ScrollView {
+        VStack(spacing: 20) {
+            ForEach(MissionPreviewData.allStatusMissions) { mission in
+                ChallengerMissionCard(model: mission)
             }
-            .background(Color.grey100)
         }
+        .padding()
     }
-    return PreviewWrapper()
+    .background(Color.grey100)
 }
 
 #Preview("ChallengerMissionCard - iOS Missions") {
-    struct PreviewWrapper: View {
-        @FocusState private var focusedMissionID: UUID?
-
-        var body: some View {
-            ScrollView {
-                VStack(spacing: 16) {
-                    ForEach(MissionPreviewData.iosMissions) { mission in
-                        ChallengerMissionCard(
-                            model: mission,
-                            focusedMissionID: $focusedMissionID
-                        ) { type, link in
-                            print("제출: \(type) - \(link ?? "없음")")
-                        }
-                    }
-                }
-                .padding()
+    ScrollView {
+        VStack(spacing: 16) {
+            ForEach(MissionPreviewData.iosMissions) { mission in
+                ChallengerMissionCard(model: mission)
             }
-            .background(Color.grey100)
         }
+        .padding()
     }
-    return PreviewWrapper()
+    .background(Color.grey100)
 }
 
 #Preview("ChallengerMissionCard - Single") {
-    struct PreviewWrapper: View {
-        @FocusState private var focusedMissionID: UUID?
-
-        var body: some View {
-            ChallengerMissionCard(
-                model: MissionPreviewData.singleMission,
-                focusedMissionID: $focusedMissionID
-            ) { type, link in
-                print("제출: \(type) - \(link ?? "없음")")
-            }
-            .padding()
-        }
-    }
-    return PreviewWrapper()
+    ChallengerMissionCard(model: MissionPreviewData.singleMission)
+        .padding()
 }
 #endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift
@@ -15,17 +15,9 @@ struct ChallengerMissionCardContent: View, Equatable {
     // MARK: - Property
 
     let model: MissionCardModel
-    let submissionType: MissionSubmissionType
-    let linkText: String
-    var focusedMissionID: FocusState<UUID?>.Binding
-    let onSubmissionTypeChanged: (MissionSubmissionType) -> Void
-    let onLinkTextChanged: (String) -> Void
-    let onSubmit: (MissionSubmissionType, String?) -> Void
 
     static func == (lhs: ChallengerMissionCardContent, rhs: ChallengerMissionCardContent) -> Bool {
-        lhs.model == rhs.model &&
-        lhs.submissionType == rhs.submissionType &&
-        lhs.linkText == rhs.linkText
+        lhs.model == rhs.model
     }
 
     // MARK: - Body
@@ -34,8 +26,7 @@ struct ChallengerMissionCardContent: View, Equatable {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
             switch model.status {
             case .notStarted, .inProgress:
-                typeSelectionSection
-                submissionView
+                missionTitleText
             case .pendingApproval, .pass, .fail:
                 missionTitleText
                 statusResultView
@@ -68,19 +59,6 @@ struct ChallengerMissionCardContent: View, Equatable {
         }
     }
 
-    private var submissionView: some View {
-        MissionSubmissionView(
-            missionID: model.id,
-            submissionType: submissionType,
-            availableSubmissionTypes: model.missionType.availableSubmissionTypes,
-            linkText: linkText,
-            focusedMissionID: focusedMissionID,
-            onSubmissionTypeChanged: onSubmissionTypeChanged,
-            onLinkTextChanged: onLinkTextChanged,
-            onSubmit: onSubmit
-        )
-    }
-
     private var pendingApprovalView: some View {
         MissionStatusResultView(
             icon: "hourglass",
@@ -105,141 +83,38 @@ struct ChallengerMissionCardContent: View, Equatable {
         )
     }
     
-    private var typeSelectionSection: some View {
-        Group {
-            let availableSubmissionTypes = model.missionType.availableSubmissionTypes
-            if availableSubmissionTypes.count > 1 {
-                Picker(
-                    selection: Binding(
-                        get: { submissionType },
-                        set: { newType in
-                            withAnimation(.easeInOut(duration: DefaultConstant.animationTime)) {
-                                onSubmissionTypeChanged(newType)
-                                if newType == .completeOnly {
-                                    onLinkTextChanged("")
-                                }
-                            }
-                        }
-                    )
-                ) {
-                    ForEach(availableSubmissionTypes, id: \.self) { type in
-                        Label(type.rawValue, systemImage: type.icon)
-                            .tag(type)
-                    }
-                } label: {
-                    EmptyView()
-                }
-                .pickerStyle(.segmented)
-            }
-        }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("ChallengerMissionCardContent - InProgress", traits: .sizeThatFitsLayout) {
+    ZStack {
+        Color.grey100.ignoresSafeArea().frame(height: 400)
+        ChallengerMissionCardContent(model: MissionPreviewData.singleMission)
+            .glass()
     }
 }
 
-// MARK: - MissionSubmissionView
-
-/// 미션 제출 UI (타입 선택 + 링크 입력 + 제출 버튼)
-fileprivate struct MissionSubmissionView: View, Equatable {
-
-    // MARK: - Property
-
-    let missionID: UUID
-    let submissionType: MissionSubmissionType
-    let availableSubmissionTypes: [MissionSubmissionType]
-    let linkText: String
-    var focusedMissionID: FocusState<UUID?>.Binding
-    let onSubmissionTypeChanged: (MissionSubmissionType) -> Void
-    let onLinkTextChanged: (String) -> Void
-    let onSubmit: (MissionSubmissionType, String?) -> Void
-
-    // MARK: - Equatable
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.missionID == rhs.missionID &&
-        lhs.submissionType == rhs.submissionType &&
-        lhs.availableSubmissionTypes == rhs.availableSubmissionTypes &&
-        lhs.linkText == rhs.linkText
-    }
-
-    // MARK: - Constants
-
-    private enum Constants {
-        static let submitButtonWidth: CGFloat = 80
-        static let borderWidth: CGFloat = 1
-    }
-
-    // MARK: - Computed Property
-
-    private var hasError: Bool {
-        !linkText.isEmpty && !linkText.isValidHTTPURL
-    }
-
-    private var isSubmitDisabled: Bool {
-        guard availableSubmissionTypes.contains(submissionType) else {
-            return true
-        }
-        return submissionType == .link && !linkText.isValidHTTPURL
-    }
-
-    // MARK: - Body
-
-    var body: some View {
-        submissionSection
-    }
-
-    // MARK: - View Components
-
-    private var submissionSection: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
-            if submissionType == .link {
-                linkInput
-            }
-            
-            if submissionType == .link && hasError {
-                Text("올바른 URL 형식이 아닙니다")
-                    .appFont(.footnote, color: .red)
-                    .transition(.opacity)
-            }
-
-            SubmitButton(
-                isDisabled: isSubmitDisabled,
-                onSubmit: {
-                    if submissionType == .link {
-                        onSubmit(.link, linkText)
-                    } else {
-                        onSubmit(.completeOnly, nil)
-                    }
+#Preview("ChallengerMissionCardContent - All Status") {
+    ScrollView {
+        VStack(spacing: 20) {
+            ForEach(MissionPreviewData.allStatusMissions) { model in
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(model.status.displayText)
+                        .appFont(.title3, color: .gray)
+                    ChallengerMissionCardContent(model: model)
+                        .padding()
+                        .background(Color.grey000)
+                        .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
                 }
-            )
+            }
         }
-        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: submissionType)
+        .padding()
     }
-
-    private var linkInput: some View {
-        TextField("", text: Binding(
-            get: { linkText },
-            set: { onLinkTextChanged($0) }),
-                  prompt: textfieldPlaceholder)
-        .focused(focusedMissionID, equals: missionID)
-        .padding(DefaultConstant.defaultTextFieldPadding)
-        .overlay(content: {
-            RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
-                .fill(.clear)
-                .strokeBorder(.grey300, style: .init())
-        })
-        .transition(
-            .asymmetric(
-                insertion: .scale(scale: 0.95).combined(with: .opacity),
-                removal: .scale(scale: 0.95).combined(with: .opacity)
-            )
-        )
-    }
-    
-    private var textfieldPlaceholder: Text {
-        Text("https://...")
-            .font(.app(.footnote))
-            .foregroundStyle(Color(.placeholderText))
-    }
+    .background(Color.grey100)
 }
+#endif
 
 // MARK: - MissionStatusResultView
 
@@ -275,96 +150,3 @@ fileprivate struct MissionStatusResultView: View, Equatable {
     }
 }
 
-// MARK: - SubmitButton
-
-/// 미션 제출 버튼 (공통 스타일)
-fileprivate struct SubmitButton: View, Equatable {
-
-    // MARK: - Property
-
-    let isDisabled: Bool
-    let onSubmit: () -> Void
-
-    // MARK: - Equatable
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.isDisabled == rhs.isDisabled
-    }
-
-    // MARK: - Body
-
-    var body: some View {
-        MainButton("제출") {
-            onSubmit()
-        }
-        .buttonStyle(.glassProminent)
-        .disabled(isDisabled)
-    }
-}
-
-// MARK: - Preview
-
-#if DEBUG
-#Preview("ChallengerMissionCardContent - InProgress", traits: .sizeThatFitsLayout) {
-    struct Demo: View {
-        @State private var submissionType: MissionSubmissionType = .link
-        @State private var linkText: String = ""
-        @FocusState private var focusedMissionID: UUID?
-
-        var body: some View {
-            ZStack {
-                Color.grey100.ignoresSafeArea().frame(height: 400)
-
-                ChallengerMissionCardContent(
-                    model: MissionPreviewData.singleMission,
-                    submissionType: submissionType,
-                    linkText: linkText,
-                    focusedMissionID: $focusedMissionID,
-                    onSubmissionTypeChanged: { submissionType = $0 },
-                    onLinkTextChanged: { linkText = $0 },
-                    onSubmit: { type, link in
-                        print("제출: \(type) - \(link ?? "없음")")
-                    }
-                )
-                .glass()
-            }
-        }
-    }
-
-    return Demo()
-}
-
-#Preview("ChallengerMissionCardContent - All Status") {
-    struct Demo: View {
-        @FocusState private var focusedMissionID: UUID?
-
-        var body: some View {
-            ScrollView {
-                VStack(spacing: 20) {
-                    ForEach(MissionPreviewData.allStatusMissions) { model in
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(model.status.displayText)
-                                .appFont(.title3, color: .gray)
-                            ChallengerMissionCardContent(
-                                model: model,
-                                submissionType: .link,
-                                linkText: "",
-                                focusedMissionID: $focusedMissionID,
-                                onSubmissionTypeChanged: { _ in },
-                                onLinkTextChanged: { _ in },
-                                onSubmit: { _, _ in }
-                            )
-                            .padding()
-                            .background(Color.grey000)
-                            .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
-                        }
-                    }
-                }
-                .padding()
-            }
-            .background(Color.grey100)
-        }
-    }
-    return Demo()
-}
-#endif

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift
@@ -26,7 +26,7 @@ struct ChallengerMissionCardContent: View, Equatable {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
             switch model.status {
             case .notStarted, .inProgress:
-                missionTitleText
+                EmptyView()
             case .pendingApproval, .pass, .fail:
                 missionTitleText
                 statusResultView

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardHeader.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardHeader.swift
@@ -84,9 +84,17 @@ struct ChallengerMissionCardHeader: View, Equatable {
             .fixedSize(horizontal: false, vertical: true)
     }
 
+    @ViewBuilder
     private var statusText: some View {
-        Text(model.status.displayText)
-            .appFont(.footnote, color: model.status.foregroundColor)
+        switch model.status {
+        case .pendingApproval, .pass, .fail:
+            Text(model.status.displayText)
+                .appFont(.footnote, color: model.status.foregroundColor)
+        default:
+            Text(model.missionTitle)
+                .appFont(.footnote, color: .grey500)
+                .lineLimit(1)
+        }
     }
 
     private var chevronIcon: some View {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerStudyView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerStudyView.swift
@@ -54,11 +54,7 @@ struct ChallengerStudyView: View {
             ChallengerCurriculumView(
                 curriculumModel: data.progress,
                 missions: data.missions
-            ) { mission, type, link in
-                Task {
-                    await viewModel.submitMission(mission, type: type, link: link)
-                }
-            }
+            )
 
         case .failed(let error):
             errorView(error: error, viewModel: viewModel)

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -33,22 +33,7 @@ struct OperatorStudyManagementView: View {
     @AppStorage(AppStorageKey.challengerId)
     private var currentChallengerId: Int = 0
 
-    @State private var selectedTab: ManagementTab = .submission
     @State private var showCreateView = false
-
-    /// 관리 화면 탭 구분
-    private enum ManagementTab: Int, CaseIterable {
-        case submission
-        case groupManagement
-
-        /// 탭 표시 제목
-        var title: String {
-            switch self {
-            case .submission: "제출 현황"
-            case .groupManagement: "스터디 그룹 관리"
-            }
-        }
-    }
 
     // MARK: - Initializer
 
@@ -73,82 +58,16 @@ struct OperatorStudyManagementView: View {
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: 0) {
-            Picker("관리", selection: $selectedTab) {
-                ForEach(ManagementTab.allCases, id: \.self) { tab in
-                    Text(tab.title).tag(tab)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
-            .padding(.vertical, DefaultSpacing.spacing8)
-
-            switch selectedTab {
-            case .submission:
-                submissionContentView
-
-            case .groupManagement:
-                groupManagementContentView
-            }
-        }
-        .task(id: selectedTab) {
-            if selectedTab == .submission {
-                await viewModel.fetchSubmissionMembers()
-            } else {
-                await viewModel.fetchGroupManagementData()
-            }
+        groupManagementContentView
+        .task {
+            await viewModel.fetchGroupManagementData()
         }
         .toolbar {
-            if selectedTab == .submission {
-                ToolBarCollection.StudyWeekFilter(
-                    weeks: viewModel.weeks,
-                    selection: $viewModel.selectedWeek,
-                    onChange: viewModel.selectWeek
-                )
-                ToolBarCollection.StudyGroupFilter(
-                    studyGroups: viewModel.studyGroups,
-                    selection: $viewModel.selectedStudyGroup,
-                    onChange: viewModel.selectStudyGroup
-                )
-            } else if canCreateStudyGroup {
+            if canCreateStudyGroup {
                 ToolBarCollection.AddBtn {
                     showCreateView = true
                 }
             }
-        }
-        .sheet(
-            item: $viewModel.selectedMemberForReview,
-            onDismiss: { viewModel.presentPendingAlert() }
-        ) { member in
-            OperatorStudyReviewSheet(
-                member: member,
-                onApprove: { feedback in
-                    await viewModel.submitReviewApproval(
-                        member: member,
-                        feedback: feedback
-                    )
-                },
-                onReject: { feedback in
-                    await viewModel.submitReviewRejection(
-                        member: member,
-                        feedback: feedback
-                    )
-                }
-            )
-        }
-        .sheet(
-            item: $viewModel.selectedMemberForBest,
-            onDismiss: { viewModel.presentPendingAlert() }
-        ) { member in
-            OperatorBestWorkbookSheet(
-                member: member,
-                onSelect: { recommendation in
-                    await viewModel.submitBestWorkbookSelection(
-                        member: member,
-                        recommendation: recommendation
-                    )
-                }
-            )
         }
         .sheet(
             item: $viewModel.addMemberGroup,
@@ -185,26 +104,6 @@ struct OperatorStudyManagementView: View {
     /// 스터디 그룹 생성 권한 확인 (보유 역할 중 회장/부회장 포함 여부)
     private var canCreateStudyGroup: Bool {
         userSession.hasAnyRole { $0.canCreateStudyGroup }
-    }
-
-    // MARK: - Submission Content View
-
-    @ViewBuilder
-    private var submissionContentView: some View {
-        switch viewModel.membersState {
-        case .idle, .loading:
-            loadingView(message: "제출 현황 불러오는 중...")
-
-        case .loaded(let members):
-            if members.isEmpty {
-                emptyView
-            } else {
-                memberListView(members: members)
-            }
-
-        case .failed(let error):
-            errorView(error: error)
-        }
     }
 
     // MARK: - Group Management View
@@ -321,13 +220,6 @@ struct OperatorStudyManagementView: View {
 
     // MARK: - Empty View
 
-    private var emptyView: some View {
-        emptyContentView(
-            title: "제출 현황 관리",
-            message: "과제를 제출한 스터디원이 없습니다."
-        )
-    }
-
     private func emptyContentView(
         title: String,
         message: String
@@ -341,56 +233,7 @@ struct OperatorStudyManagementView: View {
         .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
     }
 
-    // MARK: - Member List View
-
-    private func memberListView(members: [StudyMemberItem]) -> some View {
-        List {
-            ForEach(members) { member in
-                OperatorStudyMemberCard(member: member)
-                    .equatable()
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets(
-                        top: DefaultSpacing.spacing4,
-                        leading: DefaultConstant.defaultSafeHorizon,
-                        bottom: DefaultSpacing.spacing4,
-                        trailing: DefaultConstant.defaultSafeHorizon
-                    ))
-                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        Button {
-                            viewModel.openReviewSheet(for: member)
-                        } label: {
-                            Label("검토", systemImage: "checkmark.circle.fill")
-                        }
-                        .tint(.indigo500)
-
-                        Button {
-                            if viewModel.isBestSelectionDisabled(for: member) {
-                                viewModel.showBestSelectionDisabledAlert()
-                            } else {
-                                viewModel.selectedMemberForBest = member
-                            }
-                        } label: {
-                            Label("베스트", systemImage: "trophy")
-                        }
-                        .tint(
-                            viewModel.isBestSelectionDisabled(for: member) ? .gray : .orange
-                        )
-                    }
-            }
-        }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .contentMargins(.bottom, DefaultConstant.defaultContentBottomMargins, for: .scrollContent)
-    }
-
     // MARK: - Error View
-
-    private func errorView(error: AppError) -> some View {
-        errorView(error: error) {
-            await viewModel.fetchSubmissionMembers()
-        }
-    }
 
     private func errorView(
         error: AppError,


### PR DESCRIPTION
## ✨ PR 유형

Chore - 10기 운영 정책에 따른 기능 비활성화

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 미션 카드 확장 시 제출 UI(링크 입력, 제출 버튼)가 사라지고 미션 제목만 표시됩니다. -->

## 🛠️ 작업내용

- `ChallengerMissionCardContent`: `.notStarted`, `.inProgress` 상태에서 제출 UI 제거, 미션 제목만 표시
- `MissionSubmissionView`, `SubmitButton`, `typeSelectionSection` 제거
- 제출 관련 프로퍼티(`submissionType`, `linkText`, `focusedMissionID`, `onSubmit` 등) 전체 체인에서 제거
- `ChallengerMissionCard`: `onSubmit`, `focusedMissionID` 파라미터 제거
- `ChallengerCurriculumView`: `onMissionSubmit` 콜백 및 `focusedMissionID` 제거
- `ChallengerStudyView`: `onMissionSubmit` 클로저 제거
- 커리큘럼 목록/상세 조회 및 미션 상태 표시(대기/통과/실패)는 그대로 유지

## 📋 추후 진행 상황

이후 기수에서 웹 기반 과제 제출로 리뉴얼 예정

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift` - 제출 UI 제거 및 미션 제목만 표시 확인
- `Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCard.swift` - 제출 관련 파라미터 제거 확인
- `Features/Activity/Presentation/Components/Challenger/Curriculum/ChallengerCurriculumView.swift` - onMissionSubmit 콜백 제거 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #582