### PR TITLE
refactor: Loadable + ErrorHandler UMCFoundation 모듈로 이관

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorContext.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorContext.swift
@@ -1,0 +1,78 @@
+//
+//  ErrorContext.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 에러가 발생한 위치와 재시도 정보를 담는 컨텍스트.
+///
+/// 동일한 에러라도 발생 위치에 따라 다른 처리가 필요합니다:
+/// - 공지사항 조회 중 네트워크 에러 → "공지사항을 불러올 수 없습니다"
+/// - 출석 체크 중 네트워크 에러 → "출석 체크에 실패했습니다"
+///
+/// ## Usage
+///
+/// ```swift
+/// errorHandler.handle(error, context: ErrorContext(
+///     feature: "Notice",
+///     action: "fetchList",
+///     retryAction: { [weak self] in
+///         await self?.fetchNotices()
+///     }
+/// ))
+/// ```
+///
+/// - SeeAlso: ``ErrorHandler``, ``PresentableError``
+public struct ErrorContext: Equatable {
+
+    // MARK: - Property
+
+    /// 에러가 발생한 Feature 이름.
+    ///
+    /// Feature 폴더명과 일치시키는 것을 권장합니다.
+    ///
+    /// - Note: PascalCase 사용 (예: `"Notice"`, `"Auth"`, `"Attendance"`)
+    public let feature: String
+
+    /// 에러가 발생한 액션 이름.
+    ///
+    /// 해당 Feature 내에서 어떤 작업 중 에러가 발생했는지를 나타냅니다.
+    ///
+    /// - Note: camelCase, 동사로 시작 (예: `"fetchList"`, `"login"`, `"submitAttendance"`)
+    public let action: String
+
+    /// 에러 발생 시 재시도할 수 있는 클로저.
+    ///
+    /// 이 값이 `nil`이면 UI에서 재시도 버튼이 표시되지 않습니다.
+    ///
+    /// - Important: 클로저 내부에서 `[weak self]`를 사용하여 순환 참조를 방지하세요.
+    public let retryAction: (() async -> Void)?
+
+    // MARK: - Init
+
+    /// 새로운 ErrorContext를 생성합니다.
+    ///
+    /// - Parameters:
+    ///   - feature: 에러가 발생한 Feature 이름.
+    ///   - action: 에러가 발생한 액션 이름.
+    ///   - retryAction: 재시도 클로저. 기본값은 `nil`.
+    public init(
+        feature: String,
+        action: String,
+        retryAction: (() async -> Void)? = nil
+    ) {
+        self.feature = feature
+        self.action = action
+        self.retryAction = retryAction
+    }
+
+    // MARK: - Equatable
+
+    /// 두 ErrorContext가 같은 위치를 나타내는지 비교합니다.
+    public static func == (lhs: ErrorContext, rhs: ErrorContext) -> Bool {
+        lhs.feature == rhs.feature && lhs.action == rhs.action
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorHandler.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorHandler.swift
@@ -1,0 +1,294 @@
+//
+//  ErrorHandler.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+import os.log
+
+/// 앱 전역에서 발생하는 에러를 중앙 집중식으로 처리하는 핸들러.
+///
+/// Mediator 패턴을 적용하여 여러 ViewModel에서 발생하는 에러를 한 곳에서 수집하고 처리합니다.
+///
+/// ErrorHandler의 역할:
+/// 1. 에러 변환: `MoyaError`, `URLError` 등을 ``AppError``로 통합
+/// 2. 로깅: `os.log`를 사용하여 에러 정보 기록
+/// 3. 분석: Firebase, Sentry 등 외부 서비스로 에러 데이터 전송
+/// 4. 특수 처리: 401 Unauthorized → 자동 로그아웃
+/// 5. UI 바인딩: ``currentError``를 통해 View에서 Alert 표시
+///
+/// ## Usage
+///
+/// **App에서 Environment로 주입:**
+///
+/// ```swift
+/// @main
+/// struct AppProductApp: App {
+///     @State private var errorHandler = ErrorHandler()
+///
+///     var body: some Scene {
+///         WindowGroup {
+///             ContentView()
+///                 .environment(errorHandler)
+///                 .globalErrorAlert(errorHandler: errorHandler)
+///         }
+///     }
+/// }
+/// ```
+///
+/// **ViewModel에서 에러 처리:**
+///
+/// ```swift
+/// func fetchNotices() async {
+///     do {
+///         notices = try await useCase.execute()
+///     } catch {
+///         errorHandler.handle(error, context: ErrorContext(
+///             feature: "Notice",
+///             action: "fetchList",
+///             retryAction: { [weak self] in await self?.fetchNotices() }
+///         ))
+///     }
+/// }
+/// ```
+///
+/// - Important: 에러 처리 방식은 UX 관점에서 결정하세요.
+///   - **ErrorHandler**: 작업 흐름 중단, 즉각적인 사용자 액션이 필요한 경우 (Alert)
+///   - **Loadable**: 데이터 상태와 함께 관리, 화면 내 상태 변화 표시 (인라인)
+///
+///   예시:
+///   - 세션 만료, 권한 필요, 네트워크 오류 → ErrorHandler
+///   - 리스트 로딩 실패, 폼 검증 실패, 범위 벗어남 → Loadable
+///
+/// - Warning: 현재 특수 에러 처리는 `NotificationCenter`를 사용합니다.
+///   추후 `AppState + Environment` 패턴으로 리팩터링 예정입니다.
+///
+/// - SeeAlso: ``ErrorContext``, ``AppError``, ``PresentableError``, ``Loadable``
+@Observable
+public final class ErrorHandler {
+
+    // MARK: - Property
+
+    /// 현재 표시해야 할 에러.
+    ///
+    /// View에서 이 값을 관찰하여 에러 Alert을 표시합니다.
+    /// `nil`이면 에러가 없는 상태입니다.
+    ///
+    /// - Note: 외부에서 직접 수정할 수 없습니다. ``handle(_:context:)``를 사용하세요.
+    public private(set) var currentError: PresentableError?
+
+    /// 에러 로깅에 사용되는 Logger.
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "AppProduct",
+        category: "ErrorHandler"
+    )
+
+    // MARK: - Init
+
+    /// ErrorHandler를 초기화합니다.
+    ///
+    /// App 레벨에서 한 번만 생성하고 Environment로 주입합니다.
+    public init() {}
+
+    // MARK: - Public Methods
+
+    /// 에러를 처리합니다.
+    ///
+    /// 에러 처리의 단일 진입점입니다. 다음 순서로 처리합니다:
+    /// 1. `Error` → ``AppError`` 변환
+    /// 2. os.log로 로깅
+    /// 3. Analytics 전송
+    /// 4. 특수 케이스 처리 (401 → 로그아웃)
+    /// 5. ``currentError`` 설정 → View에서 Alert 표시
+    ///
+    /// - Parameters:
+    ///   - error: 발생한 에러. ``AppError``, `MoyaError`, `URLError` 등 모든 `Error` 타입 가능.
+    ///   - context: 에러 발생 위치와 재시도 정보를 담은 컨텍스트.
+    ///
+    /// - Precondition: Main Thread에서 호출해야 합니다.
+    public func handle(_ error: Error, context: ErrorContext) {
+        let appError = convert(error)
+
+        log(appError, context: context)
+        trackError(appError, context: context)
+
+        if handleSpecialCases(appError, context: context) {
+            return
+        }
+
+        currentError = PresentableError(
+            error: appError,
+            context: context,
+            dismissAction: { [weak self] in
+                self?.clearError()
+            },
+            retryAction: context.retryAction
+        )
+    }
+
+    /// 현재 표시 중인 에러를 초기화합니다.
+    ///
+    /// 에러 Alert이 닫힐 때 자동으로 호출됩니다.
+    public func clearError() {
+        currentError = nil
+    }
+
+    // MARK: - Private Methods
+
+    /// 임의의 Error를 AppError로 변환합니다.
+    ///
+    /// - Parameter error: 변환할 에러.
+    /// - Returns: 통합된 ``AppError``.
+    ///
+    /// - Note: 지원 타입: `AppError`, `NetworkError`, `RepositoryError`, `AuthError`,
+    ///   `ValidationError`, `DomainError`, `MoyaError`, `URLError`, `DecodingError`
+    private func convert(_ error: Error) -> AppError {
+        // 1. AppError는 그대로 반환
+        if let appError = error as? AppError {
+            return appError
+        }
+
+        // 2. NetworkError → AppError.network (Actor 기반 네트워크 클라이언트)
+        if let networkError = error as? NetworkError {
+            return .network(networkError)
+        }
+
+        // 3. RepositoryError
+        if let repositoryError = error as? RepositoryError {
+            return .repository(repositoryError)
+        }
+
+        // 4. ValidationError
+        if let validationError = error as? ValidationError {
+            return .validation(validationError)
+        }
+
+        // 5. AuthError
+        if let authError = error as? AuthError {
+            return .auth(authError)
+        }
+
+        // 6. DomainError
+        if let domainError = error as? DomainError {
+            return .domain(domainError)
+        }
+
+        // 7. URLError → NetworkError 변환
+        if let urlError = error as? URLError {
+            return .network(convertURLError(urlError))
+        }
+
+        // 8. DecodingError → RepositoryError 변환
+        if let decodingError = error as? DecodingError {
+            return .repository(.decodingError(detail: describeDecodingError(decodingError)))
+        }
+
+        // 9. 알 수 없는 에러
+        return .unknown(message: error.localizedDescription)
+    }
+
+    private func convertURLError(_ error: URLError) -> NetworkError {
+        switch error.code {
+        case .notConnectedToInternet, .networkConnectionLost:
+            return .noNetwork
+        case .timedOut:
+            return .timeout
+        default:
+            return .requestFailed(statusCode: error.errorCode, data: nil)
+        }
+    }
+
+    private func describeDecodingError(_ error: DecodingError) -> String {
+        switch error {
+        case .keyNotFound(let key, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            let location = path.isEmpty ? key.stringValue : "\(path).\(key.stringValue)"
+            return "Missing key: \(location)"
+        case .typeMismatch(let type, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "Type mismatch: expected \(type) at \(path)"
+        case .valueNotFound(let type, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "Value not found: \(type) at \(path)"
+        case .dataCorrupted(let context):
+            return "Data corrupted: \(context.debugDescription)"
+        @unknown default:
+            return "Unknown decoding error"
+        }
+    }
+
+    // MARK: - Logging
+
+    /// 에러를 os.log로 기록합니다.
+    ///
+    /// 로그 레벨은 에러의 ``AppError/severity``에 따라 결정됩니다.
+    private func log(_ error: AppError, context: ErrorContext) {
+        let message = """
+        [Error] \(context.feature)/\(context.action)
+        - Error: \(error.errorDescription ?? "Unknown")
+        - Severity: \(error.severity)
+        - Retryable: \(error.isRetryable)
+        """
+
+        switch error.severity {
+        case .info:
+            logger.info("\(message)")
+        case .warning:
+            logger.warning("\(message)")
+        case .critical:
+            logger.error("\(message)")
+        }
+    }
+
+    // MARK: - Analytics
+
+    /// 에러를 외부 분석 서비스로 전송합니다.
+    ///
+    /// - Todo: Firebase Analytics, Sentry 등 연동
+    private func trackError(_ error: AppError, context: ErrorContext) {
+        // TODO: Firebase Analytics, Sentry 등 연동 - [25.01.07] 이재원
+    }
+
+    // MARK: - Special Cases
+
+    // TODO: [Refactor] NotificationCenter → AppState + Environment 패턴으로 리팩터링 예정 - [25.01.07] 이재원
+    // 현재: NotificationCenter 사용 (타입 안전하지 않음)
+    // 개선: AppState를 주입받아 직접 상태 변경 (DIContainer 구현 후)
+
+    /// 특수 에러를 처리합니다.
+    ///
+    /// Alert 표시 대신 앱 전체 상태 변경이 필요한 에러를 처리합니다.
+    ///
+    /// - Parameters:
+    ///   - error: 처리할 에러.
+    ///   - context: 에러 컨텍스트.
+    /// - Returns: 특수 처리가 수행되었으면 `true`.
+    ///
+    /// - Warning: 현재 `NotificationCenter`를 사용합니다. 추후 리팩터링 필요.
+    private func handleSpecialCases(_ error: AppError, context: ErrorContext) -> Bool {
+        switch error {
+        // 인증 만료 → 자동 로그아웃
+        case .auth(.sessionExpired):
+            NotificationCenter.default.post(name: .authSessionExpired, object: nil)
+            return true
+
+        // NetworkError 인증 관련 에러 → 자동 로그아웃
+        case .network(.unauthorized),
+             .network(.tokenRefreshFailed),
+             .network(.noRefreshToken),
+             .network(.maxRetryExceeded):
+            NotificationCenter.default.post(name: .authSessionExpired, object: nil)
+            return true
+
+        // 승인 대기 상태 → 대기 화면으로 이동
+        case .auth(.pendingApproval):
+            NotificationCenter.default.post(name: .navigateToPendingApproval, object: nil)
+            return true
+
+        default:
+            return false
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Handler/Notification+Error.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Handler/Notification+Error.swift
@@ -1,0 +1,30 @@
+//
+//  Notification+Error.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+// MARK: - Error Notification Names
+
+// TODO: [Refactor] AppState 도입 후 제거 예정 - [25.01.07] 이재원
+extension Notification.Name {
+    /// 인증 세션이 만료되었을 때 발송되는 알림.
+    ///
+    /// 이 알림을 받으면 저장된 토큰을 삭제하고 로그인 화면으로 이동해야 합니다.
+    public static let authSessionExpired = Notification.Name("authSessionExpired")
+
+    /// 승인 대기 상태일 때 발송되는 알림.
+    ///
+    /// 이 알림을 받으면 승인 대기 안내 화면으로 이동해야 합니다.
+    public static let navigateToPendingApproval = Notification.Name("navigateToPendingApproval")
+
+    /// 출석 승인/반려 상태 변경 알림.
+    ///
+    /// 운영진이 출석을 승인/반려하면 발송됩니다.
+    /// 챌린저 ViewModel이 수신하여 `myHistory`를 갱신합니다.
+    public static let attendanceStatusChanged = Notification.Name("attendanceStatusChanged")
+
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Handler/PresentableError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Handler/PresentableError.swift
@@ -1,0 +1,64 @@
+//
+//  PresentableError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// View에 표시할 에러 정보
+public struct PresentableError: Identifiable, Equatable {
+    // MARK: - Property
+
+    public let id: UUID
+    public let error: AppError
+    public let context: ErrorContext
+    public let dismissAction: () -> Void
+    public let retryAction: (() async -> Void)?
+
+    // MARK: - Computed Property
+
+    /// Alert 타이틀
+    public var title: String {
+        switch error.severity {
+        case .info:
+            return "알림"
+        case .warning:
+            return "오류"
+        case .critical:
+            return "문제 발생"
+        }
+    }
+
+    /// 사용자에게 표시할 메시지
+    public var message: String {
+        error.userMessage
+    }
+
+    /// 재시도 버튼 표시 여부
+    public var showRetry: Bool {
+        error.isRetryable && retryAction != nil
+    }
+
+    // MARK: - Init
+
+    public init(
+        error: AppError,
+        context: ErrorContext,
+        dismissAction: @escaping () -> Void,
+        retryAction: (() async -> Void)? = nil
+    ) {
+        self.id = UUID()
+        self.error = error
+        self.context = context
+        self.dismissAction = dismissAction
+        self.retryAction = retryAction
+    }
+
+    // MARK: - Equatable
+
+    public static func == (lhs: PresentableError, rhs: PresentableError) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Loadable/Loadable.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Loadable/Loadable.swift
@@ -1,0 +1,227 @@
+//
+//  Loadable.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 비동기 데이터 로딩 상태를 나타내는 열거형.
+///
+/// ViewModel에서 API 호출 결과를 관리할 때 사용합니다.
+/// 단일 데이터 소스의 상태를 명시적으로 표현하여
+/// View에서 각 상태에 맞는 UI를 렌더링할 수 있습니다.
+///
+/// ## Usage
+///
+/// **ViewModel에서 상태 관리:**
+///
+/// ```swift
+/// @Observable
+/// final class NoticeListViewModel {
+///     private(set) var notices: Loadable<[Notice]> = .idle
+///
+///     func fetchNotices() async {
+///         notices = .loading
+///         do {
+///             let result = try await useCase.execute()
+///             notices = .loaded(result)
+///         } catch let error as AppError {
+///             notices = .failed(error)
+///         } catch {
+///             notices = .failed(.unknown(message: error.localizedDescription))
+///         }
+///     }
+/// }
+/// ```
+///
+/// **View에서 상태별 UI 렌더링:**
+///
+/// ```swift
+/// struct NoticeListView: View {
+///     @State private var viewModel: NoticeListViewModel
+///
+///     var body: some View {
+///         switch viewModel.notices {
+///         case .idle:
+///             Color.clear.task { await viewModel.fetchNotices() }
+///         case .loading:
+///             ProgressView()
+///         case .loaded(let notices):
+///             List(notices) { NoticeRow(notice: $0) }
+///         case .failed(let error):
+///             ErrorView(error: error, retryAction: { Task { await viewModel.fetchNotices() } })
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## ErrorHandler vs Loadable 선택 기준
+///
+/// | 기준 | ErrorHandler (Alert) | Loadable (인라인) |
+/// |------|---------------------|-------------------|
+/// | **사용자 액션** | 즉각적인 액션 필요 | 화면 내에서 해결 가능 |
+/// | **작업 흐름** | 중단해야 함 | 유지 가능 |
+/// | **에러 예시** | 세션 만료, 네트워크 오류 | 범위 밖, 이미 제출됨 |
+///
+/// ## 에러 타입별 catch 분기 패턴
+///
+/// ```swift
+/// do {
+///     let result = try await useCase.execute()
+///     state = .loaded(result)
+///
+/// } catch let error as DomainError {
+///     // 도메인 에러 → Loadable (인라인)
+///     state = .failed(.domain(error))
+///
+/// } catch {
+///     // 기타 에러 → ErrorHandler (Alert) + 상태 복구
+///     state = .loaded(initialData)  // 또는 .idle
+///     errorHandler.handle(error, context: ...)
+/// }
+/// ```
+///
+/// - SeeAlso: ``AppError``, ``ErrorHandler``, ``DomainError``
+public enum Loadable<T: Equatable>: Equatable {
+
+    // MARK: - Cases
+
+    /// 초기 상태.
+    ///
+    /// 아직 데이터 로딩이 시작되지 않은 상태입니다.
+    /// View가 나타날 때 `.onAppear`에서 로딩을 시작하는 트리거로 사용합니다.
+    case idle
+
+    /// 로딩 중 상태.
+    ///
+    /// 데이터를 요청 중이며 응답을 기다리는 상태입니다.
+    /// `ProgressView`나 스켈레톤 UI를 표시하세요.
+    case loading
+
+    /// 로딩 성공 상태.
+    ///
+    /// 데이터 로딩이 성공적으로 완료된 상태입니다.
+    ///
+    /// - Parameter value: 로드된 데이터.
+    case loaded(T)
+
+    /// 로딩 실패 상태.
+    ///
+    /// 데이터 로딩 중 에러가 발생한 상태입니다.
+    /// 에러 메시지와 재시도 버튼을 표시하세요.
+    ///
+    /// - Parameter error: 발생한 에러.
+    case failed(AppError)
+
+    // MARK: - Computed Property
+
+    /// 로드된 값.
+    ///
+    /// `.loaded` 상태일 때만 값을 반환하고, 그 외에는 `nil`을 반환합니다.
+    ///
+    /// ```swift
+    /// if let notices = viewModel.notices.value {
+    ///     // notices 사용
+    /// }
+    /// ```
+    public var value: T? {
+        if case .loaded(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    /// 발생한 에러.
+    ///
+    /// `.failed` 상태일 때만 에러를 반환하고, 그 외에는 `nil`을 반환합니다.
+    ///
+    /// ```swift
+    /// if let error = viewModel.notices.error {
+    ///     print(error.errorDescription)
+    /// }
+    /// ```
+    public var error: AppError? {
+        if case .failed(let error) = self {
+            return error
+        }
+        return nil
+    }
+
+    /// 로딩 중 여부.
+    ///
+    /// `ProgressView` 표시 조건으로 사용합니다.
+    ///
+    /// ```swift
+    /// if viewModel.notices.isLoading {
+    ///     ProgressView()
+    /// }
+    /// ```
+    public var isLoading: Bool {
+        if case .loading = self {
+            return true
+        }
+        return false
+    }
+
+    /// 로드 완료 여부.
+    ///
+    /// 성공(`.loaded`) 또는 실패(`.failed`) 상태인지 확인합니다.
+    /// 최초 로딩이 완료되었는지 판단할 때 사용합니다.
+    public var isComplete: Bool {
+        switch self {
+        case .loaded, .failed:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// 초기 상태 여부.
+    ///
+    /// 아직 로딩이 시작되지 않았는지 확인합니다.
+    /// `.task`에서 최초 로딩 트리거 조건으로 사용합니다.
+    ///
+    /// ```swift
+    /// .task {
+    ///     if viewModel.notices.isIdle {
+    ///        await viewModel.fetchNotices()
+    ///     }
+    /// }
+    /// ```
+    public var isIdle: Bool {
+        if case .idle = self {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Mapping
+
+    /// 로드된 값을 다른 타입으로 변환합니다.
+    ///
+    /// 함수형 프로그래밍의 `map` 패턴을 적용하여
+    /// 상태를 유지하면서 내부 값만 변환합니다.
+    ///
+    /// ```swift
+    /// let noticeCount: Loadable<Int> = viewModel.notices.map { $0.count }
+    /// ```
+    ///
+    /// - Parameter transform: 값을 변환하는 클로저.
+    /// - Returns: 변환된 값을 담은 새로운 `Loadable`.
+    ///
+    /// - Note: `.idle`, `.loading`, `.failed` 상태는 그대로 유지됩니다.
+    public func map<U: Equatable>(_ transform: (T) -> U) -> Loadable<U> {
+        switch self {
+        case .idle:
+            return .idle
+        case .loading:
+            return .loading
+        case .loaded(let value):
+            return .loaded(transform(value))
+        case .failed(let error):
+            return .failed(error)
+        }
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

♻️ 리팩토링 — Tuist 모듈 전환 1주차, Loadable + ErrorHandler UMCFoundation 이관

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (Core 모듈 이관 작업)

## 🛠️ 작업내용

- Loadable 상태 관리 enum을 `UMCFoundation/Sources/Error/Loadable/`로 이관
- ErrorHandler 시스템 3개 파일(ErrorContext, PresentableError, ErrorHandler)을 `UMCFoundation/Sources/Error/Handler/`로 이관
- Notification+Error.swift (에러 관련 Notification.Name 상수)를 `UMCFoundation/Sources/Error/Handler/`로 이관
- 모든 외부 노출 타입/프로퍼티/메서드에 `public` 접근제어자 추가
- `ErrorHandler`의 `@Observable` 매크로, `os.log` import 정상 동작 확인
- UMCFoundation 단독 빌드 성공 (BUILD SUCCEEDED, 에러 0개)
- 총 5개 파일, 693줄 추가

## 📋 추후 진행 상황

- AppProduct 원본 파일에서 `import UMCFoundation` 전환(후속 티켓)
- Activity Domain 모델 이관
- `ErrorHandler.handleSpecialCases`의 NotificationCenter → AppState 리팩터링 (별도 티켓)

## 📌 리뷰 포인트

- 각 파일의 `public` 접근제어자가 올바르게 적용되었는지 확인
- `ErrorHandler`의 private 메서드들(convert, log, trackError, handleSpecialCases)이 private으로 유지되는지 확인
- `Notification+Error.swift`의 `.attendanceStatusChanged`가 ErrorHandler와 무관하지만 같은 extension이라 함께 이관한 점

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?