### PR TITLE
refactor: Error 타입 8개 파일 UMCFoundation 모듈로 이관

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Error/LocationError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/LocationError.swift
@@ -1,0 +1,28 @@
+//
+//  LocationError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/6/26.
+//
+
+import Foundation
+
+public enum LocationError: LocalizedError {
+    case notAuthorized
+    case locationFailed(String)
+    case timeout
+    case geocodingFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notAuthorized:
+            return "위치 권한이 필요합니다."
+        case .locationFailed(let message):
+            return "위치를 가져올 수 없습니다. \(message)"
+        case .timeout:
+            return "위치 요청 시간이 초과되었습니다."
+        case .geocodingFailed(let message):
+            return "주소를 가져올 수 없습니다. \(message)"
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/AppError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/AppError.swift
@@ -1,0 +1,151 @@
+//
+//  AppError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 앱 전체에서 사용하는 통합 에러 타입.
+///
+/// 모든 에러를 래핑하여 일관된 처리를 제공합니다.
+/// ViewModel에서 에러 발생 시 이 타입으로 변환하여 처리합니다.
+///
+/// ## Usage
+///
+/// **ViewModel에서 에러 타입별 분기 처리:**
+///
+/// ```swift
+/// @MainActor
+/// func submit() async {
+///     state = .loading
+///
+///     do {
+///         let result = try await useCase.execute()
+///         state = .loaded(result)
+///
+///     } catch let error as DomainError {
+///         // 도메인 에러 → Loadable
+///         state = .failed(.domain(error))
+///
+///     } catch {
+///         // 기타 에러 → ErrorHandler (Alert) + 상태 복구
+///         state = .loaded(initialData)
+///         errorHandler.handle(error, context: .init(
+///             feature: "Feature",
+///             action: "submit",
+///             retryAction: { [weak self] in await self?.submit() }
+///         ))
+///     }
+/// }
+/// ```
+///
+/// **View에서 인라인 에러 표시:**
+///
+/// ```swift
+/// if let error = viewModel.state.error {
+///     Text(error.userMessage)
+///         .foregroundStyle(.red)
+/// }
+/// ```
+///
+/// - SeeAlso: ``ErrorHandler``, ``Loadable``, ``DomainError``
+public enum AppError: Error, LocalizedError, Equatable {
+    /// Repository 계층 에러 (서버 비즈니스 에러)
+    case repository(RepositoryError)
+
+    /// 네트워크 계층 에러 (Actor 기반 NetworkClient)
+    case network(NetworkError)
+
+    /// 입력 유효성 검증 에러
+    case validation(ValidationError)
+
+    /// 인증 관련 에러
+    case auth(AuthError)
+
+    /// 도메인(비즈니스) 에러
+    case domain(DomainError)
+
+    /// 알 수 없는 에러
+    case unknown(message: String)
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .repository(let error):
+            return error.errorDescription
+        case .network(let error):
+            return error.errorDescription
+        case .validation(let error):
+            return error.errorDescription
+        case .auth(let error):
+            return error.errorDescription
+        case .domain(let error):
+            return error.errorDescription
+        case .unknown(let message):
+            return message
+        }
+    }
+
+    // MARK: - User Message
+
+    /// 사용자에게 표시할 친화적 메시지
+    public var userMessage: String {
+        switch self {
+        case .repository(let error):
+            return error.userMessage
+        case .network(let error):
+            return error.userMessage
+        case .validation(let error):
+            return error.userMessage
+        case .auth(let error):
+            return error.userMessage
+        case .domain(let error):
+            return error.userMessage
+        case .unknown:
+            return "일시적인 오류가 발생했습니다. 다시 시도해주세요."
+        }
+    }
+
+    // MARK: - Severity
+
+    /// 에러 심각도 (표시 방식 결정에 사용)
+    public var severity: ErrorSeverity {
+        switch self {
+        case .repository:
+            return .warning
+        case .network(let error):
+            return error.severity
+        case .validation:
+            return .warning
+        case .auth:
+            return .critical
+        case .domain:
+            return .info
+        case .unknown:
+            return .warning
+        }
+    }
+
+    // MARK: - Retryable
+
+    /// 재시도 가능 여부
+    public var isRetryable: Bool {
+        switch self {
+        case .repository(let error):
+            return error.isRetryable
+        case .network(let error):
+            return error.isRetryable
+        case .validation:
+            return false
+        case .auth:
+            return false
+        case .domain:
+            return false
+        case .unknown:
+            return true
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/AuthError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/AuthError.swift
@@ -1,0 +1,86 @@
+//
+//  AuthError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 인증 관련 에러
+public enum AuthError: Error, LocalizedError, Equatable {
+    /// 로그인되지 않음
+    case notLoggedIn
+
+    /// 세션 만료
+    case sessionExpired
+
+    /// 인증 정보 오류 (아이디/비밀번호)
+    case invalidCredentials
+
+    /// 소셜 로그인 실패
+    case socialLoginFailed(provider: String, reason: String?)
+
+    /// 계정 정지
+    case accountSuspended(reason: String?)
+
+    /// 가입 승인 대기 중
+    case pendingApproval
+
+    /// 가입 거절됨
+    case rejected(reason: String?)
+
+    /// 등록되지 않은 사용자 (챌린저로 등록되지 않음)
+    case notRegisteredMember
+
+    /// 인증 코드 오류
+    case invalidVerificationCode
+
+    /// 인증 코드 만료
+    case verificationCodeExpired
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .notLoggedIn:
+            return "로그인이 필요합니다."
+        case .sessionExpired:
+            return "세션이 만료되었습니다."
+        case .invalidCredentials:
+            return "인증 정보가 올바르지 않습니다."
+        case .socialLoginFailed(let provider, let reason):
+            return "\(provider) 로그인 실패\(reason.map { ": \($0)" } ?? "")"
+        case .accountSuspended(let reason):
+            return "계정이 정지되었습니다.\(reason.map { " (\($0))" } ?? "")"
+        case .pendingApproval:
+            return "가입 승인 대기 중입니다."
+        case .rejected(let reason):
+            return "가입이 거절되었습니다.\(reason.map { " (\($0))" } ?? "")"
+        case .notRegisteredMember:
+            return "등록된 챌린저가 아닙니다."
+        case .invalidVerificationCode:
+            return "인증 번호가 올바르지 않습니다."
+        case .verificationCodeExpired:
+            return "인증 번호가 만료되었습니다."
+        }
+    }
+
+    /// 사용자에게 표시할 친화적 메시지
+    public var userMessage: String {
+        switch self {
+        case .sessionExpired:
+            return "다시 로그인해주세요."
+        case .pendingApproval:
+            return "운영진의 승인을 기다리고 있어요."
+        case .notRegisteredMember:
+            return "등록된 챌린저 정보가 없어요. 운영진에게 문의해주세요."
+        case .invalidVerificationCode:
+            return "인증 번호를 다시 확인해주세요."
+        case .verificationCodeExpired:
+            return "인증 번호가 만료되었어요. 다시 요청해주세요."
+        default:
+            return errorDescription ?? ""
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
@@ -1,0 +1,162 @@
+//
+//  DomainError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 도메인(비즈니스 로직) 관련 에러.
+///
+/// UMC 앱의 비즈니스 규칙 위반 시 발생하는 에러입니다.
+/// 일반적으로 **Loadable** 방식으로 처리합니다.
+///
+/// ## 처리 원칙
+///
+/// DomainError는 대부분 **화면을 유지**하면서 사용자에게 안내해야 합니다:
+/// - 출석 범위 밖 → 위치 이동 유도
+/// - 이미 제출됨 → 단순 안내
+/// - 사유 입력 필요 → 입력 유도
+///
+/// ## Usage
+///
+/// **UseCase에서 throw:**
+///
+/// ```swift
+/// func requestGPSAttendance() async throws -> Attendance {
+///     guard locationManager.isInsideGeofence else {
+///         throw DomainError.attendanceOutOfRange
+///     }
+///     // ...
+/// }
+/// ```
+///
+/// **ViewModel에서 catch:**
+///
+/// ```swift
+/// do {
+///     let result = try await useCase.requestGPSAttendance()
+///     state = .loaded(result)
+/// } catch let error as DomainError {
+///     // Loadable로 인라인 표시
+///     state = .failed(.domain(error))
+/// }
+/// ```
+///
+/// **View에서 인라인 표시:**
+///
+/// ```swift
+/// if let error = viewModel.state.error {
+///     Text(error.userMessage)
+///         .font(.caption)
+///         .foregroundStyle(.red)
+/// }
+/// ```
+///
+/// - Important: DomainError는 ErrorHandler가 아닌 Loadable로 처리하세요.
+///   사용자가 화면에서 직접 문제를 해결할 수 있어야 합니다.
+///
+/// - SeeAlso: ``AppError``, ``Loadable``
+public enum DomainError: Error, LocalizedError, Equatable {
+    // MARK: - 공지사항
+
+    /// 공지사항을 찾을 수 없음
+    case noticeNotFound
+
+    /// 공지사항 수정 불가
+    case cannotEditNotice
+
+    // MARK: - 출석
+
+    /// 출석 가능 범위 벗어남 (GPS)
+    case attendanceOutOfRange
+
+    /// 이미 출석 완료
+    case attendanceAlreadySubmitted
+
+    /// 출석 시간 만료
+    case attendanceTimeExpired
+
+    /// 출석 사유 입력 필요
+    case attendanceReasonRequired
+
+    // MARK: - 워크북/과제
+
+    /// 제출 기한 초과
+    case workbookDeadlinePassed
+
+    /// 이미 제출됨
+    case workbookAlreadySubmitted
+
+    /// 미션을 찾을 수 없음
+    case missionNotFound
+
+    /// 미션 링크 입력 필요
+    case missionLinkRequired
+
+    // MARK: - 커리큘럼
+
+    /// 현재 운영 중이 아닌 기수라 커리큘럼 조회 불가
+    case curriculumUnavailableForGeneration
+
+    // MARK: - 커뮤니티
+
+    /// 게시글을 찾을 수 없음
+    case postNotFound
+
+    /// 게시글 삭제 불가
+    case cannotDeletePost
+
+    // MARK: - 권한
+
+    /// 권한 부족
+    case insufficientPermission(required: String)
+
+    // MARK: - 기타
+
+    /// 커스텀 에러 메시지
+    case custom(message: String)
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .noticeNotFound:
+            return "공지사항을 찾을 수 없습니다."
+        case .cannotEditNotice:
+            return "공지사항을 수정할 수 없습니다."
+        case .attendanceOutOfRange:
+            return "출석 가능 범위를 벗어났습니다."
+        case .attendanceAlreadySubmitted:
+            return "이미 출석을 완료했습니다."
+        case .attendanceTimeExpired:
+            return "출석 시간이 지났습니다."
+        case .attendanceReasonRequired:
+            return "출석 사유를 입력해주세요."
+        case .workbookDeadlinePassed:
+            return "제출 기한이 지났습니다."
+        case .workbookAlreadySubmitted:
+            return "이미 제출한 워크북입니다."
+        case .missionNotFound:
+            return "미션을 찾을 수 없습니다."
+        case .missionLinkRequired:
+            return "링크를 입력해주세요."
+        case .curriculumUnavailableForGeneration:
+            return "현재 운영중인 기수가 아니어서 커리큘럼을 조회할 수 없습니다."
+        case .postNotFound:
+            return "게시글을 찾을 수 없습니다."
+        case .cannotDeletePost:
+            return "게시글을 삭제할 수 없습니다."
+        case .insufficientPermission(let required):
+            return "\(required) 권한이 필요합니다."
+        case .custom(let message):
+            return message
+        }
+    }
+
+    /// 사용자에게 표시할 메시지
+    public var userMessage: String {
+        errorDescription ?? ""
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/ErrorSeverity.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/ErrorSeverity.swift
@@ -1,0 +1,21 @@
+//
+//  ErrorSeverity.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 에러 심각도
+/// - 표시 방식 결정에 사용
+public enum ErrorSeverity {
+    /// 정보성 알림 (Toast로 표시)
+    case info
+
+    /// 경고 (Alert로 표시)
+    case warning
+
+    /// 심각 (강제 액션 필요 - 로그아웃 등)
+    case critical
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/NetworkError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/NetworkError.swift
@@ -1,0 +1,244 @@
+//
+//  NetworkError.swift
+//  UMCFoundation
+//
+//  Created by euijjang97 on 1/9/26.
+//
+
+import Foundation
+
+// MARK: - NetworkError
+
+/// 네트워크 계층에서 발생하는 모든 에러를 정의하는 열거형입니다.
+///
+/// NetworkClient, TokenStore, TokenRefreshService에서 발생 가능한 에러를 타입 안전하게 표현합니다.
+///
+/// - Important:
+///   - **Sendable**: Actor 간 안전한 에러 전파
+///   - **Equatable**: Loadable<T: Equatable> 상태 관리 지원
+///   - **LocalizedError**: 사용자 친화적 에러 메시지 제공
+///
+/// - Usage:
+/// ```swift
+/// do {
+///     let data = try await networkClient.request(urlRequest)
+/// } catch NetworkError.unauthorized {
+///     // 로그아웃 처리
+/// } catch NetworkError.tokenRefreshFailed {
+///     // 재로그인 유도
+/// } catch NetworkError.requestFailed(let statusCode, _) {
+///     // 서버 에러 처리
+/// }
+/// ```
+public enum NetworkError: Error, Sendable, Equatable {
+    // MARK: - Cases
+
+    /// 인증이 필요한 요청에 토큰이 없음 (401 Unauthorized)
+    ///
+    /// - 발생 시점: 로그인하지 않은 상태에서 인증 필요 API 호출
+    /// - 해결 방법: 로그인 화면으로 이동
+    case unauthorized
+
+    /// 리프레시 토큰을 사용한 토큰 갱신 실패
+    ///
+    /// - Parameter reason: 갱신 실패 원인 설명 (네트워크 에러, 서버 에러 등)
+    ///
+    /// - 발생 시점:
+    ///   - 리프레시 토큰 만료
+    ///   - 서버 토큰 갱신 API 호출 실패
+    ///   - 네트워크 연결 끊김
+    ///
+    /// - 해결 방법: 재로그인 필요
+    ///
+    /// - Note: Equatable 준수를 위해 Error? → String?로 변경
+    case tokenRefreshFailed(reason: String?)
+
+    /// 저장소에 리프레시 토큰이 없음
+    ///
+    /// - 발생 시점:
+    ///   - 로그아웃 상태
+    ///   - Keychain 데이터 손실
+    ///
+    /// - 해결 방법: 로그인 화면으로 이동
+    case noRefreshToken
+
+    /// API 요청 실패 (2xx 이외의 상태 코드)
+    ///
+    /// - Parameters:
+    ///   - statusCode: HTTP 상태 코드 (400, 403, 404, 500 등)
+    ///   - data: 서버 응답 데이터 (에러 메시지 파싱 가능)
+    ///
+    /// - 발생 시점:
+    ///   - 잘못된 요청 (400 Bad Request)
+    ///   - 권한 없음 (403 Forbidden)
+    ///   - 리소스 없음 (404 Not Found)
+    ///   - 서버 에러 (500 Internal Server Error)
+    ///
+    /// - 해결 방법: 상태 코드별 적절한 에러 처리
+    ///
+    /// - Note: Data는 Equatable이 아니므로 비교 시 제외
+    case requestFailed(statusCode: Int, data: Data?)
+
+    /// 서버 응답이 HTTPURLResponse가 아님
+    ///
+    /// - 발생 시점: 네트워크 설정 오류, 프록시 에러 등
+    /// - 해결 방법: 네트워크 연결 확인
+    case invalidResponse
+
+    /// 토큰 갱신 재시도 횟수 초과
+    ///
+    /// - 발생 시점: 401 에러 발생 후 재시도 횟수(기본 1회) 초과
+    /// - 해결 방법: 재로그인 필요
+    case maxRetryExceeded
+
+    /// 네트워크 연결 없음
+    ///
+    /// - 발생 시점: 인터넷 연결이 끊긴 상태에서 API 호출
+    /// - 해결 방법: 네트워크 연결 확인 후 재시도
+    case noNetwork
+
+    /// 요청 시간 초과
+    ///
+    /// - 발생 시점: 서버 응답이 timeout 시간 내에 오지 않음
+    /// - 해결 방법: 네트워크 상태 확인 후 재시도
+    case timeout
+
+    // MARK: - Equatable
+
+    /// Equatable 비교 구현
+    ///
+    /// - Note: requestFailed의 Data는 비교에서 제외 (Equatable 아님)
+    public static func == (lhs: NetworkError, rhs: NetworkError) -> Bool {
+        switch (lhs, rhs) {
+        case (.unauthorized, .unauthorized):
+            return true
+        case (.tokenRefreshFailed(let lReason), .tokenRefreshFailed(let rReason)):
+            return lReason == rReason
+        case (.noRefreshToken, .noRefreshToken):
+            return true
+        case (.requestFailed(let lCode, _), .requestFailed(let rCode, _)):
+            return lCode == rCode  // Data는 비교 제외
+        case (.invalidResponse, .invalidResponse):
+            return true
+        case (.maxRetryExceeded, .maxRetryExceeded):
+            return true
+        case (.noNetwork, .noNetwork):
+            return true
+        case (.timeout, .timeout):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - NetworkError + LocalizedError
+
+extension NetworkError: LocalizedError {
+    /// 사용자에게 표시할 에러 메시지를 반환합니다.
+    ///
+    /// - Returns: 에러 유형에 맞는 한글 에러 메시지
+    public var errorDescription: String? {
+        switch self {
+        case .unauthorized:
+            return "인증이 필요합니다."
+        case .tokenRefreshFailed(let reason):
+            return "토큰 갱신 실패: \(reason ?? "알 수 없음")"
+        case .noRefreshToken:
+            return "리프레시 토큰이 없습니다."
+        case .requestFailed(let statusCode, _):
+            return "요청 실패 status: \(statusCode)"
+        case .invalidResponse:
+            return "잘못된 서버 응답"
+        case .maxRetryExceeded:
+            return "최대 재시도 횟수 초과"
+        case .noNetwork:
+            return "네트워크 연결이 없습니다."
+        case .timeout:
+            return "요청 시간이 초과되었습니다."
+        }
+    }
+
+    /// 사용자에게 표시할 친화적 메시지
+    ///
+    /// ErrorHandler와의 일관성을 위해 제공됩니다.
+    public var userMessage: String {
+        switch self {
+        case .unauthorized:
+            return "로그인이 필요합니다."
+        case .tokenRefreshFailed, .noRefreshToken, .maxRetryExceeded:
+            return "세션이 만료되었습니다. 다시 로그인해주세요."
+        case .requestFailed(let statusCode, let data):
+            if let serverMessage = Self.parseServerMessage(from: data) {
+                return serverMessage
+            }
+            switch statusCode {
+            case 400...499:
+                return "요청을 처리할 수 없습니다. 다시 시도해주세요."
+            case 500...599:
+                return "서버에 일시적인 오류가 발생했습니다."
+            default:
+                return "네트워크 연결이 원활하지 않습니다."
+            }
+        case .invalidResponse:
+            return "네트워크 연결이 원활하지 않습니다."
+        case .noNetwork:
+            return "인터넷 연결을 확인해주세요."
+        case .timeout:
+            return "서버 응답이 늦어지고 있어요. 잠시 후 다시 시도해주세요."
+        }
+    }
+
+    /// 서버 응답 데이터에서 에러 메시지를 추출합니다.
+    private static func parseServerMessage(from data: Data?) -> String? {
+        guard let data else { return nil }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let message = json["message"] as? String,
+              !message.isEmpty else {
+            return nil
+        }
+        return message
+    }
+
+    /// 에러 심각도
+    ///
+    /// 로깅 및 알림 우선순위 결정에 사용됩니다.
+    public var severity: ErrorSeverity {
+        switch self {
+        case .unauthorized, .tokenRefreshFailed, .noRefreshToken, .maxRetryExceeded:
+            return .critical  // 즉시 로그아웃/재로그인 필요
+        case .requestFailed(let statusCode, _):
+            switch statusCode {
+            case 500...599:
+                return .critical  // 서버 에러
+            default:
+                return .warning   // 클라이언트 에러
+            }
+        case .invalidResponse:
+            return .warning
+        case .noNetwork, .timeout:
+            return .warning
+        }
+    }
+
+    /// 재시도 가능 여부
+    ///
+    /// ErrorHandler의 재시도 버튼 표시 여부 결정에 사용됩니다.
+    public var isRetryable: Bool {
+        switch self {
+        case .unauthorized, .tokenRefreshFailed, .noRefreshToken, .maxRetryExceeded:
+            return false  // 로그인 필요
+        case .requestFailed(let statusCode, _):
+            switch statusCode {
+            case 500...599:
+                return true  // 서버 에러는 재시도 가능
+            default:
+                return false // 클라이언트 에러는 재시도 불가
+            }
+        case .invalidResponse:
+            return true  // 네트워크 연결 재시도 가능
+        case .noNetwork, .timeout:
+            return true
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/RepositoryError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/RepositoryError.swift
@@ -1,0 +1,78 @@
+//
+//  RepositoryError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 2/3/26.
+//
+
+import Foundation
+
+/// Repository 계층에서 발생하는 에러
+///
+/// 서버 응답의 `isSuccess: false` 또는 데이터 변환 실패 시 발생합니다.
+///
+/// ## 사용 예시
+/// ```swift
+/// func getUser() async throws -> User {
+///     let response = try await adapter.request(UserAPI.getMe)
+///     let dto = try JSONDecoder().decode(CommonDTO<UserDTO>.self, from: response.data)
+///
+///     guard dto.isSuccess, let userDTO = dto.result else {
+///         throw RepositoryError.serverError(code: dto.code, message: dto.message)
+///     }
+///
+///     return userDTO.toDomain()
+/// }
+/// ```
+public enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
+
+    // MARK: - Cases
+
+    /// 서버에서 실패 응답 반환 (isSuccess: false)
+    ///
+    /// - Parameters:
+    ///   - code: 에러 코드 (e.g., "AUTH001", "USER404")
+    ///   - message: 에러 메시지
+    case serverError(code: String?, message: String?)
+
+    /// 응답 데이터 디코딩 실패
+    case decodingError(detail: String?)
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .serverError(_, let message):
+            return message ?? "서버 오류가 발생했습니다"
+        case .decodingError(let detail):
+            return "데이터 파싱 실패: \(detail ?? "알 수 없는 오류")"
+        }
+    }
+
+    // MARK: - Properties
+
+    /// 에러 코드 (서버 에러인 경우)
+    public var code: String? {
+        switch self {
+        case .serverError(let code, _):
+            return code
+        default:
+            return nil
+        }
+    }
+
+    /// 사용자에게 표시할 메시지
+    public var userMessage: String {
+        errorDescription ?? "알 수 없는 오류가 발생했습니다"
+    }
+
+    /// 재시도 가능 여부
+    public var isRetryable: Bool {
+        switch self {
+        case .serverError:
+            return true
+        case .decodingError:
+            return false
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/ValidationError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/ValidationError.swift
@@ -1,0 +1,58 @@
+//
+//  ValidationError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 입력 유효성 검증 에러
+public enum ValidationError: Error, LocalizedError, Equatable {
+    /// 필수 입력값 누락
+    case empty(field: String)
+
+    /// 형식 오류 (이메일, 전화번호 등)
+    case invalidFormat(field: String, expected: String)
+
+    /// 최소 길이 미달
+    case tooShort(field: String, minLength: Int)
+
+    /// 최대 길이 초과
+    case tooLong(field: String, maxLength: Int)
+
+    /// 유효하지 않은 값
+    case invalidValue(field: String, reason: String)
+
+    /// 두 필드 값 불일치 (비밀번호 확인 등)
+    case mismatch(field1: String, field2: String)
+
+    /// 이미 사용 중인 값 (이메일 등)
+    case alreadyInUse(field: String)
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .empty(let field):
+            return "\(field)을(를) 입력해주세요."
+        case .invalidFormat(let field, let expected):
+            return "\(field)의 형식이 올바르지 않습니다. (\(expected))"
+        case .tooShort(let field, let minLength):
+            return "\(field)은(는) 최소 \(minLength)자 이상이어야 합니다."
+        case .tooLong(let field, let maxLength):
+            return "\(field)은(는) \(maxLength)자를 초과할 수 없습니다."
+        case .invalidValue(let field, let reason):
+            return "\(field): \(reason)"
+        case .mismatch(let field1, let field2):
+            return "\(field1)와(과) \(field2)이(가) 일치하지 않습니다."
+        case .alreadyInUse(let field):
+            return "이미 사용 중인 \(field)입니다."
+        }
+    }
+
+    /// 사용자에게 표시할 메시지 (errorDescription과 동일)
+    public var userMessage: String {
+        errorDescription ?? ""
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Tuist 모듈 전환 — Error 타입 이관

## 🛠️ 작업내용

- Error 타입 8개 파일을 `UMCApp/Core/Foundation/Sources/Error/` 로 이관
  - `Types/`: AppError, DomainError, NetworkError, AuthError, RepositoryError, ValidationError, ErrorSeverity
  - `Error/`: LocationError
- 모듈 외부 노출을 위한 `public` 접근제어자 추가
  - `public enum`, `public var`, `public static func ==`
  - `private`은 유지 (`parseServerMessage` 등)
- UMCFoundation 타겟 단독 빌드 성공 확인

## 📋 추후 진행 상황

- Loadable + ErrorHandler → UMCFoundation 이관 (#2 티켓)
- Attendance 도메인 모델 이관 (#3 티켓)

## 📌 리뷰 포인트

- `public` 접근제어자가 빠진 선언이 없는지 확인
- 원본 파일과 로직 차이 없이 `public` 추가 + 헤더 모듈명 변경만 되었는지 확인

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

closes #588