### PR TITLE
♻️ [Refactor] BusinessCard 피처 모듈 분리 및 RealityKit 캡슐화 (#617)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,13 +48,14 @@ UMCApp/
 │   ├── DesignSystem/              # 디자인 토큰, 색상
 │   ├── UIComponents/              # 공용 UI 컴포넌트 (Kingfisher)
 │   └── DI/                        # 의존성 주입 컨테이너
-└── Features/                      # 6개 기능 모듈
-    ├── Auth/
-    ├── Home/
-    ├── Notice/
+└── Features/                      # 7개 기능 모듈
     ├── Activity/
+    ├── Auth/
+    ├── BusinessCard/              # 전자명함 (3D 렌더링 캡슐화 경계 모듈)
     ├── Community/
-    └── MyPage/
+    ├── Home/
+    ├── MyPage/
+    └── Notice/
 ```
 
 ### 모듈 의존성 방향
@@ -71,6 +72,8 @@ Core Modules          (Foundation / Network / DesignSystem / UIComponents / DI)
     ↓
 External Packages     (Moya 15.0.3 / Kingfisher 8.6.1)
 ```
+
+> **경계 정책 — BusinessCard**: `Model3D`/`RealityView` 등 RealityKit 렌더링은 `BusinessCardPresentation` 내부에만 캡슐화한다. MyPage·Home·Community·Activity·Auth 등 명함을 노출하는 Feature는 `BusinessCardPresentation`만 링크하며, RealityKit을 직접 링크하지 않는다.
 
 ### Feature 모듈 구조
 

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -1,4 +1,9 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = featureProject(name: "Activity")
+let project = featureProject(
+    name: "Activity",
+    presentationExtraDependencies: [
+        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
+    ]
+)

--- a/UMCApp/Features/Auth/Project.swift
+++ b/UMCApp/Features/Auth/Project.swift
@@ -1,4 +1,9 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = featureProject(name: "Auth")
+let project = featureProject(
+    name: "Auth",
+    presentationExtraDependencies: [
+        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
+    ]
+)

--- a/UMCApp/Features/BusinessCard/Data/Sources/BusinessCardData.swift
+++ b/UMCApp/Features/BusinessCard/Data/Sources/BusinessCardData.swift
@@ -1,0 +1,3 @@
+import BusinessCardDomain
+
+public enum BusinessCardData {}

--- a/UMCApp/Features/BusinessCard/Domain/Sources/BusinessCardDomain.swift
+++ b/UMCApp/Features/BusinessCard/Domain/Sources/BusinessCardDomain.swift
@@ -1,0 +1,1 @@
+public enum BusinessCardDomain {}

--- a/UMCApp/Features/BusinessCard/Presentation/Sources/BusinessCardPresentation.swift
+++ b/UMCApp/Features/BusinessCard/Presentation/Sources/BusinessCardPresentation.swift
@@ -1,0 +1,3 @@
+import BusinessCardDomain
+
+public enum BusinessCardPresentation {}

--- a/UMCApp/Features/BusinessCard/Project.swift
+++ b/UMCApp/Features/BusinessCard/Project.swift
@@ -1,0 +1,4 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = featureProject(name: "BusinessCard")

--- a/UMCApp/Features/Community/Project.swift
+++ b/UMCApp/Features/Community/Project.swift
@@ -1,4 +1,9 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = featureProject(name: "Community")
+let project = featureProject(
+    name: "Community",
+    presentationExtraDependencies: [
+        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
+    ]
+)

--- a/UMCApp/Features/Home/Project.swift
+++ b/UMCApp/Features/Home/Project.swift
@@ -1,4 +1,9 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = featureProject(name: "Home")
+let project = featureProject(
+    name: "Home",
+    presentationExtraDependencies: [
+        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
+    ]
+)

--- a/UMCApp/Features/MyPage/Project.swift
+++ b/UMCApp/Features/MyPage/Project.swift
@@ -1,4 +1,9 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = featureProject(name: "MyPage")
+let project = featureProject(
+    name: "MyPage",
+    presentationExtraDependencies: [
+        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
+    ]
+)

--- a/UMCApp/Project.swift
+++ b/UMCApp/Project.swift
@@ -23,6 +23,7 @@ let project = Project(
             ],
             dependencies: [
                 .project(target: "AuthPresentation", path: .relativeToRoot("Features/Auth")),
+                .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
                 .project(target: "NoticePresentation", path: .relativeToRoot("Features/Notice")),
                 .project(target: "ActivityPresentation", path: .relativeToRoot("Features/Activity")),
                 .project(target: "HomePresentation", path: .relativeToRoot("Features/Home")),


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 전자명함(BusinessCard)을 독립 Feature 모듈로 분리하고, RealityKit 렌더링 의존성을 경계 모듈 내부로 캡슐화합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음. 모듈 구조/의존성 그래프 변경만 포함.

## 🛠️ 작업내용

- `Features/BusinessCard/` Feature 모듈 신설
    - Clean Architecture 3타겟 구성(`BusinessCardDomain` / `BusinessCardData` / `BusinessCardPresentation`)
    - `featureProject` 헬퍼로 Tuist 프로젝트 정의
- RealityKit(`Model3D` / `RealityView`) 렌더링을 `BusinessCardPresentation` 내부에만 캡슐화하는 경계 정책 수립
- 명함을 소비하는 Feature의 `Presentation` 타겟에 `BusinessCardPresentation` 의존성 연결
    - Activity / Auth / Community / Home / MyPage
- `UMCApp` 앱 타겟에 `BusinessCardPresentation` 링크 추가
- `CLAUDE.md`에 BusinessCard 경계 정책 및 Feature 목록(6→7개) 반영

## 📋 추후 진행 상황

- `BusinessCardDomain` / `BusinessCardData` / `BusinessCardPresentation` 실제 구현 (엔티티 / 리포지토리 / 3D 렌더 뷰)
- 기존 MyPage·Home 등에서 명함을 노출하던 지점을 `BusinessCardPresentation` 공개 API 호출로 전환

## 📌 리뷰 포인트

- `UMCApp/Features/BusinessCard/Project.swift` — 신규 Feature 모듈 정의가 기존 Feature와 동일한 규칙(`featureProject` 헬퍼)을 따르는지
- `UMCApp/Project.swift` — 앱 타겟이 `BusinessCardPresentation`만 링크하고 RealityKit을 직접 링크하지 않는지
- `UMCApp/Features/{Activity,Auth,Community,Home,MyPage}/Project.swift` — Presentation 타겟에 `BusinessCardPresentation` 의존성이 동일한 방식으로 추가됐는지
- `CLAUDE.md` — BusinessCard 경계 정책 문구가 실제 의존성 방향과 일치하는지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)