### PR TITLE
♻️ [Refactor] 공지 에디터 주석 복원

### DIFF
--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -12,6 +12,10 @@ import SwiftData
 import SwiftUI
 import TipKit
 
+/// UMC 동아리 운영 관리 앱의 진입점
+///
+/// 앱 상태(splash/login/signUp/main)에 따라 루트 화면을 전환하고,
+/// DIContainer, ErrorHandler, ModelContainer를 하위 뷰에 주입합니다.
 @main
 struct AppProductApp: App {
 
@@ -26,16 +30,22 @@ struct AppProductApp: App {
 
     // MARK: - AppState
 
+    /// 앱 전체 화면 상태
     private enum AppState: Equatable {
+        /// 스플래시 화면 (토큰 검사 중)
         case splash
+        /// 로그인 화면
         case login
+        /// 회원가입 화면
         case signUp(
             verificationToken: String,
             email: String?,
             fullName: String?,
             postRegisterLoginContext: PostRegisterLoginContext?
         )
+        /// 승인 대기 화면
         case pendingApproval
+        /// 메인 화면 (탭)
         case main
     }
     
@@ -137,10 +147,12 @@ extension AppProductApp {
         .animation(.easeInOut(duration: 0.28), value: appState)
     }
     
+    /// Auth Feature의 UseCase Provider
     private var authProvider: AuthUseCaseProviding {
         container.resolve(AuthUseCaseProviding.self)
     }
 
+    /// 앱 상태를 애니메이션과 함께 전환합니다.
     private func transition(to state: AppState) {
         guard state != appState else { return }
         withAnimation {
@@ -148,6 +160,7 @@ extension AppProductApp {
         }
     }
 
+    /// ErrorHandler의 currentError를 AlertPrompt 바인딩으로 변환합니다.
     private var errorAlertBinding: Binding<AlertPrompt?> {
         Binding(
             get: {
@@ -172,6 +185,7 @@ extension AppProductApp {
         )
     }
 
+    /// 루트 화면 전환에 사용하는 공통 트랜지션
     private var rootTransition: AnyTransition {
         .asymmetric(
             insertion: .opacity.combined(with: .move(edge: .trailing)),
@@ -185,6 +199,7 @@ extension AppProductApp {
         _ = AuthController.handleOpenUrl(url: url)
     }
     
+    /// AppDelegate 초기 설정을 1회만 수행합니다.
     private func configureAppDelegateIfNeeded() {
         guard !didConfigureAppDelegate else { return }
         didConfigureAppDelegate = true
@@ -194,6 +209,7 @@ extension AppProductApp {
         )
     }
     
+    /// 세션 만료 시 캐시 초기화 후 로그인 화면으로 전환합니다.
     private func handleAuthSessionExpired() {
         UserDefaults.standard.set(false, forKey: AppStorageKey.canAutoLogin)
         Task {
@@ -203,6 +219,7 @@ extension AppProductApp {
         transition(to: .login)
     }
 
+    /// 하위 뷰에서 앱 상태를 전환할 수 있도록 제공하는 AppFlow Environment 값
     private var appFlow: AppFlow {
         AppFlow(
             showLogin: { transition(to: .login) },
@@ -226,6 +243,10 @@ extension AppProductApp {
         )
     }
     
+    /// SwiftData ModelContainer를 생성합니다.
+    ///
+    /// CloudKit 동기화를 시도하고, 실패 시 로컬 저장소로 폴백합니다.
+    /// - Returns: 생성된 ModelContainer (CloudKit 또는 로컬)
     private static func makeModelContainer() -> ModelContainer {
         let schema = Schema([
             NoticeHistoryData.self,
@@ -244,6 +265,7 @@ extension AppProductApp {
                 configurations: [cloudConfiguration]
             )
         } catch {
+            // CloudKit 설정/권한/모델 제약 이슈가 있으면 로컬 저장소로 폴백합니다.
             print("SwiftData CloudKit init failed. Fallback to local store: \(error)")
             
             do {

--- a/AppProduct/AppProduct/Core/Common/Error/Handler/ErrorHandler.swift
+++ b/AppProduct/AppProduct/Core/Common/Error/Handler/ErrorHandler.swift
@@ -9,13 +9,78 @@ import Foundation
 import FoundationModels
 import os.log
 
+/// 앱 전역에서 발생하는 에러를 중앙 집중식으로 처리하는 핸들러.
+///
+/// Mediator 패턴을 적용하여 여러 ViewModel에서 발생하는 에러를 한 곳에서 수집하고 처리합니다.
+///
+/// ErrorHandler의 역할:
+/// 1. 에러 변환: `MoyaError`, `URLError` 등을 ``AppError``로 통합
+/// 2. 로깅: `os.log`를 사용하여 에러 정보 기록
+/// 3. 분석: Firebase, Sentry 등 외부 서비스로 에러 데이터 전송
+/// 4. 특수 처리: 401 Unauthorized → 자동 로그아웃
+/// 5. UI 바인딩: ``currentError``를 통해 View에서 Alert 표시
+///
+/// ## Usage
+///
+/// **App에서 Environment로 주입:**
+///
+/// ```swift
+/// @main
+/// struct AppProductApp: App {
+///     @State private var errorHandler = ErrorHandler()
+///
+///     var body: some Scene {
+///         WindowGroup {
+///             ContentView()
+///                 .environment(errorHandler)
+///                 .globalErrorAlert(errorHandler: errorHandler)
+///         }
+///     }
+/// }
+/// ```
+///
+/// **ViewModel에서 에러 처리:**
+///
+/// ```swift
+/// func fetchNotices() async {
+///     do {
+///         notices = try await useCase.execute()
+///     } catch {
+///         errorHandler.handle(error, context: ErrorContext(
+///             feature: "Notice",
+///             action: "fetchList",
+///             retryAction: { [weak self] in await self?.fetchNotices() }
+///         ))
+///     }
+/// }
+/// ```
+///
+/// - Important: 에러 처리 방식은 UX 관점에서 결정하세요.
+///   - **ErrorHandler**: 작업 흐름 중단, 즉각적인 사용자 액션이 필요한 경우 (Alert)
+///   - **Loadable**: 데이터 상태와 함께 관리, 화면 내 상태 변화 표시 (인라인)
+///
+///   예시:
+///   - 세션 만료, 권한 필요, 네트워크 오류 → ErrorHandler
+///   - 리스트 로딩 실패, 폼 검증 실패, 범위 벗어남 → Loadable
+///
+/// - Warning: 현재 특수 에러 처리는 `NotificationCenter`를 사용합니다.
+///   추후 `AppState + Environment` 패턴으로 리팩터링 예정입니다.
+///
+/// - SeeAlso: ``ErrorContext``, ``AppError``, ``PresentableError``, ``Loadable``
 @Observable
 final class ErrorHandler {
 
     // MARK: - Property
 
+    /// 현재 표시해야 할 에러.
+    ///
+    /// View에서 이 값을 관찰하여 에러 Alert을 표시합니다.
+    /// `nil`이면 에러가 없는 상태입니다.
+    ///
+    /// - Note: 외부에서 직접 수정할 수 없습니다. ``handle(_:context:)``를 사용하세요.
     private(set) var currentError: PresentableError?
 
+    /// 에러 로깅에 사용되는 Logger.
     private let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "AppProduct",
         category: "ErrorHandler"
@@ -23,11 +88,29 @@ final class ErrorHandler {
 
     // MARK: - Init
 
+    /// ErrorHandler를 초기화합니다.
+    ///
+    /// App 레벨에서 한 번만 생성하고 Environment로 주입합니다.
     init() {}
 
     // MARK: - Public Methods
 
+    /// 에러를 처리합니다.
+    ///
+    /// 에러 처리의 단일 진입점입니다. 다음 순서로 처리합니다:
+    /// 1. `Error` → ``AppError`` 변환
+    /// 2. os.log로 로깅
+    /// 3. Analytics 전송
+    /// 4. 특수 케이스 처리 (401 → 로그아웃)
+    /// 5. ``currentError`` 설정 → View에서 Alert 표시
+    ///
+    /// - Parameters:
+    ///   - error: 발생한 에러. ``AppError``, `MoyaError`, `URLError` 등 모든 `Error` 타입 가능.
+    ///   - context: 에러 발생 위치와 재시도 정보를 담은 컨텍스트.
+    ///
+    /// - Precondition: Main Thread에서 호출해야 합니다.
     func handle(_ error: Error, context: ErrorContext) {
+        // 사용자가 의도적으로 취소한 경우 — Alert 없이 종료
         if error is CancellationError {
             logger.info("[\(context.feature)/\(context.action)] Task cancelled")
             return
@@ -52,26 +135,55 @@ final class ErrorHandler {
         )
     }
 
+    /// 현재 표시 중인 에러를 초기화합니다.
+    ///
+    /// 에러 Alert이 닫힐 때 자동으로 호출됩니다.
     func clearError() {
         currentError = nil
     }
 
     // MARK: - Private Methods
 
+    /// 임의의 Error를 AppError로 변환합니다.
+    ///
+    /// - Parameter error: 변환할 에러.
+    /// - Returns: 통합된 ``AppError``.
+    ///
+    /// - Note: 지원 타입: `AppError`, `NetworkError`, `RepositoryError`, `AuthError`,
+    ///   `ValidationError`, `DomainError`, `MoyaError`, `URLError`, `DecodingError`
     private func convert(_ error: Error) -> AppError {
+        // 1. AppError는 그대로 반환
         if let appError = error as? AppError { return appError }
+
+        // 2. NetworkError → AppError.network (Actor 기반 네트워크 클라이언트)
         if let networkError = error as? NetworkError { return .network(networkError) }
+
+        // 3. RepositoryError
         if let repositoryError = error as? RepositoryError { return .repository(repositoryError) }
+
+        // 4. ValidationError
         if let validationError = error as? ValidationError { return .validation(validationError) }
+
+        // 5. AuthError
         if let authError = error as? AuthError { return .auth(authError) }
+
+        // 6. DomainError
         if let domainError = error as? DomainError { return .domain(domainError) }
+
+        // 7. URLError → NetworkError 변환
         if let urlError = error as? URLError { return .network(convertURLError(urlError)) }
+
+        // 8. DecodingError → RepositoryError 변환
         if let decodingError = error as? DecodingError {
             return .repository(.decodingError(detail: describeDecodingError(decodingError)))
         }
+
+        // 9. LanguageModelSession.GenerationError → DomainError 변환
         if let generationError = error as? LanguageModelSession.GenerationError {
             return .domain(.custom(message: describeGenerationError(generationError)))
         }
+
+        // 10. 알 수 없는 에러
         return .unknown(message: error.localizedDescription)
     }
 
@@ -132,6 +244,9 @@ final class ErrorHandler {
 
     // MARK: - Logging
 
+    /// 에러를 os.log로 기록합니다.
+    ///
+    /// 로그 레벨은 에러의 ``AppError/severity``에 따라 결정됩니다.
     private func log(_ error: AppError, context: ErrorContext) {
         let message = """
         [Error] \(context.feature)/\(context.action)
@@ -152,6 +267,9 @@ final class ErrorHandler {
 
     // MARK: - Analytics
 
+    /// 에러를 외부 분석 서비스로 전송합니다.
+    ///
+    /// - Todo: Firebase Analytics, Sentry 등 연동
     private func trackError(_ error: AppError, context: ErrorContext) {
         // TODO: Firebase Analytics, Sentry 등 연동 - [25.01.07] 이재원
     }
@@ -159,12 +277,27 @@ final class ErrorHandler {
     // MARK: - Special Cases
 
     // TODO: [Refactor] NotificationCenter → AppState + Environment 패턴으로 리팩터링 예정 - [25.01.07] 이재원
+    // 현재: NotificationCenter 사용 (타입 안전하지 않음)
+    // 개선: AppState를 주입받아 직접 상태 변경 (DIContainer 구현 후)
+
+    /// 특수 에러를 처리합니다.
+    ///
+    /// Alert 표시 대신 앱 전체 상태 변경이 필요한 에러를 처리합니다.
+    ///
+    /// - Parameters:
+    ///   - error: 처리할 에러.
+    ///   - context: 에러 컨텍스트.
+    /// - Returns: 특수 처리가 수행되었으면 `true`.
+    ///
+    /// - Warning: 현재 `NotificationCenter`를 사용합니다. 추후 리팩터링 필요.
     private func handleSpecialCases(_ error: AppError, context: ErrorContext) -> Bool {
         switch error {
+        // 인증 만료 → 자동 로그아웃
         case .auth(.sessionExpired):
             NotificationCenter.default.post(name: .authSessionExpired, object: nil)
             return true
 
+        // NetworkError 인증 관련 에러 → 자동 로그아웃
         case .network(.unauthorized),
              .network(.tokenRefreshFailed),
              .network(.noRefreshToken),
@@ -172,6 +305,7 @@ final class ErrorHandler {
             NotificationCenter.default.post(name: .authSessionExpired, object: nil)
             return true
 
+        // 승인 대기 상태 → 대기 화면으로 이동
         case .auth(.pendingApproval):
             NotificationCenter.default.post(name: .navigateToPendingApproval, object: nil)
             return true

--- a/AppProduct/AppProduct/Features/MyPage/Domain/Models/ProductTeamIntroduction.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Domain/Models/ProductTeamIntroduction.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// 프로덕트 팀 소개 화면에 표시할 정적 콘텐츠 모델입니다.
 struct ProductTeamIntroduction: Sendable {
     let paragraphs: [String]
     let teamPageURLString: String

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/ProductTeamIntroductionView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/ProductTeamIntroductionView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 마이페이지에서 프로덕트 팀 소개 글을 표시하는 화면입니다.
 struct ProductTeamIntroductionView: View {
     // MARK: - Property
 

--- a/AppProduct/AppProduct/Features/Notice/Data/AITokenDailyUsageRecord.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/AITokenDailyUsageRecord.swift
@@ -8,6 +8,10 @@
 import Foundation
 import SwiftData
 
+/// AI 토큰 일일 사용량 로컬 저장 모델 (SwiftData + CloudKit Sync)
+///
+/// 멤버별 당일 AI 개선 기능 토큰 누적 사용량을 보존합니다.
+/// 키는 (memberId, date의 startOfDay) 조합으로 식별합니다.
 @Model
 final class AITokenDailyUsageRecord {
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeItem/NoticeItem.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeItem/NoticeItem.swift
@@ -28,6 +28,8 @@ private enum Constant {
 
 // MARK: - NoticeItem
 
+/// 공지 탭 - 리스트
+
 struct NoticeItem: View {
     // MARK: - Properties
 
@@ -77,6 +79,7 @@ private struct NoticeItemPresenter: View, Equatable {
     }
 }
 
+/// 태그 + 필독 + 알림 + 날짜
 private struct TopSection: View, Equatable {
     let model: NoticeItemModel
 
@@ -107,6 +110,7 @@ private struct TopSection: View, Equatable {
     }
 }
 
+/// 제목 + 내용
 private struct ContentSection: View, Equatable {
     let model: NoticeItemModel
 
@@ -124,6 +128,7 @@ private struct ContentSection: View, Equatable {
     }
 }
 
+/// 작성자 + 링크/투표 여부 + 조회수
 private struct BottomSection: View, Equatable {
     let model: NoticeItemModel
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarTypes.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarTypes.swift
@@ -7,12 +7,14 @@
 
 import Foundation
 
+/// 공지 에디터 툴바의 표시 상태를 정의합니다.
 enum EditorToolbarMode {
     case `default`
     case textSelected
     case tableCell
 }
 
+/// 공지 에디터 단락 스타일 프리셋을 정의합니다.
 enum EditorParagraphStyle: String, CaseIterable {
     case title
     case heading
@@ -21,22 +23,38 @@ enum EditorParagraphStyle: String, CaseIterable {
     case mono
 }
 
+/// 공지 에디터 목록 스타일을 정의합니다.
 enum EditorListStyle {
     case bullet
     case dash
     case number
 }
 
+/// 공지 에디터 전역 상수입니다.
 enum EditorConstants {
+    /// 블록 인용문에 적용되는 들여쓰기(pt) 값입니다. 에디터와 역직렬화에서 공통 사용합니다.
     static let blockquoteIndent: CGFloat = 14
 }
 
 extension NSAttributedString.Key {
+
+    /// 블록 인용문 적용 여부를 저장하는 키입니다.
     static let editorBlockquote = NSAttributedString.Key("EditorToolbarBlockquote")
+
+    /// 블록 인용문 테두리 색상을 저장하는 키입니다.
     static let editorBlockquoteBorderColor = NSAttributedString.Key("EditorToolbarBlockquoteBorderColor")
+
+    /// 블록 인용문 이전의 headIndent 값을 저장하는 키입니다.
     static let editorBlockquoteBaseHeadIndent = NSAttributedString.Key("EditorToolbarBlockquoteBaseHeadIndent")
+
+    /// 블록 인용문 이전의 firstLineHeadIndent 값을 저장하는 키입니다.
     static let editorBlockquoteBaseFirstLineHeadIndent = NSAttributedString.Key("EditorToolbarBlockquoteBaseFirstLineHeadIndent")
+
+    /// 현재 목록 스타일 식별자를 저장하는 키입니다.
     static let editorListStyle = NSAttributedString.Key("EditorToolbarListStyle")
-    /// UIKit이 커서 이동 시 typingAttributes의 oblique matrix를 버리므로 italic 활성 상태를 별도 추적합니다.
+
+    /// Pretendard oblique italic 상태를 저장하는 키입니다.
+    /// UIKit이 커서 이동 시 typingAttributes의 oblique matrix를 버리므로
+    /// 이 키로 italic 활성 상태를 별도 추적합니다.
     static let editorItalic = NSAttributedString.Key("EditorToolbarItalic")
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarViewModel+FormattingHelpers.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarViewModel+FormattingHelpers.swift
@@ -13,6 +13,7 @@ extension EditorToolbarViewModel {
 
     // MARK: - Font Helpers
 
+    /// 저장된 폰트 속성 또는 기본 폰트를 반환합니다.
     func resolvedFont(from attribute: Any?, at location: Int, in storage: NSTextStorage) -> UIFont {
         if let font = attribute as? UIFont {
             return font
@@ -26,6 +27,10 @@ extension EditorToolbarViewModel {
         return font(for: .body)
     }
 
+    /// 지정한 단락 스타일에 대응하는 폰트를 반환합니다.
+    ///
+    /// 에디터와 상세 화면이 동일한 Pretendard 폰트를 사용하도록 Pretendard 기반으로 반환합니다.
+    /// Pretendard 폰트를 찾지 못한 경우 시스템 폰트로 폴백합니다.
     func font(for style: EditorParagraphStyle) -> UIFont {
         switch style {
         case .title:
@@ -41,7 +46,9 @@ extension EditorToolbarViewModel {
         }
     }
 
-    /// Pretendard italic은 변형 폰트가 없으므로 oblique matrix로 기울임을 표현합니다.
+    /// 폰트의 심볼릭 트레이트 토글 결과를 계산합니다.
+    ///
+    /// Pretendard 폰트는 italic 변형이 없으므로 oblique matrix로 기울임을 표현합니다.
     func updatedFont(from font: UIFont, toggling trait: UIFontDescriptor.SymbolicTraits, enabled: Bool) -> UIFont {
         // Pretendard 폰트 전용 처리
         if font.fontName.hasPrefix("Pretendard") {
@@ -89,12 +96,16 @@ extension EditorToolbarViewModel {
         return .systemFont(ofSize: font.pointSize, weight: resolvedWeight)
     }
 
+    /// 폰트의 굵기 값을 추정합니다.
     func weight(for font: UIFont) -> CGFloat {
         let traits = font.fontDescriptor.object(forKey: .traits) as? [UIFontDescriptor.TraitKey: Any]
         return traits?[.weight] as? CGFloat ?? UIFont.Weight.regular.rawValue
     }
 
-    /// Pretendard-SemiBold는 symbolicTraits에 .traitBold가 없으므로 폰트 이름으로 판별합니다.
+    /// Pretendard 커스텀 폰트를 포함하여 bold 여부를 정확히 판별합니다.
+    ///
+    /// Pretendard-SemiBold는 `UIFontDescriptor.symbolicTraits`에 `.traitBold`가
+    /// 포함되지 않으므로 폰트 이름 기반으로 판별합니다.
     func isFontBold(_ font: UIFont) -> Bool {
         if font.fontName.hasPrefix("Pretendard") {
             return font.fontName.contains("Bold") || font.fontName.contains("SemiBold")
@@ -104,6 +115,10 @@ extension EditorToolbarViewModel {
 
     // MARK: - Uniform Attribute Checks
 
+    /// 주어진 범위의 모든 폰트가 동일 트레이트를 가지는지 확인합니다.
+    ///
+    /// Pretendard 폰트는 italic 변형이 없어 oblique matrix로 표현되므로,
+    /// `.traitItalic` 확인 시 matrix.c 값도 함께 감지합니다.
     func rangeHasUniformFontTrait(_ range: NSRange, trait: UIFontDescriptor.SymbolicTraits, in storage: NSTextStorage) -> Bool {
         guard range.length > 0 else { return false }
 
@@ -132,6 +147,7 @@ extension EditorToolbarViewModel {
         return hasContent && isUniform
     }
 
+    /// 주어진 범위의 모든 텍스트가 동일 장식을 가지는지 확인합니다.
     func rangeHasUniformTextDecoration(_ range: NSRange, key: NSAttributedString.Key, in storage: NSTextStorage) -> Bool {
         guard range.length > 0 else { return false }
 
@@ -150,6 +166,7 @@ extension EditorToolbarViewModel {
         return hasContent && isUniform
     }
 
+    /// 현재 범위에 동일한 강조 색이 적용되었는지 확인합니다.
     func uniformHighlightColor(in range: NSRange, storage: NSTextStorage) -> Color? {
         guard range.length > 0 else { return nil }
 
@@ -174,6 +191,7 @@ extension EditorToolbarViewModel {
 
     // MARK: - Style Detection
 
+    /// 지정 위치의 단락 스타일 속성을 반환합니다.
     func nsParagraphStyle(at location: Int, in storage: NSTextStorage) -> NSParagraphStyle {
         guard storage.length > 0, location < storage.length else {
             return NSParagraphStyle.default
@@ -181,6 +199,7 @@ extension EditorToolbarViewModel {
         return storage.attribute(.paragraphStyle, at: location, effectiveRange: nil) as? NSParagraphStyle ?? .default
     }
 
+    /// 현재 위치의 폰트 속성으로 대표 단락 스타일을 판별합니다.
     func detectedParagraphStyle(at location: Int, in storage: NSTextStorage) -> EditorParagraphStyle {
         let fontAttribute = storage.length > 0 && location < storage.length
             ? storage.attribute(.font, at: location, effectiveRange: nil)
@@ -204,6 +223,7 @@ extension EditorToolbarViewModel {
         return .body
     }
 
+    /// 현재 위치에 블록 인용문 속성이 적용되었는지 확인합니다.
     func isBlockquoteAttributeEnabled(at location: Int, in storage: NSTextStorage) -> Bool {
         guard storage.length > 0, location < storage.length else { return false }
         return (storage.attribute(.editorBlockquote, at: location, effectiveRange: nil) as? Bool) == true
@@ -211,6 +231,7 @@ extension EditorToolbarViewModel {
 
     // MARK: - List Helpers
 
+    /// 목록 스타일에 대응하는 접두사 문자열을 반환합니다.
     func listPrefix(for style: EditorListStyle) -> String {
         switch style {
         case .bullet:
@@ -222,6 +243,7 @@ extension EditorToolbarViewModel {
         }
     }
 
+    /// 목록 스타일을 저장하기 위한 식별자를 반환합니다.
     func listStyleIdentifier(for style: EditorListStyle) -> String {
         switch style {
         case .bullet:
@@ -233,6 +255,7 @@ extension EditorToolbarViewModel {
         }
     }
 
+    /// 단락 문자열의 기존 목록 접두사 범위를 찾습니다.
     func existingListPrefixRange(in paragraphText: String) -> NSRange? {
         let nsString = paragraphText as NSString
         let fullRange = NSRange(location: 0, length: nsString.length)
@@ -242,6 +265,7 @@ extension EditorToolbarViewModel {
 
     private static let listPrefixRegex = try! NSRegularExpression(pattern: "^(?:•|–|\\d+\\.)\\s+")
 
+    /// 현재 단락에 적용된 목록 스타일을 판별합니다.
     func detectedListStyle(in paragraphRange: NSRange, storage: NSTextStorage) -> EditorListStyle? {
         let paragraphText = (storage.string as NSString).substring(with: paragraphRange)
         if paragraphText.hasPrefix("• ") {
@@ -258,6 +282,7 @@ extension EditorToolbarViewModel {
 
     // MARK: - Color Helpers
 
+    /// 두 UIKit 색상이 동일한지 비교합니다.
     func colorsEqual(_ lhs: UIColor?, _ rhs: UIColor?) -> Bool {
         switch (lhs, rhs) {
         case (nil, nil):

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarViewModel+RangeHelpers.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarViewModel+RangeHelpers.swift
@@ -12,6 +12,7 @@ extension EditorToolbarViewModel {
 
     // MARK: - Range Helpers
 
+    /// 유효한 선택 범위를 텍스트 스토리지 길이에 맞게 보정합니다.
     func clampedSelectedRange(in storage: NSTextStorage) -> NSRange {
         let safeLocation = selectedRange.location == NSNotFound ? 0 : min(max(selectedRange.location, 0), storage.length)
         let requestedLength = selectedRange.length == NSNotFound ? 0 : max(selectedRange.length, 0)
@@ -19,6 +20,7 @@ extension EditorToolbarViewModel {
         return NSRange(location: safeLocation, length: safeLength)
     }
 
+    /// 속성 조회에 사용할 안전한 위치를 계산합니다.
     func safeAttributeLocation(for range: NSRange, in storage: NSTextStorage) -> Int {
         guard storage.length > 0 else { return 0 }
         if range.location < storage.length {
@@ -27,17 +29,23 @@ extension EditorToolbarViewModel {
         return max(0, storage.length - 1)
     }
 
+    /// 현재 단락 범위를 계산합니다.
+    /// EOF 빈 줄(커서가 storage.length에 있고 마지막 문자가 \n인 경우)도 올바르게 처리합니다.
     func currentParagraphRange(in storage: NSTextStorage) -> NSRange {
         guard storage.length > 0 else {
             return NSRange(location: 0, length: 0)
         }
 
         let clampedRange = clampedSelectedRange(in: storage)
+        // NSString.paragraphRange는 location == length를 허용하므로
+        // storage.length - 1로 clamp하지 않습니다.
         let anchorLocation = min(clampedRange.location, storage.length)
         let nsString = storage.string as NSString
         return nsString.paragraphRange(for: NSRange(location: anchorLocation, length: 0))
     }
 
+    /// 커서가 EOF 빈 단락에 있는지 확인합니다.
+    /// EOF 빈 단락에서는 storage attribute 대신 typingAttributes를 기준으로 처리해야 합니다.
     func isAtEOFEmptyParagraph(in storage: NSTextStorage) -> Bool {
         let clampedRange = clampedSelectedRange(in: storage)
         return storage.length > 0
@@ -45,6 +53,7 @@ extension EditorToolbarViewModel {
             && (storage.string as NSString).character(at: storage.length - 1) == 0x0A // \n
     }
 
+    /// 선택 범위가 걸친 전체 단락 범위를 계산합니다.
     func selectedParagraphRange(in storage: NSTextStorage) -> NSRange {
         guard storage.length > 0 else {
             return NSRange(location: 0, length: 0)
@@ -60,6 +69,7 @@ extension EditorToolbarViewModel {
         return nsString.paragraphRange(for: NSRange(location: anchorLocation, length: 0))
     }
 
+    /// 단락 범위를 개별 단락 배열로 분해합니다.
     func paragraphRanges(in range: NSRange, storage: NSTextStorage) -> [NSRange] {
         guard storage.length > 0, range.length > 0 else { return [] }
 
@@ -79,6 +89,8 @@ extension EditorToolbarViewModel {
         return ranges
     }
 
+    /// 동기화 시 사용할 실제 속성 조회 범위를 계산합니다.
+    /// EOF 빈 단락에서는 nil을 반환하여 typingAttributes 기반 처리를 유도합니다.
     func syncRange(in storage: NSTextStorage) -> NSRange? {
         let clampedRange = clampedSelectedRange(in: storage)
         if clampedRange.length > 0 {
@@ -86,12 +98,14 @@ extension EditorToolbarViewModel {
         }
 
         guard storage.length > 0 else { return nil }
+        // EOF 빈 단락(커서가 storage.length에 있는 경우)은 nil 반환
         if clampedRange.location >= storage.length {
             return nil
         }
         return NSRange(location: clampedRange.location, length: 1)
     }
 
+    /// 선택 치환 후 커서 위치와 길이를 보정합니다.
     func adjustSelectedRange(forReplacing range: NSRange, with replacementLength: Int) {
         let delta = replacementLength - range.length
         let selectionEnd = NSMaxRange(selectedRange)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarViewModel.swift
@@ -103,6 +103,7 @@ final class EditorToolbarViewModel {
         toggleTextDecoration(.strikethroughStyle, enabled: !isStrikethrough, style: NSUnderlineStyle.single.rawValue)
     }
 
+    /// 현재 단락의 블록 인용문 스타일을 토글합니다.
     @MainActor
     func toggleBlockquote() {
         guard let storage = textStorage else { return }
@@ -414,6 +415,7 @@ final class EditorToolbarViewModel {
             return
         }
 
+        // 빈 에디터 또는 EOF 빈 단락: typingAttributes만으로 상태를 결정합니다.
         if storage.length == 0 || isAtEOFEmptyParagraph(in: storage), let tv = textView {
             syncFormattingStateFromTypingAttributes(tv)
             return

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarViewModel.swift
@@ -9,57 +9,95 @@ import Foundation
 import SwiftUI
 import UIKit
 
+/// 공지 에디터 툴바의 서식 상태와 편집 액션을 관리합니다.
 @Observable
 final class EditorToolbarViewModel {
 
     // MARK: - Property
 
+    /// 블록 인용문에 적용할 기본 들여쓰기 값입니다.
     private let blockquoteIndent: CGFloat = EditorConstants.blockquoteIndent
+
+    /// 일반 들여쓰기 증감 단위입니다.
     private let indentStep: CGFloat = 24
 
+    /// 현재 툴바의 표시 모드입니다.
     var toolbarMode: EditorToolbarMode = .default
+
+    /// 포맷 패널 노출 여부입니다.
     private(set) var isFormatPanelVisible: Bool = false
+
+    /// 에디터(리치 텍스트 뷰)가 포커스 상태인지 여부입니다.
     private(set) var isEditorActive: Bool = false
+
+    /// 선택 영역이 굵게 표시되는지 여부입니다.
     private(set) var isBold: Bool = false
+
+    /// 선택 영역이 기울임꼴인지 여부입니다.
     private(set) var isItalic: Bool = false
+
     /// italic 토글 직후 UIKit 리셋을 거슬러 상태를 일시 보존합니다.
     private var _pendingItalicEnabled: Bool?
+
+    /// 선택 영역에 밑줄이 적용되었는지 여부입니다.
     private(set) var isUnderline: Bool = false
+
+    /// 선택 영역에 취소선이 적용되었는지 여부입니다.
     private(set) var isStrikethrough: Bool = false
+
+    /// 현재 단락에 블록 인용문 스타일이 적용되었는지 여부입니다.
     private(set) var isBlockquote: Bool = false
+
+    /// 현재 단락의 대표 단락 스타일입니다.
     private(set) var paragraphStyle: EditorParagraphStyle = .body
+
+    /// 현재 단락에 적용된 목록 스타일입니다.
     private(set) var activeListStyle: EditorListStyle?
+
+    /// 선택 영역에 적용된 배경 강조 색상입니다.
     private(set) var highlightColor: Color?
 
+    /// UITextView 연결 후 주입받는 편집 대상 텍스트 스토리지입니다.
     weak var textStorage: NSTextStorage?
+
+    /// 타이핑 속성 제어를 위한 UITextView 참조입니다.
     weak var textView: UITextView?
 
+    /// 사용자가 명시적으로 활성화한 형광펜 색상입니다. nil이면 비활성 상태입니다.
     private(set) var activeHighlightColor: UIColor?
+
+    /// 현재 UITextView의 선택 범위입니다.
     var selectedRange: NSRange = NSRange(location: 0, length: 0)
 
     // MARK: - Function
 
+    /// 기본 상태로 초기화합니다.
     init() { }
 
+    /// 선택 영역의 폰트에 굵게 서식을 토글합니다.
     @MainActor
     func toggleBold() {
         toggleFontTrait(.traitBold, shouldEnable: !isBold)
     }
 
+    /// 선택 영역의 폰트에 기울임꼴 서식을 토글합니다.
     @MainActor
     func toggleItalic() {
         toggleFontTrait(.traitItalic, shouldEnable: !isItalic)
     }
 
+    /// 첫 타이핑 후 italic 임시 추적 플래그를 초기화합니다.
     func clearPendingItalic() {
         _pendingItalicEnabled = nil
     }
 
+    /// 선택 영역의 텍스트에 밑줄 서식을 토글합니다.
     @MainActor
     func toggleUnderline() {
         toggleTextDecoration(.underlineStyle, enabled: !isUnderline, style: NSUnderlineStyle.single.rawValue)
     }
 
+    /// 선택 영역의 텍스트에 취소선 서식을 토글합니다.
     @MainActor
     func toggleStrikethrough() {
         toggleTextDecoration(.strikethroughStyle, enabled: !isStrikethrough, style: NSUnderlineStyle.single.rawValue)
@@ -168,6 +206,7 @@ final class EditorToolbarViewModel {
         syncFormattingState()
     }
 
+    /// 선택된 단락 범위에 지정한 단락 스타일 폰트를 적용합니다.
     @MainActor
     func applyParagraphStyle(_ style: EditorParagraphStyle) {
         guard let storage = textStorage else { return }
@@ -178,12 +217,14 @@ final class EditorToolbarViewModel {
         storage.addAttribute(.font, value: font, range: paragraphRange)
         storage.endEditing()
 
+        // 커서 이후 입력 텍스트에도 동일한 폰트가 적용되도록 typingAttributes 동기화
         textView?.typingAttributes[.font] = font
 
         onFormattingApplied?()
         syncFormattingState()
     }
 
+    /// 현재 단락 시작 부분에 목록 접두사를 적용하거나, 이미 같은 스타일이면 제거합니다.
     @MainActor
     func applyList(_ style: EditorListStyle) {
         guard let storage = textStorage else { return }
@@ -229,6 +270,7 @@ final class EditorToolbarViewModel {
             length: oldPrefixLength
         )
 
+        // 삽입할 접두사에 적용할 폰트: 기존 단락 본문의 폰트 → typingAttributes 폰트 → body 기본폰트 순으로 사용
         let contentOffset = replacementRange.location + oldPrefixLength
         let prefixFont: UIFont
         if contentOffset < storage.length {
@@ -246,6 +288,7 @@ final class EditorToolbarViewModel {
         storage.addAttribute(.editorListStyle, value: listStyleIdentifier(for: style), range: currentParagraphRange(in: storage))
         storage.endEditing()
 
+        // 커서가 기존 접두사 내부에 있었으면 새 접두사 뒤로, 아니면 delta만큼 보정
         let oldPrefixEnd = paragraphRange.location + oldPrefixLength
         let delta = prefix.utf16.count - oldPrefixLength
         let newCursor: Int
@@ -261,21 +304,25 @@ final class EditorToolbarViewModel {
         syncFormattingState()
     }
 
+    /// 선택된 단락 범위의 들여쓰기를 한 단계 증가시킵니다.
     @MainActor
     func applyIndent() {
         adjustParagraphIndent(by: indentStep)
     }
 
+    /// 선택된 단락 범위의 들여쓰기를 한 단계 감소시킵니다.
     @MainActor
     func applyOutdent() {
         adjustParagraphIndent(by: -indentStep)
     }
 
+    /// 선택 영역의 배경 강조 색상을 적용하고, 이후 입력되는 텍스트에도 해당 색을 유지합니다.
     @MainActor
     func applyHighlight(color: Color) {
         let uiColor = UIColor(color)
         activeHighlightColor = uiColor
 
+        // 선택 영역이 있으면 기존 텍스트에도 적용
         if let storage = textStorage {
             let clampedRange = clampedSelectedRange(in: storage)
             if clampedRange.length > 0 {
@@ -285,16 +332,19 @@ final class EditorToolbarViewModel {
             }
         }
 
+        // 이후 입력 텍스트에도 적용 (typingAttributes)
         textView?.typingAttributes[.backgroundColor] = uiColor
 
         onFormattingApplied?()
         syncFormattingState()
     }
 
+    /// 선택 영역의 배경 강조 색상을 제거하고, 이후 입력되는 텍스트의 하이라이트도 해제합니다.
     @MainActor
     func clearHighlight() {
         activeHighlightColor = nil
 
+        // 선택 영역이 있으면 기존 텍스트에서도 제거
         if let storage = textStorage {
             let clampedRange = clampedSelectedRange(in: storage)
             if clampedRange.length > 0 {
@@ -304,13 +354,16 @@ final class EditorToolbarViewModel {
             }
         }
 
+        // 이후 입력 텍스트 하이라이트 해제
         textView?.typingAttributes.removeValue(forKey: .backgroundColor)
 
         onFormattingApplied?()
         syncFormattingState()
     }
 
-    /// 하이라이트 영역을 벗어나면 다음 입력에 색이 번지지 않도록 typingAttributes를 정리합니다.
+    /// 활성 하이라이트 색상이 있으면 커서 위치의 기존 배경색과 비교하여
+    /// 일치하는 경우에만 typingAttributes에 재적용합니다.
+    /// 하이라이트 영역을 벗어나면 다음 입력에 색이 번지지 않도록 합니다.
     @MainActor
     func reapplyActiveHighlightIfNeeded() {
         guard let uiColor = activeHighlightColor,
@@ -326,10 +379,12 @@ final class EditorToolbarViewModel {
         }
     }
 
+    /// 포맷 패널 노출 상태를 토글합니다.
     func toggleFormatPanel() {
         isFormatPanelVisible.toggle()
     }
 
+    /// 포맷 패널을 닫습니다.
     func dismissFormatPanel() {
         isFormatPanelVisible = false
     }
@@ -339,15 +394,19 @@ final class EditorToolbarViewModel {
         isEditorActive = active
     }
 
+    /// 서식이 실제로 변경된 후 호출됩니다. (attributedText 바인딩 동기화용)
     var onFormattingApplied: (() -> Void)?
 
-    /// typingAttributes 변경 시 attributedText 재할당을 건너뛰고 placeholder만 갱신합니다.
+    /// typingAttributes만 변경된 경우 placeholder 갱신만 수행합니다.
+    /// attributedText 바인딩 재할당을 건너뛰어 불필요한 SwiftUI 갱신을 방지합니다.
     var onPlaceholderNeedsUpdate: (() -> Void)?
 
+    /// typingAttributes 변경 후 placeholder 갱신을 요청합니다.
     private func notifyPlaceholderUpdate() {
         onPlaceholderNeedsUpdate?()
     }
 
+    /// 선택 영역의 실제 속성을 읽어 툴바 상태를 동기화합니다.
     @MainActor
     func syncFormattingState() {
         guard let storage = textStorage else {
@@ -373,7 +432,9 @@ final class EditorToolbarViewModel {
         if clampedRange.length == 0, let tv = textView {
             let typingFont = tv.typingAttributes[.font] as? UIFont ?? font(for: .body)
             isBold = isFontBold(typingFont)
-            // UIKit이 커서 이동 시 oblique matrix를 리셋하므로 .editorItalic 커스텀 키로 상태를 추적합니다.
+            // .editorItalic 커스텀 키를 우선 확인합니다.
+            // UIKit이 typingAttributes를 재계산할 때 oblique matrix는 소실되지만
+            // 커스텀 키는 reinject 패턴으로 재주입됩니다.
             if let pending = _pendingItalicEnabled {
                 isItalic = pending
             } else if let editorItalicFlag = tv.typingAttributes[.editorItalic] as? Bool {
@@ -397,8 +458,8 @@ final class EditorToolbarViewModel {
         paragraphStyle = detectedParagraphStyle(at: paragraphLocation, in: storage)
         activeListStyle = detectedListStyle(in: paragraphRange, storage: storage)
 
-        // clearHighlight() 이후 커서가 하이라이트 텍스트 위에 있어도 툴바가 잘못 활성화되지 않도록
-        // typingAttributes 기준으로 읽습니다.
+        // 선택 없을 때: typingAttributes 기준으로 하이라이트 상태를 읽어
+        // clearHighlight() 이후에도 커서가 하이라이트된 텍스트 위에 있으면 툴바가 잘못 활성화되는 문제를 방지합니다.
         if clampedRange.length == 0, let tv = textView {
             if let uiColor = tv.typingAttributes[.backgroundColor] as? UIColor {
                 highlightColor = Color(uiColor: uiColor)
@@ -412,6 +473,7 @@ final class EditorToolbarViewModel {
 
     // MARK: - Private
 
+    /// 선택 영역의 폰트 심볼릭 트레이트를 토글합니다.
     @MainActor
     private func toggleFontTrait(_ trait: UIFontDescriptor.SymbolicTraits, shouldEnable: Bool) {
         guard let storage = textStorage else { return }
@@ -450,6 +512,7 @@ final class EditorToolbarViewModel {
         syncFormattingState()
     }
 
+    /// 선택 영역의 선형 텍스트 장식을 토글합니다.
     @MainActor
     private func toggleTextDecoration(_ key: NSAttributedString.Key, enabled: Bool, style: Int) {
         guard let storage = textStorage else { return }
@@ -476,6 +539,7 @@ final class EditorToolbarViewModel {
         syncFormattingState()
     }
 
+    /// 선택된 단락 범위의 들여쓰기 값을 안전하게 조정합니다.
     @MainActor
     private func adjustParagraphIndent(by delta: CGFloat) {
         guard let storage = textStorage else { return }
@@ -509,6 +573,8 @@ final class EditorToolbarViewModel {
         syncFormattingState()
     }
 
+    /// 포맷 상태를 기본값으로 되돌립니다.
+    /// 빈 에디터 또는 EOF 빈 단락에서 typingAttributes만으로 툴바 상태를 동기화합니다.
     private func syncFormattingStateFromTypingAttributes(_ tv: UITextView) {
         let attrs = tv.typingAttributes
         let typingFont = attrs[.font] as? UIFont ?? font(for: .body)
@@ -541,6 +607,7 @@ final class EditorToolbarViewModel {
         }
     }
 
+    /// 폰트 크기로부터 문단 스타일을 추론합니다.
     private func detectedParagraphStyleFromFont(_ font: UIFont) -> EditorParagraphStyle {
         let size = font.pointSize
         if abs(size - 28) < 0.5 { return .title }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+AI.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+AI.swift
@@ -14,9 +14,13 @@ extension NoticeEditorViewModel {
 
     // MARK: - Types
 
+    /// AI 토큰 사용량 스냅샷
     struct AITokenUsage: Equatable {
+        /// 직전 1회 실행에서 소비한 토큰 수
         let lastRunTokens: Int
+        /// 에디터가 열린 뒤 누적 사용량 (직전 실행 포함)
         let cumulativeUsed: Int
+        /// 모델 컨텍스트 윈도우 크기
         let total: Int
 
         var remaining: Int { max(0, total - cumulativeUsed) }
@@ -28,6 +32,8 @@ extension NoticeEditorViewModel {
 
     // MARK: - AI Content Improvement
 
+    /// AI 개선 요청 진입점. availability 체크 후 확인 다이얼로그를 띄운다.
+    /// 실제 실행은 다이얼로그의 "작성하기" 버튼 탭 시 startAIImprovement()로 이어짐.
     @MainActor
     func requestAIImprovement() {
         let plainText = richAttributedContent.string.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -53,12 +59,19 @@ extension NoticeEditorViewModel {
         showAIConfirmation = true
     }
 
+    /// 확인 다이얼로그에서 "작성하기" 버튼 탭 시 호출된다.
     @MainActor
     func startAIImprovement() async {
         showAIConfirmation = false
         await improveContentWithAI()
     }
 
+    /// Foundation Model을 사용해 공지 본문을 개선합니다.
+    ///
+    /// 현재 본문 텍스트를 온디바이스 언어 모델로 개선하여 재작성합니다.
+    /// 처리 중에는 `isAIProcessing`이 true가 되며, 스트리밍 진행 상황은 `aiStreamingText`에 반영됩니다.
+    /// iOS 26.4 이상에서는 `aiTokenUsage`에 에디터 세션 누적 기준 토큰 사용량이 반영되며,
+    /// 정상 완료 후에는 `showAICompletionSummary`가 true가 되어 사용자가 확인 버튼을 누를 때까지 오버레이가 유지됩니다.
     @MainActor
     func improveContentWithAI() async {
         let plainText = richAttributedContent.string.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -145,6 +158,7 @@ extension NoticeEditorViewModel {
         }
     }
 
+    /// 완료 요약 오버레이를 닫습니다. 확인 버튼 핸들러에서 호출됩니다.
     @MainActor
     func dismissAICompletionSummary() {
         showAICompletionSummary = false
@@ -153,11 +167,14 @@ extension NoticeEditorViewModel {
 
     // MARK: - Token Usage
 
+    /// 모델의 컨텍스트 윈도우 크기를 조회합니다. (iOS 26.4+)
     private func resolveContextSize() -> Int? {
         guard #available(iOS 26.4, *) else { return nil }
         return SystemLanguageModel.default.contextSize
     }
 
+    /// 현재 세션 트랜스크립트 기준 이번 실행 토큰 사용량을 갱신하고, 누적값을 반영한 스냅샷을 `aiTokenUsage`에 세팅합니다.
+    /// - Returns: 이번 실행에서 소비된 토큰 수 (실패 시 0)
     @MainActor
     private func updateTokenUsage(session: LanguageModelSession, contextSize: Int) async -> Int {
         guard #available(iOS 26.4, *) else { return 0 }
@@ -177,6 +194,9 @@ extension NoticeEditorViewModel {
 
     // MARK: - SwiftData Persistence
 
+    /// 에디터 진입 시 당일 토큰 사용량을 복원합니다.
+    ///
+    /// 당일 레코드가 존재하면 `aiCumulativeUsedTokens`를 복원하고, 없으면 0을 유지합니다.
     @MainActor
     func restoreDailyTokenUsage() {
         guard let modelContext else { return }
@@ -190,9 +210,14 @@ extension NoticeEditorViewModel {
             if let record = records.first(where: { $0.memberId == currentMemberId && $0.date == today }) {
                 aiCumulativeUsedTokens = record.usedTokens
             }
-        } catch {}
+        } catch {
+            // 복원 실패해도 에디터 동작에 영향 없이 0으로 유지
+        }
     }
 
+    /// AI 개선 성공 완료 시 당일 누적 토큰 사용량을 SwiftData에 저장합니다.
+    ///
+    /// 저장 실패 시 AI 결과(본문 교체)에는 영향을 주지 않습니다.
     @MainActor
     private func persistDailyTokenUsage(lastRunTokens: Int) {
         guard let modelContext, lastRunTokens > 0 else { return }
@@ -215,6 +240,8 @@ extension NoticeEditorViewModel {
             }
 
             try modelContext.save()
-        } catch {}
+        } catch {
+            // 저장 실패해도 AI 실행 결과에 영향 없음
+        }
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
@@ -11,10 +11,12 @@ extension NoticeEditorViewModel {
 
     // MARK: - Save
 
+    /// 수정 화면에서 실제 편집 가능한 값이 변경되었는지 반환합니다.
     var hasEditableChanges: Bool {
         hasBaseContentChanges || hasLinkChanges || hasImageChanges || hasVoteChanges
     }
 
+    /// 공지사항 저장 (생성 or 수정)
     @MainActor
     func saveNotice() async {
         switch mode {
@@ -25,6 +27,9 @@ extension NoticeEditorViewModel {
         }
     }
 
+    /// 새 공지사항을 생성합니다.
+    ///
+    /// 이미지 업로드 -> 공지 생성 -> 투표 첨부(선택) 순서로 진행됩니다.
     @MainActor
     func createNewNotice() async {
         createState = .loading
@@ -68,6 +73,9 @@ extension NoticeEditorViewModel {
         }
     }
 
+    /// 기존 공지사항을 수정합니다.
+    ///
+    /// 변경된 필드(제목/내용, 링크, 이미지, 투표)만 선별적으로 API를 호출합니다.
     @MainActor
     func updateExistingNotice(noticeId: Int) async {
         createState = .loading
@@ -76,6 +84,7 @@ extension NoticeEditorViewModel {
             var latestNotice: NoticeDetail?
             var didUpdateAnyField = false
 
+            // 변경 감지된 필드만 개별 API 호출
             if hasBaseContentChanges {
                 latestNotice = try await noticeUseCase.updateNotice(
                     noticeId: noticeId,
@@ -151,6 +160,7 @@ extension NoticeEditorViewModel {
         }
     }
 
+    /// 공지에 투표를 생성합니다.
     @MainActor
     func createVote(noticeId: Int) async throws -> AddVoteResponseDTO {
         let options = sanitizedVoteOptions()
@@ -167,6 +177,7 @@ extension NoticeEditorViewModel {
         )
     }
 
+    /// 공지 생성 API용 TargetInfoDTO를 구성합니다.
     func buildTargetInfo() -> TargetInfoDTO {
         let currentGeneration = resolvedGisuId > 0 ? resolvedGisuId : 0
         let selectedBranchId = subCategorySelection.selectedBranch?.id
@@ -214,6 +225,7 @@ extension NoticeEditorViewModel {
         }
     }
 
+    /// 에디터 폼 상태를 초기값으로 리셋합니다.
     func resetForm() {
         title = ""
         content = ""
@@ -224,12 +236,14 @@ extension NoticeEditorViewModel {
         allowAlert = true
     }
 
+    /// 링크 첨부 카드에서 입력된 값 중 실제 전송 가능한 링크만 추출합니다.
     func sanitizedLinksForRequest() -> [String] {
         noticeLinks
             .map { $0.link.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
     }
 
+    /// 제목/내용 변경 여부
     var hasBaseContentChanges: Bool {
         let currentTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let currentContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -238,6 +252,7 @@ extension NoticeEditorViewModel {
         return currentTitle != baseTitle || currentContent != baseContent
     }
 
+    /// 링크 전체 교체 변경 여부
     var hasLinkChanges: Bool {
         let currentLinks = sanitizedLinksForRequest()
         let baseLinks = originalLinks
@@ -246,10 +261,12 @@ extension NoticeEditorViewModel {
         return currentLinks != baseLinks
     }
 
+    /// 이미지 전체 교체 변경 여부
     var hasImageChanges: Bool {
         let hasPendingNewImages = noticeImages.contains { $0.fileId == nil && $0.imageData != nil }
         if hasPendingNewImages { return true }
 
+        // imageId가 없는 응답 케이스는 URL 기준으로 변경 감지
         if originalImageIds.isEmpty {
             let currentImageURLs = noticeImages.compactMap(\.imageURL)
             return currentImageURLs != originalImageURLs
@@ -259,15 +276,18 @@ extension NoticeEditorViewModel {
         return currentImageIds != originalImageIds
     }
 
+    /// 투표 변경 여부
     var hasVoteChanges: Bool {
         currentVoteSnapshot != initialVoteSnapshot
     }
 
+    /// 현재 화면 상태에서 전송 가능한 투표 스냅샷
     var currentVoteSnapshot: VoteSnapshot? {
         guard shouldSendVoteRequest else { return nil }
         return makeVoteSnapshot(from: voteFormData)
     }
 
+    /// 투표 폼 데이터로 비교 가능한 스냅샷을 생성합니다.
     func makeVoteSnapshot(from form: VoteFormData) -> VoteSnapshot {
         VoteSnapshot(
             title: form.title.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -281,6 +301,7 @@ extension NoticeEditorViewModel {
         )
     }
 
+    /// 투표 요청 전송 여부를 판단합니다.
     var shouldSendVoteRequest: Bool {
         guard isVoteConfirmed else { return false }
 
@@ -288,12 +309,14 @@ extension NoticeEditorViewModel {
         return !title.isEmpty && sanitizedVoteOptions().count >= 2
     }
 
+    /// 투표 옵션 입력값 중 실제 전송 가능한 옵션만 추출합니다.
     func sanitizedVoteOptions() -> [String] {
         voteFormData.options
             .map { $0.text.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
     }
 
+    /// 저장 실패를 전역 ErrorHandler로 전달합니다.
     func handleError(_ error: Error, action: String) {
         guard let errorHandler else { return }
         errorHandler.handle(
@@ -302,6 +325,10 @@ extension NoticeEditorViewModel {
         )
     }
 
+    /// 공지 작성/수정 관련 서버 에러를 즉시 Alert로 표시합니다.
+    ///
+    /// 서버가 내려준 NOTICE 계열 메시지는 작성 화면에서 바로 노출해
+    /// 사용자가 저장 실패 원인을 즉시 이해할 수 있도록 합니다.
     @discardableResult
     func presentNoticeServerErrorAlert(for error: RepositoryError) -> Bool {
         guard case let .serverError(code, message) = error else {
@@ -320,6 +347,7 @@ extension NoticeEditorViewModel {
         return true
     }
 
+    /// 권한 오류 등 HTTP 실패 응답의 서버 메시지를 작성 화면 Alert로 표시합니다.
     @discardableResult
     func presentNoticeRequestErrorAlert(for error: NetworkError) -> Bool {
         guard case let .requestFailed(statusCode, data) = error else {
@@ -359,6 +387,7 @@ extension NoticeEditorViewModel {
         return nil
     }
 
+    /// 저장 시점에만 파일 업로드 플로우를 실행하고 fileId 배열을 반환합니다.
     @MainActor
     func uploadPendingImagesIfNeeded() async throws -> [String] {
         for index in noticeImages.indices {
@@ -381,6 +410,10 @@ extension NoticeEditorViewModel {
         return noticeImages.compactMap { $0.fileId }
     }
 
+    /// 수정 이미지 교체 API에 전달할 imageId 목록을 구성합니다.
+    ///
+    /// - fileId가 있는 항목은 그대로 사용
+    /// - fileId가 없는 기존 원격 이미지(URL)는 상세 재조회 후 URL→ID 매핑으로 보완
     @MainActor
     func resolveImageIdsForUpdate(noticeId: Int) async throws -> [String] {
         let hasUnresolvedRemoteImage = noticeImages.contains {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
@@ -12,6 +12,7 @@ extension NoticeEditorViewModel {
 
     // MARK: - Public State
 
+    /// 현재 권한 기준으로 노출 가능한 서브카테고리 목록입니다.
     var visibleSubCategories: [EditorSubCategory] {
         Self.allowedSubCategories(
             for: selectedCategory,
@@ -25,15 +26,19 @@ extension NoticeEditorViewModel {
 
     // MARK: - Public Action
 
+    /// 조직 타입 기준으로 메인 카테고리 목록을 갱신합니다.
     func applyOrganizationType(_ organizationTypeRawValue: String) {
         organizationType = OrganizationType(rawValue: organizationTypeRawValue)
+        // 메뉴/권한 정책은 memberRole 기준으로만 관리합니다.
     }
 
+    /// 멤버 역할 기준으로 메인 카테고리/서브카테고리 정책을 갱신합니다.
     func applyMemberRole(_ memberRoleRawValue: String) {
         memberRole = ManagementTeam(rawValue: memberRoleRawValue)
         applyEditorPolicyAndReloadTargets()
     }
 
+    /// 뷰에서 사용자 컨텍스트(AppStorage)를 전달받아 반영합니다.
     func updateUserContext(gisuId: Int, chapterId: Int) {
         userGisuId = gisuId
         userChapterId = chapterId
@@ -45,10 +50,12 @@ extension NoticeEditorViewModel {
         }
     }
 
+    /// View 계층의 ErrorHandler를 바인딩합니다.
     func updateErrorHandler(_ handler: ErrorHandler) {
         errorHandler = handler
     }
 
+    /// 현재 메인 카테고리에 맞는 타겟 목록을 조회합니다.
     @MainActor
     func loadTargetOptions() async {
         targetOptionsState = .loading
@@ -141,6 +148,7 @@ extension NoticeEditorViewModel {
         normalizeSelectionForCurrentCategory()
     }
 
+    /// 메인 카테고리를 선택하고 해당 타겟 옵션을 로드합니다.
     func selectCategory(_ category: EditorMainCategory) {
         guard availableCategories.contains(category) else { return }
         selectedCategory = category
@@ -150,6 +158,7 @@ extension NoticeEditorViewModel {
         }
     }
 
+    /// 서브카테고리 토글
     func toggleSubCategory(_ subCategory: EditorSubCategory) {
         guard visibleSubCategories.contains(subCategory) else { return }
 
@@ -163,6 +172,7 @@ extension NoticeEditorViewModel {
         normalizeSelectionForCurrentCategory()
     }
 
+    /// 지부 선택 토글
     func toggleBranch(_ branch: NoticeTargetOption) {
         guard visibleSubCategories.contains(.branch) else { return }
 
@@ -179,6 +189,7 @@ extension NoticeEditorViewModel {
         normalizeSelectionForCurrentCategory()
     }
 
+    /// 학교 선택 토글
     func toggleSchool(_ school: NoticeTargetOption) {
         guard visibleSubCategories.contains(.school) else { return }
 
@@ -195,6 +206,7 @@ extension NoticeEditorViewModel {
         normalizeSelectionForCurrentCategory()
     }
 
+    /// 파트 선택 토글
     func togglePart(_ part: UMCPartType) {
         guard visibleSubCategories.contains(.part) else { return }
 
@@ -217,6 +229,7 @@ extension NoticeEditorViewModel {
         subCategorySelection.selectedSubCategories.contains(subCategory)
     }
 
+    /// 게시판 분류 칩의 시각적 선택 상태를 반환합니다.
     func isSubCategoryHighlighted(_ subCategory: EditorSubCategory) -> Bool {
         switch subCategory {
         case .all:
@@ -242,6 +255,7 @@ extension NoticeEditorViewModel {
         subCategorySelection.selectedParts.contains(part)
     }
 
+    /// 필터형 서브카테고리(지부/학교/파트)를 탭했을 때 선택 상태를 보장합니다.
     func selectSubCategoryIfNeeded(_ subCategory: EditorSubCategory) {
         guard subCategory.hasFilter else { return }
         guard visibleSubCategories.contains(subCategory) else { return }
@@ -253,6 +267,7 @@ extension NoticeEditorViewModel {
         normalizeSelectionForCurrentCategory()
     }
 
+    /// 서브카테고리에 맞는 타겟 선택 시트를 엽니다.
     func openSheet(for subCategory: EditorSubCategory) {
         guard subCategory.hasFilter else { return }
         guard visibleSubCategories.contains(subCategory) else { return }
@@ -275,6 +290,7 @@ extension NoticeEditorViewModel {
 
     // MARK: - Edit Bootstrap
 
+    /// 수정할 공지 데이터를 에디터 상태로 로드합니다.
     func loadNoticeForEdit(_ notice: NoticeDetail) {
         title = notice.title
         content = notice.content
@@ -332,6 +348,7 @@ extension NoticeEditorViewModel {
 
     // MARK: - Helper
 
+    /// 조직 타입/역할에 따라 사용 가능한 메인 카테고리 목록을 반환합니다.
     static func availableCategories(
         for _: OrganizationType?,
         memberRole: ManagementTeam?
@@ -340,10 +357,12 @@ extension NoticeEditorViewModel {
         return [.all, .central]
     }
 
+    /// 레거시 시그니처 유지용 래퍼입니다.
     static func availableCategories(for organizationType: OrganizationType?) -> [EditorMainCategory] {
         availableCategories(for: organizationType, memberRole: nil)
     }
 
+    /// 해당 서브카테고리의 필터 선택 상태를 초기화합니다.
     func clearFilterForSubCategory(_ subCategory: EditorSubCategory) {
         switch subCategory {
         case .branch:
@@ -381,6 +400,7 @@ private extension NoticeEditorViewModel {
         }
     }
 
+    /// 역할 변경 시 에디터 정책(카테고리/서브카테고리)을 재적용하고 타겟 옵션을 다시 로드합니다.
     func applyEditorPolicyAndReloadTargets() {
         let categories = Self.availableCategories(
             for: organizationType,
@@ -402,6 +422,7 @@ private extension NoticeEditorViewModel {
         }
     }
 
+    /// 현재 카테고리에 맞지 않는 서브카테고리 선택을 정리하고 일관된 상태로 보정합니다.
     func normalizeSelectionForCurrentCategory() {
         let allowed = Set(visibleSubCategories)
         subCategorySelection.selectedSubCategories = subCategorySelection
@@ -418,11 +439,13 @@ private extension NoticeEditorViewModel {
             subCategorySelection.selectedParts = []
         }
 
+        // 지부/학교 동시 지정 방지
         if subCategorySelection.selectedBranch != nil && subCategorySelection.selectedSchool != nil {
             subCategorySelection.selectedSchool = nil
             subCategorySelection.selectedSubCategories.remove(.school)
         }
 
+        // 더 이상 숨겨진 "전체" 기본값을 사용하지 않습니다.
         if allowed.isEmpty {
             subCategorySelection.selectedSubCategories = []
             subCategorySelection.selectedBranch = nil
@@ -432,11 +455,13 @@ private extension NoticeEditorViewModel {
             subCategorySelection.selectedSubCategories.remove(.all)
         }
 
+        // 기수 미선택 시 금지 조합 방지
         if resolvedGisuId <= 0 && !subCategorySelection.selectedParts.isEmpty {
             subCategorySelection.selectedParts = []
             subCategorySelection.selectedSubCategories.remove(.part)
         }
 
+        // 옵션 목록에서 제거된 항목 정리
         if let selectedBranch = subCategorySelection.selectedBranch,
            !branchOptions.contains(selectedBranch) {
             subCategorySelection.selectedBranch = nil

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
@@ -381,6 +381,7 @@ extension NoticeEditorViewModel {
 // MARK: - Private Policy
 private extension NoticeEditorViewModel {
 
+    /// 메인 카테고리와 역할 조합에 따라 노출 가능한 서브카테고리를 반환합니다.
     static func allowedSubCategories(
         for category: EditorMainCategory,
         memberRole: ManagementTeam?

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+VoteAttachment.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+VoteAttachment.swift
@@ -15,6 +15,7 @@ extension NoticeEditorViewModel {
 
     // MARK: - Vote Action
 
+    /// 투표 폼 시트를 표시합니다. 이미 확정된 투표가 있으면 안내 Alert을 보여줍니다.
     func showVotingFormSheet() {
         if isVoteConfirmed {
             alertPrompt = AlertPrompt(
@@ -30,6 +31,7 @@ extension NoticeEditorViewModel {
         }
     }
 
+    /// 투표 편집을 취소하고 원본 상태로 복원합니다.
     func cancelVotingEdit() {
         if isVoteConfirmed, let original = originalVoteFormData {
             voteFormData = original
@@ -41,12 +43,14 @@ extension NoticeEditorViewModel {
         showVoting = false
     }
 
+    /// 투표 폼 입력을 확정합니다.
     func confirmVote() {
         isVoteConfirmed = true
         originalVoteFormData = nil
         showVoting = false
     }
 
+    /// 확정된 투표를 수정 모드로 전환합니다. 원본 데이터를 스냅샷에 저장합니다.
     func editVote() {
         originalVoteFormData = VoteFormData(
             title: voteFormData.title,
@@ -59,17 +63,20 @@ extension NoticeEditorViewModel {
         showVoting = true
     }
 
+    /// 투표를 삭제하고 폼을 초기화합니다.
     func deleteVote() {
         voteFormData = VoteFormData()
         isVoteConfirmed = false
         originalVoteFormData = nil
     }
 
+    /// 투표 옵션을 추가합니다. 최대 개수 제한을 초과하면 무시됩니다.
     func addVoteOption() {
         guard voteFormData.canAddOption else { return }
         voteFormData.options.append(VoteOptionItem())
     }
 
+    /// 투표 옵션을 삭제합니다. 최소 개수 미만이면 무시됩니다.
     func removeVoteOption(_ option: VoteOptionItem) {
         guard voteFormData.canRemoveOption else { return }
         voteFormData.options.removeAll { $0.id == option.id }
@@ -77,6 +84,10 @@ extension NoticeEditorViewModel {
 
     // MARK: - Image Action
 
+    /// 선택한 PhotosPickerItem을 JPEG로 변환해 첨부 이미지 목록에 반영합니다.
+    ///
+    /// - 원본 파일명이 존재하면 이름을 유지하고 확장자만 `.jpg`로 정규화합니다.
+    /// - HEIC/HEIF 등은 `UIImage` 디코딩 후 JPEG로 변환하여 업로드 포맷을 통일합니다.
     @MainActor
     func loadSelectedPhotoItemsForNoticeUpload() async {
         guard !selectedPhotoItems.isEmpty else { return }
@@ -109,6 +120,9 @@ extension NoticeEditorViewModel {
         selectedPhotoItems.removeAll()
     }
 
+    /// 선택한 이미지를 로컬 카드 목록으로 반영합니다.
+    ///
+    /// 실제 서버 업로드는 저장 시점(`saveNotice`)에서만 수행됩니다.
     @MainActor
     func didLoadImages(images: [UIImage]) async {
         for image in images {
@@ -125,18 +139,21 @@ extension NoticeEditorViewModel {
         selectedPhotoItems.removeAll()
     }
 
+    /// 첨부 이미지 목록에서 지정 항목을 제거합니다.
     func removeImage(_ item: NoticeImageItem) {
         noticeImages.removeAll { $0.id == item.id }
     }
 
     // MARK: - Link Action
 
+    /// 첨부 링크 목록에서 지정 항목을 제거합니다.
     func removeLink(_ link: NoticeLinkItem) {
         noticeLinks.removeAll { $0.id == link.id }
     }
 
     // MARK: - Private
 
+    /// PhotosPickerItem에서 원본 파일명을 추출합니다.
     private func originalFileName(from item: PhotosPickerItem) -> String? {
         guard let identifier = item.itemIdentifier else { return nil }
         let fetchedAssets = PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil)
@@ -144,6 +161,7 @@ extension NoticeEditorViewModel {
         return PHAssetResource.assetResources(for: asset).first?.originalFilename
     }
 
+    /// 원본 파일명을 JPEG 확장자로 정규화합니다.
     private func normalizedJPEGFileName(_ sourceName: String?, fallbackIndex: Int) -> String {
         let fallback = "notice_image_\(Int(Date().timeIntervalSince1970))_\(fallbackIndex).jpg"
         guard let sourceName,

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
@@ -35,6 +35,7 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
 
     // MARK: - Mode
 
+    /// 편집 모드 (생성 or 수정)
     let mode: NoticeEditorMode
 
     // MARK: - User Context
@@ -55,8 +56,13 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
         UserDefaults.standard.integer(forKey: AppStorageKey.schoolId)
     }
 
+    /// 사용자 조직 타입 (AppStorage 반영)
     var organizationType: OrganizationType?
+
+    /// 사용자 권한/역할 (AppStorage 반영)
     var memberRole: ManagementTeam?
+
+    /// 뷰에서 전달받는 사용자 컨텍스트(우선 적용)
     var userGisuId: Int?
     var userChapterId: Int?
     var selectedGenerationValue: Int?
@@ -76,8 +82,13 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
 
     // MARK: - View State
 
+    /// 공지 생성/수정 상태
+    ///
+    /// ViewModel 기능을 extension 파일로 분리해 관리하므로,
+    /// 동일 타입 extension에서도 상태 전환이 가능하도록 setter를 내부 공개합니다.
     var createState: Loadable<NoticeDetail> = .idle
 
+    /// 선택된 메인 카테고리
     var selectedCategory: EditorMainCategory {
         didSet {
             if oldValue != selectedCategory {
@@ -86,52 +97,117 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
         }
     }
 
+    /// 서브카테고리 선택 상태
     var subCategorySelection = EditorSubCategorySelection()
+
+    /// 공지 타겟(지부, 학교, 파트) 시트 표시 여부
     var activeSheetType: TargetSheetType?
+
+    /// 사용자 조직 타입에 따라 노출 가능한 메인 카테고리 목록
     var availableCategories: [EditorMainCategory]
+
+    /// 지부 선택 시트 목록 (중앙 선택 시)
     var branchOptions: [NoticeTargetOption] = []
+
+    /// 학교 선택 시트 목록
     var schoolOptions: [NoticeTargetOption] = []
+
+    /// 타겟(지부/학교/파트) 시트 데이터 로딩 상태
     var targetOptionsState: Loadable<Bool> = .idle
+
+    /// 공지사항 제목
     var title: String = ""
+
+    /// 공지사항 본문 (일반 텍스트 — 서버 전송용)
     var content: String = ""
+
+    /// 리치 텍스트 에디터 툴바 ViewModel
     var editorToolbarViewModel: EditorToolbarViewModel = EditorToolbarViewModel()
+
+    /// 리치 텍스트 에디터 본문 (NSAttributedString — 로컬 편집용)
     var richAttributedContent: NSAttributedString = NSAttributedString(string: "")
+
+    /// 투표 폼 시트 표시 여부
     var showVoting: Bool = false
+
+    /// 투표 폼 데이터
     var voteFormData: VoteFormData = VoteFormData()
+
+    /// 투표 확정 여부
     var isVoteConfirmed: Bool = false
+
+    /// 화면 AlertPrompt
     var alertPrompt: AlertPrompt?
+
+    /// PhotosPicker 선택 아이템
     var selectedPhotoItems: [PhotosPickerItem] = []
+
+    /// 로드된 UIImage 목록
     var selectedImages: [UIImage] = []
+
+    /// 첨부 이미지 카드 목록
     var noticeImages: [NoticeImageItem] = []
+
+    /// 첨부 링크 카드 목록
     var noticeLinks: [NoticeLinkItem] = []
+
+    /// 알림 발송 여부
     var allowAlert: Bool = true
 
     // MARK: - AI State
 
+    /// AI 개선 시작 전 확인 다이얼로그 표시 여부
     var showAIConfirmation: Bool = false
+
+    /// AI 글 개선 처리 중 여부
     var isAIProcessing: Bool = false
+
+    /// AI 스트리밍 진행 중 현재까지 생성된 텍스트 (진행 상황 표시용)
     var aiStreamingText: String = ""
+
+    /// AI 토큰 사용량 (iOS 26.4+ 에서만 채워짐)
     var aiTokenUsage: AITokenUsage?
+
+    /// 에디터가 열려 있는 동안 성공적으로 확정된 AI 토큰 누적 사용량
     var aiCumulativeUsedTokens: Int = 0
+
+    /// AI 개선 완료 후 확인 버튼 대기 중 상태 (오버레이 유지용)
     var showAICompletionSummary: Bool = false
 
     // MARK: - Edit Snapshot
 
+    /// 수정 화면 원본 제목
     var originalTitle: String = ""
+
+    /// 수정 화면 원본 본문
     var originalContent: String = ""
+
+    /// 수정 화면 원본 링크 목록
     var originalLinks: [String] = []
+
+    /// 수정 화면 원본 이미지 ID 목록 (순서 유지)
     var originalImageIds: [String] = []
+    /// 수정 화면 원본 이미지 URL 목록 (ID 미포함 응답 대비)
     var originalImageURLs: [String] = []
+
+    /// 수정 화면 원본 투표 폼
     var originalVoteFormData: VoteFormData?
+
+    /// 수정 진입 시점의 원본 투표 스냅샷
     var initialVoteSnapshot: VoteSnapshot?
 
     // MARK: - Derived State
 
+    /// 수정 모드 여부
     var isEditMode: Bool {
         if case .edit = mode { return true }
         return false
     }
 
+    /// 저장 가능 여부
+    ///
+    /// 생성: 제목/내용 필수
+    /// 수정: 제목/내용 필수 + 실제 변경사항 존재
     var canSubmit: Bool {
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -170,6 +246,7 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
 
     // MARK: - Helper
 
+    /// 선택된 gisuId를 사용자 표시용 기수 값으로 역매핑합니다.
     func refreshSelectedGenerationValue() {
         let currentGisuId = resolvedGisuId
         guard currentGisuId > 0 else {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
@@ -11,6 +11,9 @@ import PhotosUI
 import SwiftData
 import UIKit
 
+/// 공지사항 에디터 ViewModel
+///
+/// 공지 생성/수정, 카테고리/타겟 선택, 이미지/링크/투표 첨부 상태를 관리합니다.
 @Observable
 final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/MarkdownRenderedView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/MarkdownRenderedView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import UIKit
 
+/// 마크다운 문자열을 서식이 적용된 상태로 표시하는 read-only 뷰입니다.
 struct MarkdownRenderedView: View {
 
     let markdown: String
@@ -66,6 +67,7 @@ private struct _MarkdownTextViewRepresentable: UIViewRepresentable {
         uiView.setNeedsBlockquoteRefresh()
     }
 
+    /// HTML 문자열을 서식이 적용된 NSAttributedString으로 변환합니다.
     private static func attributedStringFromHTML(
         _ html: String,
         baseFont: UIFont

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 
+/// 공지사항 상세 화면
+///
+/// 공지 본문, 투표, 이미지, 링크를 표시하며 열람 통계 및 수정/삭제 기능을 제공합니다.
 struct NoticeDetailView: View {
 
     // MARK: - Property
@@ -82,6 +85,7 @@ struct NoticeDetailView: View {
         }
     }
 
+    /// 공지 상세 로드 실패 상태 UI
     private func failedSection(error: AppError) -> some View {
         RetryContentUnavailableView(
             title: Constants.failedTitleText,
@@ -102,6 +106,7 @@ struct NoticeDetailView: View {
         await viewModel.fetchNoticeDetail()
     }
 
+    /// 공지 상세 데이터가 로드된 상태의 스크롤 본문
     private func detailContent(_ data: NoticeDetail) -> some View {
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: Constants.topSectionSpacing) {
@@ -123,6 +128,7 @@ struct NoticeDetailView: View {
 
     // MARK: - Top Section
 
+    /// 공지 제목, 작성자, 작성일, 수신 대상을 표시합니다.
     private func topSection(_ data: NoticeDetail) -> some View {
         VStack(alignment: .leading, spacing: Constants.topSectionSpacing) {
             mainInfo(data)
@@ -131,6 +137,7 @@ struct NoticeDetailView: View {
         .padding(.horizontal, Constants.horizontalPadding)
     }
 
+    /// 필독 칩 + 공지 제목 영역
     private func mainInfo(_ data: NoticeDetail) -> some View {
         VStack(alignment: .leading, spacing: Constants.topSectionSpacing) {
             Text(data.title)
@@ -138,6 +145,7 @@ struct NoticeDetailView: View {
         }
     }
 
+    /// 작성자 프로필, 작성일, 수신 대상 영역
     private func subInfo(_ data: NoticeDetail) -> some View {
         VStack(alignment: .leading, spacing: Constants.subInfoSpacing) {
             HStack {
@@ -200,6 +208,7 @@ struct NoticeDetailView: View {
 
     // MARK: - Bottom Section
 
+    /// 공지 본문/투표/이미지/링크를 순서대로 구성합니다.
     private func bottomSection(_ data: NoticeDetail) -> some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
             MarkdownRenderedView(markdown: data.content)
@@ -263,6 +272,7 @@ struct NoticeDetailView: View {
 
     // MARK: - Toolbar
 
+    /// 수정/삭제 메뉴를 포함하는 네비게이션 툴바
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         if currentNotice != nil, !toolbarActions.isEmpty {
@@ -270,6 +280,7 @@ struct NoticeDetailView: View {
         }
     }
 
+    /// 권한에 따라 동적으로 구성되는 툴바 액션 목록
     private var toolbarActions: [ToolBarCollection.ToolbarTrailingMenu.ActionItem] {
         var actions: [ToolBarCollection.ToolbarTrailingMenu.ActionItem] = []
 
@@ -299,6 +310,7 @@ struct NoticeDetailView: View {
 
     // MARK: - Bottom Bar
 
+    /// 펼침 상태 수신 확인 카드 inset
     @ViewBuilder
     private func expandedReadStatusInset() -> some View {
         if shouldShowReadStatusInset && !isReadStatusBarCollapsed {
@@ -317,6 +329,7 @@ struct NoticeDetailView: View {
         }
     }
 
+    /// 압축 상태 원형 버튼 inset
     @ViewBuilder
     private func collapsedReadStatusInset() -> some View {
         if shouldShowReadStatusInset && isReadStatusBarCollapsed {
@@ -344,12 +357,14 @@ struct NoticeDetailView: View {
         }
     }
 
+    /// 축소된 하단 바를 다시 펼칩니다.
     private func expandReadStatusBar() {
         withAnimation(Constants.collapseAnimation) {
             isReadStatusBarCollapsed = false
         }
     }
 
+    /// 수신 확인 현황 시트를 구성합니다.
     private func readStatusSheet() -> some View {
         NoticeReadStatusSheet(viewModel: viewModel)
             .presentationDetents(Constants.detailSheetDetents)
@@ -358,6 +373,7 @@ struct NoticeDetailView: View {
 
     // MARK: - Task
 
+    /// 화면 진입 시 읽음 처리, 열람 현황, 권한, 상세 데이터를 로드합니다.
     @MainActor
     private func onTask() async {
         viewModel.updateErrorHandler(errorHandler)
@@ -380,6 +396,7 @@ struct NoticeDetailView: View {
 
     // MARK: - Private Methods
 
+    /// 공지 수정 처리
     private func handleEditNotice() {
         guard viewModel.isDetailPreparedForEdit else {
             viewModel.alertPrompt = AlertPrompt(
@@ -400,10 +417,13 @@ struct NoticeDetailView: View {
         }
     }
 
+    /// 현재 상세 모델을 우선 사용하고, 이미지 메타데이터가 비어있을 때만 1회 보강 조회 후 수정 화면으로 진입합니다.
     @MainActor
     private func openEditorUsingCurrentOrHydratedDetail() async {
         guard var notice = currentNotice else { return }
 
+        // 디버그/요약 모델 경로에서 이미지 메타데이터(id)가 비어있으면
+        // 에디터에서 기존 이미지를 복원할 수 없으므로 보강 조회를 수행합니다.
         let needsImageHydration = !notice.images.isEmpty &&
             (notice.imageItems.isEmpty || notice.imageItems.contains(where: { $0.id.isEmpty }))
 
@@ -412,7 +432,9 @@ struct NoticeDetailView: View {
                 let hydrated = try await viewModel.noticeUseCase.getDetailNotice(noticeId: viewModel.noticeID)
                 notice = hydrated
                 viewModel.noticeState = .loaded(hydrated)
-            } catch {}
+            } catch {
+                // 보강 조회 실패 시 현재 모델로 계속 진행
+            }
         }
 
         let noticeID = Int(notice.id) ?? 0
@@ -422,6 +444,7 @@ struct NoticeDetailView: View {
         pathStore.noticePath.append(.notice(.editor(mode: editMode, selectedGisuId: nil)))
     }
 
+    /// 공지 삭제 처리
     private func handleDeleteNotice() {
         guard currentNotice != nil else { return }
         guard viewModel.canDeleteNotice else {
@@ -432,11 +455,13 @@ struct NoticeDetailView: View {
         viewModel.showDeleteConfirmation(onDeleteRequested: closeDetailScreenImmediately)
     }
 
+    /// 삭제 확인 시 상세 화면을 즉시 닫습니다.
     private func closeDetailScreenImmediately() {
         guard !pathStore.noticePath.isEmpty else { return }
         pathStore.noticePath.removeLast()
     }
 
+    /// 수정/삭제 권한 없음 안내
     private func showNoPermissionAlert() {
         viewModel.alertPrompt = AlertPrompt(
             id: .init(),
@@ -446,18 +471,22 @@ struct NoticeDetailView: View {
         )
     }
 
+    /// PathStore 접근
     private var pathStore: PathStore {
         di.resolve(PathStore.self)
     }
 
+    /// 공지 상세의 타입(중앙/지부/교내/파트)을 내비게이션 서브타이틀로 노출합니다.
     private var noticeTypeSubtitle: String {
         currentNotice?.noticeType.rawValue ?? ""
     }
 
+    /// 현재 로드된 공지 상세 데이터 (loaded 상태일 때만 존재)
     private var currentNotice: NoticeDetail? {
         viewModel.noticeState.value
     }
 
+    /// 상세 로드 실패/로딩 상태에서는 하단 수신 확인 inset을 숨깁니다.
     private var shouldShowReadStatusInset: Bool {
         guard viewModel.canViewReadStatus else { return false }
         if case .loaded = viewModel.noticeState {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/AttachmentMenuButton.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/AttachmentMenuButton.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import PhotosUI
 
+/// 공지 에디터 첨부 툴바의 클립 메뉴 버튼(사진/투표)입니다.
 struct AttachmentMenuButton: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/HighlightMenuButton.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/HighlightMenuButton.swift
@@ -10,6 +10,7 @@ import UIKit
 
 // MARK: - HighlightColor
 
+/// 리치 텍스트 에디터의 형광펜 색상 옵션입니다.
 enum HighlightColor: CaseIterable {
     case none, purple, pink, orange, mint, blue
 
@@ -27,6 +28,7 @@ enum HighlightColor: CaseIterable {
         }
     }
 
+    /// 텍스트에 적용되는 반투명 배경 색상 (none이면 nil)
     var swiftUIColor: Color? {
         switch self {
         case .none:   return nil
@@ -38,6 +40,7 @@ enum HighlightColor: CaseIterable {
         }
     }
 
+    /// 메뉴 아이콘에 표시되는 진한 색상
     var displayColor: Color {
         switch self {
         case .none:   return .black
@@ -49,6 +52,7 @@ enum HighlightColor: CaseIterable {
         }
     }
 
+    /// Menu 아이콘용 컬러 원형 UIImage (template 렌더링 무시)
     var circleImage: UIImage {
         let size = CGSize(width: 18, height: 18)
         let renderer = UIGraphicsImageRenderer(size: size)
@@ -62,6 +66,7 @@ enum HighlightColor: CaseIterable {
 
 // MARK: - HighlightMenuButton
 
+/// 공지 에디터 첨부 툴바의 형광펜 색상 선택 메뉴입니다.
 struct HighlightMenuButton: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/ListMenuButton.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/ListMenuButton.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 공지 에디터 첨부 툴바의 목록 스타일 선택 메뉴입니다.
 struct ListMenuButton: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/NoticeEditorAttachmentToolbar.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/NoticeEditorAttachmentToolbar.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import PhotosUI
 
+/// 공지 에디터 하단에 노출되는 첨부/서식 통합 스크롤 툴바입니다.
 struct NoticeEditorAttachmentToolbar: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/ToolbarButtonStyles.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/ToolbarButtonStyles.swift
@@ -16,6 +16,7 @@ fileprivate enum ToolbarButtonConstants {
 
 // MARK: - ToolbarIconButton
 
+/// 에디터 첨부 툴바에서 사용하는 공용 아이콘 버튼입니다.
 struct ToolbarIconButton: View {
 
     // MARK: - Property
@@ -42,6 +43,7 @@ struct ToolbarIconButton: View {
 
 // MARK: - ToolbarTextFormatButton
 
+/// 인라인 서식 텍스트 버튼 (B/I/U/S)입니다. 활성 여부에 따라 실제 서식 미리보기를 적용합니다.
 struct ToolbarTextFormatButton: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorBindings.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorBindings.swift
@@ -11,6 +11,7 @@ import PhotosUI
 
 // MARK: - ViewModifier
 
+/// 공지 에디터 화면의 onChange / task 등 상태 동기화 계열 modifier를 묶은 ViewModifier입니다.
 struct NoticeEditorBindings: ViewModifier {
 
     // MARK: - Property
@@ -31,8 +32,10 @@ struct NoticeEditorBindings: ViewModifier {
     // MARK: - Constants
 
     private enum Constants {
+        /// 이미지/투표 섹션 스크롤 앵커 ID
         static let imageSectionScrollID: String = "notice_editor_image_section"
         static let voteSectionScrollID: String = "notice_editor_vote_section"
+        /// 링크 추가 후 스크롤/포커스 안정화 대기 시간
         static let linkScrollDelayNanos: UInt64 = 120_000_000
     }
 
@@ -69,6 +72,7 @@ struct NoticeEditorBindings: ViewModifier {
 
     // MARK: - Handlers
 
+    /// 링크 아이템이 추가되면 신규 카드로 스크롤하고 포커스 안정화를 대기합니다.
     fileprivate func handleNoticeLinksCountChanged(oldValue: Int, newValue: Int) {
         guard newValue > oldValue, let targetID = newlyAddedLinkID else { return }
 
@@ -82,6 +86,7 @@ struct NoticeEditorBindings: ViewModifier {
         }
     }
 
+    /// 이미지 아이템이 추가되면 이미지 섹션으로 자동 스크롤합니다.
     fileprivate func handleNoticeImagesCountChanged(oldValue: Int, newValue: Int) {
         guard newValue > oldValue else { return }
         withAnimation(.easeOut(duration: 0.2)) {
@@ -89,6 +94,7 @@ struct NoticeEditorBindings: ViewModifier {
         }
     }
 
+    /// 투표가 생성되면 투표 섹션으로 자동 스크롤합니다.
     fileprivate func handleVoteConfirmStateChanged(oldValue: Bool, newValue: Bool) {
         guard !oldValue, newValue else { return }
         withAnimation(.easeOut(duration: 0.2)) {
@@ -96,6 +102,7 @@ struct NoticeEditorBindings: ViewModifier {
         }
     }
 
+    /// 저장 상태 변화에 따라 화면 동작을 제어합니다.
     fileprivate func handleCreateStateChanged(_ state: Loadable<NoticeDetail>) {
         switch state {
         case .loaded:
@@ -105,6 +112,7 @@ struct NoticeEditorBindings: ViewModifier {
         }
     }
 
+    /// 선택된 사진 아이템 변경 시 이미지를 로드합니다.
     fileprivate func handleSelectedPhotoItemsChanged(_ newItems: [PhotosPickerItem]) {
         guard !newItems.isEmpty else { return }
         Task {
@@ -112,11 +120,13 @@ struct NoticeEditorBindings: ViewModifier {
         }
     }
 
+    /// AppStorage 사용자 컨텍스트 변경을 ViewModel에 반영합니다.
     fileprivate func handleUserContextChanged(gisuId: Int, chapterId: Int) {
         let editorGisuId = selectedGisuId ?? gisuId
         viewModel.updateUserContext(gisuId: editorGisuId, chapterId: chapterId)
     }
 
+    /// 형광펜 색상 선택 변경을 에디터 툴바에 반영합니다.
     fileprivate func handleHighlightColorChanged(_ newValue: HighlightColor) {
         Task { @MainActor in
             if let color = newValue.swiftUIColor {
@@ -127,6 +137,7 @@ struct NoticeEditorBindings: ViewModifier {
         }
     }
 
+    /// AI 처리 상태 변경 시 키보드 리사인을 처리합니다.
     fileprivate func handleAIProcessingChanged(_ isProcessing: Bool) {
         if isProcessing {
             UIApplication.shared.sendAction(
@@ -137,8 +148,9 @@ struct NoticeEditorBindings: ViewModifier {
     }
 }
 
-// MARK: - Sub-Modifiers
+// MARK: - Sub-Modifiers (body 타입체크 부담 분산)
 
+/// 스크롤 앵커 관련 변경 (링크 추가, 이미지 추가, 투표 확정) onChange 묶음
 private struct ScrollAnchorChanges: ViewModifier {
     let owner: NoticeEditorBindings
 
@@ -156,6 +168,7 @@ private struct ScrollAnchorChanges: ViewModifier {
     }
 }
 
+/// 저장 상태 및 미디어(사진 피커) 변경 onChange 묶음
 private struct SaveAndMediaChanges: ViewModifier {
     let owner: NoticeEditorBindings
 
@@ -170,6 +183,7 @@ private struct SaveAndMediaChanges: ViewModifier {
     }
 }
 
+/// AppStorage 기반 사용자 컨텍스트 변경 onChange 묶음
 private struct AppStorageChanges: ViewModifier {
     let owner: NoticeEditorBindings
 
@@ -190,6 +204,7 @@ private struct AppStorageChanges: ViewModifier {
     }
 }
 
+/// 툴바(형광펜, AI 처리) 관련 변경 onChange 묶음
 private struct ToolbarChanges: ViewModifier {
     let owner: NoticeEditorBindings
 
@@ -207,6 +222,7 @@ private struct ToolbarChanges: ViewModifier {
 // MARK: - View Extension
 
 extension View {
+    /// 공지 에디터의 상태 동기화 계열 modifier를 일괄 적용합니다.
     func noticeEditorBindings(
         viewModel: NoticeEditorViewModel,
         selectedHighlightColor: Binding<HighlightColor>,

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorPresentations.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorPresentations.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 // MARK: - ViewModifier
 
+/// 공지 에디터 화면의 sheet/fullScreenCover/overlay/alert 등 프레젠테이션 계열 modifier를 묶은 ViewModifier입니다.
 struct NoticeEditorPresentations: ViewModifier {
 
     // MARK: - Property
@@ -72,12 +73,14 @@ struct NoticeEditorPresentations: ViewModifier {
 
     // MARK: - View Builders
 
+    /// 타겟 선택 시트를 표시합니다.
     private func targetSheet(_ sheetType: TargetSheetType) -> some View {
         TargetSheetView(viewModel: viewModel, sheetType: sheetType)
             .presentationDetents(targetSheetDetents(for: sheetType))
             .presentationDragIndicator(.visible)
     }
 
+    /// 투표 폼 시트를 표시합니다.
     private func votingSheet() -> some View {
         VotingFormSheetView(
             formData: $viewModel.voteFormData,
@@ -87,6 +90,7 @@ struct NoticeEditorPresentations: ViewModifier {
         )
     }
 
+    /// 타겟 선택 시트 높이 설정
     private func targetSheetDetents(for sheetType: TargetSheetType) -> Set<PresentationDetent> {
         switch sheetType {
         case .part, .branch:
@@ -100,6 +104,7 @@ struct NoticeEditorPresentations: ViewModifier {
 // MARK: - View Extension
 
 extension View {
+    /// 공지 에디터의 프레젠테이션 계열 modifier를 일괄 적용합니다.
     func noticeEditorPresentations(viewModel: NoticeEditorViewModel) -> some View {
         modifier(NoticeEditorPresentations(viewModel: viewModel))
     }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 import PhotosUI
 import SwiftData
 
+/// 공지사항 작성/수정 에디터 화면
+///
+/// 카테고리 선택, 제목/본문 입력, 이미지/링크/투표 첨부를 지원합니다.
 struct NoticeEditorView: View {
 
     // MARK: - Property
@@ -17,25 +20,44 @@ struct NoticeEditorView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(ErrorHandler.self) private var errorHandler
 
+    /// 사용자 조직 타입 (중앙/지부/학교)
     @AppStorage(AppStorageKey.organizationType) private var organizationType: String = ""
+
+    /// 사용자 지부명
     @AppStorage(AppStorageKey.chapterName) private var chapterName: String = ""
+
+    /// 사용자 학교명
     @AppStorage(AppStorageKey.schoolName) private var schoolName: String = ""
+
+    /// 사용자 기수 ID
     @AppStorage(AppStorageKey.gisuId) private var gisuId: Int = 0
+
+    /// 사용자 지부 ID
     @AppStorage(AppStorageKey.chapterId) private var chapterId: Int = 0
+
+    /// 사용자 역할
     @AppStorage(AppStorageKey.memberRole) private var memberRoleRaw: String = ""
 
     @State private var viewModel: NoticeEditorViewModel
     private let selectedGisuId: Int?
 
+    /// 링크 추가 직후 자동 스크롤/포커스에 사용할 링크 ID
     @State private var newlyAddedLinkID: UUID?
+
+    /// 사진 첨부 피커 노출 여부
     @State private var isPhotoPickerPresented = false
+
+    /// 현재 선택된 형광펜 색상 (.none = 비활성)
     @State private var selectedHighlightColor: HighlightColor = .none
 
+    /// 제목/내용 입력 포커스 제어
     @FocusState private var isTitleFieldFocused: Bool
     @FocusState private var isContentFieldFocused: Bool
 
+    /// ScrollView 높이 (본문 영역이 남은 공간을 채우기 위해 사용)
     @State private var scrollViewHeight: CGFloat = 0
 
+    /// 본문이 화면을 꽉 채우도록 최소 높이 계산
     private var editorMinHeight: CGFloat {
         max(scrollViewHeight, 400)
     }
@@ -102,6 +124,7 @@ struct NoticeEditorView: View {
 
     // MARK: - Content
 
+    /// 본문 콘텐츠 영역
     private var editorMainContent: some View {
         VStack(spacing: DefaultSpacing.spacing16) {
             NoticeEditorTextFieldSection(
@@ -140,6 +163,7 @@ struct NoticeEditorView: View {
 
     // MARK: - Top Safe Area
 
+    /// 상단 안전 영역: 공지 대상 선택 칩
     @ViewBuilder
     private func topSafeAreaContent() -> some View {
         if viewModel.selectedCategory.hasSubCategories
@@ -156,6 +180,7 @@ struct NoticeEditorView: View {
 
     // MARK: - Bottom Safe Area
 
+    /// 하단 안전 영역: 첨부·서식 도구 툴바 (제목 또는 내용에 포커스 시에만 표시)
     @ViewBuilder
     private func bottomSafeAreaContent() -> some View {
         if isTitleFieldFocused || viewModel.editorToolbarViewModel.isEditorActive {
@@ -181,6 +206,7 @@ struct NoticeEditorView: View {
 
     // MARK: - Toolbar
 
+    /// 공지 생성/수정 화면 상단 툴바
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         if !viewModel.isEditMode {
@@ -216,6 +242,7 @@ struct NoticeEditorView: View {
 
     // MARK: - Navigation
 
+    /// 화면 타이틀
     private var navigationTitle: String {
         if viewModel.isEditMode {
             return "공지 수정"
@@ -224,6 +251,7 @@ struct NoticeEditorView: View {
         return menuItemLabel(viewModel.selectedCategory)
     }
 
+    /// 메인 카테고리 서브타이틀
     private var navigationSubtitle: String {
         if viewModel.isEditMode {
             switch viewModel.selectedCategory {
@@ -242,6 +270,7 @@ struct NoticeEditorView: View {
         }
     }
 
+    /// 메인 카테고리 선택 바인딩
     private var categoryBinding: Binding<EditorMainCategory> {
         Binding(
             get: { viewModel.selectedCategory },
@@ -249,6 +278,7 @@ struct NoticeEditorView: View {
         )
     }
 
+    /// 상단 메뉴 항목 라벨 (권한/선택 기수 반영)
     private func menuItemLabel(_ category: EditorMainCategory) -> String {
         switch category {
         case .central:
@@ -260,23 +290,27 @@ struct NoticeEditorView: View {
 
     // MARK: - Function
 
+    /// 제목 필드 제출 시 내용 필드로 포커스를 이동합니다.
     private func moveFocusToContentField() {
         isTitleFieldFocused = false
         isContentFieldFocused = true
     }
 
+    /// 링크 첨부를 추가하고 자동 포커스 대상을 갱신합니다.
     private func addLinkAttachment() {
         let newItem = NoticeLinkItem()
         viewModel.noticeLinks.append(newItem)
         newlyAddedLinkID = newItem.id
     }
 
+    /// 공지 저장을 실행합니다.
     private func saveNotice() {
         Task {
             await viewModel.saveNotice()
         }
     }
 
+    /// 서브카테고리 칩 탭 이벤트를 처리합니다.
     private func handleSubCategoryTap(_ subCategory: EditorSubCategory) {
         if subCategory.hasFilter {
             viewModel.selectSubCategoryIfNeeded(subCategory)
@@ -287,10 +321,14 @@ struct NoticeEditorView: View {
         viewModel.toggleSubCategory(subCategory)
     }
 
+    /// AI 도우미 버튼 탭
     private func handleTapAI() {
         viewModel.requestAIImprovement()
     }
 
+    // MARK: - Helper
+
+    /// 앞뒤 공백/개행 제거 후 비어있으면 fallback을 반환합니다.
     private func normalizedName(from rawValue: String, fallback: String) -> String {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? fallback : trimmed
@@ -301,6 +339,7 @@ struct NoticeEditorView: View {
 
 private extension NoticeEditorView {
     enum Constants {
+        /// 이미지/투표 섹션 스크롤 앵커 ID (NoticeEditorBindings 와 동기화)
         static let imageSectionScrollID: String = "notice_editor_image_section"
         static let voteSectionScrollID: String = "notice_editor_vote_section"
     }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AILoadingOverlay.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AILoadingOverlay.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// AI 글 개선 처리 중/완료 시 표시되는 전체 화면 오버레이입니다.
 struct AILoadingOverlay: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/BlockquoteTextView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/BlockquoteTextView.swift
@@ -7,12 +7,26 @@
 
 import UIKit
 
+/// 인용구 속성이 적용된 단락에 왼쪽 세로 경계선을 렌더링하는 UITextView 서브클래스입니다.
 final class BlockquoteTextView: UITextView {
 
     // MARK: - Property
 
+    /// 인용구 영역별 개별 경계선 레이어를 관리합니다.
     private var blockquoteLayers: [CAShapeLayer] = []
+
+    /// `refreshBlockquoteBorders` 호출이 필요한 상태임을 나타냅니다.
     private var needsBlockquoteRefresh = false
+
+    // MARK: - Initializer
+
+    override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
 
     // MARK: - Layout
 
@@ -26,11 +40,15 @@ final class BlockquoteTextView: UITextView {
 
     // MARK: - Blockquote Rendering
 
+    /// 다음 레이아웃 패스에서 인용구 경계선을 갱신하도록 예약합니다.
     func setNeedsBlockquoteRefresh() {
         needsBlockquoteRefresh = true
         setNeedsLayout()
     }
 
+    /// 텍스트 스토리지에서 인용구 속성을 읽어 왼쪽 경계선 레이어를 즉시 업데이트합니다.
+    ///
+    /// 연속된 인용구 단락을 하나의 그룹으로 병합하여 단일 경계선을 그립니다.
     func refreshBlockquoteBorders() {
         needsBlockquoteRefresh = false
         CATransaction.begin()
@@ -38,6 +56,8 @@ final class BlockquoteTextView: UITextView {
         defer { CATransaction.commit() }
 
         let storage = textStorage
+
+        // 기존 레이어 모두 제거
         blockquoteLayers.forEach { $0.removeFromSuperlayer() }
         blockquoteLayers.removeAll()
 
@@ -53,6 +73,7 @@ final class BlockquoteTextView: UITextView {
         let fragPadding = textContainer.lineFragmentPadding
         let nsString = storage.string as NSString
 
+        // 연속된 인용구 단락을 하나의 그룹으로 병합하여 단일 경계선을 생성합니다.
         var location = 0
         var groupMinY: CGFloat = .greatestFiniteMagnitude
         var groupMaxY: CGFloat = -.greatestFiniteMagnitude
@@ -117,6 +138,7 @@ final class BlockquoteTextView: UITextView {
             location = next
         }
 
+        // 마지막 그룹이 문서 끝까지 이어지는 경우 플러시
         if hasActiveGroup {
             // EOF 빈 단락(커서만 있는 상태): extraLineFragmentRect로 높이 보정
             // 마지막 저장 문자와 커서의 typingAttributes 모두 인용구여야 확장합니다.

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/FormatPanel/FormatPanelView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/FormatPanel/FormatPanelView.swift
@@ -43,6 +43,7 @@ fileprivate enum Constants {
     ]
 }
 
+/// 공지 에디터에서 단락/인라인/목록 서식을 제어하는 패널
 struct FormatPanelView: View {
 
     // MARK: - Property
@@ -50,6 +51,7 @@ struct FormatPanelView: View {
     @Bindable var viewModel: EditorToolbarViewModel
     @State private var isHighlightPalettePresented = false
 
+    /// ViewModel의 highlightColor와 팔레트 색상을 비교하여 현재 선택된 인덱스를 반환합니다.
     private var selectedHighlightIndex: Int? {
         guard let vmColor = viewModel.highlightColor else { return nil }
         return Constants.highlightPalette.firstIndex { colorsApproximatelyEqual($0.color, vmColor) }
@@ -91,7 +93,7 @@ struct FormatPanelView: View {
         }
     }
 
-    // MARK: - Row1
+    // MARK: - Row1 Paragraph
 
     private var paragraphRow: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -116,7 +118,7 @@ struct FormatPanelView: View {
         }
     }
 
-    // MARK: - Row2
+    // MARK: - Row2 Inline
 
     private var inlineRow: some View {
         HStack(alignment: .top, spacing: Constants.containerSpacing) {
@@ -240,7 +242,7 @@ struct FormatPanelView: View {
         }
     }
 
-    // MARK: - Row3
+    // MARK: - Row3 List
 
     private var listRow: some View {
         HStack(spacing: Constants.controlSpacing) {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+Blockquote.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+Blockquote.swift
@@ -9,6 +9,9 @@ extension RichTextCoordinator {
 
     // MARK: - Blockquote Enter
 
+    /// 인용구 단락에서 Enter 키 입력을 처리합니다.
+    /// - 빈 인용구 줄: 인용구 속성 제거(탈출)하고 false 반환
+    /// - 내용 있는 인용구 줄: 같은 인용구 속성으로 새 줄 삽입하고 false 반환
     func handleReturnInBlockquote(textView: BlockquoteTextView, range: NSRange) -> Bool {
         let storage = textView.textStorage
         guard storage.length > 0 else { return true }
@@ -28,7 +31,7 @@ extension RichTextCoordinator {
         }
         guard isInBlockquote else { return true }
 
-        // EOF 빈 단락이면 trailing \n(storage.length - 1)에서 blockquote 속성을 읽습니다.
+        // attribute 읽기용 위치: EOF 빈 단락이면 trailing \n(storage.length - 1)에서 blockquote 속성을 읽습니다.
         let checkLocation = min(paragraphRange.location, max(0, storage.length - 1))
         let paragraphText = nsString.substring(with: paragraphRange)
         // zero-width space(\u{200B})는 빈 인용구 플레이스홀더이므로 내용으로 취급하지 않습니다.

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+Blockquote.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+Blockquote.swift
@@ -48,9 +48,12 @@ extension RichTextCoordinator {
             normalStyle.firstLineHeadIndent = baseLine
 
             storage.beginEditing()
+            // ZWS 플레이스홀더가 포함되어 있으면 함께 제거합니다.
             let cleanedText = paragraphText.replacingOccurrences(of: "\u{200B}", with: "")
             if cleanedText.count != paragraphText.count {
                 storage.replaceCharacters(in: paragraphRange, with: cleanedText)
+                // ZWS 제거 후 해당 단락이 완전히 사라졌거나(EOF) 스토리지가 비었으면
+                // 스토리지 속성 수정을 건너뛰고 typingAttributes만 정리합니다.
                 if storage.length > 0, paragraphRange.location < storage.length {
                     let safeLocation = min(paragraphRange.location, storage.length - 1)
                     let updatedRange = (storage.string as NSString)
@@ -79,8 +82,9 @@ extension RichTextCoordinator {
             let mutableNormal = (normalStyle.mutableCopy() as? NSMutableParagraphStyle) ?? NSMutableParagraphStyle()
             textView.typingAttributes[.paragraphStyle] = (mutableNormal.copy() as? NSParagraphStyle) ?? mutableNormal
 
+            // 인용구 탈출 시 경계선을 즉시 제거합니다.
             // setNeedsBlockquoteRefresh()는 다음 layoutSubviews까지 지연되어
-            // 이전 경계선이 한 프레임 남을 수 있으므로 즉시 갱신합니다.
+            // 이전 경계선이 한 프레임 남을 수 있습니다.
             textView.refreshBlockquoteBorders()
             parent.attributedText = textView.attributedText
             parent.toolbarViewModel.selectedRange = textView.selectedRange
@@ -88,7 +92,7 @@ extension RichTextCoordinator {
             return false
         }
 
-        // 내용 있는 인용구 줄: 같은 인용구 속성으로 새 줄 이어받기
+        // 내용 있는 인용구 줄 → 같은 인용구 속성으로 새 줄 이어받기
         let borderColor = storage.attribute(.editorBlockquoteBorderColor, at: checkLocation, effectiveRange: nil) as? UIColor ?? UIColor.systemGray3
         let baseHeadNum = storage.attribute(.editorBlockquoteBaseHeadIndent, at: checkLocation, effectiveRange: nil) as? NSNumber
         let baseLineNum = storage.attribute(.editorBlockquoteBaseFirstLineHeadIndent, at: checkLocation, effectiveRange: nil) as? NSNumber
@@ -129,6 +133,9 @@ extension RichTextCoordinator {
 
     // MARK: - Blockquote TypingAttributes Cleanup
 
+    /// 백스페이스 등으로 텍스트가 모두 삭제되었거나
+    /// 현재 단락에 인용구 속성이 없는데 typingAttributes에 인용구 들여쓰기가
+    /// 남아 있는 경우, typingAttributes와 storage 단락 속성을 모두 리셋합니다.
     func cleanupBlockquoteTypingAttributesIfNeeded(
         in textView: UITextView
     ) {
@@ -152,12 +159,14 @@ extension RichTextCoordinator {
             return (ps?.headIndent ?? 0) >= blockquoteIndent || hasBaseAttr
         }()
 
+        // typingAttributes에 인용구 관련 속성이 없으면 정리 불필요
         let hasBlockquoteTyping = (textView.typingAttributes[NSAttributedString.Key.editorBlockquote] as? Bool) == true
         let typingStyle = textView.typingAttributes[.paragraphStyle] as? NSParagraphStyle
         let hasBlockquoteIndent = (typingStyle?.headIndent ?? 0) >= blockquoteIndent
 
         guard hasBlockquoteTyping || hasBlockquoteIndent || hasStorageBlockquoteIndent else { return }
 
+        // 저장소가 비어있거나 현재 단락에 인용구 속성이 없으면 정리
         let isCurrentParagraphBlockquote: Bool = {
             guard storage.length > 0 else { return false }
             let pRange = (storage.string as NSString).paragraphRange(
@@ -168,11 +177,15 @@ extension RichTextCoordinator {
         }()
 
         // typingAttributes에 인용구가 명시적으로 활성화되어 있으면
-        // storage가 비어도 사용자가 인용구 모드를 유지하고 있을 수 있으므로 정리하지 않습니다.
-        if hasBlockquoteTyping { return }
+        // 인용구 입력 중이므로 정리하지 않습니다.
+        // (storage가 비어도 사용자가 인용구 모드를 유지하고 있을 수 있음)
+        if hasBlockquoteTyping {
+            return
+        }
 
         guard storage.length == 0 || !isCurrentParagraphBlockquote else { return }
 
+        // base indent 값을 먼저 읽어 둔 뒤 키를 삭제합니다.
         let typingBaseHead = (textView.typingAttributes[.editorBlockquoteBaseHeadIndent] as? NSNumber)
             .map { CGFloat($0.doubleValue) } ?? 0
         let typingBaseLine = (textView.typingAttributes[.editorBlockquoteBaseFirstLineHeadIndent] as? NSNumber)
@@ -183,12 +196,14 @@ extension RichTextCoordinator {
         textView.typingAttributes.removeValue(forKey: NSAttributedString.Key.editorBlockquoteBaseHeadIndent)
         textView.typingAttributes.removeValue(forKey: NSAttributedString.Key.editorBlockquoteBaseFirstLineHeadIndent)
 
+        // 기존 paragraphStyle을 보존하고 indent를 base 값으로 복원합니다.
         let existingTypingStyle = textView.typingAttributes[.paragraphStyle] as? NSParagraphStyle ?? .default
         let cleanTypingStyle = (existingTypingStyle.mutableCopy() as? NSMutableParagraphStyle) ?? NSMutableParagraphStyle()
         cleanTypingStyle.headIndent = typingBaseHead
         cleanTypingStyle.firstLineHeadIndent = typingBaseLine
         textView.typingAttributes[.paragraphStyle] = cleanTypingStyle.copy()
 
+        // storage의 현재 단락에 남은 인용구 들여쓰기도 정리
         if hasStorageBlockquoteIndent, storage.length > 0 {
             let loc = min(cursorLoc, storage.length - 1)
             let nsString = storage.string as NSString
@@ -225,6 +240,7 @@ extension RichTextCoordinator {
         let blockquoteIndent = EditorConstants.blockquoteIndent
         guard storage.length > 0 else { return }
 
+        // typingAttributes에 인용구가 활성화되어 있으면 인용구 입력 중이므로 정리하지 않습니다.
         guard (textView.typingAttributes[.editorBlockquote] as? Bool) != true else { return }
 
         // 단락 시작 위치에서 확인하여 커스텀 키가 없는 중간 문자에 의한 오탐을 방지합니다.
@@ -241,6 +257,7 @@ extension RichTextCoordinator {
         let paragraphRange = nsString.paragraphRange(for: NSRange(location: loc, length: 0))
         guard paragraphRange.length > 0 else { return }
 
+        // 기존 paragraphStyle을 보존하고 indent를 base 값으로 복원합니다.
         let baseHead = (storage.attribute(.editorBlockquoteBaseHeadIndent, at: loc, effectiveRange: nil) as? NSNumber)
             .map { CGFloat($0.doubleValue) } ?? 0
         let baseLine = (storage.attribute(.editorBlockquoteBaseFirstLineHeadIndent, at: loc, effectiveRange: nil) as? NSNumber)
@@ -273,8 +290,11 @@ extension RichTextCoordinator {
         textView.typingAttributes[.paragraphStyle] = cleanTypingPS.copy()
     }
 
-    /// UIKit은 커서 이동 시 커스텀 NSAttributedString.Key를 버립니다.
-    /// storage의 현재 단락 시작 위치에서 인용구 속성을 읽어 typingAttributes에 재주입합니다.
+    /// UIKit이 커서 이동 시 typingAttributes에서 버린 인용구 커스텀 키를 재주입합니다.
+    ///
+    /// UIKit은 `.font`, `.paragraphStyle` 등 표준 키만 typingAttributes에 유지하고,
+    /// `.editorBlockquote` 등 커스텀 키는 소실됩니다.
+    /// storage의 현재 단락 시작 위치에서 인용구 속성을 읽어 typingAttributes에 반영합니다.
     func reinjectBlockquoteTypingAttributesIfNeeded(in textView: UITextView) {
         let storage = textView.textStorage
         guard storage.length > 0 else { return }
@@ -316,7 +336,8 @@ extension RichTextCoordinator {
             textView.typingAttributes.removeValue(forKey: .editorBlockquoteBaseFirstLineHeadIndent)
         }
 
-        // Pretendard italic: UIKit은 커서 이동 시 oblique matrix를 소실시킵니다.
+        // Pretendard italic: storage의 .editorItalic 속성을 typingAttributes에 재주입합니다.
+        // UIKit은 커서 이동 시 typingAttributes를 재계산하면서 oblique matrix를 소실시킵니다.
         let isItalicInStorage = (storage.attribute(.editorItalic, at: italicCheckLoc, effectiveRange: nil) as? Bool) == true
 
         if isItalicInStorage {
@@ -333,11 +354,13 @@ extension RichTextCoordinator {
     // MARK: - ZWS Cleanup
 
     /// 빈 인용구 활성화 시 삽입한 ZWS 플레이스홀더를 정리합니다.
-    /// 실제 콘텐츠가 입력된 후에만 ZWS를 제거하며, 커서 단락만 스캔합니다.
+    /// 실제 콘텐츠가 입력된 후에만 ZWS를 제거합니다.
+    /// 커서가 위치한 단락만 스캔하여 O(1) 비용으로 처리합니다.
     func stripZeroWidthSpacesIfNeeded(in textView: UITextView) {
         let storage = textView.textStorage
         guard storage.length > 0 else { return }
 
+        // 커서 주변 단락으로 범위를 제한하여 성능을 보장합니다.
         let cursorLocation = textView.selectedRange.location
         let nsString = storage.string as NSString
         let paragraphRange = nsString.paragraphRange(
@@ -346,8 +369,10 @@ extension RichTextCoordinator {
         let paragraphText = nsString.substring(with: paragraphRange)
 
         guard paragraphText.contains("\u{200B}") else { return }
+        // ZWS 외에 실제 콘텐츠가 없으면(빈 인용구 상태) 제거하지 않습니다.
         guard paragraphText.contains(where: { !$0.isNewline && !$0.isWhitespace && $0 != "\u{200B}" }) else { return }
 
+        // ZWS 제거 전: 해당 단락의 인용구 속성을 기록합니다.
         let checkLoc = min(paragraphRange.location, storage.length - 1)
         let wasBlockquote = (storage.attribute(.editorBlockquote, at: checkLoc, effectiveRange: nil) as? Bool) == true
         let savedBorderColor = storage.attribute(.editorBlockquoteBorderColor, at: checkLoc, effectiveRange: nil) as? UIColor
@@ -355,6 +380,7 @@ extension RichTextCoordinator {
         let savedBaseLine = storage.attribute(.editorBlockquoteBaseFirstLineHeadIndent, at: checkLoc, effectiveRange: nil) as? NSNumber
         let savedParagraphStyle = storage.attribute(.paragraphStyle, at: checkLoc, effectiveRange: nil) as? NSParagraphStyle
 
+        // 단락 내 ZWS 위치를 수집한 뒤 뒤에서부터 삭제합니다.
         let paragraphNSString = paragraphText as NSString
         var zwsOffsets: [Int] = []
         var searchStart = 0
@@ -376,6 +402,7 @@ extension RichTextCoordinator {
             storage.replaceCharacters(in: NSRange(location: paragraphRange.location + offset, length: 1), with: "")
         }
 
+        // ZWS 제거 후: 인용구 속성 세트 전체를 무조건 재적용합니다.
         // replaceCharacters로 ZWS를 제거하면 attribute run이 병합되면서
         // 일부 속성만 소실될 수 있으므로, 전체 세트를 일관되게 재적용합니다.
         if wasBlockquote, storage.length > 0 {
@@ -404,7 +431,9 @@ extension RichTextCoordinator {
         textView.selectedRange = NSRange(location: min(newCursor, storage.length), length: 0)
         isSuppressingSelectionSync = false
 
-        // UIKit은 selectedRange 변경 시 커스텀 키를 버리므로, 재계산 후에 덮어써야 유지됩니다.
+        // typingAttributes 복원은 selectedRange 변경 이후에 수행합니다.
+        // UIKit은 selectedRange 변경 시 typingAttributes를 재계산하면서
+        // 커스텀 키를 버리므로, 재계산 후에 덮어써야 유지됩니다.
         if wasBlockquote {
             textView.typingAttributes[.editorBlockquote] = true
             if let color = savedBorderColor { textView.typingAttributes[.editorBlockquoteBorderColor] = color }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+List.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+List.swift
@@ -9,6 +9,8 @@ extension RichTextCoordinator {
 
     // MARK: - List Enter
 
+    /// 목록 단락에서 Enter 키 입력을 처리합니다.
+    /// - 반환값: true이면 UIKit이 기본 Enter 처리를 수행, false이면 직접 처리 완료
     func handleReturnInList(textView: BlockquoteTextView, range: NSRange) -> Bool {
         let storage = textView.textStorage
         guard storage.length > 0 else { return true }
@@ -18,13 +20,14 @@ extension RichTextCoordinator {
         let paragraphLocation = min(range.location, storage.length)
         let nsString = storage.string as NSString
         let paragraphRange = nsString.paragraphRange(for: NSRange(location: paragraphLocation, length: 0))
-        // EOF 빈 단락(location >= storage.length): detectListPrefix가 nil을 반환합니다.
+        // EOF 빈 단락(location >= storage.length): paragraphText가 빈 문자열이어서 detectListPrefix가 nil을 반환합니다.
         let paragraphText = paragraphRange.location < storage.length ? nsString.substring(with: paragraphRange) : ""
 
         guard let (prefix, listKind) = detectListPrefix(in: paragraphText) else {
             return true
         }
 
+        // 접두사 이후 실제 콘텐츠 존재 여부 확인 (NSString 기반으로 통일)
         let prefixNSLength = (prefix as NSString).length
         let paragraphNSStr = paragraphText as NSString
         let contentAfterPrefix = paragraphNSStr.length > prefixNSLength ? paragraphNSStr.substring(from: prefixNSLength) : ""
@@ -67,8 +70,9 @@ extension RichTextCoordinator {
         let currentFont = textView.typingAttributes[.font] as? UIFont ?? UIFont.preferredFont(forTextStyle: .body)
         let listStyleID = listStyleID(for: listKind)
 
+        // 새 줄 속성은 허용 목록 방식으로 구성합니다.
         // 인라인 서식(.link, .underlineStyle, .strikethroughStyle, .backgroundColor)이
-        // 다음 목록 항목으로 번지는 것을 방지하기 위해 허용 목록 방식으로 구성합니다.
+        // 다음 목록 항목으로 번지는 것을 방지합니다.
         var newLineAttrs: [NSAttributedString.Key: Any] = [.font: currentFont]
         if let paragraphStyle = textView.typingAttributes[.paragraphStyle] {
             newLineAttrs[.paragraphStyle] = paragraphStyle
@@ -103,6 +107,7 @@ extension RichTextCoordinator {
         let newCursor = range.location + (newLineString as NSString).length
         textView.selectedRange = NSRange(location: newCursor, length: 0)
         scheduleScrollCursorToVisible(in: textView)
+        // 인라인 서식이 다음 목록 항목으로 번지지 않도록 typingAttributes를 재구성합니다.
         textView.typingAttributes = newLineAttrs
 
         parent.attributedText = textView.attributedText
@@ -114,15 +119,19 @@ extension RichTextCoordinator {
     // MARK: - Numbered List Renumber
 
     /// 번호 목록 항목을 삽입한 이후 뒤따르는 번호 목록 단락을 재번호합니다.
-    /// 단일 beginEditing/endEditing 블록으로 delegate 알림을 1회만 발생시킵니다.
+    ///
+    /// 전체 재번호 작업을 단일 beginEditing/endEditing 블록으로 감싸
+    /// delegate 알림을 1회만 발생시켜 SwiftUI 다중 재렌더를 방지합니다.
     func renumberFollowingNumberedList(from insertedEnd: Int, expectedNext: Int, in storage: NSTextStorage, font: UIFont) {
         var currentNumber = expectedNext
         var location = insertedEnd
 
+        // 삽입된 새 줄(다음 항목)의 다음 단락부터 순회 시작
         var nsString = storage.string as NSString
         let newParagraph = nsString.paragraphRange(for: NSRange(location: min(location, max(0, storage.length - 1)), length: 0))
         location = NSMaxRange(newParagraph)
 
+        // 단일 editing 트랜잭션: N개 항목을 재번호해도 delegate 알림 1회만 발생
         storage.beginEditing()
         while location < storage.length {
             nsString = storage.string as NSString  // replaceCharacters 이후 항상 갱신
@@ -157,6 +166,7 @@ extension RichTextCoordinator {
 
     // MARK: - List Prefix Detection
 
+    /// 단락 텍스트에서 목록 접두사와 종류를 감지합니다.
     func detectListPrefix(in paragraphText: String) -> (prefix: String, kind: EditorListStyle)? {
         if paragraphText.hasPrefix("• ") { return ("• ", .bullet) }
         if paragraphText.hasPrefix("– ") { return ("– ", .dash) }
@@ -173,6 +183,7 @@ extension RichTextCoordinator {
 
     static let numberListPrefixRegex = try! NSRegularExpression(pattern: "^(\\d+)\\.\\s+")
 
+    /// 현재 접두사를 기반으로 다음 목록 항목의 접두사를 계산합니다.
     func nextListPrefix(for kind: EditorListStyle, currentPrefix: String) -> String {
         switch kind {
         case .bullet: return "• "
@@ -184,6 +195,7 @@ extension RichTextCoordinator {
         }
     }
 
+    /// 목록 스타일에 대한 저장 식별자를 반환합니다.
     func listStyleID(for style: EditorListStyle) -> String {
         switch style {
         case .bullet: return "bullet"

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+List.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+List.swift
@@ -34,7 +34,7 @@ extension RichTextCoordinator {
         let hasContent = contentAfterPrefix.contains { !$0.isNewline && !$0.isWhitespace }
 
         if !hasContent {
-            // 빈 목록 줄: 접두사만 제거하고 목록 탈출
+            // 빈 목록 줄 → 접두사만 제거하고 목록 탈출
             let removeRange = NSRange(location: paragraphRange.location, length: prefixNSLength)
             let fontLocation = min(paragraphRange.location, storage.length - 1)
             let currentFont = storage.attribute(.font, at: fontLocation, effectiveRange: nil) as? UIFont
@@ -65,7 +65,7 @@ extension RichTextCoordinator {
             return false
         }
 
-        // 내용 있는 목록 줄: 다음 항목 접두사를 자동으로 이어받습니다.
+        // 내용 있는 목록 줄 → 다음 항목 접두사를 자동으로 이어받습니다
         let nextPrefix = nextListPrefix(for: listKind, currentPrefix: prefix)
         let currentFont = textView.typingAttributes[.font] as? UIFont ?? UIFont.preferredFont(forTextStyle: .body)
         let listStyleID = listStyleID(for: listKind)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+Placeholder.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+Placeholder.swift
@@ -52,12 +52,15 @@ extension RichTextCoordinator {
 
         let placeholderText = parent.placeholder
         // 포커스 여부와 관계없이 내용이 비어있으면 placeholder를 표시합니다.
+        // 빈 에디터에 포커스가 들어가도 어떤 필드인지 알 수 있습니다.
         let showPlaceholder = textView.attributedText.length == 0
         placeholderLabel.isHidden = !showPlaceholder
+        // VoiceOver: accessibilityHint로 placeholder를 제공합니다.
         textView.accessibilityHint = showPlaceholder ? placeholderText : nil
 
         guard showPlaceholder else { return }
 
+        // typingAttributes에서 현재 서식을 읽어 placeholder에 미리보기로 반영합니다.
         let typingAttrs = textView.typingAttributes
         let font = typingAttrs[.font] as? UIFont
             ?? textView.font

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+Scroll.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+Scroll.swift
@@ -9,6 +9,8 @@ extension RichTextCoordinator {
 
     // MARK: - Scroll
 
+    /// 다음 run loop에서 커서 스크롤을 1회만 실행하도록 예약합니다.
+    /// 빠른 입력/붙여넣기에서 예약이 누적되는 것을 방지합니다.
     func scheduleScrollCursorToVisible(in textView: UITextView) {
         pendingScrollWork?.cancel()
         let work = DispatchWorkItem { [weak self, weak textView] in
@@ -19,6 +21,8 @@ extension RichTextCoordinator {
         DispatchQueue.main.async(execute: work)
     }
 
+    /// 프로그래매틱 텍스트 삽입 이후 커서가 화면에 보이도록 가장 가까운 UIScrollView를 스크롤합니다.
+    ///
     /// isScrollEnabled = false인 UITextView는 자체 커서 추적을 하지 않으므로
     /// 부모 ScrollView를 직접 찾아 scrollRectToVisible을 호출합니다.
     func scrollCursorToVisible(in textView: UITextView) {
@@ -38,6 +42,7 @@ extension RichTextCoordinator {
                 let visibleMinY = scrollView.contentOffset.y + topInset
                 let visibleMaxY = scrollView.contentOffset.y + scrollView.bounds.height - bottomInset
 
+                // 커서가 이미 visible rect 안에 있으면 스크롤 불필요
                 if rectInScrollView.minY >= visibleMinY && rectInScrollView.maxY <= visibleMaxY {
                     return
                 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator.swift
@@ -26,14 +26,17 @@ final class RichTextCoordinator: NSObject, UITextViewDelegate {
     // MARK: - UITextViewDelegate
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        // 한글 등 IME 조합 중에는 Enter 커스텀 처리를 건너뜁니다.
+        // markedTextRange != nil이면 조합이 진행 중이므로 UIKit 기본 동작을 유지합니다.
         if let bqTextView = textView as? BlockquoteTextView {
             // 인용구가 아닌 단락에 인용구 들여쓰기가 남아있으면
             // UIKit이 문자를 삽입하기 전에 미리 정리하여 들여쓰기 상속을 방지합니다.
             cleanupOrphanedBlockquoteIndent(in: bqTextView, at: range.location)
 
-            // 한글 등 IME 조합 중(markedTextRange != nil)에는 Enter 커스텀 처리를 건너뜁니다.
             if text == "\n", textView.markedTextRange == nil {
+                // blockquote Enter 처리를 먼저 시도합니다. 처리됐으면 list 처리는 건너뜁니다.
                 if !handleReturnInBlockquote(textView: bqTextView, range: range) { return false }
+                // 목록 Enter 처리를 시도합니다.
                 return handleReturnInList(textView: bqTextView, range: range)
             }
         }
@@ -41,17 +44,23 @@ final class RichTextCoordinator: NSObject, UITextViewDelegate {
     }
 
     func textViewDidChange(_ textView: UITextView) {
+        // italic 토글 후 첫 타이핑: _pendingItalicEnabled 플래그를 초기화합니다.
+        // 이후부터는 storage 속성과 .editorItalic 커스텀 키로 상태를 추적합니다.
         parent.toolbarViewModel.clearPendingItalic()
 
+        // 빈 인용구 활성화 시 삽입한 ZWS 플레이스홀더를 실제 콘텐츠 입력 후 정리합니다.
+        // IME 조합 중에는 건드리지 않습니다.
         if textView.markedTextRange == nil {
             stripZeroWidthSpacesIfNeeded(in: textView)
         }
 
+        // 백스페이스 등으로 텍스트가 모두 삭제되어 인용구가 해제된 경우
+        // typingAttributes에 남아 있는 인용구 들여쓰기를 리셋합니다.
         cleanupBlockquoteTypingAttributesIfNeeded(in: textView)
 
         // IME 조합 중(markedTextRange != nil)에는 바인딩 갱신을 보류합니다.
-        // SwiftUI .onChange가 발화되면 MarkdownSerializer.serialize가 실행되어
-        // 조합 입력이 깨지거나 커서가 튀는 원인이 됩니다.
+        // SwiftUI .onChange가 발화되면 상위에서 MarkdownSerializer.serialize가
+        // 실행되어 조합 입력이 깨지거나 커서가 튀는 원인이 됩니다.
         if textView.markedTextRange == nil {
             parent.attributedText = textView.attributedText
         }
@@ -60,23 +69,28 @@ final class RichTextCoordinator: NSObject, UITextViewDelegate {
         }
         updatePlaceholder(in: textView)
 
+        // 인용구 경계선: 일반 입력으로 줄바꿈/삭제 시에도 갱신
         if let bqTextView = textView as? BlockquoteTextView {
             bqTextView.setNeedsBlockquoteRefresh()
         }
 
+        // 일반 타이핑/붙여넣기 시에도 커서가 키보드 뒤에 숨지 않도록 합니다.
         scheduleScrollCursorToVisible(in: textView)
     }
 
     func textViewDidChangeSelection(_ textView: UITextView) {
+        // 내부 커서 보정 중에는 동기화를 건너뜁니다.
         guard !isSuppressingSelectionSync else { return }
-        // IME 조합 중에는 툴바 깜빡임과 렌더링 지연이 발생합니다.
+        // IME 조합 중(한글 등)에는 선택 범위가 빈번하게 변경됩니다.
+        // 조합 중 서식 동기화를 수행하면 툴바 깜빡임과 렌더링 지연이 발생합니다.
         guard textView.markedTextRange == nil else { return }
 
-        // UIKit은 커서 이동 시 커스텀 NSAttributedString.Key를 버립니다.
+        // UIKit은 커서 이동 시 typingAttributes를 재계산하면서
+        // 커스텀 NSAttributedString.Key를 버립니다.
         // storage의 단락 시작 위치에서 인용구 속성을 읽어 재주입합니다.
         reinjectBlockquoteTypingAttributesIfNeeded(in: textView)
 
-        // textViewDidChange에서 보류했던 바인딩을 반영합니다.
+        // IME 조합이 끝난 시점: textViewDidChange에서 보류했던 바인딩을 반영합니다.
         if !parent.attributedText.isEqual(textView.attributedText) {
             parent.attributedText = textView.attributedText
         }
@@ -95,6 +109,7 @@ final class RichTextCoordinator: NSObject, UITextViewDelegate {
 
     func textViewDidEndEditing(_ textView: UITextView) {
         isEditing = false
+        // 편집 종료 시 IME 조합 중 보류했던 바인딩을 확실히 반영합니다.
         if !parent.attributedText.isEqual(textView.attributedText) {
             parent.attributedText = textView.attributedText
         }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextViewRepresentable.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextViewRepresentable.swift
@@ -6,6 +6,8 @@
 import SwiftUI
 import UIKit
 
+// NoticeRichTextView.swift 내부에서만 사용되는 UIViewRepresentable 래퍼입니다.
+// underscore prefix는 모듈 내부 구현 세부사항임을 나타냅니다.
 struct RichTextViewRepresentable: UIViewRepresentable {
 
     // MARK: - Property
@@ -23,7 +25,7 @@ struct RichTextViewRepresentable: UIViewRepresentable {
         textView.isScrollEnabled = false
         textView.backgroundColor = .clear
         textView.font = UIFont(name: "Pretendard-Regular", size: 16) ?? UIFont.preferredFont(forTextStyle: .body)
-        // Pretendard는 Dynamic Type 미지원 커스텀 폰트이므로 false로 설정합니다.
+        // Pretendard는 Dynamic Type 스케일 미지원 커스텀 폰트이므로 false로 설정합니다.
         // true이면 접근성 글자 크기 변경 시 UIKit이 시스템 폰트로 폴백할 수 있습니다.
         textView.adjustsFontForContentSizeCategory = false
         textView.accessibilityLabel = "내용"
@@ -58,9 +60,10 @@ struct RichTextViewRepresentable: UIViewRepresentable {
 
         if !uiView.attributedText.isEqual(attributedText) {
             // IME 조합 중(한글 등) attributedText 강제 재주입은 조합 문자를 깨뜨립니다.
+            // 텍스트 재주입만 건너뛰고, 아래 툴바/placeholder 갱신은 계속 실행합니다.
             if uiView.markedTextRange == nil {
                 // UITextView.attributedText setter는 typingAttributes를 리셋하므로
-                // 커스텀 속성 보존을 위해 재주입 전후로 저장/복원합니다.
+                // 인용구 등 커스텀 속성을 보존하기 위해 재주입 전후로 저장/복원합니다.
                 let savedTypingAttributes = uiView.typingAttributes
                 let selectedRange = context.coordinator.clampedSelectedRange(for: uiView.selectedRange, in: attributedText)
                 uiView.attributedText = attributedText

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextViewRepresentable.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextViewRepresentable.swift
@@ -40,6 +40,7 @@ struct RichTextViewRepresentable: UIViewRepresentable {
         let coordinator = context.coordinator
         toolbarViewModel.onFormattingApplied = { [weak textView, weak coordinator] in
             guard let textView, let coordinator else { return }
+            // IME 조합 중에는 바인딩 갱신을 보류하여 조합 문자열이 깨지는 것을 방지합니다.
             if textView.markedTextRange == nil {
                 coordinator.parent.attributedText = textView.attributedText
             }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownAttributeBuilder.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownAttributeBuilder.swift
@@ -96,6 +96,8 @@ enum MarkdownAttributeBuilder {
             return monospacedFont
         }
 
+        // Pretendard 커스텀 폰트는 symbolic traits 방식이 아닌 폰트명 직접 지정으로 처리
+        // Pretendard에 italic 변형이 없으므로 oblique matrix로 기울임 표현
         if baseFont.fontName.hasPrefix("Pretendard") {
             let fontName = style.isBold ? "Pretendard-SemiBold" : "Pretendard-Regular"
             var font = UIFont(name: fontName, size: pointSize) ?? baseFont.withSize(pointSize)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownBlockParser.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownBlockParser.swift
@@ -68,28 +68,35 @@ enum MarkdownBlockParser {
         let lineRange = NSRange(location: 0, length: lineNSString.length)
 
         if let match = MarkdownRegex.h3.firstMatch(in: line, range: lineRange) {
+            // ### 텍스트 → 단락 스타일 subheading (17pt)
             markdownBody = lineNSString.substring(from: match.range.length)
             style.fontSize = 17
             style.isBold = true
         } else if let match = MarkdownRegex.h2.firstMatch(in: line, range: lineRange) {
+            // ## 텍스트 → 단락 스타일 heading (22pt)
             markdownBody = lineNSString.substring(from: match.range.length)
             style.fontSize = 22
             style.isBold = true
         } else if let match = MarkdownRegex.h1.firstMatch(in: line, range: lineRange) {
+            // # 텍스트 → 단락 스타일 title (28pt)
             markdownBody = lineNSString.substring(from: match.range.length)
             style.fontSize = 28
             style.isBold = true
         } else if let match = MarkdownRegex.blockquote.firstMatch(in: line, range: lineRange) {
+            // > 텍스트 → 인용구 (headIndent > 0 + .editorBlockquote attribute)
             markdownBody = lineNSString.substring(from: match.range.length)
             style.paragraphStyle = MarkdownAttributeBuilder.quoteParagraphStyle()
             style.isBlockquote = true
         } else if let match = MarkdownRegex.bulletList.firstMatch(in: line, range: lineRange) {
+            // - 텍스트 → bullet prefix •
             markdownBody = lineNSString.substring(from: match.range.length)
             literalPrefix = "• "
         } else if let match = MarkdownRegex.dashList.firstMatch(in: line, range: lineRange) {
+            // – 텍스트 → dash prefix –
             markdownBody = lineNSString.substring(from: match.range.length)
             literalPrefix = "– "
         } else if let match = MarkdownRegex.numberList.firstMatch(in: line, range: lineRange) {
+            // 1. 텍스트 → number prefix 숫자.
             let marker = lineNSString.substring(with: match.range(at: 1))
             markdownBody = lineNSString.substring(from: match.range.length)
             literalPrefix = "\(marker). "

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownBlockSerializer.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownBlockSerializer.swift
@@ -103,16 +103,20 @@ enum MarkdownBlockSerializer {
         let firstContentLocation = contentRange.location + firstContentOffset
         let font = attributedString.attribute(.font, at: firstContentLocation, effectiveRange: nil) as? UIFont
 
+        // 속성 기반 판별을 텍스트 prefix보다 먼저 수행 (제목/인용구가 목록처럼 보이는 텍스트로 시작해도 안전)
         let isBlockquote = (attributedString.attribute(.editorBlockquote, at: firstContentLocation, effectiveRange: nil) as? Bool) == true
         if isBlockquote {
+            // 인용구 (.editorBlockquote attribute) → > 텍스트
             return MarkdownBlockContext(markdownPrefix: "> ", inlineRange: contentRange, blockImpliedBold: false)
         }
 
         if let font, abs(font.pointSize - 28) < 0.5 {
+            // 단락 스타일 title (28pt) → # 텍스트
             return MarkdownBlockContext(markdownPrefix: "# ", inlineRange: contentRange, blockImpliedBold: true)
         }
 
         if let font, abs(font.pointSize - 22) < 0.5 {
+            // 단락 스타일 heading (22pt) → ## 텍스트
             return MarkdownBlockContext(markdownPrefix: "## ", inlineRange: contentRange, blockImpliedBold: true)
         }
 
@@ -120,11 +124,14 @@ enum MarkdownBlockSerializer {
            abs(font.pointSize - 17) < 0.5,
            font.fontDescriptor.symbolicTraits.contains(.traitBold),
            isParagraphDominantlySubheading(in: attributedString, range: contentRange) {
+            // 단락 스타일 subheading (17pt) → ### 텍스트
             return MarkdownBlockContext(markdownPrefix: "### ", inlineRange: contentRange, blockImpliedBold: true)
         }
 
+        // 텍스트 prefix 기반 목록 판별 (속성 판별 이후)
         if let match = MarkdownRegex.bulletPrefix
             .firstMatch(in: paragraphString as String, range: NSRange(location: 0, length: fullLength)) {
+            // Bullet prefix • → - 텍스트
             return MarkdownBlockContext(
                 markdownPrefix: "- ",
                 inlineRange: NSRange(location: contentRange.location + match.range.length, length: contentRange.length - match.range.length),
@@ -134,6 +141,7 @@ enum MarkdownBlockSerializer {
 
         if let match = MarkdownRegex.dashPrefix
             .firstMatch(in: paragraphString as String, range: NSRange(location: 0, length: fullLength)) {
+            // Dash prefix – → – 텍스트
             return MarkdownBlockContext(
                 markdownPrefix: "– ",
                 inlineRange: NSRange(location: contentRange.location + match.range.length, length: contentRange.length - match.range.length),
@@ -144,6 +152,8 @@ enum MarkdownBlockSerializer {
         if let match = MarkdownRegex.numberPrefix
             .firstMatch(in: paragraphString as String, range: NSRange(location: 0, length: fullLength)) {
             let marker = paragraphString.substring(with: match.range(at: 1))
+
+            // Number prefix 숫자. → 1. 텍스트
             return MarkdownBlockContext(
                 markdownPrefix: "\(marker). ",
                 inlineRange: NSRange(location: contentRange.location + match.range.length, length: contentRange.length - match.range.length),
@@ -216,6 +226,7 @@ enum MarkdownBlockSerializer {
             if let font = value as? UIFont,
                abs(font.pointSize - 17) < 0.5,
                font.fontDescriptor.symbolicTraits.contains(.traitBold) {
+                // This run qualifies as subheading
             } else {
                 allSubheading = false
                 stop.pointee = true

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownEscaping.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownEscaping.swift
@@ -45,6 +45,7 @@ enum MarkdownEscaping {
         var escaped = ""
 
         for character in text {
+            // '<', '>' 포함: 사용자가 입력한 </u>, </mark> 등이 deserialize 시 닫는 태그로 오파싱되는 것을 방지
             if "\\*_[]()~`<>".contains(character) {
                 escaped.append("\\")
             }
@@ -137,6 +138,8 @@ enum MarkdownEscaping {
 
         for character in text {
             if isEscaping {
+                // escape 대상 문자: backslash 제거 후 문자만 추가
+                // 비대상 문자: backslash도 유지 (e.g. C:\Users → C:\Users)
                 if !escapedMarkdownCharacters.contains(character) {
                     unescaped.append("\\")
                 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownInlineParser.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownInlineParser.swift
@@ -55,6 +55,7 @@ enum MarkdownInlineParser {
 
             switch token.kind {
             case .code:
+                // `텍스트` → mono font (백슬래시 이스케이프 제거 후 적용)
                 var codeStyle = style
                 codeStyle.isMonospaced = true
                 let rawCodeText = (remainingText as NSString).substring(with: token.match.range(at: 1))
@@ -62,6 +63,7 @@ enum MarkdownInlineParser {
                 mutableAttributedString.append(attributedPlainText(codeText, baseFont: baseFont, style: codeStyle))
 
             case .link:
+                // [텍스트](url) → NSLinkAttributeName (허용 scheme: https, http, mailto, tel)
                 let label = (remainingText as NSString).substring(with: token.match.range(at: 1))
                 let rawURL = (remainingText as NSString).substring(with: token.match.range(at: 2))
                 var linkStyle = style
@@ -73,12 +75,14 @@ enum MarkdownInlineParser {
                 mutableAttributedString.append(parseInlineMarkdown(label, baseFont: baseFont, style: linkStyle))
 
             case .underline:
+                // <u>텍스트</u> → Underline
                 var underlineStyle = style
                 underlineStyle.isUnderlined = true
                 let underlineText = (remainingText as NSString).substring(with: token.match.range(at: 1))
                 mutableAttributedString.append(parseInlineMarkdown(underlineText, baseFont: baseFont, style: underlineStyle))
 
             case .highlight:
+                // <mark color="R,G,B,A">텍스트</mark> → backgroundColor
                 var highlightStyle = style
                 let colorRange = token.match.range(at: 1)
                 let textRange = token.match.range(at: 2)
@@ -93,12 +97,14 @@ enum MarkdownInlineParser {
                 mutableAttributedString.append(parseInlineMarkdown(highlightText, baseFont: baseFont, style: highlightStyle))
 
             case .strikethrough:
+                // ~~텍스트~~ → Strikethrough
                 var strikeStyle = style
                 strikeStyle.isStruck = true
                 let strikeText = (remainingText as NSString).substring(with: token.match.range(at: 1))
                 mutableAttributedString.append(parseInlineMarkdown(strikeText, baseFont: baseFont, style: strikeStyle))
 
             case .boldItalicMixed, .boldItalicStars:
+                // **_텍스트_** / ***텍스트*** → Bold + Italic
                 var boldItalicStyle = style
                 boldItalicStyle.isBold = true
                 boldItalicStyle.isItalic = true
@@ -106,12 +112,14 @@ enum MarkdownInlineParser {
                 mutableAttributedString.append(parseInlineMarkdown(boldItalicText, baseFont: baseFont, style: boldItalicStyle))
 
             case .bold:
+                // **텍스트** → Bold
                 var boldStyle = style
                 boldStyle.isBold = true
                 let boldText = (remainingText as NSString).substring(with: token.match.range(at: 1))
                 mutableAttributedString.append(parseInlineMarkdown(boldText, baseFont: baseFont, style: boldStyle))
 
             case .italicAsterisk, .italicUnderscore:
+                // *텍스트* / _텍스트_ → Italic
                 var italicStyle = style
                 italicStyle.isItalic = true
                 let italicText = (remainingText as NSString).substring(with: token.match.range(at: 1))

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownInlineSerializer.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Serializer/MarkdownInlineSerializer.swift
@@ -65,12 +65,15 @@ enum MarkdownInlineSerializer {
     static func serializeSegment(text: String, attributes: [NSAttributedString.Key: Any], blockImpliedBold: Bool = false) -> String {
         let font = attributes[.font] as? UIFont
         let traits = font?.fontDescriptor.symbolicTraits ?? []
+        // 헤딩/부머리말 블록은 폰트 자체가 bold이므로, 블록 레벨에서 이미 implied된 bold는 인라인 ** 마커로 이중 래핑하지 않는다.
+        // Pretendard는 커스텀 폰트라 symbolic trait보다 폰트명으로 bold를 판별하는 편이 더 신뢰할 수 있습니다.
         let isBold: Bool
         if let font, font.fontName.hasPrefix("Pretendard") {
             isBold = (font.fontName.contains("Bold") || font.fontName.contains("SemiBold")) && !blockImpliedBold
         } else {
             isBold = traits.contains(.traitBold) && !blockImpliedBold
         }
+        // Pretendard는 italic 변형이 없어 oblique matrix로 기울임을 표현하므로 matrix.c 값도 함께 확인합니다.
         let isItalic: Bool
         if let font, font.fontName.hasPrefix("Pretendard") {
             isItalic = font.fontDescriptor.matrix.c != 0.0
@@ -83,34 +86,43 @@ enum MarkdownInlineSerializer {
         let highlightColor = attributes[.backgroundColor] as? UIColor
         let linkValue = attributes[.link]
 
+        // 빈 인용구 삽입 시 사용하는 zero-width space를 직렬화 결과에서 제거합니다.
         let cleanedText = text.replacingOccurrences(of: "\u{200B}", with: "")
         guard !cleanedText.isEmpty else { return "" }
 
         var content = MarkdownEscaping.escapeMarkdownText(cleanedText)
 
         if isMonospaced {
+            // mono font → `텍스트`
             content = "`\(MarkdownEscaping.escapeMarkdownCodeText(text))`"
         } else if isBold && isItalic {
+            // Bold + Italic → **_텍스트_**
             content = "**_\(content)_**"
         } else {
             if isBold {
+                // Bold (traits .bold) → **텍스트**
                 content = "**\(content)**"
             }
 
             if isItalic {
+                // Italic (traits .italic) → *텍스트*
                 content = "*\(content)*"
             }
         }
 
         if isUnderlined && isMonospaced == false {
+            // Underline → <u>텍스트</u>
             content = "<u>\(content)</u>"
         }
 
         if isStruck && isMonospaced == false {
+            // Strikethrough → ~~텍스트~~
             content = "~~\(content)~~"
         }
 
         if let highlightColor, isMonospaced == false {
+            // Highlight → <mark color="R,G,B,A">텍스트</mark>
+            // Dynamic/grayscale color는 sRGB 변환 실패 가능 → resolvedColor fallback 후 재시도, 둘 다 실패하면 skip
             var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
             let didConvert: Bool
             if highlightColor.getRed(&r, green: &g, blue: &b, alpha: &a) {
@@ -134,6 +146,7 @@ enum MarkdownInlineSerializer {
                 rawURLString = String(describing: linkValue)
             }
 
+            // NSLinkAttributeName → [텍스트](url) (`)`, `\` escape)
             let escapedURL = MarkdownEscaping.escapeMarkdownLinkDestination(rawURLString)
             content = "[\(content)](\(escapedURL))"
         }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Toolbar/DefaultToolbarView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Toolbar/DefaultToolbarView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 공지 에디터의 기본 액세서리 툴바입니다.
 struct DefaultToolbarView: View {
     @Bindable var viewModel: EditorToolbarViewModel
     var onTapAI: () -> Void

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Toolbar/TableCellToolbarView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Toolbar/TableCellToolbarView.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 
+/// 표 셀 편집 전용 툴바입니다.
+///
+/// 들여쓰기, 내어쓰기, 인용구 토글과 목록 스타일 선택 액션을 제공합니다.
 struct TableCellToolbarView: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Toolbar/TextSelectedToolbarView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/Toolbar/TextSelectedToolbarView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 텍스트 선택 상태에서 노출되는 인라인 서식 툴바입니다.
 struct TextSelectedToolbarView: View {
 
     @Bindable var viewModel: EditorToolbarViewModel

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorImageSection.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorImageSection.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 공지 에디터의 첨부 이미지 목록 섹션입니다.
 struct NoticeEditorImageSection: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorLinkSection.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorLinkSection.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 공지 에디터의 첨부 링크 목록 섹션입니다.
 struct NoticeEditorLinkSection: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorSubCategorySection.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorSubCategorySection.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 공지 에디터 상단의 공지 대상(서브카테고리) 칩 섹션입니다.
 struct NoticeEditorSubCategorySection: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorTextFieldSection.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorTextFieldSection.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 공지 에디터의 제목 + 리치 텍스트 입력 섹션입니다.
 struct NoticeEditorTextFieldSection: View {
 
     // MARK: - Property

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorVoteSection.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sections/NoticeEditorVoteSection.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 공지 에디터의 투표 첨부 섹션입니다.
 struct NoticeEditorVoteSection: View {
 
     // MARK: - Property
@@ -28,7 +29,7 @@ struct NoticeEditorVoteSection: View {
         }
     }
 
-    // MARK: - View Builders
+    // MARK: - Components
 
     private var voteAttachmentCard: some View {
         Group {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sheets/TargetSheetView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sheets/TargetSheetView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// 공지 수신 대상 선택 시트 (지부/학교/파트)
 struct TargetSheetView: View {
 
     // MARK: - Property
@@ -18,6 +19,7 @@ struct TargetSheetView: View {
 
     // MARK: - Constants
 
+    /// 타겟 선택 시트의 레이아웃/문구 상수 모음
     private enum Constants {
         static let sectionSpacing: CGFloat = DefaultSpacing.spacing12
         static let chipSpacing: CGFloat = DefaultSpacing.spacing12
@@ -64,6 +66,7 @@ struct TargetSheetView: View {
     
     // MARK: - Content
 
+    /// 선택된 시트 타입에 맞는 필터 섹션을 반환합니다.
     @ViewBuilder
     private var statefulSheetContent: some View {
         switch viewModel.targetOptionsState {
@@ -105,6 +108,7 @@ struct TargetSheetView: View {
 
     // MARK: - Retry
 
+    /// 타겟 옵션 로드 실패 시 재시도합니다. 중복 호출을 방지합니다.
     @MainActor
     private func retryTargetOptions() async {
         guard !isRetryingTargetOptions else { return }
@@ -115,6 +119,7 @@ struct TargetSheetView: View {
     
     // MARK: - Section Builders
 
+    /// 지부 대상 선택 섹션
     private var branchFilterSection: some View {
         selectionSection {
             FlowLayout(spacing: Constants.chipSpacing) {
@@ -128,6 +133,7 @@ struct TargetSheetView: View {
         }
     }
     
+    /// 학교 대상 선택 섹션
     private var schoolFilterSection: some View {
         selectionSection {
             ScrollView(.vertical) {
@@ -145,6 +151,7 @@ struct TargetSheetView: View {
         }
     }
     
+    /// 파트 대상 선택 섹션
     private var partFilterSection: some View {
         selectionSection {
             FlowLayout(spacing: Constants.chipSpacing) {
@@ -163,6 +170,7 @@ struct TargetSheetView: View {
     
     // MARK: - Shared Section
 
+    /// 타겟 선택 칩 레이아웃을 공통화합니다.
     @ViewBuilder
     private func selectionSection<Content: View>(
         @ViewBuilder content: () -> Content

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sheets/VotingFormSheetView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Sheets/VotingFormSheetView.swift
@@ -7,18 +7,28 @@
 
 import SwiftUI
 
+/// 투표 생성/수정 폼 시트
+///
+/// 제목, 항목(2~5개), 익명/복수선택 토글, 시작/마감일 설정을 제공합니다.
 struct VotingFormSheetView: View, Equatable {
 
     // MARK: - Property
-
+    /// 투표 폼 데이터 바인딩
     @Binding var formData: VoteFormData
+    /// 취소 액션
     var onCancel: () -> Void
+    /// 확인 액션
     var onConfirm: () -> Void
+    /// 시트 모드(생성/수정)
     var mode: VoteEditorMode = .create
 
+    /// 확인 버튼 로컬 로딩 상태
     @State private var isSubmitting: Bool = false
+
+    /// DEBUG 런치 인자로 강제 로딩 상태를 표시합니다.
     @State private var isDebugLoading: Bool = false
 
+    /// 투표 에디터 모드
     enum VoteEditorMode {
         case create
         case edit
@@ -73,6 +83,7 @@ struct VotingFormSheetView: View, Equatable {
 
     // MARK: - Content
 
+    /// 스크롤 본문 콘텐츠
     private var contentView: some View {
         VStack(spacing: DefaultSpacing.spacing12) {
             titleSection
@@ -92,6 +103,7 @@ struct VotingFormSheetView: View, Equatable {
 
     // MARK: - Toolbar
 
+    /// 상단 툴바 액션(취소/확인)
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         ToolBarCollection.CancelBtn(action: onCancel)
@@ -113,12 +125,13 @@ struct VotingFormSheetView: View, Equatable {
         }
     }
 
+    /// 모드에 따른 네비게이션 타이틀
     private var navigationTitle: NavigationModifier.Navititle {
         mode == .create ? .voteCreate : .voteEdit
     }
     
     // MARK: - Title Section
-
+    /// 투표 제목 입력 섹션
     private var titleSection: some View {
         VStack {
             TextField(
@@ -135,7 +148,7 @@ struct VotingFormSheetView: View, Equatable {
     }
     
     // MARK: - Options
-
+    /// 투표 항목 입력 섹션
     private var optionsSection: some View {
         VStack(spacing: DefaultSpacing.spacing8) {
             ForEach($formData.options) { $option in
@@ -145,6 +158,7 @@ struct VotingFormSheetView: View, Equatable {
         }
     }
 
+    /// 단일 투표 항목 행
     private func optionRow(option: Binding<VoteOptionItem>) -> some View {
         let index = optionIndex(for: option.wrappedValue)
 
@@ -176,7 +190,7 @@ struct VotingFormSheetView: View, Equatable {
     }
 
     // MARK: - Add Option Button
-
+    /// 항목 추가 버튼
     private var addOptionButton: some View {
         Button {
             addOption()
@@ -195,7 +209,7 @@ struct VotingFormSheetView: View, Equatable {
     }
 
     // MARK: - Toggle Section
-
+    /// 익명/복수선택 토글 섹션
     private var toggleSection: some View {
         VStack(spacing: DefaultSpacing.spacing16) {
             toggleItem(title: Constants.anonymousVoteTitle, isOn: $formData.isAnonymous)
@@ -204,6 +218,7 @@ struct VotingFormSheetView: View, Equatable {
         .padding(.top, Constants.toggleTopMargin)
     }
 
+    /// 토글 공통 행
     private func toggleItem(title: String, isOn: Binding<Bool>) -> some View {
         HStack(spacing: DefaultSpacing.spacing8) {
             Text(title)
@@ -218,7 +233,7 @@ struct VotingFormSheetView: View, Equatable {
     }
     
     // MARK: - Date Section
-
+    /// 투표 시작일/마감일 섹션
     private var dateSection: some View {
         VStack(spacing: DefaultSpacing.spacing16) {
             dateRow(
@@ -235,6 +250,7 @@ struct VotingFormSheetView: View, Equatable {
         .padding(.top, Constants.dateTopMargin)
     }
 
+    /// 날짜 선택 공통 행
     private func dateRow(
         title: String,
         selection: Binding<Date>,
@@ -257,20 +273,23 @@ struct VotingFormSheetView: View, Equatable {
     }
 
     // MARK: - Function
-
+    /// 현재 옵션의 인덱스를 반환합니다.
     private func optionIndex(for option: VoteOptionItem) -> Int {
         formData.options.firstIndex(where: { $0.id == option.id }) ?? 0
     }
 
+    /// 최소 옵션 개수(2개) 이후부터 삭제 버튼 노출
     private func canDeleteOption(at index: Int) -> Bool {
         index >= VoteFormData.minOptionCount
     }
 
+    /// 새 옵션을 추가합니다.
     private func addOption() {
         guard formData.canAddOption else { return }
         formData.options.append(VoteOptionItem())
     }
 
+    /// 선택한 옵션을 제거합니다.
     private func removeOption(_ option: VoteOptionItem) {
         guard formData.canRemoveOption else { return }
         formData.options.removeAll { $0.id == option.id }
@@ -278,6 +297,7 @@ struct VotingFormSheetView: View, Equatable {
 
     // MARK: - Date Binding
 
+    /// 시작일 바인딩(선택일 00:00:00 고정)
     private var startDateBinding: Binding<Date> {
         Binding(
             get: { formData.startDate },
@@ -287,6 +307,7 @@ struct VotingFormSheetView: View, Equatable {
         )
     }
 
+    /// 마감일 바인딩(선택일 23:59:59 고정)
     private var endDateBinding: Binding<Date> {
         Binding(
             get: { formData.endDate },
@@ -303,26 +324,30 @@ struct VotingFormSheetView: View, Equatable {
         )
     }
 
+    /// 마감일 최소 허용값(시작일 + 1일)
     private var endDateLowerBound: Date {
         Calendar.current.date(byAdding: .day, value: 1, to: formData.startDate) ?? formData.startDate
     }
     
+    /// 확인 버튼 로딩 상태(실제 제출 + DEBUG 강제 상태)
     private var isConfirmButtonLoading: Bool {
         isSubmitting || isDebugLoading
     }
 
+    /// 확인 버튼 탭 처리
     private func handleConfirmTap() {
         guard !isConfirmButtonLoading else { return }
         isSubmitting = true
         onConfirm()
 
         Task { @MainActor in
-            // 시트가 즉시 닫히지 않을 경우를 대비해 다음 프레임에 로딩 상태를 복구합니다.
+            // 시트가 즉시 닫히지 않는 경우를 대비해 다음 프레임에 로딩 상태 복구
             await Task.yield()
             isSubmitting = false
         }
     }
 
+    /// DEBUG 런치 인자로 투표 시트 툴바 로딩 상태를 강제 표시합니다.
     private func applyDebugLoadingStateIfNeeded() {
         #if DEBUG
         isDebugLoading = ProcessInfo.processInfo.arguments.contains(Constants.debugLoadingArgument)


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 커밋 `5055cfa1`(PR #606에 포함, squash-merge됨)에서 **코드 단순화와 함께 실수로 삭제된 doc/inline 주석**을 일괄 복원합니다. 코드 로직 변경은 **0**이며, 순수하게 주석만 되돌립니다.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음.

## 🛠️ 작업내용

- **1차 복원** (`d0e31534` → cherry-pick `ca1778fc`): 47개 파일 +759 / -36 lines
  - Core + NoticeEditor ViewModel 7파일, Editor Toolbar 4파일
  - NoticeEditor Views + Sections 14파일, RichText Editor 12파일
  - Markdown Serializer + Detail + Sheets + Misc 14파일
- **마무리 패스** (`1d7290d8` → cherry-pick `925fc2a1`): 8개 파일 +49 / -11 lines
  - RichTextCoordinator+Blockquote 32줄(ZWS/cleanup/reinject doc + inline)
  - EditorToolbarViewModel, NoticeEditorViewModel, +Targeting, +List, RichTextViewRepresentable, TextSelectedToolbarView, SubCategorySection 각 1~3줄

### 복원 방식
- 커밋 `5055cfa1^`(리팩토링 직전) 버전을 원본으로 삼아 **주석 라인만** 추출
- `jeong-ios-dev` 서브에이전트 5개 병렬 + 최종 마무리 1개로 총 49개 파일에 걸쳐 복원
- **코드 단순화(private/guard/if-chain 압축 등)는 그대로 유지**

### 복원 불가 항목 (1건)
- `NoticeEditorLinkSection.swift`의 `// MARK: - Constants` — 해당 `Constants` enum 자체가 리팩토링 시 inline으로 제거되어 앵커 코드가 존재하지 않아 복원 불가

## 📋 추후 진행 상황

- 향후 리팩토링 시 주석을 코드와 함께 실수로 지우지 않도록 AI 보조 단순화 프로세스 점검 필요

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Core/Common/Error/Handler/ErrorHandler.swift` — 클래스 레벨 Usage 문서(52줄) 복원 확인
- `AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarViewModel.swift` — 프로퍼티/함수 doc 주석 전체 복원
- `AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift` — 프로퍼티 그룹별 doc 주석 복원
- `AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/RichTextEditor/NoticeRichText/RichTextCoordinator+Blockquote.swift` — ZWS/cleanup/reinject 관련 inline 주석 복원

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)