### PR TITLE
🐛[Fix] 공지 상세 진입 시 투표 및 열람 수 로딩 처리 누락 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerPendingApprovalView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Attendance/ChallengerPendingApprovalView.swift
@@ -44,7 +44,7 @@ struct ChallengerPendingApprovalView: View {
             .font(.system(size: Constant.iconSize))
             .foregroundStyle(.yellow)
             .rotationEffect(.degrees(isRotating ? 360 : 0))
-            .onAppear {
+            .task {
                 withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
                     isRotating = true
                 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -166,12 +166,10 @@ struct OperatorStudyManagementView: View {
                         }
                     )
                     .equatable()
-                    .onAppear {
-                        Task {
-                            await viewModel.loadMoreGroupManagementDataIfNeeded(
-                                currentGroupID: group.id
-                            )
-                        }
+                    .task {
+                        await viewModel.loadMoreGroupManagementDataIfNeeded(
+                            currentGroupID: group.id
+                        )
                     }
                 }
 

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
@@ -160,7 +160,7 @@ struct FailedVerificationUMC: View {
         )
         .padding(.top, Constants.verifyButtonTopPadding)
         .disabled(isInteractionDisabled)
-        .onAppear {
+        .task {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 isBouncing = true
             }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
@@ -80,7 +80,7 @@ struct PenaltyCard: View, Equatable {
         .clipped()
         .clipShape(.rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true))
         .glassEffect(.regular, in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius))
-        .onAppear {
+        .task {
             clampCurrentIndex()
         }
         .onChange(of: generations.count) { _, _ in

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/ChallengerFormView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/ChallengerFormView.swift
@@ -92,7 +92,7 @@ struct ChallengerFormView: View {
                 .onTapGesture {
                     tap?(participant)
                 }
-                .onAppear {
+                .task {
                     // 마지막 아이템 도달 시 페이지네이션 트리거
                     if participant.selectionKey == challenger.last?.selectionKey {
                         onBottomReached?()

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -17,6 +17,7 @@ extension NoticeDetailViewModel {
         if noticeState.isIdle {
             noticeState = .loading
         }
+        defer { isVoteLoading = false }
 
         do {
             let noticeDetail = try await noticeUseCase.getDetailNotice(noticeId: noticeID)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -66,6 +66,9 @@ final class NoticeDetailViewModel {
     /// 투표 응답 전송 진행 상태
     var isSubmittingVote: Bool = false
 
+    /// 공지 상세 초기 fetch 완료 전까지 투표 영역 로딩 표시 여부
+    var isVoteLoading: Bool = true
+
     /// 공지 ID
     let noticeID: Int
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -248,6 +248,16 @@ struct NoticeDetailView: View {
                     : Constants.attachmentToVoteSpacing
                 )
                 .padding(.horizontal, Constants.horizontalPadding)
+            } else if viewModel.isVoteLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 80)
+                    .padding(
+                        .top,
+                        data.images.isEmpty
+                        ? Constants.contentToVoteSpacing
+                        : Constants.attachmentToVoteSpacing
+                    )
+                    .padding(.horizontal, Constants.horizontalPadding)
             }
 
             if !data.links.isEmpty {
@@ -310,7 +320,7 @@ struct NoticeDetailView: View {
                 confirmedCount: viewModel.confirmedCount,
                 totalCount: viewModel.totalCount,
                 readRate: viewModel.readRate,
-                isLoading: viewModel.isReadStaticsLoading && viewModel.readStatics == nil
+                isLoading: viewModel.readStatics == nil
             ) {
                 viewModel.openReadStatusSheet()
             }
@@ -376,18 +386,14 @@ struct NoticeDetailView: View {
         }
 
         async let detailTask: Void = viewModel.fetchNoticeDetail()
-        async let staticsTask: Void = viewModel.prefetchReadStaticsIfNeeded()
         async let permissionTask: Void = viewModel.fetchNoticePermission()
         async let markAsReadTask = viewModel.markAsReadIfNeeded()
 
-        let didMarkAsRead = await markAsReadTask
+        await markAsReadTask
         await detailTask
-        await staticsTask
         await permissionTask
-        if didMarkAsRead {
-            viewModel.applyOptimisticReadStatics()
-            Task { await viewModel.prefetchReadStaticsIfNeeded(forceReload: true) }
-        }
+        // statics는 markAsRead 완료 후 순차 조회하여 서버 반영값을 정확히 수신
+        await viewModel.prefetchReadStaticsIfNeeded()
     }
 
     // MARK: - Private Methods

--- a/AppProduct/AppProduct/Utilities/RemoteImage/RemoteImage.swift
+++ b/AppProduct/AppProduct/Utilities/RemoteImage/RemoteImage.swift
@@ -99,7 +99,7 @@ struct RemoteImage: View {
                     .resizable()
                     .interpolation(.high)
                     .antialiased(true)
-                    .onAppear {
+                    .task {
                         isLoading = true
                     }
             } else {


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix - 공지 상세글 진입 시 투표 영역 및 열람 수 로딩 처리 누락

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->

## 🛠️ 작업내용

**[투표 영역 로딩 처리]**
- `isVoteLoading: Bool = true` 프로퍼티 추가 — 초기 fetch 완료 전까지 `true` 유지
- `fetchNoticeDetail()` 완료 시 `defer { isVoteLoading = false }` 로 항상 해제
- `bottomSection` 에서 `vote == nil && isVoteLoading` 일 때 `ProgressView` 표시 → 투표 영역이 갑자기 툭 등장하는 문제 해결

**[열람 수 로딩 처리]**
- `NoticeReadStatusButton` 의 `isLoading` 조건을 `readStatics == nil` 로 변경
- 기존: `isReadStaticsLoading && readStatics == nil` → fetch 시작 전 순간에 0/0 이 노출되는 문제 존재
- 변경 후: `readStatics` 가 없는 모든 구간(fetch 전 포함)을 로딩 상태로 처리

**[열람 수 역방향 갱신 버그 수정 — 5→4 현상]**
- 기존 구조: `staticsTask` 와 `markAsReadTask` 를 동시에 시작 → statics 응답이 markAsRead 이후에 도달하면 이미 +1 반영된 값을 수신, 이후 `applyOptimisticReadStatics()` 가 한 번 더 +1 → 5 표시 → forceReload → 4로 역전
- 변경: statics fetch 를 markAsRead 완료 후 순차 실행, `applyOptimisticReadStatics()` 제거 → 서버 반영값을 항상 정확하게 수신

**[기타 — .onAppear → .task 전환]**
- `ChallengerPendingApprovalView`, `OperatorStudyManagementView`, `FailedVerificationUMC`, `PenaltyCard`, `ChallengerFormView`, `RemoteImage` 에서 `.onAppear` 내부 비동기 작업을 `.task` 로 교체

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift` — `isVoteLoading` 초기값 및 생명주기 확인
- `Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift` — `fetchNoticeDetail()` 의 `defer` 처리 확인
- `Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift` — `onTask()` 의 statics 순차 조회 흐름 및 `isLoading` 조건 변경 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)