### PR TITLE
✨ [Feat] 게스트 모드 진입점 추가 (#609)

### DIFF
--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -23,6 +23,7 @@ struct AppProductApp: App {
 
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var container: DIContainer
+    @State private var guestContainer: DIContainer
     @State private var didConfigureAppDelegate: Bool = false
     @State private var errorHandler: ErrorHandler = .init()
     @State private var appState: AppState = .splash
@@ -45,8 +46,10 @@ struct AppProductApp: App {
         )
         /// 승인 대기 화면
         case pendingApproval
-        /// 메인 화면 (탭)
+        /// 메인 화면 (탭, 인증 세션)
         case main
+        /// 게스트 메인 화면 (탭, 비인증 세션)
+        case guestMain
     }
     
     init() {
@@ -57,6 +60,7 @@ struct AppProductApp: App {
                 modelContext: sharedModelContainer.mainContext
             )
         )
+        _guestContainer = State(initialValue: DIContainer.guest())
         try? Tips.configure()
     }
     
@@ -142,6 +146,12 @@ extension AppProductApp {
             case .main:
                 UmcTab()
                     .transition(rootTransition)
+
+            case .guestMain:
+                UmcTab()
+                    .environment(\.di, guestContainer)
+                    .environment(\.appSessionMode, .guest)
+                    .transition(rootTransition)
             }
         }
         .animation(.easeInOut(duration: 0.28), value: appState)
@@ -224,6 +234,7 @@ extension AppProductApp {
         AppFlow(
             showLogin: { transition(to: .login) },
             showMain: { transition(to: .main) },
+            showGuestMain: { transition(to: .guestMain) },
             showSignUp: {
                 verificationToken,
                 email,

--- a/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
+++ b/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
@@ -365,4 +365,122 @@ extension DIContainer {
 
         return container
     }
+
+    /// 게스트 세션용 DIContainer를 반환합니다.
+    ///
+    /// 네트워크 클라이언트를 초기화하지 않으며, 모든 Repository는 Mock 구현체로 구성됩니다.
+    /// Apple 리뷰어가 OAuth 없이 앱을 탐색할 수 있도록 제공되는 영구 공개 경로입니다.
+    static func guest() -> DIContainer {
+        let container = DIContainer()
+        container.register(PathStore.self) { PathStore() }
+        container.register(NavigationRouter.self) { NavigationRouter() }
+        container.register(UserSessionManager.self) { UserSessionManager() }
+
+        // MARK: - Storage (no-op)
+        container.register(StorageRepositoryProtocol.self) {
+            MockStorageRepository()
+        }
+
+        // MARK: - Authorization (no-op)
+        container.register(AuthorizationRepositoryProtocol.self) {
+            MockAuthorizationRepository()
+        }
+        container.register(AuthorizationUseCaseProtocol.self) {
+            AuthorizationUseCase(
+                repository: container.resolve(AuthorizationRepositoryProtocol.self)
+            )
+        }
+
+        // MARK: - Activity Feature
+        container.register(ActivityRepositoryProviding.self) {
+            ActivityRepositoryProvider.mock()
+        }
+        container.register(ActivityUseCaseProviding.self) {
+            ActivityUseCaseProvider(
+                repositoryProvider: container.resolve(ActivityRepositoryProviding.self),
+                classifierRepository: ScheduleClassifierRepositoryImpl()
+            )
+        }
+
+        // MARK: - Auth Feature
+        container.register(AuthRepositoryProviding.self) {
+            AuthRepositoryProvider.mock()
+        }
+        container.register(AuthUseCaseProviding.self) {
+            AuthUseCaseProvider(
+                repositoryProvider: container.resolve(AuthRepositoryProviding.self),
+                tokenStore: GuestTokenStore()
+            )
+        }
+
+        // MARK: - Home Feature
+        container.register(HomeRepositoryProtocol.self) {
+            MockHomeRepository()
+        }
+        container.register(ScheduleRepositoryProtocol.self) {
+            MockScheduleRepository()
+        }
+        container.register(ChallengerGenRepositoryProtocol.self) {
+            MockChallengerGenRepository()
+        }
+        container.register(ChallengerSearchRepositoryProtocol.self) {
+            MockChallengerSearchRepository()
+        }
+        container.register(HomeUseCaseProviding.self) {
+            HomeUseCaseProvider(
+                homeRepository: container.resolve(HomeRepositoryProtocol.self),
+                scheduleRepository: container.resolve(ScheduleRepositoryProtocol.self),
+                classifierRepository: ScheduleClassifierRepositoryImpl(),
+                challengerSearchRepository: container.resolve(
+                    ChallengerSearchRepositoryProtocol.self
+                )
+            )
+        }
+
+        // MARK: - Notice Feature
+        container.register(NoticeRepositoryProtocol.self) {
+            MockNoticeRepository()
+        }
+        container.register(NoticeReadRepositoryProtocol.self) {
+            MockNoticeReadRepository()
+        }
+        container.register(NoticeUseCaseProtocol.self) {
+            NoticeUseCase(
+                repository: container.resolve(NoticeRepositoryProtocol.self),
+                storageRepository: container.resolve(StorageRepositoryProtocol.self)
+            )
+        }
+
+        // MARK: - MyPage Feature
+        container.register(MyPageRepositoryProtocol.self) {
+            MockMyPageRepository()
+        }
+        container.register(MyPageUseCaseProviding.self) {
+            MyPageUseCaseProvider(
+                repository: container.resolve(MyPageRepositoryProtocol.self)
+            )
+        }
+
+        // MARK: - Community Feature
+        container.register(CommunityRepositoryProtocol.self) {
+            MockCommunityRepository()
+        }
+        container.register(CommunityPostRepositoryProtocol.self) {
+            MockCommunityPostRepository()
+        }
+        container.register(CommunityDetailRepositoryProtocol.self) {
+            MockCommunityDetailRepository()
+        }
+        container.register(CommunityUseCaseProviding.self) {
+            CommunityUseCaseProvider(
+                communityRepository: container.resolve(CommunityRepositoryProtocol.self),
+                communityPostRepository: container.resolve(CommunityPostRepositoryProtocol.self),
+                communityDetailRepository: container.resolve(
+                    CommunityDetailRepositoryProtocol.self
+                )
+            )
+        }
+
+        return container
+    }
 }

--- a/AppProduct/AppProduct/Core/Mock/AttendancePreviewData.swift
+++ b/AppProduct/AppProduct/Core/Mock/AttendancePreviewData.swift
@@ -9,10 +9,10 @@ import Foundation
 import SwiftUI
 import SwiftData
 
-#if DEBUG
 /// 출석 관련 프리뷰에서 사용하는 더미 데이터 모음
 struct AttendancePreviewData {
 
+    #if DEBUG
     static let errorHandler = ErrorHandler()
     static let container: DIContainer = {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
@@ -32,6 +32,7 @@ struct AttendancePreviewData {
         errorHandler: errorHandler,
         challengeAttendanceUseCase: mockUseCase  // 시뮬레이터 테스트용 Mock 사용
     )
+    #endif
 
     static let sessionId: SessionID = SessionID(value: "iOS_8")
     static let userId: UserID = UserID(value: "River_")
@@ -466,6 +467,7 @@ struct AttendancePreviewData {
 
 // MARK: - Attendance Status Preview
 
+#if DEBUG
 /// 출석 상태별 배지 디자인을 확인하는 프리뷰 뷰
 struct AttendanceStatusPreview: View {
     var body: some View {

--- a/AppProduct/AppProduct/Core/Mock/GuestMocks.swift
+++ b/AppProduct/AppProduct/Core/Mock/GuestMocks.swift
@@ -1,0 +1,76 @@
+//
+//  GuestMocks.swift
+//  AppProduct
+//
+
+import Foundation
+
+// MARK: - GuestTokenStore
+
+/// 게스트 세션용 TokenStore
+///
+/// Keychain에 접근하지 않으며, 토큰은 항상 nil을 반환합니다.
+actor GuestTokenStore: TokenStore {
+
+    func getAccessToken() async -> String? { nil }
+
+    func getRefreshToken() async -> String? { nil }
+
+    func save(accessToken: String, refreshToken: String) async throws {}
+
+    func clear() async throws {}
+}
+
+// MARK: - MockStorageRepository
+
+/// 게스트 세션용 Storage Repository Mock
+///
+/// 파일 업로드 기능을 사용하지 않는 게스트 세션에서 의존성을 충족합니다.
+final class MockStorageRepository: StorageRepositoryProtocol {
+
+    func prepareUpload(
+        fileName: String,
+        contentType: String,
+        fileSize: Int,
+        category: StorageFileCategory
+    ) async throws -> StoragePrepareUploadResponseDTO {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func uploadFile(
+        to url: String,
+        data: Data,
+        method: String,
+        headers: [String: String]?,
+        contentType: String?
+    ) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func confirmUpload(fileId: String) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func deleteFile(fileId: String) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+}
+
+// MARK: - MockAuthorizationRepository
+
+/// 게스트 세션용 Authorization Repository Mock
+///
+/// 모든 리소스에 대해 빈 권한 집합을 반환합니다.
+final class MockAuthorizationRepository: AuthorizationRepositoryProtocol {
+
+    func getResourcePermission(
+        resourceType: AuthorizationResourceType,
+        resourceId: Int
+    ) async throws -> ResourcePermission {
+        ResourcePermission(
+            resourceType: resourceType,
+            resourceId: resourceId,
+            grantedPermissions: []
+        )
+    }
+}

--- a/AppProduct/AppProduct/Core/Mock/MyPageMockData.swift
+++ b/AppProduct/AppProduct/Core/Mock/MyPageMockData.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-#if DEBUG
 enum MyPageMockData {
     static let profile = ProfileData(
         challengeId: 269,
@@ -141,4 +140,3 @@ enum MyPageMockData {
         }
     }
 }
-#endif

--- a/AppProduct/AppProduct/Core/Mock/StudyGroupPreviewData.swift
+++ b/AppProduct/AppProduct/Core/Mock/StudyGroupPreviewData.swift
@@ -8,7 +8,6 @@
 import Foundation
 import SwiftData
 
-#if DEBUG
 struct StudyGroupPreviewData {
     static let container: DIContainer = {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
@@ -191,4 +190,3 @@ struct StudyGroupPreviewData {
         return formatter.date(from: string) ?? Date()
     }
 }
-#endif

--- a/AppProduct/AppProduct/Core/Mock/StudyMemberPreviewData.swift
+++ b/AppProduct/AppProduct/Core/Mock/StudyMemberPreviewData.swift
@@ -5,7 +5,6 @@
 //  Created by jaewon Lee on 2/8/26.
 //
 
-#if DEBUG
 import Foundation
 
 extension StudyMemberItem {
@@ -177,4 +176,3 @@ extension StudyMemberItem {
         return items
     }()
 }
-#endif

--- a/AppProduct/AppProduct/Features/Activity/Data/Provider/ActivityRepositoryProvider.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Provider/ActivityRepositoryProvider.swift
@@ -56,7 +56,6 @@ final class ActivityRepositoryProvider: ActivityRepositoryProviding {
 
 extension ActivityRepositoryProvider {
     /// Mock Repository들로 구성된 Provider 생성
-    #if DEBUG
     static func mock() -> ActivityRepositoryProvider {
         ActivityRepositoryProvider(
             challengerAttendanceRepository: MockAttendanceRepository(),
@@ -66,7 +65,6 @@ extension ActivityRepositoryProvider {
             memberRepository: MockMemberRepository()
         )
     }
-    #endif
 
     /// 실제 API 연결 Provider 생성
     ///

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockActivityRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockActivityRepository.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-#if DEBUG
 /// Activity Repository Mock 구현 (개발/테스트용)
 final class MockActivityRepository: ActivityRepositoryProtocol {
 
@@ -22,4 +21,3 @@ final class MockActivityRepository: ActivityRepositoryProtocol {
         return AttendancePreviewData.userId
     }
 }
-#endif

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockAttendanceRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockAttendanceRepository.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-#if DEBUG
 /// Preview 및 테스트용 Mock AttendanceRepository
 ///
 /// 실제 네트워크 요청 없이 더미 데이터를 반환합니다.
@@ -153,4 +152,3 @@ final class MockAttendanceRepository: ChallengerAttendanceRepositoryProtocol,
         1
     }
 }
-#endif

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockStudyRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockStudyRepository.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-#if DEBUG
 // MARK: - MockStudyRepository
 
 /// Study Repository Mock 구현체
@@ -314,4 +313,3 @@ final class MockStudyRepository: StudyRepositoryProtocol {
         try await Task.sleep(for: .milliseconds(300))
     }
 }
-#endif

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/StudyGroupInfo.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/StudyGroupInfo.swift
@@ -70,7 +70,6 @@ struct StudyGroupInfo: Identifiable, Equatable {
 
 // MARK: - Preview Data
 
-#if DEBUG
 extension StudyGroupInfo {
     static let preview = StudyGroupInfo(
         serverID: "group_001",
@@ -110,4 +109,3 @@ extension StudyGroupInfo {
         ]
     )
 }
-#endif

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/StudyGroupItem.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/StudyGroupItem.swift
@@ -41,7 +41,6 @@ struct StudyGroupItem: Identifiable, Equatable, Hashable {
         part: nil
     )
 
-    #if DEBUG
     static let preview: [StudyGroupItem] = [
         .all,
         StudyGroupItem(
@@ -87,5 +86,4 @@ struct StudyGroupItem: Identifiable, Equatable, Hashable {
             part: .pm
         )
     ]
-    #endif
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
@@ -85,6 +85,13 @@ final class LoginViewModel {
         }
     }
 
+    /// 게스트 모드 진입
+    ///
+    /// Keychain 및 네트워크에 접근하지 않고 즉시 메인 탭으로 전환합니다.
+    func enterGuestMode(appFlow: AppFlow) {
+        appFlow.showGuestMain()
+    }
+
     /// Apple 로그인 실행
     @MainActor
     func loginWithApple() {

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -51,6 +51,9 @@ struct LoginView: View {
                 },
                 onAppleTapped: {
                     viewModel.loginWithApple()
+                },
+                onGuestTapped: {
+                    viewModel.enterGuestMode(appFlow: appFlow)
                 }
             )
         }
@@ -112,10 +115,9 @@ fileprivate struct BottomSocialBtns: View {
 
     // MARK: - Constant
 
-    /// 레이아웃 상수
     private enum Constants {
-        /// 소셜 버튼 간 수직 간격
         static let btnSpacing: CGFloat = 16
+        static let guestBtnTopSpacing: CGFloat = DefaultSpacing.spacing12
     }
 
     // MARK: - Property
@@ -123,29 +125,37 @@ fileprivate struct BottomSocialBtns: View {
     let isLoading: Bool
     var onKakaoTapped: () -> Void
     var onAppleTapped: () -> Void
+    var onGuestTapped: () -> Void
 
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: Constants.btnSpacing) {
-            ForEach(SocialType.appConnectableCases, id: \.self) { btn in
-                Button(action: {
-                    switch btn {
-                    case .kakao:
-                        onKakaoTapped()
-                    case .apple:
-                        onAppleTapped()
-                    case .google:
-                        break
-                    }
-                }, label: {
-                    btn.image
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                })
-                .glassEffect(.regular.interactive())
-                .disabled(isLoading)
+        VStack(spacing: 0) {
+            VStack(spacing: Constants.btnSpacing) {
+                ForEach(SocialType.appConnectableCases, id: \.self) { btn in
+                    Button(action: {
+                        switch btn {
+                        case .kakao:
+                            onKakaoTapped()
+                        case .apple:
+                            onAppleTapped()
+                        case .google:
+                            break
+                        }
+                    }, label: {
+                        btn.image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                    })
+                    .glassEffect(.regular.interactive())
+                    .disabled(isLoading)
+                }
             }
+
+            MainButton("먼저 살펴보기", action: onGuestTapped)
+                .buttonStyle(.glass)
+                .padding(.top, Constants.guestBtnTopSpacing)
+                .disabled(isLoading)
         }
         .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
         .padding(.bottom, DefaultConstant.defaultSafeBottom)

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -127,54 +127,66 @@ fileprivate struct BottomSocialBtns: View, Equatable {
         lhs.isLoading == rhs.isLoading
     }
 
-    // MARK: - Function
-
-    private func accessibilityLabel(for type: SocialType) -> String {
-        switch type {
-        case .kakao: return "카카오로 로그인"
-        case .apple: return "Apple로 로그인"
-        case .google: return "Google로 로그인"
-        }
-    }
-
     // MARK: - Body
 
     var body: some View {
         GlassEffectContainer {
             VStack(spacing: 0) {
-                VStack(spacing: DefaultSpacing.spacing16) {
-                    ForEach(SocialType.appConnectableCases, id: \.self) { btn in
-                        Button(action: {
-                            switch btn {
-                            case .kakao:
-                                onKakaoTapped()
-                            case .apple:
-                                onAppleTapped()
-                            case .google:
-                                break
-                            }
-                        }, label: {
-                            btn.image
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                        })
-                        .glassEffect(.regular.interactive())
-                        .disabled(isLoading)
-                        .accessibilityLabel(Text(accessibilityLabel(for: btn)))
-                        .accessibilityHint(Text("소셜 계정으로 로그인합니다"))
-                    }
-                }
-
-                MainButton("먼저 살펴보기", action: onGuestTapped)
-                    .buttonStyle(.glass)
-                    .padding(.top, DefaultSpacing.spacing12)
-                    .disabled(isLoading)
-                    .accessibilityLabel(Text("먼저 살펴보기"))
-                    .accessibilityHint(Text("로그인 없이 앱을 둘러봅니다"))
+                socialButtonList
+                guestButton
             }
         }
         .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
         .padding(.bottom, DefaultConstant.defaultSafeBottom)
+    }
+
+    // MARK: - Subviews
+
+    private var socialButtonList: some View {
+        VStack(spacing: DefaultSpacing.spacing16) {
+            ForEach(SocialType.appConnectableCases, id: \.self) { btn in
+                socialButton(for: btn)
+            }
+        }
+    }
+
+    private func socialButton(for type: SocialType) -> some View {
+        Button(action: { handleSocialTap(type) }) {
+            type.image
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        }
+        .glassEffect(.regular.interactive())
+        .disabled(isLoading)
+        .accessibilityLabel(Text(accessibilityLabel(for: type)))
+        .accessibilityHint(Text("소셜 계정으로 로그인합니다"))
+    }
+
+    private var guestButton: some View {
+        MainButton("먼저 살펴보기", action: onGuestTapped)
+            .buttonStyle(.glass)
+            .padding(.top, DefaultSpacing.spacing12)
+            .disabled(isLoading)
+            .accessibilityLabel(Text("먼저 살펴보기"))
+            .accessibilityHint(Text("로그인 없이 앱을 둘러봅니다"))
+    }
+
+    // MARK: - Function
+
+    private func handleSocialTap(_ type: SocialType) {
+        switch type {
+        case .kakao: onKakaoTapped()
+        case .apple: onAppleTapped()
+        default: break
+        }
+    }
+
+    private func accessibilityLabel(for type: SocialType) -> String {
+        switch type {
+        case .kakao: return "카카오로 로그인"
+        case .apple: return "Apple로 로그인"
+        default: return type.rawValue + "로 로그인"
+        }
     }
 }
 

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -56,6 +56,7 @@ struct LoginView: View {
                     viewModel.enterGuestMode(appFlow: appFlow)
                 }
             )
+            .equatable()
         }
         .onChange(of: viewModel.destination) { _, newDestination in
             guard let newDestination else { return }
@@ -111,14 +112,7 @@ fileprivate struct TopLogo: View, Equatable {
 // MARK: - BottomSocialBtns
 
 /// 하단 소셜 로그인 버튼 영역
-fileprivate struct BottomSocialBtns: View {
-
-    // MARK: - Constant
-
-    private enum Constants {
-        static let btnSpacing: CGFloat = 16
-        static let guestBtnTopSpacing: CGFloat = DefaultSpacing.spacing12
-    }
+fileprivate struct BottomSocialBtns: View, Equatable {
 
     // MARK: - Property
 
@@ -127,35 +121,57 @@ fileprivate struct BottomSocialBtns: View {
     var onAppleTapped: () -> Void
     var onGuestTapped: () -> Void
 
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.isLoading == rhs.isLoading
+    }
+
+    // MARK: - Function
+
+    private func accessibilityLabel(for type: SocialType) -> String {
+        switch type {
+        case .kakao: return "카카오로 로그인"
+        case .apple: return "Apple로 로그인"
+        case .google: return "Google로 로그인"
+        }
+    }
+
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: 0) {
-            VStack(spacing: Constants.btnSpacing) {
-                ForEach(SocialType.appConnectableCases, id: \.self) { btn in
-                    Button(action: {
-                        switch btn {
-                        case .kakao:
-                            onKakaoTapped()
-                        case .apple:
-                            onAppleTapped()
-                        case .google:
-                            break
-                        }
-                    }, label: {
-                        btn.image
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                    })
-                    .glassEffect(.regular.interactive())
-                    .disabled(isLoading)
+        GlassEffectContainer {
+            VStack(spacing: 0) {
+                VStack(spacing: DefaultSpacing.spacing16) {
+                    ForEach(SocialType.appConnectableCases, id: \.self) { btn in
+                        Button(action: {
+                            switch btn {
+                            case .kakao:
+                                onKakaoTapped()
+                            case .apple:
+                                onAppleTapped()
+                            case .google:
+                                break
+                            }
+                        }, label: {
+                            btn.image
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        })
+                        .glassEffect(.regular.interactive())
+                        .disabled(isLoading)
+                        .accessibilityLabel(Text(accessibilityLabel(for: btn)))
+                        .accessibilityHint(Text("소셜 계정으로 로그인합니다"))
+                    }
                 }
-            }
 
-            MainButton("먼저 살펴보기", action: onGuestTapped)
-                .buttonStyle(.glass)
-                .padding(.top, Constants.guestBtnTopSpacing)
-                .disabled(isLoading)
+                MainButton("먼저 살펴보기", action: onGuestTapped)
+                    .buttonStyle(.glass)
+                    .padding(.top, DefaultSpacing.spacing12)
+                    .disabled(isLoading)
+                    .accessibilityLabel(Text("먼저 살펴보기"))
+                    .accessibilityHint(Text("로그인 없이 앱을 둘러봅니다"))
+            }
         }
         .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
         .padding(.bottom, DefaultConstant.defaultSafeBottom)

--- a/AppProduct/AppProduct/Features/Community/Data/Repositories/Mock/MockCommunityRepositories.swift
+++ b/AppProduct/AppProduct/Features/Community/Data/Repositories/Mock/MockCommunityRepositories.swift
@@ -1,0 +1,98 @@
+//
+//  MockCommunityRepositories.swift
+//  AppProduct
+//
+
+import Foundation
+
+// MARK: - MockCommunityRepository
+
+/// 게스트 세션 및 프리뷰용 Community Repository Mock 구현체
+final class MockCommunityRepository: CommunityRepositoryProtocol {
+
+    func getSchools() async throws -> [String] {
+        []
+    }
+
+    func getTrophies(query: TrophyListQuery) async throws -> [CommunityFameItemModel] {
+        []
+    }
+
+    func getPosts(query: PostListQuery) async throws -> (
+        items: [CommunityItemModel],
+        hasNext: Bool
+    ) {
+        (items: [], hasNext: false)
+    }
+
+    func getSearch(query: PostSearchQuery) async throws -> (
+        items: [CommunityItemModel],
+        hasNext: Bool
+    ) {
+        (items: [], hasNext: false)
+    }
+}
+
+// MARK: - MockCommunityPostRepository
+
+/// 게스트 세션 및 프리뷰용 Community Post Repository Mock 구현체
+final class MockCommunityPostRepository: CommunityPostRepositoryProtocol {
+
+    func postPosts(request: PostRequestDTO) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func postLightning(request: CreateLightningPostRequestDTO) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func patchPosts(postId: Int, request: PostRequestDTO) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func patchLightning(postId: Int, request: CreateLightningPostRequestDTO) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+}
+
+// MARK: - MockCommunityDetailRepository
+
+/// 게스트 세션 및 프리뷰용 Community Detail Repository Mock 구현체
+final class MockCommunityDetailRepository: CommunityDetailRepositoryProtocol {
+
+    func deletePost(postId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func deleteComment(postId: Int, commentId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func getComments(postId: Int) async throws -> [CommunityCommentModel] {
+        []
+    }
+
+    func getPostDetail(postId: Int) async throws -> CommunityItemModel {
+        throw DomainError.postNotFound
+    }
+
+    func postScrap(postId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func postLike(postId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func postComment(postId: Int, request: PostCommentRequest) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func postPostReport(postId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func postCommentReport(commentId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+}

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
@@ -1,0 +1,101 @@
+//
+//  MockHomeRepository.swift
+//  AppProduct
+//
+
+import Foundation
+
+// MARK: - MockHomeRepository
+
+/// 게스트 세션 및 프리뷰용 Home Repository Mock 구현체
+///
+/// 네트워크 없이 정적 데이터를 반환합니다.
+final class MockHomeRepository: HomeRepositoryProtocol {
+
+    // MARK: - Function
+
+    func getMyProfile() async throws -> HomeProfileResult {
+        HomeProfileResult(
+            memberId: 0,
+            schoolId: 0,
+            schoolName: "UMC 대학교",
+            latestChallengerId: nil,
+            latestGisuId: nil,
+            chapterId: nil,
+            chapterName: "UMC",
+            part: nil,
+            seasonTypes: [.days(0)],
+            roles: [],
+            generations: []
+        )
+    }
+
+    func getSchedules(
+        year: Int,
+        month: Int
+    ) async throws -> [Date: [ScheduleData]] {
+        [:]
+    }
+
+    func getScheduleDetail(
+        scheduleId: Int
+    ) async throws -> ScheduleDetailData {
+        throw DomainError.custom(message: "게스트 세션에서는 일정 상세를 조회할 수 없습니다.")
+    }
+
+    func getRecentNotices(
+        query: NoticeListRequestDTO
+    ) async throws -> [RecentNoticeData] {
+        []
+    }
+
+    func registerFCMToken(fcmToken: String) async throws {}
+}
+
+// MARK: - MockScheduleRepository
+
+/// 게스트 세션 및 프리뷰용 Schedule Repository Mock 구현체
+final class MockScheduleRepository: ScheduleRepositoryProtocol {
+
+    func generateSchedule(schedule: GenerateScheduleRequetDTO) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func updateSchedule(scheduleId: Int, schedule: UpdateScheduleRequestDTO) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func deleteScheduleWithAttendance(scheduleId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+}
+
+// MARK: - MockChallengerGenRepository
+
+/// 게스트 세션 및 프리뷰용 ChallengerGen Repository Mock 구현체
+final class MockChallengerGenRepository: ChallengerGenRepositoryProtocol {
+
+    func replaceMappings(_ pairs: [(gen: Int, gisuId: Int)]) throws {}
+
+    func fetchGenGisuIdPairs() throws -> [(gen: Int, gisuId: Int)] {
+        []
+    }
+}
+
+// MARK: - MockChallengerSearchRepository
+
+/// 게스트 세션 및 프리뷰용 ChallengerSearch Repository Mock 구현체
+final class MockChallengerSearchRepository: ChallengerSearchRepositoryProtocol {
+
+    func searchChallengers(
+        query: ChallengerSearchRequestDTO
+    ) async throws -> ChallengerSearchResponseDTO {
+        let json = """
+        {"cursor":{"content":[],"nextCursor":null,"hasNext":false}}
+        """
+        return try JSONDecoder().decode(
+            ChallengerSearchResponseDTO.self,
+            from: Data(json.utf8)
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/MyPage/Data/Repository/Mock/MockMyPageRepository.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Repository/Mock/MockMyPageRepository.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-#if DEBUG
 final class MockMyPageRepository: MyPageRepositoryProtocol {
     func fetchMyProfile() async throws -> ProfileData {
         MyPageMockData.profile
@@ -84,4 +83,3 @@ final class MockMyPageRepository: MyPageRepositoryProtocol {
         MyPageMockData.terms(for: termsType)
     }
 }
-#endif

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeReadRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeReadRepository.swift
@@ -1,0 +1,26 @@
+//
+//  MockNoticeReadRepository.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 게스트 세션 및 프리뷰용 NoticeRead Repository Mock 구현체
+///
+/// SwiftData 없이 메모리 기반으로 읽음 상태를 관리합니다.
+final class MockNoticeReadRepository: NoticeReadRepositoryProtocol {
+
+    // MARK: - Property
+
+    private var readIds: Set<String> = []
+
+    // MARK: - Function
+
+    func fetchReadNoticeIDs(memberId: Int) throws -> Set<String> {
+        readIds
+    }
+
+    func markAsRead(noticeId: String, memberId: Int) throws {
+        readIds.insert(noticeId)
+    }
+}

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeRepository.swift
@@ -1,0 +1,168 @@
+//
+//  MockNoticeRepository.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 게스트 세션 및 프리뷰용 Notice Repository Mock 구현체
+///
+/// 네트워크 없이 NoticeMockData 기반 정적 데이터를 반환합니다.
+final class MockNoticeRepository: NoticeRepositoryProtocol {
+
+    // MARK: - 공지 생성
+
+    func createNotice(
+        body: PostNoticeRequestDTO,
+        links: [String],
+        imageIds: [String]
+    ) async throws -> NoticeDetail {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func postNotice(body: PostNoticeRequestDTO) async throws -> NoticeItemModel {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func addVote(
+        noticeId: Int,
+        body: AddVoteRequestDTO
+    ) async throws -> AddVoteResponseDTO {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func addLink(noticeId: Int, links: [String]) async throws -> NoticeItemModel {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func addImage(noticeId: Int, imageIds: [String]) async throws -> NoticeItemModel {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func sendReminder(noticeId: Int, targetIds: [Int]) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func readNotice(noticeId: Int) async throws {}
+
+    func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    // MARK: - 공지 수정
+
+    func updateNotice(
+        noticeId: Int,
+        body: UpdateNoticeRequestDTO
+    ) async throws -> NoticeDetail {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func updateLinks(
+        noticeId: Int,
+        links: [String]
+    ) async throws -> NoticeDetail {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func updateImages(
+        noticeId: Int,
+        imageIds: [String]
+    ) async throws -> NoticeDetail {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    // MARK: - 공지 조회
+
+    func getAllNotices(
+        request: NoticeListRequestDTO
+    ) async throws -> NoticePageDTO<NoticeDTO> {
+        NoticePageDTO(
+            content: [],
+            page: "0",
+            size: "20",
+            totalElements: "0",
+            totalPages: "0",
+            hasNext: false,
+            hasPrevious: false
+        )
+    }
+
+    func getDetailNotice(noticeId: Int) async throws -> NoticeDetail {
+        guard let item = NoticeMockData.items.first else {
+            throw DomainError.noticeNotFound
+        }
+        return NoticeDetail(
+            id: "\(noticeId)",
+            generation: item.generation,
+            scope: item.scope,
+            category: item.category,
+            isMustRead: item.mustRead,
+            title: item.title,
+            content: item.content,
+            authorID: "0",
+            authorNickname: nil,
+            authorName: item.writer,
+            authorImageURL: nil,
+            createdAt: item.date,
+            updatedAt: nil,
+            targetAudience: TargetAudience.all(generation: item.generation, scope: item.scope),
+            hasPermission: false,
+            images: item.images,
+            links: item.links,
+            vote: item.vote
+        )
+    }
+
+    func getReadStatics(noticeId: Int) async throws -> NoticeReadStaticsDTO {
+        NoticeReadStaticsDTO(
+            totalCount: "0",
+            readCount: "0",
+            unreadCount: "0",
+            readRate: "0"
+        )
+    }
+
+    func getReadStatusList(
+        noticeId: Int,
+        cursorId: Int,
+        filterType: String,
+        organizationIds: [Int],
+        status: String
+    ) async throws -> NoticeReadStatusResponseDTO {
+        let json = """
+        {"content":[],"nextCursor":"0","hasNext":false}
+        """
+        let data = Data(json.utf8)
+        return try JSONDecoder().decode(NoticeReadStatusResponseDTO.self, from: data)
+    }
+
+    func searchNotice(
+        keyword: String,
+        request: NoticeListRequestDTO
+    ) async throws -> NoticePageDTO<NoticeDTO> {
+        NoticePageDTO(
+            content: [],
+            page: "0",
+            size: "20",
+            totalElements: "0",
+            totalPages: "0",
+            hasNext: false,
+            hasPrevious: false
+        )
+    }
+
+    // MARK: - 공지 삭제
+
+    func deleteNotice(noticeId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func deleteVote(noticeId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+}

--- a/AppProduct/AppProduct/Resource/EnvrionmentKey/AppFlowEnvironmentKey.swift
+++ b/AppProduct/AppProduct/Resource/EnvrionmentKey/AppFlowEnvironmentKey.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct AppFlow {
     let showLogin: () -> Void
     let showMain: () -> Void
+    let showGuestMain: () -> Void
     let showSignUp: (
         String,
         String?,
@@ -21,6 +22,7 @@ struct AppFlow {
     static let noop = AppFlow(
         showLogin: {},
         showMain: {},
+        showGuestMain: {},
         showSignUp: { _, _, _, _ in },
         showPendingApproval: {},
         logout: {}

--- a/AppProduct/AppProduct/Resource/EnvrionmentKey/AppSessionModeEnvironmentKey.swift
+++ b/AppProduct/AppProduct/Resource/EnvrionmentKey/AppSessionModeEnvironmentKey.swift
@@ -1,0 +1,32 @@
+//
+//  AppSessionModeEnvironmentKey.swift
+//  AppProduct
+//
+
+import SwiftUI
+
+// MARK: - AppSessionMode
+
+/// 앱 세션의 인증 모드를 나타내는 열거형
+///
+/// 하위 뷰에서 `@Environment(\.appSessionMode)`로 접근하여
+/// 게스트 세션 여부에 따라 쓰기 액션을 제어할 수 있습니다.
+enum AppSessionMode: Equatable {
+    /// 정상 OAuth 인증 세션
+    case authenticated
+    /// 게스트 세션 (네트워크 미사용, Mock 데이터)
+    case guest
+}
+
+// MARK: - EnvironmentKey
+
+struct AppSessionModeEnvironmentKey: EnvironmentKey {
+    static let defaultValue: AppSessionMode = .authenticated
+}
+
+extension EnvironmentValues {
+    var appSessionMode: AppSessionMode {
+        get { self[AppSessionModeEnvironmentKey.self] }
+        set { self[AppSessionModeEnvironmentKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
## Summary

- 로그인 화면에 \"먼저 살펴보기\" 게스트 진입 버튼 추가
- `AppSessionMode` 열거형 및 게스트 전용 `DIContainer.guest()` 팩토리 도입
- 게스트 전용 Mock Repository(Home/Notice/Community/Auth/Storage 등) 구성
- Mock Preview Data(`#if DEBUG` 가드 제거) Release 빌드 참조 가능하도록 정리
- 로그인 화면 `GlassEffectContainer` 래핑, 디자인 토큰·접근성 레이블 개선

## Context

App Store 심사 가이드라인 2.1(a) 재거절 대응. Apple 리뷰어가 카카오 OAuth의 \"평소와 다른 로그인\" 이메일 인증을 통과하지 못해 심사 진입 자체가 차단된 문제를 해결.

기존 리뷰어 전용 데모 빌드 / Remote Config 방안은 가이드라인 2.3.1(미끼·변경 금지) 위반 리스크로 기각하고, **실제 사용자에게도 공개되는 게스트 모드**로 정책 리스크 없이 로그인 우회 경로 제공.

관련 이슈: #609
후속 이슈: #610 (Mock 확장 + 쓰기 액션 토스트), #611 (Review Notes 업데이트)

## Test plan

- [ ] Debug 빌드 성공 확인
- [ ] Release 빌드 성공 확인
- [ ] 로그인 화면에서 \"먼저 살펴보기\" 버튼 노출 및 탭 동작 확인
- [ ] 게스트 모드 진입 후 홈/공지/커뮤니티 기본 탐색 가능 여부 확인
- [ ] 게스트 모드에서 토큰 저장소·보안 저장소가 Mock으로 격리되는지 확인
- [ ] 소셜 로그인 정상 경로 회귀 없는지 확인
- [ ] 접근성: VoiceOver로 \"카카오로 로그인\"/\"Apple로 로그인\"/\"먼저 살펴보기\" 레이블 읽히는지 확인