### PR TITLE
♻️ [Refactor] Attendance 도메인 모델 ActivityDomain 모듈 이관

### DIFF
--- a/UMCApp/Features/Activity/Domain/Sources/ActivityDomain.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/ActivityDomain.swift
@@ -1,1 +1,0 @@
-public protocol ActivityUseCase {}

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceStatus.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceStatus.swift
@@ -1,0 +1,52 @@
+//
+//  AttendanceStatus.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+public enum AttendanceStatus: String, CaseIterable {
+    case beforeAttendance = "pending"
+    case pendingApproval
+    case present
+    case late
+    case absent
+
+    /// 배지/버튼에 표시할 텍스트
+    public var displayText: String {
+        switch self {
+        case .beforeAttendance: return "출석 전"
+        case .pendingApproval: return "승인 대기"
+        case .present: return "출석"
+        case .late: return "지각"
+        case .absent: return "결석"
+        }
+    }
+}
+
+// MARK: - Server Status Mapping
+extension AttendanceStatus {
+    /// 서버 API 상태 문자열 → Domain enum 변환
+    ///
+    /// - Parameter serverStatus: 서버 응답 status 필드
+    ///   (e.g., "PRESENT", "LATE", "ABSENT", "PENDING",
+    ///    "PRESENT_PENDING", "LATE_PENDING", "EXCUSED",
+    ///    "EXCUSED_PENDING")
+    public init(serverStatus: String) {
+        switch serverStatus {
+        case "PRESENT", "EXCUSED": self = .present
+        case "LATE": self = .late
+        case "ABSENT": self = .absent
+        case "PENDING": self = .beforeAttendance
+        case "PRESENT_PENDING", "LATE_PENDING", "EXCUSED_PENDING": self = .pendingApproval
+        default:
+            if serverStatus.hasSuffix("_PENDING") {
+                self = .pendingApproval
+            } else {
+                self = .beforeAttendance
+            }
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceTimeWindow.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceTimeWindow.swift
@@ -1,0 +1,25 @@
+//
+//  AttendanceTimeWindow.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 출석 시간대 상태 (시간 체크 전용)
+///
+/// `isWithinAttendanceTime(session:)`에서 현재 시간이 어느 시간대에 속하는지 반환합니다.
+public enum AttendanceTimeWindow {
+    /// 출석 시간 전 (아직 출석 체크 불가)
+    case tooEarly
+
+    /// 정시 출석 가능 시간대 (GPS 출석 가능)
+    case onTime
+
+    /// 지각 시간대 (사유 제출 필요)
+    case lateWindow
+
+    /// 마감됨 (결석 사유 제출 필요)
+    case expired
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/MyAttendanceItemStatus.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/MyAttendanceItemStatus.swift
@@ -1,0 +1,39 @@
+//
+//  MyAttendanceItemStatus.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+public enum MyAttendanceItemStatus: Equatable {
+    case pendingApproval
+    case present
+    case late
+    case absent
+
+    /// 배지/버튼에 표시할 텍스트
+    public var text: String {
+        switch self {
+        case .pendingApproval: return "승인 대기"
+        case .present: return "출석"
+        case .late: return "지각"
+        case .absent: return "결석"
+        }
+    }
+}
+
+extension MyAttendanceItemStatus {
+    /// AttendanceStatus에서 변환
+    /// - Note: beforeAttendance 상태는 nil 반환 (리스트에 표시 안함)
+    public init?(from status: AttendanceStatus) {
+        switch status {
+        case .pendingApproval: self = .pendingApproval
+        case .present: self = .present
+        case .late: self = .late
+        case .absent: self = .absent
+        case .beforeAttendance: return nil
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/Attendance.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/Attendance.swift
@@ -1,0 +1,79 @@
+//
+//  Attendance.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 출석 Domain 핵심 엔티티
+///
+/// GPS 출석과 사유 출석을 모두 표현하며,
+/// 불변 값 타입으로 상태 변경 시 `copy` 기반 빌더 메서드를 제공합니다.
+public struct Attendance: Identifiable, Equatable {
+    public let id: UUID
+    public let sessionId: SessionID
+    public let userId: UserID
+    public let type: AttendanceType
+    public let status: AttendanceStatus
+    public let locationVerification: LocationVerification?
+    public let reason: String?
+    public let createdAt: Date
+
+    public init(
+        id: UUID = .init(),
+        sessionId: SessionID,
+        userId: UserID,
+        type: AttendanceType,
+        status: AttendanceStatus,
+        locationVerification: LocationVerification? = nil,
+        reason: String? = nil,
+        createdAt: Date = .now
+    ) {
+        self.id = id
+        self.sessionId = sessionId
+        self.userId = userId
+        self.type = type
+        self.status = status
+        self.locationVerification = locationVerification
+        self.reason = reason
+        self.createdAt = createdAt
+    }
+
+    public func approved(with verification: LocationVerification) -> Self {
+        copy(status: .present, locationVerification: verification)
+    }
+
+    public func beforeAttendance() -> Self {
+        copy(status: .beforeAttendance)
+    }
+
+    public func rejected(status: AttendanceStatus) -> Self {
+        copy(status: status)
+    }
+
+    public func late(reason: String) -> Self {
+        copy(status: .late, reason: reason)
+    }
+
+    public func absent(reason: String) -> Self {
+        copy(status: .absent, reason: reason)
+    }
+
+    private func copy(
+        type: AttendanceType? = nil,
+        status: AttendanceStatus? = nil,
+        reason: String? = nil,
+        locationVerification: LocationVerification? = nil
+    ) -> Self {
+        .init(
+            sessionId: self.sessionId,
+            userId: self.userId,
+            type: type ?? self.type,
+            status: status ?? self.status,
+            locationVerification: locationVerification ?? self.locationVerification,
+            reason: reason ?? self.reason
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceHistoryItem.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceHistoryItem.swift
@@ -1,0 +1,50 @@
+//
+//  AttendanceHistoryItem.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+/// 출석 이력 항목 Domain 모델
+///
+/// `GET /api/v1/attendances/history` 및
+/// `GET /api/v1/attendances/challenger/{challengerId}/history` 응답 매핑
+
+import Foundation
+
+public struct AttendanceHistoryItem: Equatable, Identifiable {
+    public let id: UUID
+    public let attendanceId: Int
+    public let scheduleId: Int
+    public let scheduleName: String
+    public let tags: [String]
+    public let scheduledDate: String
+    public let startTime: String
+    public let endTime: String
+    public let status: AttendanceStatus
+    public let statusDisplay: String
+
+    public init(
+        id: UUID = .init(),
+        attendanceId: Int,
+        scheduleId: Int,
+        scheduleName: String,
+        tags: [String],
+        scheduledDate: String,
+        startTime: String,
+        endTime: String,
+        status: AttendanceStatus,
+        statusDisplay: String
+    ) {
+        self.id = id
+        self.attendanceId = attendanceId
+        self.scheduleId = scheduleId
+        self.scheduleName = scheduleName
+        self.tags = tags
+        self.scheduledDate = scheduledDate
+        self.startTime = startTime
+        self.endTime = endTime
+        self.status = status
+        self.statusDisplay = statusDisplay
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendancePolicy.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendancePolicy.swift
@@ -1,0 +1,23 @@
+//
+//  AttendancePolicy.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+import CoreLocation
+
+/// 출석 정책 상수
+///
+/// GPS 출석의 지오펜스 반경과 시간 기준(정시/지각/결석)을 정의합니다.
+public enum AttendancePolicy {
+    /// GPS 출석 유효 반경 (미터)
+    public static let geofenceRadius: CLLocationDistance = 50.0
+
+    /// 정시 출석 허용 시간 (분) — 세션 시작 후 이 시간 내 출석 시 '출석'
+    public static let onTimeThresholdMinutes: Int = 10
+
+    /// 지각 허용 시간 (분) — 정시 이후 이 시간 내 출석 시 '지각'
+    public static let lateThresholdMinutes: Int = 30
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceRecord.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceRecord.swift
@@ -1,0 +1,34 @@
+//
+//  AttendanceRecord.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+/// 출석 기록 상세 Domain 모델
+///
+/// `GET /api/v1/attendances/{recordId}` 응답 매핑
+
+import Foundation
+
+public struct AttendanceRecord: Equatable, Identifiable {
+    public let id: Int
+    public let attendanceSheetId: Int
+    public let memberId: String
+    public let status: AttendanceStatus
+    public let memo: String?
+
+    public init(
+        id: Int,
+        attendanceSheetId: Int,
+        memberId: String,
+        status: AttendanceStatus,
+        memo: String?
+    ) {
+        self.id = id
+        self.attendanceSheetId = attendanceSheetId
+        self.memberId = memberId
+        self.status = status
+        self.memo = memo
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceType.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceType.swift
@@ -1,0 +1,19 @@
+//
+//  AttendanceType.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 출석 방식
+///
+/// GPS 위치 인증 출석과 사유 기반 출석 두 가지를 구분합니다.
+public enum AttendanceType: String {
+    /// GPS 위치 인증을 통한 출석
+    case gps
+
+    /// 사유 제출을 통한 출석 (지각/결석 사유)
+    case reason
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AvailableAttendanceSchedule.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AvailableAttendanceSchedule.swift
@@ -1,0 +1,52 @@
+//
+//  AvailableAttendanceSchedule.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+/// 출석 가능 일정 Domain 모델
+///
+/// `GET /api/v1/attendances/available` 응답 매핑
+
+import Foundation
+
+public struct AvailableAttendanceSchedule: Equatable, Identifiable {
+    public let id: UUID
+    public let scheduleId: Int
+    public let scheduleName: String
+    public let tags: [String]
+    public let startTime: String
+    public let endTime: String
+    public let sheetId: Int
+    public let recordId: Int?
+    public let status: AttendanceStatus
+    public let statusDisplay: String
+    public let locationVerified: Bool
+
+    public init(
+        id: UUID = .init(),
+        scheduleId: Int,
+        scheduleName: String,
+        tags: [String],
+        startTime: String,
+        endTime: String,
+        sheetId: Int,
+        recordId: Int?,
+        status: AttendanceStatus,
+        statusDisplay: String,
+        locationVerified: Bool
+    ) {
+        self.id = id
+        self.scheduleId = scheduleId
+        self.scheduleName = scheduleName
+        self.tags = tags
+        self.startTime = startTime
+        self.endTime = endTime
+        self.sheetId = sheetId
+        self.recordId = recordId
+        self.status = status
+        self.statusDisplay = statusDisplay
+        self.locationVerified = locationVerified
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/LocationVerification.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/LocationVerification.swift
@@ -1,0 +1,30 @@
+//
+//  LocationVerification.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// GPS 출석 위치 인증 결과
+///
+/// 사용자의 GPS 좌표가 세션 장소 지오펜스 내에 있는지 검증한 결과를 담습니다.
+public struct LocationVerification: Equatable {
+    public let isVerified: Bool
+    public let coordinate: Coordinate
+    public let address: Address
+    public let verifiedAt: Date
+
+    public init(
+        isVerified: Bool,
+        coordinate: Coordinate,
+        address: Address,
+        verifiedAt: Date
+    ) {
+        self.isVerified = isVerified
+        self.coordinate = coordinate
+        self.address = address
+        self.verifiedAt = verifiedAt
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/MemberAttendanceRecord.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/MemberAttendanceRecord.swift
@@ -1,0 +1,38 @@
+//
+//  MemberAttendanceRecord.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+/// 멤버 출석/활동 기록
+///
+/// 멤버 상세 화면에서 출석 이력을 표시하기 위한 모델입니다.
+/// SessionInfo의 title과 Attendance 정보를 포함합니다.
+
+import Foundation
+
+public struct MemberAttendanceRecord: Identifiable, Equatable {
+    public let id: UUID
+
+    /// 세션 제목
+    public let sessionTitle: String
+
+    /// 주차 (예: 1, 2, 3...)
+    public let week: Int
+
+    /// 출석 정보
+    public let status: AttendanceStatus
+
+    public init(
+        id: UUID = UUID(),
+        sessionTitle: String,
+        week: Int,
+        status: AttendanceStatus
+    ) {
+        self.id = id
+        self.sessionTitle = sessionTitle
+        self.week = week
+        self.status = status
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/PendingAttendanceRecord.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/PendingAttendanceRecord.swift
@@ -1,0 +1,48 @@
+//
+//  PendingAttendanceRecord.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 승인 대기 출석 항목 Domain 모델
+///
+/// `GET /api/v1/attendances/pending/{scheduleId}` 응답 매핑
+public struct PendingAttendanceRecord: Equatable, Identifiable {
+    public let id: UUID
+    public let attendanceId: Int
+    public let memberId: String
+    public let memberName: String
+    public let nickname: String
+    public let profileImageLink: URL?
+    public let schoolName: String
+    public let status: AttendanceStatus
+    public let reason: String?
+    public let requestedAt: Date
+
+    public init(
+        id: UUID = .init(),
+        attendanceId: Int,
+        memberId: String,
+        memberName: String,
+        nickname: String,
+        profileImageLink: URL?,
+        schoolName: String,
+        status: AttendanceStatus,
+        reason: String?,
+        requestedAt: Date
+    ) {
+        self.id = id
+        self.attendanceId = attendanceId
+        self.memberId = memberId
+        self.memberName = memberName
+        self.nickname = nickname
+        self.profileImageLink = profileImageLink
+        self.schoolName = schoolName
+        self.status = status
+        self.reason = reason
+        self.requestedAt = requestedAt
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Identifier/Identifier.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Identifier/Identifier.swift
@@ -1,0 +1,43 @@
+//
+//  Identifier.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+// MARK: - Identifier
+// 서버 API 통신용 식별자 타입들
+// - 타입 안전성: String 간 혼동 방지 (SessionID vs UserID)
+// - SwiftUI Identifiable용 UUID와는 별개 (UUID는 ForEach/List diffing 전용)
+
+/// 세션(스터디/세미나) 식별자
+/// - 출석 요청, 세션 조회 등 서버 API 호출 시 사용
+public struct SessionID: Hashable, Codable {
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+}
+
+/// 사용자 식별자
+/// - 출석 요청, 사용자 정보 조회 등 서버 API 호출 시 사용
+public struct UserID: Hashable, Codable {
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+}
+
+/// 출석 기록 식별자
+/// - 출석 상태 변경, 출석 기록 조회 등 서버 API 호출 시 사용
+public struct AttendanceID: Hashable, Codable {
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Map/Address.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Map/Address.swift
@@ -1,0 +1,23 @@
+//
+//  Address.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 주소 정보
+///
+/// 지오코딩 결과로 얻은 주소를 전체/시/구 단위로 구분하여 저장합니다.
+public struct Address: Equatable {
+    public let fullAddress: String
+    public let city: String
+    public let district: String
+
+    public init(fullAddress: String, city: String, district: String) {
+        self.fullAddress = fullAddress
+        self.city = city
+        self.district = district
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Map/Coordinate.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Map/Coordinate.swift
@@ -1,0 +1,21 @@
+//
+//  Coordinate.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 위경도 좌표
+///
+/// GPS 출석, 지도 표시 등에서 사용하는 위치 좌표 값 타입입니다.
+public struct Coordinate: Hashable, Codable, Sendable {
+    public let latitude: Double
+    public let longitude: Double
+
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Map/Geofence.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Map/Geofence.swift
@@ -1,0 +1,22 @@
+//
+//  Geofence.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+import CoreLocation
+
+/// 지오펜스 영역
+///
+/// 세션 장소를 중심으로 한 원형 영역으로, GPS 출석 유효 범위를 정의합니다.
+public struct Geofence {
+    public let center: Coordinate
+    public let radiusInMeters: CLLocationDistance
+
+    public init(center: Coordinate, radiusInMeters: CLLocationDistance) {
+        self.center = center
+        self.radiusInMeters = radiusInMeters
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorPendingMember.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorPendingMember.swift
@@ -1,0 +1,72 @@
+//
+//  OperatorPendingMember.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 승인 대기 중인 멤버 정보
+///
+/// 출석 승인을 기다리고 있는 멤버의 정보를 담습니다.
+public struct OperatorPendingMember: Identifiable, Equatable {
+    public let id: UUID
+    public let serverID: String?
+    public let name: String
+    public let nickname: String?
+    public let university: String
+    public let requestTime: Date
+    public let reason: String?
+    public let profileImageURL: String?
+
+    public init(
+        id: UUID = .init(),
+        serverID: String? = nil,
+        name: String,
+        nickname: String? = nil,
+        university: String,
+        requestTime: Date,
+        reason: String? = nil,
+        profileImageURL: String? = nil
+    ) {
+        self.id = id
+        self.serverID = serverID
+        self.name = name
+        self.nickname = nickname
+        self.university = university
+        self.requestTime = requestTime
+        self.reason = reason
+        self.profileImageURL = profileImageURL
+    }
+
+    /// 사유가 있는지 여부
+    public var hasReason: Bool {
+        reason != nil && !(reason?.isEmpty ?? true)
+    }
+
+    /// 표시용 이름 (닉네임/이름 또는 이름만)
+    public var displayName: String {
+        if let nickname = nickname {
+            return "\(nickname)/\(name)"
+        }
+        return name
+    }
+}
+
+// MARK: - Domain → Presentation 변환
+
+extension OperatorPendingMember {
+    /// PendingAttendanceRecord(Domain) → OperatorPendingMember(Presentation) 변환
+    public init(from record: PendingAttendanceRecord) {
+        self.init(
+            serverID: String(record.attendanceId),
+            name: record.memberName,
+            nickname: record.nickname,
+            university: record.schoolName,
+            requestTime: record.requestedAt,
+            reason: record.reason,
+            profileImageURL: record.profileImageLink?.absoluteString
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceStats.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceStats.swift
@@ -1,0 +1,49 @@
+//
+//  ScheduleAttendanceStats.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 일정별 출석 통계
+///
+/// `GET /api/v1/schedules` 응답에서 출석 집계 필드만 추출한 모델.
+/// `attendanceRate`는 0.0-1.0 범위 (DTO에서 변환 완료).
+public struct ScheduleAttendanceStats: Equatable, Sendable {
+    public let scheduleId: Int
+    public let name: String
+    public let date: String
+    public let startTime: String
+    public let endTime: String
+    public let locationName: String
+    public let totalCount: Int
+    public let presentCount: Int
+    public let pendingCount: Int
+    public let attendanceRate: Double
+
+    public init(
+        scheduleId: Int,
+        name: String,
+        date: String,
+        startTime: String,
+        endTime: String,
+        locationName: String,
+        totalCount: Int,
+        presentCount: Int,
+        pendingCount: Int,
+        attendanceRate: Double
+    ) {
+        self.scheduleId = scheduleId
+        self.name = name
+        self.date = date
+        self.startTime = startTime
+        self.endTime = endTime
+        self.locationName = locationName
+        self.totalCount = totalCount
+        self.presentCount = presentCount
+        self.pendingCount = pendingCount
+        self.attendanceRate = attendanceRate
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (Domain 모델 이관)

## 🛠️ 작업내용

- Attendance 관련 도메인 모델/열거형 18개 파일을 `ActivityDomain` Tuist 모듈로 이관
- SwiftUI 의존성 완전 제거 (`AttendanceStatus`, `MyAttendanceItemStatus`의 Color 프로퍼티)
- `memberId` 타입을 `Int` → `String`으로 변경 (서버 응답 타입과 일치)
- `SessionID`, `UserID`, `AttendanceID` 강타입 Identifier wrapper 이관
- 보조 타입 함께 이관: `Coordinate`, `Address`, `Geofence`, `OperatorPendingMember`
- `MyAttendanceItemModel`, `OperatorSessionAttendance`는 Session 의존으로 제외 (#604)

resolves #590

## 📋 추후 진행 상황

- [ ] #604 — Session 모델 + 잔여 Attendance 모델 ActivityDomain 이관
- [ ] Color 매핑 Presentation extension 복원 (#604에 포함)
- [ ] Identifier 타입 UMCFoundation 승격 검토 (크로스 Feature 사용 시)

## 📌 리뷰 포인트

- `Domain/Sources/Enums/Attendance/` — SwiftUI Color 프로퍼티 제거가 적절한지 (backgroundColor, fontColor)
- `Domain/Sources/Models/Attendance/AttendanceRecord.swift`, `PendingAttendanceRecord.swift` — `memberId: Int → String` 타입 변경
- `Domain/Sources/Models/Identifier/Identifier.swift` — 강타입 ID wrapper 구조
- 모든 타입의 `public` 접근제어자 + `public init` 적용 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)