### PR TITLE
chore: superpowers 로컬 캐시 및 docs 브레인스토밍 디렉터리 무시

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ AppProduct/AppProduct/Features/*/Data/Generated/
 
 # Firebase local config
 GoogleService-Info.plist
+
+# Superpowers / brainstorming local caches
+.superpowers/
+docs/superpowers/


### PR DESCRIPTION
## Summary

- `.superpowers/` 와 `docs/superpowers/` 두 디렉터리를 `.gitignore`에 추가
- 전자 명함 Phase 1 브레인스토밍·피그마 스펙 작업 중 생성되는 로컬 전용 산출물이 저장소에 유입되지 않도록 정리

## Why

- `.superpowers/` : Superpowers 플러그인의 brainstorming 세션 캐시 (로컬 작업 전용)
- `docs/superpowers/` : Claude Code 세션에서 생성되는 spec/placeholder 등 임시 산출물
- 기존에는 개별 파일만 방치되어 있어 `git status` 노이즈 및 실수 커밋 위험이 있었음

## Test plan

- [x] `.gitignore` diff 4줄 추가만 포함
- [x] `git status`에서 `docs/` untracked 경고 사라짐 확인
- [x] 기존 추적 파일 영향 없음