### PR TITLE
♻️ [Refactor] OperatorStudyGroupEditSheet onSave 클로저를 @Bindable ViewModel로 교체

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Study/OperatorStudyGroupEditSheet.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Study/OperatorStudyGroupEditSheet.swift
@@ -14,14 +14,8 @@ struct OperatorStudyGroupEditSheet: View {
     // MARK: - Property
 
     @Environment(\.dismiss) private var dismiss
-    @State private var name: String
-    @State private var selectedPart: UMCPartType
+    @Bindable var viewModel: OperatorStudyManagementViewModel
     @State private var isSaving = false
-
-    /// 수정 대상 그룹 정보
-    let detail: StudyGroupInfo
-    /// 저장 완료 콜백 (이름, 파트 전달)
-    let onSave: (String, UMCPartType) async -> Bool
 
     fileprivate enum Constants {
         static let allParts: [UMCPartType] = UMCPartType.allCases
@@ -36,17 +30,9 @@ struct OperatorStudyGroupEditSheet: View {
 
     // MARK: - Initializer
 
-    /// - Parameters:
-    ///   - detail: 수정할 그룹 정보 (초기값으로 사용)
-    ///   - onSave: 저장 시 호출될 콜백
-    init(
-        detail: StudyGroupInfo,
-        onSave: @escaping (String, UMCPartType) async -> Bool
-    ) {
-        self.detail = detail
-        self.onSave = onSave
-        _name = State(initialValue: detail.name)
-        _selectedPart = State(initialValue: detail.part)
+    /// - Parameter viewModel: 스터디 관리 ViewModel (`editingName`, `editingPart`로 상태를 관리합니다)
+    init(viewModel: OperatorStudyManagementViewModel) {
+        self.viewModel = viewModel
     }
 
     // MARK: - Body
@@ -86,7 +72,7 @@ struct OperatorStudyGroupEditSheet: View {
             Text("그룹 이름")
                 .appFont(.subheadline, color: .grey700)
 
-            TextField("그룹 이름 지정", text: $name)
+            TextField("그룹 이름 지정", text: $viewModel.editingName)
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(.black)
                 .autocorrectionDisabled(true)
@@ -110,12 +96,12 @@ struct OperatorStudyGroupEditSheet: View {
             Menu {
                 ForEach(Constants.allParts, id: \.self) { part in
                     Button {
-                        selectedPart = part
+                        viewModel.editingPart = part
                     } label: {
                         HStack {
                             Image(systemName: part.icon)
                             Text(part.name)
-                            if selectedPart == part {
+                            if viewModel.editingPart == part {
                                 Image(systemName: "checkmark")
                             }
                         }
@@ -124,10 +110,10 @@ struct OperatorStudyGroupEditSheet: View {
                 }
             } label: {
                 HStack(spacing: Constants.blockSpacing) {
-                    Image(systemName: selectedPart.icon)
-                        .foregroundStyle(selectedPart.color)
-                    Text(selectedPart.name)
-                        .appFont(.body, color: selectedPart.color)
+                    Image(systemName: viewModel.editingPart.icon)
+                        .foregroundStyle(viewModel.editingPart.color)
+                    Text(viewModel.editingPart.name)
+                        .appFont(.body, color: viewModel.editingPart.color)
                     Spacer()
                     Image(systemName: "chevron.up.chevron.down")
                         .foregroundStyle(.grey500)
@@ -145,7 +131,7 @@ struct OperatorStudyGroupEditSheet: View {
     // MARK: - Action
 
     private var isSaveDisabled: Bool {
-        name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        viewModel.editingName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private func submit() {
@@ -154,9 +140,14 @@ struct OperatorStudyGroupEditSheet: View {
         isSaving = true
 
         Task { @MainActor in
-            let isSuccess = await onSave(
-                name.trimmingCharacters(in: .whitespacesAndNewlines),
-                selectedPart
+            guard let groupID = viewModel.editingGroup?.id else {
+                isSaving = false
+                return
+            }
+            let isSuccess = await viewModel.updateGroup(
+                groupID: groupID,
+                name: viewModel.editingName.trimmingCharacters(in: .whitespacesAndNewlines),
+                part: viewModel.editingPart
             )
             isSaving = false
             if isSuccess {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorStudyManagementViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorStudyManagementViewModel.swift
@@ -49,6 +49,12 @@ final class OperatorStudyManagementViewModel {
     /// 편집 중인 그룹 (시트 표시용)
     var editingGroup: StudyGroupInfo?
 
+    /// 편집 시트 이름 입력 상태
+    var editingName: String = ""
+
+    /// 편집 시트 파트 선택 상태
+    var editingPart: UMCPartType = .pm
+
     /// 멤버 추가 대상 그룹 (시트 표시용)
     var addMemberGroup: StudyGroupInfo?
 
@@ -403,6 +409,8 @@ final class OperatorStudyManagementViewModel {
 
     /// 그룹 편집 시트 표시
     func showEditSheet(for group: StudyGroupInfo) {
+        editingName = group.name
+        editingPart = group.part
         editingGroup = group
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -81,17 +81,8 @@ struct OperatorStudyManagementView: View {
                 challenger: $viewModel.selectedChallengers
             )
         }
-        .sheet(item: $viewModel.editingGroup) { group in
-            OperatorStudyGroupEditSheet(
-                detail: group,
-                onSave: { name, part in
-                    await viewModel.updateGroup(
-                        groupID: group.id,
-                        name: name,
-                        part: part
-                    )
-                }
-            )
+        .sheet(item: $viewModel.editingGroup) { _ in
+            OperatorStudyGroupEditSheet(viewModel: viewModel)
         }
         .navigationDestination(isPresented: $showCreateView) {
             OperatorStudyGroupCreateView(viewModel: viewModel)


### PR DESCRIPTION
## ✨ PR 유형

Refactor - 클로저 기반 콜백을 @Bindable ViewModel 직접 참조로 교체

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 (리팩토링) -->

## 🛠️ 작업내용

- `OperatorStudyGroupEditSheet`의 `onSave: (String, UMCPartType) async -> Bool` 클로저 제거
- `@Bindable var viewModel: OperatorStudyManagementViewModel` 직접 주입으로 변경
- `@State private var name`, `@State private var selectedPart` 제거, 상태 관리를 ViewModel로 이동
- `OperatorStudyManagementViewModel`에 `editingName: String`, `editingPart: UMCPartType` 프로퍼티 추가
- `showEditSheet(for:)`에서 `editingName`, `editingPart` 초기화 후 `editingGroup` 설정
- `OperatorStudyManagementView`의 `.sheet` 클로저에서 그룹 캡처 및 콜백 전달 코드 제거

## 📋 추후 진행 상황

<!-- 없음 -->

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Components/Operation/Study/OperatorStudyGroupEditSheet.swift` - @Bindable 패턴 적용 및 로컬 @State 제거 확인
- `Features/Activity/Presentation/ViewModels/Operation/OperatorStudyManagementViewModel.swift` - editingName/editingPart 초기화 타이밍 (showEditSheet 호출 시)
- `Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift` - sheet 클로저 간소화 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)