### PR TITLE
✨ [Feat] 게스트 모드 Mock 데이터 표시 및 쓰기 액션 토스트 가드 (#610)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/UIComponents/GuestActionToast/GuestActionToast.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/GuestActionToast/GuestActionToast.swift
@@ -1,0 +1,108 @@
+//
+//  GuestActionToast.swift
+//  AppProduct
+//
+
+import SwiftUI
+
+// MARK: - GuestActionToast
+
+/// 게스트 모드 전용 플로팅 토스트
+///
+/// 쓰기 액션 직후 4초간 표시되며, 인증 세션에서는 절대 노출되지 않습니다.
+/// View Modifier `.guestActionToast(isPresented:onLoginTapped:)` 를 통해 사용합니다.
+struct GuestActionToast: View {
+
+    // MARK: - Property
+
+    let onLoginTapped: () -> Void
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing8) {
+            Text("게스트 모드에서는 저장되지 않아요. 로그인하면 실제로 반영됩니다")
+                .appFont(.footnote)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.primary)
+
+            Button(action: onLoginTapped) {
+                Text("지금 로그인하기")
+                    .appFont(.footnoteEmphasis)
+                    .foregroundStyle(.indigo500)
+            }
+        }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .padding(.vertical, DefaultSpacing.spacing12)
+        .frame(maxWidth: .infinity)
+        .glassEffect(.regular)
+        .clipShape(
+            ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+}
+
+// MARK: - View+GuestActionToastModifier
+
+private struct GuestActionToastModifier: ViewModifier {
+
+    @Binding var isPresented: Bool
+    let onLoginTapped: () -> Void
+
+    @Environment(\.appSessionMode) private var sessionMode
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottom) {
+                if isPresented && sessionMode == .guest {
+                    GuestActionToast(onLoginTapped: {
+                        isPresented = false
+                        onLoginTapped()
+                    })
+                    .padding(.bottom, DefaultConstant.defaultSafeBottom)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .task {
+                        try? await Task.sleep(for: .seconds(4))
+                        withAnimation {
+                            isPresented = false
+                        }
+                    }
+                    .animation(.spring(duration: 0.35), value: isPresented)
+                }
+            }
+            .onChange(of: sessionMode) { _, newMode in
+                if newMode != .guest {
+                    isPresented = false
+                }
+            }
+    }
+}
+
+extension View {
+    /// 게스트 모드 한정 토스트. 인증 세션에서는 절대 노출되지 않음.
+    func guestActionToast(
+        isPresented: Binding<Bool>,
+        onLoginTapped: @escaping () -> Void
+    ) -> some View {
+        modifier(GuestActionToastModifier(
+            isPresented: isPresented,
+            onLoginTapped: onLoginTapped
+        ))
+    }
+}
+
+// MARK: - Preview
+
+#Preview("GuestActionToast") {
+    ZStack {
+        Color.grey100.ignoresSafeArea()
+
+        GuestActionToast(onLoginTapped: {})
+            .padding()
+    }
+    .environment(\.appSessionMode, .guest)
+}

--- a/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
+++ b/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
@@ -398,7 +398,8 @@ extension DIContainer {
         container.register(ActivityUseCaseProviding.self) {
             ActivityUseCaseProvider(
                 repositoryProvider: container.resolve(ActivityRepositoryProviding.self),
-                classifierRepository: ScheduleClassifierRepositoryImpl()
+                classifierRepository: ScheduleClassifierRepositoryImpl(),
+                challengerAttendanceUseCaseOverride: GuestChallengerAttendanceUseCase()
             )
         }
 
@@ -450,6 +451,14 @@ extension DIContainer {
                 storageRepository: container.resolve(StorageRepositoryProtocol.self)
             )
         }
+        container.register(NoticeEditorTargetRepositoryProtocol.self) {
+            MockNoticeEditorTargetRepository()
+        }
+        container.register(NoticeEditorTargetUseCaseProtocol.self) {
+            NoticeEditorTargetUseCase(
+                repository: container.resolve(NoticeEditorTargetRepositoryProtocol.self)
+            )
+        }
 
         // MARK: - MyPage Feature
         container.register(MyPageRepositoryProtocol.self) {
@@ -462,6 +471,9 @@ extension DIContainer {
         }
 
         // MARK: - Community Feature
+        container.register(TMapGeocodingRepositoryProtocol.self) {
+            MockTMapGeocodingRepository()
+        }
         container.register(CommunityRepositoryProtocol.self) {
             MockCommunityRepository()
         }

--- a/AppProduct/AppProduct/Core/Mock/CommunityMockData.swift
+++ b/AppProduct/AppProduct/Core/Mock/CommunityMockData.swift
@@ -1,0 +1,199 @@
+//
+//  CommunityMockData.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 게스트 세션 및 프리뷰용 커뮤니티 Mock 데이터
+enum CommunityMockData {
+
+    // MARK: - Posts
+
+    static let posts: [CommunityItemModel] = [
+        CommunityItemModel(
+            postId: 1001,
+            userId: 101,
+            category: .free,
+            title: "UMC 9기 시작하신 분들 화이팅!",
+            content: "9기 OT 다녀왔는데 분위기 너무 좋았어요. 이번 기수도 잘 부탁드립니다 🙌",
+            profileImage: nil,
+            userName: "홍길동",
+            userNickname: "길동이",
+            part: .front(type: .ios),
+            createdAt: Date().addingTimeInterval(-60 * 30),
+            likeCount: 42,
+            commentCount: 5,
+            scrapCount: 3,
+            isLiked: false,
+            isScrapped: false,
+            isAuthor: false,
+            lightningInfo: nil
+        ),
+        CommunityItemModel(
+            postId: 1002,
+            userId: 102,
+            category: .question,
+            title: "SwiftUI @Observable 마이그레이션 질문",
+            content: "@StateObject에서 @State로 바꿀 때 기존 @Published는 어떻게 정리하시나요?",
+            profileImage: nil,
+            userName: "김미주",
+            userNickname: "마티",
+            part: .front(type: .ios),
+            createdAt: Date().addingTimeInterval(-60 * 60 * 2),
+            likeCount: 13,
+            commentCount: 4,
+            scrapCount: 1,
+            isLiked: true,
+            isScrapped: false,
+            isAuthor: false,
+            lightningInfo: nil
+        ),
+        CommunityItemModel(
+            postId: 1003,
+            userId: 103,
+            category: .lighting,
+            title: "⚡️ 강남역 번개 스터디 모집",
+            content: "iOS 아키텍처 얘기하실 분 3명 모집합니다. 커피값은 각자!",
+            profileImage: nil,
+            userName: "박준혁",
+            userNickname: "제이",
+            part: .front(type: .ios),
+            createdAt: Date().addingTimeInterval(-60 * 60 * 5),
+            likeCount: 7,
+            commentCount: 2,
+            scrapCount: 0,
+            isLiked: false,
+            isScrapped: false,
+            isAuthor: false,
+            lightningInfo: CommunityLightningInfo(
+                meetAt: Date().addingTimeInterval(60 * 60 * 24 * 2),
+                location: "서울 강남구 강남대로 지하역",
+                maxParticipants: 4,
+                openChatUrl: "https://open.kakao.com/o/sample"
+            )
+        ),
+        CommunityItemModel(
+            postId: 1004,
+            userId: 104,
+            category: .information,
+            title: "iOS 파트 Xcode 26 Beta 후기",
+            content: "Liquid Glass API가 생각보다 쾌적해요. 다만 List는 여전히 주의가 필요합니다.",
+            profileImage: nil,
+            userName: "이예지",
+            userNickname: "소피",
+            part: .front(type: .ios),
+            createdAt: Date().addingTimeInterval(-60 * 60 * 26),
+            likeCount: 21,
+            commentCount: 3,
+            scrapCount: 5,
+            isLiked: false,
+            isScrapped: true,
+            isAuthor: false,
+            lightningInfo: nil
+        ),
+        CommunityItemModel(
+            postId: 1005,
+            userId: 105,
+            category: .habit,
+            title: "매일 1커밋 챌린지 3일차",
+            content: "오늘은 에러 핸들러 리팩토링 했어요. 같이 하실 분 댓글 주세요!",
+            profileImage: nil,
+            userName: "정의찬",
+            userNickname: "제옹",
+            part: .pm,
+            createdAt: Date().addingTimeInterval(-60 * 60 * 48),
+            likeCount: 9,
+            commentCount: 1,
+            scrapCount: 0,
+            isLiked: false,
+            isScrapped: false,
+            isAuthor: false,
+            lightningInfo: nil
+        )
+    ]
+
+    // MARK: - Comments
+
+    static let comments: [CommunityCommentModel] = [
+        CommunityCommentModel(
+            commentId: 1,
+            userId: 201,
+            profileImage: nil,
+            userName: "박경운",
+            userNickname: "하늘",
+            content: "좋은 글 감사합니다! 저도 많이 배워갑니다.",
+            createdAt: Date().addingTimeInterval(-60 * 10),
+            isAuthor: false
+        ),
+        CommunityCommentModel(
+            commentId: 2,
+            userId: 202,
+            profileImage: nil,
+            userName: "강하나",
+            userNickname: "와나",
+            content: "공감합니다 🙌",
+            createdAt: Date().addingTimeInterval(-60 * 30),
+            isAuthor: false
+        )
+    ]
+
+    // MARK: - Trophies
+
+    static let trophies: [CommunityFameItemModel] = [
+        CommunityFameItemModel(
+            week: 1,
+            university: "UMC 대학교",
+            profileImage: nil,
+            userName: "이예지",
+            part: .front(type: .ios),
+            workbookTitle: "SwiftUI 화면 구성 및 상태 관리",
+            content: "@State/@Binding 기반 카드 UI 구현 및 네비게이션 연결까지 깔끔하게 수행했습니다.",
+            url: "https://github.com/example/workbook-1"
+        ),
+        CommunityFameItemModel(
+            week: 2,
+            university: "UMC 대학교",
+            profileImage: nil,
+            userName: "박경운",
+            part: .server(type: .spring),
+            workbookTitle: "Spring Boot REST API 설계",
+            content: "도메인 분리와 예외 처리 컨벤션이 인상적입니다.",
+            url: "https://github.com/example/workbook-2"
+        ),
+        CommunityFameItemModel(
+            week: 3,
+            university: "UMC 대학교",
+            profileImage: nil,
+            userName: "양지애",
+            part: .design,
+            workbookTitle: "모바일 내비게이션 디자인",
+            content: "사용성 테스트 기반으로 IA를 재구성한 사례가 훌륭합니다.",
+            url: "https://github.com/example/workbook-3"
+        )
+    ]
+
+    // MARK: - Helpers
+
+    static func fallbackPost(postId: Int) -> CommunityItemModel {
+        CommunityItemModel(
+            postId: postId,
+            userId: 0,
+            category: .free,
+            title: "게스트 모드 게시글",
+            content: "게스트 모드에서 표시되는 Mock 게시글입니다.",
+            profileImage: nil,
+            userName: "홍길동",
+            userNickname: "길동이",
+            part: .front(type: .ios),
+            createdAt: Date(),
+            likeCount: 0,
+            commentCount: 0,
+            scrapCount: 0,
+            isLiked: false,
+            isScrapped: false,
+            isAuthor: false,
+            lightningInfo: nil
+        )
+    }
+}

--- a/AppProduct/AppProduct/Core/Mock/GuestMocks.swift
+++ b/AppProduct/AppProduct/Core/Mock/GuestMocks.swift
@@ -3,6 +3,7 @@
 //  AppProduct
 //
 
+import CoreLocation
 import Foundation
 
 // MARK: - GuestTokenStore
@@ -73,4 +74,143 @@ final class MockAuthorizationRepository: AuthorizationRepositoryProtocol {
             grantedPermissions: []
         )
     }
+}
+
+// MARK: - MockNoticeEditorTargetRepository
+
+/// 게스트 세션용 NoticeEditorTarget Repository Mock
+///
+/// 공지 에디터의 타겟(지부/학교) 선택 시트에서 빈 목록을 반환합니다.
+final class MockNoticeEditorTargetRepository: NoticeEditorTargetRepositoryProtocol {
+
+    func fetchAllBranches() async throws -> [NoticeTargetOption] { [] }
+
+    func fetchBranches(gisuId: Int) async throws -> [NoticeTargetOption] { [] }
+
+    func fetchBranchName(chapterId: Int) async throws -> String { "" }
+
+    func fetchAllSchools() async throws -> [NoticeTargetOption] { [] }
+
+    func fetchSchools(gisuId: Int) async throws -> [NoticeTargetOption] { [] }
+
+    func fetchSchools(inChapterId chapterId: Int, gisuId: Int) async throws -> [NoticeTargetOption] { [] }
+}
+
+// MARK: - MockTMapGeocodingRepository
+
+/// 게스트 세션용 TMap 지오코딩 Repository Mock
+///
+/// 장소 선택 시 좌표 조회 없이 nil을 반환합니다.
+final class MockTMapGeocodingRepository: TMapGeocodingRepositoryProtocol {
+
+    func geocodeCoordinate(from address: String) async -> CLLocationCoordinate2D? {
+        nil
+    }
+}
+
+// MARK: - GuestChallengerAttendanceUseCase
+
+/// 게스트 세션용 ChallengerAttendance UseCase
+///
+/// 위치 권한 체크 및 지오펜스 검증을 우회하여 Mock 성공을 반환합니다.
+/// 실제 LocationManager.requestAuthorization() 호출은 ViewModel/View 레이어에서 그대로 진행됩니다.
+final class GuestChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProtocol {
+
+    var isInsideGeofence: Bool { true }
+    var isLocationAuthorized: Bool { true }
+
+    func fetchAvailableSchedules() async throws -> [AvailableAttendanceSchedule] {
+        [
+            AvailableAttendanceSchedule(
+                scheduleId: 1,
+                scheduleName: "9기 OT",
+                tags: ["SEMINAR", "ALL"],
+                startTime: "10:00:00",
+                endTime: "12:00:00",
+                sheetId: 1,
+                recordId: 1,
+                status: .beforeAttendance,
+                statusDisplay: "출석 전",
+                locationVerified: true
+            )
+        ]
+    }
+
+    func fetchMyHistory() async throws -> [AttendanceHistoryItem] {
+        [
+            AttendanceHistoryItem(
+                attendanceId: 1,
+                scheduleId: 1,
+                scheduleName: "9기 OT",
+                tags: ["SEMINAR", "ALL"],
+                scheduledDate: "2024-01-15",
+                startTime: "14:30",
+                endTime: "16:00",
+                status: .present,
+                statusDisplay: "출석"
+            )
+        ]
+    }
+
+    func requestGPSAttendance(
+        sessionId: SessionID,
+        userId: UserID,
+        sheetId: Int
+    ) async throws -> Attendance {
+        Attendance(
+            sessionId: sessionId,
+            userId: userId,
+            type: .gps,
+            status: .beforeAttendance,
+            locationVerification: LocationVerification(
+                isVerified: true,
+                coordinate: Coordinate(latitude: 37.5, longitude: 127.0),
+                address: .init(fullAddress: "서울특별시", city: "서울", district: ""),
+                verifiedAt: .now
+            ),
+            reason: nil
+        )
+    }
+
+    func submitLateReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        sheetId: Int
+    ) async throws -> Attendance {
+        Attendance(
+            sessionId: sessionId,
+            userId: userId,
+            type: .reason,
+            status: .pendingApproval,
+            locationVerification: nil,
+            reason: reason
+        )
+    }
+
+    func submitAbsentReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        sheetId: Int
+    ) async throws -> Attendance {
+        Attendance(
+            sessionId: sessionId,
+            userId: userId,
+            type: .reason,
+            status: .pendingApproval,
+            locationVerification: nil,
+            reason: reason
+        )
+    }
+
+    func isWithinAttendanceTime(info: SessionInfo) -> AttendanceTimeWindow {
+        .onTime
+    }
+
+    func getAddressToCurrentLocation() async throws -> String {
+        "서울특별시 중구"
+    }
+
+    func stopGeofenceMonitoring() async {}
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Provider/ActivityUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Provider/ActivityUseCaseProvider.swift
@@ -61,7 +61,8 @@ final class ActivityUseCaseProvider: ActivityUseCaseProviding {
 
     init(
         repositoryProvider: ActivityRepositoryProviding,
-        classifierRepository: ScheduleClassifierRepository
+        classifierRepository: ScheduleClassifierRepository,
+        challengerAttendanceUseCaseOverride: ChallengerAttendanceUseCaseProtocol? = nil
     ) {
         self.fetchSessionsUseCase = FetchSessionsUseCase(
             repository: repositoryProvider.activityRepository
@@ -69,9 +70,10 @@ final class ActivityUseCaseProvider: ActivityUseCaseProviding {
         self.fetchUserIdUseCase = FetchUserIdUseCase(
             repository: repositoryProvider.activityRepository
         )
-        self.challengerAttendanceUseCase = ChallengerAttendanceUseCase(
-            repository: repositoryProvider.challengerAttendanceRepository
-        )
+        self.challengerAttendanceUseCase = challengerAttendanceUseCaseOverride
+            ?? ChallengerAttendanceUseCase(
+                repository: repositoryProvider.challengerAttendanceRepository
+            )
         self.operatorAttendanceUseCase = OperatorAttendanceUseCase(
             repository: repositoryProvider.operatorAttendanceRepository
         )

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Challenger/ChallengerAttendanceViewModel.swift
@@ -23,6 +23,9 @@ final class ChallengerAttendanceViewModel {
     /// 재시도 중 여부 (RetryContentUnavailableView용)
     private(set) var isRetrying: Bool = false
 
+    /// 출석 완료 신호 (View에서 `.onChange(of:)` 로 감지해 게스트 토스트를 표시)
+    var didCompleteAttendance: Bool = false
+
     private var statusObserver: (any NSObjectProtocol)?
 
     /// 폴링 대상 세션 (View에서 주입)
@@ -228,6 +231,7 @@ final class ChallengerAttendanceViewModel {
                 sessionId: info.sessionId, userId: userId, sheetId: sheetId)
             session.updateState(.loaded(result))
             session.markSubmitted()
+            didCompleteAttendance = true
 
         } catch let error as DomainError {
             session.updateState(.failed(.domain(error)))

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -25,6 +25,9 @@ private final class MapViewModelCache {
 struct ChallengerAttendanceSessionView: View {
     @State private var expandedSessionId: Session.ID?
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.appFlow) private var appFlow
+    @Environment(\.appSessionMode) private var sessionMode
+    @State private var showGuestToast: Bool = false
     @State private var attendanceViewModel: ChallengerAttendanceViewModel
     @State private var mapViewModelCache = MapViewModelCache()
 
@@ -130,6 +133,17 @@ struct ChallengerAttendanceSessionView: View {
             Task {
                 await attendanceViewModel.geofenceCleanup()
             }
+        }
+        .onChange(of: attendanceViewModel.didCompleteAttendance) { _, completed in
+            if completed, sessionMode.isGuest {
+                showGuestToast = true
+            }
+            if completed {
+                attendanceViewModel.didCompleteAttendance = false
+            }
+        }
+        .guestActionToast(isPresented: $showGuestToast) {
+            appFlow.showLogin()
         }
     }
     

--- a/AppProduct/AppProduct/Features/Community/Data/Repositories/Mock/MockCommunityRepositories.swift
+++ b/AppProduct/AppProduct/Features/Community/Data/Repositories/Mock/MockCommunityRepositories.swift
@@ -11,25 +11,38 @@ import Foundation
 final class MockCommunityRepository: CommunityRepositoryProtocol {
 
     func getSchools() async throws -> [String] {
-        []
+        ["UMC 대학교", "성균관대학교", "한양대학교", "서울대학교", "연세대학교"]
     }
 
     func getTrophies(query: TrophyListQuery) async throws -> [CommunityFameItemModel] {
-        []
+        try await Task.sleep(for: .milliseconds(200))
+        return CommunityMockData.trophies
     }
 
     func getPosts(query: PostListQuery) async throws -> (
         items: [CommunityItemModel],
         hasNext: Bool
     ) {
-        (items: [], hasNext: false)
+        try await Task.sleep(for: .milliseconds(200))
+        let all = CommunityMockData.posts
+        guard let category = query.category else {
+            return (items: all, hasNext: false)
+        }
+        let filtered = all.filter { $0.category.rawValue == category }
+        return (items: filtered, hasNext: false)
     }
 
     func getSearch(query: PostSearchQuery) async throws -> (
         items: [CommunityItemModel],
         hasNext: Bool
     ) {
-        (items: [], hasNext: false)
+        try await Task.sleep(for: .milliseconds(200))
+        let keyword = query.keyword.lowercased()
+        let filtered = CommunityMockData.posts.filter {
+            $0.title.lowercased().contains(keyword) ||
+            $0.content.lowercased().contains(keyword)
+        }
+        return (items: filtered, hasNext: false)
     }
 }
 
@@ -57,28 +70,14 @@ final class MockCommunityDetailRepository: CommunityDetailRepositoryProtocol {
     func deleteComment(postId: Int, commentId: Int) async throws {}
 
     func getComments(postId: Int) async throws -> [CommunityCommentModel] {
-        []
+        CommunityMockData.comments
     }
 
     func getPostDetail(postId: Int) async throws -> CommunityItemModel {
-        CommunityItemModel(
-            postId: postId,
-            userId: 1001,
-            category: .free,
-            title: "게스트 모드 게시글",
-            content: "게스트 모드에서 표시되는 Mock 게시글입니다.",
-            profileImage: nil,
-            userName: "홍길동",
-            userNickname: "길동이",
-            part: .front(type: .ios),
-            createdAt: Date(),
-            likeCount: 0,
-            commentCount: 0,
-            scrapCount: 0,
-            isLiked: false,
-            isAuthor: false,
-            lightningInfo: nil
-        )
+        if let match = CommunityMockData.posts.first(where: { $0.postId == postId }) {
+            return match
+        }
+        return CommunityMockData.posts.first ?? CommunityMockData.fallbackPost(postId: postId)
     }
 
     func postScrap(postId: Int) async throws {}

--- a/AppProduct/AppProduct/Features/Community/Data/Repositories/Mock/MockCommunityRepositories.swift
+++ b/AppProduct/AppProduct/Features/Community/Data/Repositories/Mock/MockCommunityRepositories.swift
@@ -38,21 +38,13 @@ final class MockCommunityRepository: CommunityRepositoryProtocol {
 /// 게스트 세션 및 프리뷰용 Community Post Repository Mock 구현체
 final class MockCommunityPostRepository: CommunityPostRepositoryProtocol {
 
-    func postPosts(request: PostRequestDTO) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func postPosts(request: PostRequestDTO) async throws {}
 
-    func postLightning(request: CreateLightningPostRequestDTO) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func postLightning(request: CreateLightningPostRequestDTO) async throws {}
 
-    func patchPosts(postId: Int, request: PostRequestDTO) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func patchPosts(postId: Int, request: PostRequestDTO) async throws {}
 
-    func patchLightning(postId: Int, request: CreateLightningPostRequestDTO) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func patchLightning(postId: Int, request: CreateLightningPostRequestDTO) async throws {}
 }
 
 // MARK: - MockCommunityDetailRepository
@@ -60,39 +52,42 @@ final class MockCommunityPostRepository: CommunityPostRepositoryProtocol {
 /// 게스트 세션 및 프리뷰용 Community Detail Repository Mock 구현체
 final class MockCommunityDetailRepository: CommunityDetailRepositoryProtocol {
 
-    func deletePost(postId: Int) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func deletePost(postId: Int) async throws {}
 
-    func deleteComment(postId: Int, commentId: Int) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func deleteComment(postId: Int, commentId: Int) async throws {}
 
     func getComments(postId: Int) async throws -> [CommunityCommentModel] {
         []
     }
 
     func getPostDetail(postId: Int) async throws -> CommunityItemModel {
-        throw DomainError.postNotFound
+        CommunityItemModel(
+            postId: postId,
+            userId: 1001,
+            category: .free,
+            title: "게스트 모드 게시글",
+            content: "게스트 모드에서 표시되는 Mock 게시글입니다.",
+            profileImage: nil,
+            userName: "홍길동",
+            userNickname: "길동이",
+            part: .front(type: .ios),
+            createdAt: Date(),
+            likeCount: 0,
+            commentCount: 0,
+            scrapCount: 0,
+            isLiked: false,
+            isAuthor: false,
+            lightningInfo: nil
+        )
     }
 
-    func postScrap(postId: Int) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func postScrap(postId: Int) async throws {}
 
-    func postLike(postId: Int) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func postLike(postId: Int) async throws {}
 
-    func postComment(postId: Int, request: PostCommentRequest) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func postComment(postId: Int, request: PostCommentRequest) async throws {}
 
-    func postPostReport(postId: Int) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func postPostReport(postId: Int) async throws {}
 
-    func postCommentReport(commentId: Int) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func postCommentReport(commentId: Int) async throws {}
 }

--- a/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/ViewModels/CommunityDetailViewModel.swift
@@ -37,6 +37,9 @@ class CommunityDetailViewModel {
     var commentText: String = ""
     var alertPrompt: AlertPrompt?
 
+    /// 댓글 작성 완료 트리거 (게스트 토스트 표시용)
+    var didCompleteComment: Bool = false
+
     // MARK: - Init
 
     init(
@@ -278,6 +281,7 @@ class CommunityDetailViewModel {
                 request: request
             )
             isPostingComment = false
+            didCompleteComment = true
             // 댓글 작성 후 목록 새로고침
             await fetchComments()
         } catch {

--- a/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityDetailView.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityDetailView.swift
@@ -17,9 +17,12 @@ struct CommunityDetailView: View {
     @State private var vm: CommunityDetailViewModel
     @State private var isCommentInputExpanded: Bool = false
     @State private var isCommentInputHidden: Bool = true
+    @State private var showGuestToast: Bool = false
     @FocusState private var isCommentFieldFocused: Bool
     @Environment(\.di) private var di
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.appFlow) private var appFlow
+    @Environment(\.appSessionMode) private var sessionMode
     @Environment(ErrorHandler.self) var errorHandler
 
     /// 커뮤니티 상세에서 사용하는 내비게이션 경로 저장소입니다.
@@ -117,6 +120,17 @@ struct CommunityDetailView: View {
             }
         }
         .alertPrompt(item: $vm.alertPrompt)
+        .onChange(of: vm.didCompleteComment) { _, completed in
+            if completed, sessionMode.isGuest {
+                showGuestToast = true
+            }
+            if completed {
+                vm.didCompleteComment = false
+            }
+        }
+        .guestActionToast(isPresented: $showGuestToast) {
+            appFlow.showLogin()
+        }
         .umcDefaultBackground()
     }
 

--- a/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityPostView.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityPostView.swift
@@ -14,6 +14,11 @@ struct CommunityPostView: View {
 
     @Environment(ErrorHandler.self) var errorHandler
     @Environment(\.dismiss) var dismiss
+    @Environment(\.appFlow) private var appFlow
+    @Environment(\.appSessionMode) private var sessionMode
+
+    @State private var showGuestToast: Bool = false
+
     private let mode: PostMode
 
     enum PostMode {
@@ -108,8 +113,14 @@ struct CommunityPostView: View {
         // 생성 성공 시 화면 자동 닫기
         .onChange(of: vm.submitState) {
             if case .loaded = vm.submitState {
+                if sessionMode.isGuest {
+                    showGuestToast = true
+                }
                 dismiss()
             }
+        }
+        .guestActionToast(isPresented: $showGuestToast) {
+            appFlow.showLogin()
         }
     }
     

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
@@ -15,18 +15,83 @@ final class MockHomeRepository: HomeRepositoryProtocol {
     // MARK: - Function
 
     func getMyProfile() async throws -> HomeProfileResult {
-        HomeProfileResult(
-            memberId: 0,
-            schoolId: 0,
+        try await Task.sleep(for: .milliseconds(200))
+        return HomeProfileResult(
+            memberId: 1001,
+            schoolId: 1,
             schoolName: "UMC 대학교",
-            latestChallengerId: nil,
-            latestGisuId: nil,
-            chapterId: nil,
-            chapterName: "UMC",
-            part: nil,
-            seasonTypes: [.days(0)],
-            roles: [],
-            generations: []
+            latestChallengerId: 1001,
+            latestGisuId: 9,
+            chapterId: 1,
+            chapterName: "Nova",
+            part: .front(type: .ios),
+            seasonTypes: [
+                .days(82),
+                .gens([7, 8, 9])
+            ],
+            roles: [
+                ChallengerRole(
+                    challengerId: 1001,
+                    gisu: 9,
+                    gisuId: 9,
+                    roleType: .challenger,
+                    responsiblePart: .front(type: .ios),
+                    organizationType: .school,
+                    organizationId: 1
+                )
+            ],
+            generations: [
+                GenerationData(
+                    gisuId: 9,
+                    gen: 9,
+                    penaltyPoint: 1,
+                    rewardPoint: 3,
+                    pointLogs: [
+                        PointLogItem(
+                            reason: "우수 워크북",
+                            date: "04.10",
+                            point: 2,
+                            isReward: true
+                        ),
+                        PointLogItem(
+                            reason: "지각",
+                            date: "04.05",
+                            point: -1,
+                            isReward: false
+                        ),
+                        PointLogItem(
+                            reason: "스터디 발표",
+                            date: "03.28",
+                            point: 1,
+                            isReward: true
+                        )
+                    ],
+                    penaltyLogs: [
+                        PenaltyInfoItem(
+                            reason: "지각",
+                            date: "2026.04.05",
+                            penaltyPoint: 1
+                        )
+                    ]
+                ),
+                GenerationData(
+                    gisuId: 8,
+                    gen: 8,
+                    penaltyPoint: 0,
+                    rewardPoint: 2,
+                    pointLogs: [],
+                    penaltyLogs: []
+                )
+            ],
+            generationOrganizations: [
+                GenerationOrganizationContext(
+                    gen: 9,
+                    chapterId: 1,
+                    chapterName: "Nova",
+                    schoolId: 1,
+                    schoolName: "UMC 대학교"
+                )
+            ]
         )
     }
 
@@ -34,7 +99,47 @@ final class MockHomeRepository: HomeRepositoryProtocol {
         year: Int,
         month: Int
     ) async throws -> [Date: [ScheduleData]] {
-        [:]
+        try await Task.sleep(for: .milliseconds(200))
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = ServerDateTimeConverter.kstTimeZone
+
+        let today = calendar.startOfDay(for: Date())
+        let inTwoDays = calendar.date(byAdding: .day, value: 2, to: today) ?? today
+        let inFiveDays = calendar.date(byAdding: .day, value: 5, to: today) ?? today
+
+        return [
+            today: [
+                ScheduleData(
+                    scheduleId: 1,
+                    title: "9기 해커톤 OT",
+                    startsAt: today.addingTimeInterval(60 * 60 * 14),
+                    endsAt: today.addingTimeInterval(60 * 60 * 16),
+                    status: "참여 예정",
+                    dDay: 0
+                )
+            ],
+            inTwoDays: [
+                ScheduleData(
+                    scheduleId: 2,
+                    title: "iOS 파트 스터디",
+                    startsAt: inTwoDays.addingTimeInterval(60 * 60 * 19),
+                    endsAt: inTwoDays.addingTimeInterval(60 * 60 * 21),
+                    status: "참여 예정",
+                    dDay: 2
+                )
+            ],
+            inFiveDays: [
+                ScheduleData(
+                    scheduleId: 3,
+                    title: "UMCON 컨퍼런스",
+                    startsAt: inFiveDays.addingTimeInterval(60 * 60 * 10),
+                    endsAt: inFiveDays.addingTimeInterval(60 * 60 * 18),
+                    status: "참여 예정",
+                    dDay: 5
+                )
+            ]
+        ]
     }
 
     func getScheduleDetail(
@@ -46,7 +151,28 @@ final class MockHomeRepository: HomeRepositoryProtocol {
     func getRecentNotices(
         query: NoticeListRequestDTO
     ) async throws -> [RecentNoticeData] {
-        []
+        try await Task.sleep(for: .milliseconds(200))
+        let now = Date()
+        return [
+            RecentNoticeData(
+                noticeId: 1,
+                category: .operationsTeam,
+                title: "9th UMC Hackathon 모집 신청 안내",
+                createdAt: now
+            ),
+            RecentNoticeData(
+                noticeId: 2,
+                category: .operationsTeam,
+                title: "🗣️ 9th UMC 동아리 연합 컨퍼런스 신청 모집 안내",
+                createdAt: now.addingTimeInterval(-60 * 60 * 24)
+            ),
+            RecentNoticeData(
+                noticeId: 3,
+                category: .univ,
+                title: "[투표] 9기 기말고사 뒤풀이 메뉴 선정 안내",
+                createdAt: now.addingTimeInterval(-60 * 60 * 48)
+            )
+        ]
     }
 
     func registerFCMToken(fcmToken: String) async throws {}
@@ -75,10 +201,20 @@ final class MockScheduleRepository: ScheduleRepositoryProtocol {
 /// 게스트 세션 및 프리뷰용 ChallengerGen Repository Mock 구현체
 final class MockChallengerGenRepository: ChallengerGenRepositoryProtocol {
 
-    func replaceMappings(_ pairs: [(gen: Int, gisuId: Int)]) throws {}
+    private var pairs: [(gen: Int, gisuId: Int)] = [
+        (gen: 7, gisuId: 7),
+        (gen: 8, gisuId: 8),
+        (gen: 9, gisuId: 9)
+    ]
+
+    func replaceMappings(_ pairs: [(gen: Int, gisuId: Int)]) throws {
+        if !pairs.isEmpty {
+            self.pairs = pairs
+        }
+    }
 
     func fetchGenGisuIdPairs() throws -> [(gen: Int, gisuId: Int)] {
-        []
+        pairs
     }
 }
 

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyPageProfileView.swift
@@ -17,9 +17,12 @@ struct MyPageProfileView: View {
     @Environment(\.di) private var di
     @Environment(ErrorHandler.self) private var errorHandler
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.appFlow) private var appFlow
+    @Environment(\.appSessionMode) private var sessionMode
     @State private var showAddActivityLogAlert: Bool = false
     @State private var challengerCode: String = ""
     @State private var alertPrompt: AlertPrompt?
+    @State private var showGuestToast: Bool = false
 
     init(container: DIContainer, profileData: ProfileData) {
         let provider = container.resolve(MyPageUseCaseProviding.self)
@@ -59,6 +62,9 @@ struct MyPageProfileView: View {
             message: challengerCodeAlertMessage
         )
         .alertPrompt(item: $alertPrompt)
+        .guestActionToast(isPresented: $showGuestToast) {
+            appFlow.showLogin()
+        }
     }
     
     /// 섹션 구현부
@@ -119,6 +125,9 @@ struct MyPageProfileView: View {
         Task {
             do {
                 try await viewModel.submitProfileUpdate()
+                if sessionMode.isGuest {
+                    showGuestToast = true
+                }
                 dismiss()
             } catch {
                 errorHandler.handle(

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeRepository.swift
@@ -17,41 +17,45 @@ final class MockNoticeRepository: NoticeRepositoryProtocol {
         links: [String],
         imageIds: [String]
     ) async throws -> NoticeDetail {
-        throw DomainError.insufficientPermission(required: "인증")
+        try await mockDetail(noticeId: 0)
     }
 
     func postNotice(body: PostNoticeRequestDTO) async throws -> NoticeItemModel {
-        throw DomainError.insufficientPermission(required: "인증")
+        guard let item = NoticeMockData.items.first else {
+            throw DomainError.noticeNotFound
+        }
+        return item
     }
 
     func addVote(
         noticeId: Int,
         body: AddVoteRequestDTO
     ) async throws -> AddVoteResponseDTO {
-        throw DomainError.insufficientPermission(required: "인증")
+        let json = #"{"noticeVoteId":"0","voteId":"0"}"#
+        return try JSONDecoder().decode(AddVoteResponseDTO.self, from: Data(json.utf8))
     }
 
     func addLink(noticeId: Int, links: [String]) async throws -> NoticeItemModel {
-        throw DomainError.insufficientPermission(required: "인증")
+        guard let item = NoticeMockData.items.first else {
+            throw DomainError.noticeNotFound
+        }
+        return item
     }
 
     func addImage(noticeId: Int, imageIds: [String]) async throws -> NoticeItemModel {
-        throw DomainError.insufficientPermission(required: "인증")
+        guard let item = NoticeMockData.items.first else {
+            throw DomainError.noticeNotFound
+        }
+        return item
     }
 
-    func sendReminder(noticeId: Int, targetIds: [Int]) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func sendReminder(noticeId: Int, targetIds: [Int]) async throws {}
 
     func readNotice(noticeId: Int) async throws {}
 
-    func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws {}
 
-    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws {}
 
     // MARK: - 공지 수정
 
@@ -59,21 +63,21 @@ final class MockNoticeRepository: NoticeRepositoryProtocol {
         noticeId: Int,
         body: UpdateNoticeRequestDTO
     ) async throws -> NoticeDetail {
-        throw DomainError.insufficientPermission(required: "인증")
+        try await mockDetail(noticeId: noticeId)
     }
 
     func updateLinks(
         noticeId: Int,
         links: [String]
     ) async throws -> NoticeDetail {
-        throw DomainError.insufficientPermission(required: "인증")
+        try await mockDetail(noticeId: noticeId)
     }
 
     func updateImages(
         noticeId: Int,
         imageIds: [String]
     ) async throws -> NoticeDetail {
-        throw DomainError.insufficientPermission(required: "인증")
+        try await mockDetail(noticeId: noticeId)
     }
 
     // MARK: - 공지 조회
@@ -158,11 +162,35 @@ final class MockNoticeRepository: NoticeRepositoryProtocol {
 
     // MARK: - 공지 삭제
 
-    func deleteNotice(noticeId: Int) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
-    }
+    func deleteNotice(noticeId: Int) async throws {}
 
-    func deleteVote(noticeId: Int) async throws {
-        throw DomainError.insufficientPermission(required: "인증")
+    func deleteVote(noticeId: Int) async throws {}
+
+    // MARK: - Private
+
+    private func mockDetail(noticeId: Int) async throws -> NoticeDetail {
+        guard let item = NoticeMockData.items.first else {
+            throw DomainError.noticeNotFound
+        }
+        return NoticeDetail(
+            id: "\(noticeId)",
+            generation: item.generation,
+            scope: item.scope,
+            category: item.category,
+            isMustRead: item.mustRead,
+            title: item.title,
+            content: item.content,
+            authorID: "0",
+            authorNickname: nil,
+            authorName: item.writer,
+            authorImageURL: nil,
+            createdAt: item.date,
+            updatedAt: nil,
+            targetAudience: TargetAudience.all(generation: item.generation, scope: item.scope),
+            hasPermission: false,
+            images: item.images,
+            links: item.links,
+            vote: item.vote
+        )
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeRepository.swift
@@ -85,12 +85,14 @@ final class MockNoticeRepository: NoticeRepositoryProtocol {
     func getAllNotices(
         request: NoticeListRequestDTO
     ) async throws -> NoticePageDTO<NoticeDTO> {
-        NoticePageDTO(
-            content: [],
+        try await Task.sleep(for: .milliseconds(200))
+        let content = try MockNoticeDTOFactory.makeAll()
+        return NoticePageDTO(
+            content: content,
             page: "0",
-            size: "20",
-            totalElements: "0",
-            totalPages: "0",
+            size: "\(content.count)",
+            totalElements: "\(content.count)",
+            totalPages: "1",
             hasNext: false,
             hasPrevious: false
         )
@@ -149,12 +151,18 @@ final class MockNoticeRepository: NoticeRepositoryProtocol {
         keyword: String,
         request: NoticeListRequestDTO
     ) async throws -> NoticePageDTO<NoticeDTO> {
-        NoticePageDTO(
-            content: [],
+        try await Task.sleep(for: .milliseconds(200))
+        let keyword = keyword.lowercased()
+        let content = try MockNoticeDTOFactory.makeAll().filter {
+            $0.title.lowercased().contains(keyword) ||
+            $0.content.lowercased().contains(keyword)
+        }
+        return NoticePageDTO(
+            content: content,
             page: "0",
-            size: "20",
-            totalElements: "0",
-            totalPages: "0",
+            size: "\(content.count)",
+            totalElements: "\(content.count)",
+            totalPages: "1",
             hasNext: false,
             hasPrevious: false
         )
@@ -192,5 +200,119 @@ final class MockNoticeRepository: NoticeRepositoryProtocol {
             links: item.links,
             vote: item.vote
         )
+    }
+}
+
+// MARK: - Mock DTO Factory
+
+/// NoticeDTO에는 memberwise init이 없어 JSON 디코딩으로 Mock 인스턴스를 생성합니다.
+private enum MockNoticeDTOFactory {
+
+    static func makeAll() throws -> [NoticeDTO] {
+        let dtos = try [
+            makeDTO(
+                id: "1",
+                title: "9th UMC Hackathon 모집 신청 안내",
+                content: "챌린저 여러분께서 기다리시던 9th UMC Hackathon이 진행됩니다!",
+                viewCount: 445,
+                shouldSendNotification: true,
+                authorNickname: "사과",
+                authorName: "김아요",
+                targetGisu: "9",
+                targetGisuId: "9",
+                targetChapterId: nil,
+                targetSchoolId: nil,
+                chapterName: nil,
+                schoolName: nil
+            ),
+            makeDTO(
+                id: "2",
+                title: "🗣️ 9th UMC 동아리 연합 컨퍼런스 신청 모집 안내",
+                content: "2026년 9th UMCON이 다가오고 있습니다!",
+                viewCount: 421,
+                shouldSendNotification: true,
+                authorNickname: "사과",
+                authorName: "김아요",
+                targetGisu: "9",
+                targetGisuId: "9",
+                targetChapterId: nil,
+                targetSchoolId: nil,
+                chapterName: nil,
+                schoolName: nil
+            ),
+            makeDTO(
+                id: "3",
+                title: "[투표] 9기 기말고사 뒤풀이 메뉴 선정 안내",
+                content: "9기 UMC대 챌린저 여러분 안녕하세요! 기말고사 뒤풀이 회식 메뉴를 결정하고자 합니다.",
+                viewCount: 32,
+                shouldSendNotification: false,
+                authorNickname: "애플",
+                authorName: "박사과",
+                targetGisu: "9",
+                targetGisuId: "9",
+                targetChapterId: "1",
+                targetSchoolId: "1",
+                chapterName: "Nova",
+                schoolName: "UMC 대학교"
+            ),
+            makeDTO(
+                id: "4",
+                title: "9기 해커톤 현장 사진 공유",
+                content: "지난 주말 진행된 해커톤 현장 사진을 공유합니다.",
+                viewCount: 256,
+                shouldSendNotification: false,
+                authorNickname: "너드",
+                authorName: "이서버",
+                targetGisu: "9",
+                targetGisuId: "9",
+                targetChapterId: nil,
+                targetSchoolId: nil,
+                chapterName: nil,
+                schoolName: nil
+            )
+        ]
+        return dtos
+    }
+
+    private static func makeDTO(
+        id: String,
+        title: String,
+        content: String,
+        viewCount: Int,
+        shouldSendNotification: Bool,
+        authorNickname: String,
+        authorName: String,
+        targetGisu: String?,
+        targetGisuId: String,
+        targetChapterId: String?,
+        targetSchoolId: String?,
+        chapterName: String?,
+        schoolName: String?
+    ) throws -> NoticeDTO {
+        let createdAt = ISO8601DateFormatter().string(from: Date())
+        var dict: [String: Any] = [
+            "id": id,
+            "title": title,
+            "content": content,
+            "shouldSendNotification": shouldSendNotification,
+            "viewCount": "\(viewCount)",
+            "createdAt": createdAt,
+            "authorNickname": authorNickname,
+            "authorName": authorName,
+            "targetInfo": [
+                "targetGisu": targetGisu as Any,
+                "targetGisuId": targetGisuId,
+                "targetChapterId": targetChapterId as Any,
+                "targetSchoolId": targetSchoolId as Any,
+                "chapterName": chapterName as Any,
+                "schoolName": schoolName as Any
+            ]
+        ]
+        if let authorChallengerId = Optional<String>.some("0") {
+            dict["authorChallengerId"] = authorChallengerId
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: dict, options: [])
+        return try JSONDecoder().decode(NoticeDTO.self, from: data)
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
@@ -53,6 +53,7 @@ extension NoticeEditorViewModel {
             }
 
             createState = .loaded(notice)
+            didCompleteWrite = true
             resetForm()
         } catch let error as DomainError {
             createState = .failed(.domain(error))
@@ -131,6 +132,7 @@ extension NoticeEditorViewModel {
                 createState = .loaded(
                     try await noticeUseCase.getDetailNotice(noticeId: noticeId)
                 )
+                didCompleteWrite = true
                 return
             }
 
@@ -141,6 +143,7 @@ extension NoticeEditorViewModel {
                     try await noticeUseCase.getDetailNotice(noticeId: noticeId)
                 )
             }
+            didCompleteWrite = true
         } catch let error as DomainError {
             createState = .failed(.domain(error))
             handleError(error, action: "updateNotice")

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
@@ -91,6 +91,12 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
     /// 동일 타입 extension에서도 상태 전환이 가능하도록 setter를 내부 공개합니다.
     var createState: Loadable<NoticeDetail> = .idle
 
+    /// 쓰기 액션(생성/수정) 완료 신호
+    ///
+    /// View에서 `.onChange(of:)` 로 감지해 게스트 토스트를 표시합니다.
+    /// `.loaded` 전이 시 `true`로 설정되며, View가 소비한 뒤 `false`로 초기화합니다.
+    var didCompleteWrite: Bool = false
+
     /// 선택된 메인 카테고리
     var selectedCategory: EditorMainCategory {
         didSet {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
@@ -19,6 +19,10 @@ struct NoticeEditorView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(ErrorHandler.self) private var errorHandler
+    @Environment(\.appFlow) private var appFlow
+    @Environment(\.appSessionMode) private var sessionMode
+
+    @State private var showGuestToast: Bool = false
 
     /// 사용자 조직 타입 (중앙/지부/학교)
     @AppStorage(AppStorageKey.organizationType) private var organizationType: String = ""
@@ -120,6 +124,17 @@ struct NoticeEditorView: View {
         .safeAreaBar(edge: .top, content: topSafeAreaContent)
         .safeAreaBar(edge: .bottom, alignment: .leading, content: bottomSafeAreaContent)
         .noticeEditorPresentations(viewModel: viewModel)
+        .onChange(of: viewModel.didCompleteWrite) { _, completed in
+            if completed, sessionMode.isGuest {
+                showGuestToast = true
+            }
+            if completed {
+                viewModel.didCompleteWrite = false
+            }
+        }
+        .guestActionToast(isPresented: $showGuestToast) {
+            appFlow.showLogin()
+        }
     }
 
     // MARK: - Content

--- a/AppProduct/AppProduct/Resource/EnvrionmentKey/AppSessionModeEnvironmentKey.swift
+++ b/AppProduct/AppProduct/Resource/EnvrionmentKey/AppSessionModeEnvironmentKey.swift
@@ -16,6 +16,8 @@ enum AppSessionMode: Equatable {
     case authenticated
     /// 게스트 세션 (네트워크 미사용, Mock 데이터)
     case guest
+
+    var isGuest: Bool { self == .guest }
 }
 
 // MARK: - EnvironmentKey


### PR DESCRIPTION
## Summary

- 게스트 모드 진입 시 Home/Notice/Community 탭이 비어 있던 문제 해결 — Mock Repository들이 실제로 표시될 데이터를 반환하도록 수정
- 글쓰기/수정/출석 등 게스트가 허용되지 않은 액션은 서버 호출 없이 `GuestActionToast`로 안내
- 게스트용 DIContainer 누락 의존성 보완 및 Release 빌드 이슈 수정

## Context

App Store Guideline 2.1(a) 대응으로 추가된 게스트 모드(#609)가 UI만 있고 데이터가 비어 있어 리뷰어가 기능을 확인할 수 없었습니다. Mock Repository에 Mock 데이터를 주입해 모든 탭이 대표 콘텐츠를 보여주도록 하고, 쓰기성 액션은 토스트로 차단합니다.

## Changes

- `MockHomeRepository`: 프로필(roles·generations·chapter)/일정 3건/최근 공지 3건 반환
- `MockChallengerGenRepository.fetchGenGisuIdPairs()`: 7·8·9기 매핑 반환으로 공지 리스트 gate 통과
- `MockCommunityRepositories`: 카테고리별 게시글 5건·댓글 2건·명예의전당 3건
- `MockNoticeRepository`: JSON 팩토리 경유로 `NoticeDTO` 4건 구성 (memberwise init 없음 대응)
- `Core/Mock/CommunityMockData.swift` 신규
- 쓰기 액션 가드: Notice 에디터 / Community Post 작성·댓글 / MyPage 프로필 수정 / GPS 출석

## Test plan

- [x] iPhone 16 Pro 시뮬레이터 Debug 빌드 성공 (`xcodebuild ... build`)
- [ ] 게스트 모드 → Home 탭에 프로필/일정/최근 공지 표시 확인
- [ ] 게스트 모드 → Notice 탭에 공지 리스트 4건 표시 확인
- [ ] 게스트 모드 → Community 탭에 게시글 5건 + 명예의전당 3건 표시 확인
- [ ] 게시글 작성 / 댓글 / 출석 / 프로필 수정 시도 → 토스트 표시 & 서버 호출 없음 확인

## Dependencies

- Base: `feat/609` (PR #612) — 머지 후 이 PR의 base가 자동으로 `develop`으로 업데이트됨

Closes #610