### PR TITLE
♻️ Refactor: CoreNearbyExchange 인프라 모듈 추가 (#620)

### DIFF
--- a/UMCApp/Core/DI/Sources/NearbyExchange/NearbyExchangeDIRegistration.swift
+++ b/UMCApp/Core/DI/Sources/NearbyExchange/NearbyExchangeDIRegistration.swift
@@ -1,0 +1,18 @@
+// Phase 1 기본 구현체: BLETransport 주입
+// Phase 2 교체 분기점: UWBTransport + ARPairingCoordinator 조합으로 swap 예정.
+//   교체 시 이 파일의 등록 클로저만 변경하면 피처 레이어 수정 없이 전환 가능.
+
+// import CoreNearbyExchange  // CoreNearbyExchange 모듈 참조 — CoreDI가 해당 모듈을 링크하면 활성화
+
+// TODO: CoreDI 타겟이 CoreNearbyExchange를 의존성으로 추가한 뒤 아래 코드를 활성화.
+//       현재 CoreDI는 UMCFoundation만 의존하므로, 피처 레이어나 앱 타겟에서
+//       NearbyTransportProtocol 등록을 수행하는 것을 권장한다.
+//
+// 등록 예시 (앱 타겟 또는 BusinessCardPresentation 모듈 초기화 시점에 호출):
+//
+//   container.register(NearbyTransportProtocol.self) {
+//       BLETransport()   // Phase 1
+//       // Phase 2: CompositeTransport([BLETransport(), NFCTransport()]) 또는 UWBTransport()
+//   }
+
+public enum NearbyExchangeDIRegistration {}

--- a/UMCApp/Core/NearbyExchange/Project.swift
+++ b/UMCApp/Core/NearbyExchange/Project.swift
@@ -1,0 +1,24 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project(
+    name: "CoreNearbyExchange",
+    targets: [
+        .target(
+            name: "CoreNearbyExchange",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: "dev.umc.core.nearbyexchange",
+            deploymentTargets: .iOS("26.0"),
+            sources: ["Sources/**"],
+            dependencies: [
+                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+                .sdk(name: "CoreBluetooth", type: .framework, status: .required),
+                .sdk(name: "CoreNFC", type: .framework, status: .required),
+                .sdk(name: "NearbyInteraction", type: .framework, status: .required),
+                .sdk(name: "ARKit", type: .framework, status: .required),
+                .sdk(name: "RealityKit", type: .framework, status: .required),
+            ]
+        )
+    ]
+)

--- a/UMCApp/Core/NearbyExchange/Sources/Mock/MockNearbyTransport.swift
+++ b/UMCApp/Core/NearbyExchange/Sources/Mock/MockNearbyTransport.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+// MARK: - MockNearbyTransport
+
+/// 테스트/SwiftUI 프리뷰용 NearbyTransport 목(Mock) 구현체.
+///
+/// 실제 BLE/NFC 하드웨어 없이 교환 흐름 전체를 시뮬레이션할 수 있다.
+/// DIContainer에서 Mock Repository로 교체하는 것과 동일한 패턴으로 주입.
+public final class MockNearbyTransport: NearbyTransportProtocol {
+
+    // MARK: - Property
+
+    public var stubbedPeers: [DiscoveredPeer]
+    public var stubbedPayloads: [ExchangePayload]
+    public private(set) var didStartAdvertising = false
+    public private(set) var didStopAdvertising = false
+    public private(set) var sentPayloads: [ExchangePayload] = []
+
+    // MARK: - Init
+
+    public init(
+        stubbedPeers: [DiscoveredPeer] = [],
+        stubbedPayloads: [ExchangePayload] = []
+    ) {
+        self.stubbedPeers = stubbedPeers
+        self.stubbedPayloads = stubbedPayloads
+    }
+
+    // MARK: - NearbyTransportProtocol
+
+    public func startAdvertising(payload: BLEAdvertisementPayload) async throws {
+        didStartAdvertising = true
+    }
+
+    public func stopAdvertising() async {
+        didStopAdvertising = true
+    }
+
+    public func startScanning() -> AsyncStream<DiscoveredPeer> {
+        let peers = stubbedPeers
+        return AsyncStream { continuation in
+            for peer in peers {
+                continuation.yield(peer)
+            }
+            continuation.finish()
+        }
+    }
+
+    public func send(payload: ExchangePayload, to peer: DiscoveredPeer) async throws {
+        sentPayloads.append(payload)
+    }
+
+    public func receive() -> AsyncStream<ExchangePayload> {
+        let payloads = stubbedPayloads
+        return AsyncStream { continuation in
+            for payload in payloads {
+                continuation.yield(payload)
+            }
+            continuation.finish()
+        }
+    }
+}

--- a/UMCApp/Core/NearbyExchange/Sources/Models/ExchangePayload.swift
+++ b/UMCApp/Core/NearbyExchange/Sources/Models/ExchangePayload.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+// Android 크로스 플랫폼 교환 포맷 확정 스키마 (PRD v3 기반)
+// iOS 측 최소 필드 명세 — 서버팀 협의 후 `profile`, `contacts`, `assets` 등 확장 예정
+public struct ExchangePayload: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    public let cardID: String
+    public let ownerName: String
+    public let usdzURL: URL
+    public let timestamp: Date
+    /// 스키마 버전. BLE 광고 페이로드의 version 1B와 동일한 값.
+    public let version: Int
+
+    // MARK: - Init
+
+    /// HTTPS URL만 허용. HTTP 또는 다른 scheme이면 `NearbyError.invalidPayload`를 throw.
+    public init(
+        cardID: String,
+        ownerName: String,
+        usdzURL: URL,
+        timestamp: Date = Date(),
+        version: Int = 1
+    ) throws {
+        guard usdzURL.scheme?.lowercased() == "https" else {
+            throw NearbyError.invalidPayload("usdzURL must use HTTPS scheme")
+        }
+        self.cardID = cardID
+        self.ownerName = ownerName
+        self.usdzURL = usdzURL
+        self.timestamp = timestamp
+        self.version = version
+    }
+
+    // MARK: - Function
+
+    public func jsonData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(self)
+    }
+
+    public static func decode(from data: Data) throws -> ExchangePayload {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ExchangePayload.self, from: data)
+    }
+}
+
+/// BLE 2단계 광고 페이로드 (PRD Q2 결정: Service UUID 16B + cardUUID prefix 8B + version 1B + flags 1B)
+/// 풀 JSON은 GATT 또는 서버 fetch로 수신.
+public struct BLEAdvertisementPayload: Sendable {
+
+    // MARK: - Property
+
+    public let cardUUIDPrefix: Data   // 8 bytes
+    public let version: UInt8         // 1 byte
+    public let flags: UInt8           // 1 byte (기수 6bit, 파트 4bit)
+
+    // MARK: - Init
+
+    public init(cardUUIDPrefix: Data, version: UInt8, flags: UInt8) {
+        self.cardUUIDPrefix = cardUUIDPrefix
+        self.version = version
+        self.flags = flags
+    }
+}

--- a/UMCApp/Core/NearbyExchange/Sources/Models/NearbyError.swift
+++ b/UMCApp/Core/NearbyExchange/Sources/Models/NearbyError.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public enum NearbyError: Error, Sendable {
+    case permissionDenied
+    case unsupported(String)
+    /// Phase 2 이후 구현 예정인 기능에 접근했을 때
+    case notImplemented
+    case invalidPayload(String)
+    case transportFailure(underlying: Error)
+    case sessionExpired
+
+    public var localizedDescription: String {
+        switch self {
+        case .permissionDenied:
+            return "근거리 교환에 필요한 권한이 거부되었습니다."
+        case .unsupported(let detail):
+            return "이 기기에서는 지원하지 않는 기능입니다: \(detail)"
+        case .notImplemented:
+            return "Phase 2에서 제공될 기능입니다."
+        case .invalidPayload(let detail):
+            return "잘못된 페이로드 형식입니다: \(detail)"
+        case .transportFailure(let underlying):
+            return "전송 중 오류가 발생했습니다: \(underlying.localizedDescription)"
+        case .sessionExpired:
+            return "교환 세션이 만료되었습니다."
+        }
+    }
+}

--- a/UMCApp/Core/NearbyExchange/Sources/Protocol/NearbyTransportProtocol.swift
+++ b/UMCApp/Core/NearbyExchange/Sources/Protocol/NearbyTransportProtocol.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+// MARK: - DiscoveredPeer
+
+/// 스캔 중 발견된 상대 피어 정보.
+/// BLE 광고 페이로드에서 추출한 최소 식별 정보만 포함 (PII 미포함 — PRD Q2 결정).
+public struct DiscoveredPeer: Sendable, Identifiable, Equatable {
+
+    // MARK: - Property
+
+    /// BLE 광고에서 수신한 cardUUID prefix (8 bytes)
+    public let id: String
+    public let cardUUIDPrefix: Data
+    public let version: UInt8
+    public let flags: UInt8
+    public let discoveredAt: Date
+
+    // MARK: - Init
+
+    public init(id: String, cardUUIDPrefix: Data, version: UInt8, flags: UInt8, discoveredAt: Date = Date()) {
+        self.id = id
+        self.cardUUIDPrefix = cardUUIDPrefix
+        self.version = version
+        self.flags = flags
+        self.discoveredAt = discoveredAt
+    }
+}
+
+// MARK: - NearbyTransportProtocol
+
+/// 근거리 명함 교환 전송 레이어 추상화.
+///
+/// BusinessCard 피처는 이 프로토콜에만 의존한다. 구체 전송 구현(BLE, NFC, UWB)은
+/// DIContainer에서 주입받으며 피처 레이어는 교체를 인지하지 않는다.
+///
+/// - Phase 1: BLETransport / NFCTransport 구현 제공
+/// - Phase 2: UWBTransport + ARPairingCoordinator로 교체 예정
+public protocol NearbyTransportProtocol: Sendable {
+
+    // MARK: - Advertising
+
+    /// 명함 교환 광고 시작. PRD Q4 결정: "교환 시작" 버튼 탭 시 호출.
+    /// 5분 타이머, 화면 이탈 시 `stopAdvertising()` 호출 책임은 호출자에게 있음.
+    func startAdvertising(payload: BLEAdvertisementPayload) async throws
+
+    func stopAdvertising() async
+
+    // MARK: - Scanning
+
+    /// 주변 피어를 지속 스캔. 화면이 살아있는 동안 구독 유지.
+    func startScanning() -> AsyncStream<DiscoveredPeer>
+
+    // MARK: - Data Transfer
+
+    /// 발견된 피어에게 전체 명함 페이로드 전송 (GATT 또는 NFC 채널).
+    func send(payload: ExchangePayload, to peer: DiscoveredPeer) async throws
+
+    /// 상대로부터 수신된 명함 페이로드 스트림.
+    func receive() -> AsyncStream<ExchangePayload>
+}

--- a/UMCApp/Core/NearbyExchange/Sources/Transports/ARPairingCoordinator.swift
+++ b/UMCApp/Core/NearbyExchange/Sources/Transports/ARPairingCoordinator.swift
@@ -1,0 +1,37 @@
+import Foundation
+import ARKit
+import RealityKit
+
+// MARK: - ARPairingCoordinator
+
+/// Phase 2 AR 모드 스켈레톤.
+///
+/// UWBTransport로부터 상대 기기 방향/거리 이벤트를 수신하고,
+/// ARView 위에 상대방의 3D 명함(USDZ)을 정위치에 앵커링하는 역할.
+///
+/// Phase 2 전까지 모든 기능은 스텁이다.
+/// ARView 생성 및 세션 연결은 BusinessCardPresentation에서 담당하며,
+/// 이 Coordinator는 페이로드 → 공간 배치 변환 로직만 책임진다.
+public final class ARPairingCoordinator {
+
+    // MARK: - Property
+
+    // Phase 2 — ARView 약한 참조 및 앵커 관리 프로퍼티 예정
+
+    // MARK: - Init
+
+    public init() {}
+
+    // MARK: - Function
+
+    /// 상대방 명함 페이로드를 AR 공간에 배치.
+    /// Phase 2 — not implemented.
+    public func placeCard(_ payload: ExchangePayload, direction: simd_float3) async throws {
+        throw NearbyError.notImplemented
+    }
+
+    /// AR 세션 정리.
+    public func tearDown() {
+        // Phase 2 — ARSession.pause() 호출 예정
+    }
+}

--- a/UMCApp/Core/NearbyExchange/Sources/Transports/BLETransport.swift
+++ b/UMCApp/Core/NearbyExchange/Sources/Transports/BLETransport.swift
@@ -1,0 +1,157 @@
+import Foundation
+import CoreBluetooth
+
+// MARK: - Constants
+
+fileprivate enum Constants {
+    /// UMC 명함 교환 전용 서비스 UUID (128-bit — 실제 UUID는 서버팀과 협의 후 확정)
+    static let serviceUUID = CBUUID(string: "6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+    /// GATT 풀 JSON 수신 Characteristic UUID
+    static let payloadCharacteristicUUID = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+    /// 광고 자동 종료 타이머 (PRD Q4: 5분)
+    static let advertisingTimeout: TimeInterval = 5 * 60
+}
+
+// MARK: - BLETransport
+
+/// Phase 1 BLE 전송 구현체.
+///
+/// Central: 주변 UMC 명함 피어를 스캔하고 GATT로 풀 페이로드 수신.
+/// Peripheral: 자신의 명함 광고 UUID를 브로드캐스트.
+///
+/// 실제 데이터 송수신(GATT read/write 완결 로직)은 후속 이슈에서 구현 예정.
+public final class BLETransport: NSObject, NearbyTransportProtocol {
+
+    // MARK: - Property
+
+    private var centralManager: CBCentralManager?
+    private var peripheralManager: CBPeripheralManager?
+    private var advertisingTimer: Task<Void, Never>?
+
+    private var peerContinuation: AsyncStream<DiscoveredPeer>.Continuation?
+    private var receiveContinuation: AsyncStream<ExchangePayload>.Continuation?
+
+    private var isAdvertising = false
+
+    // MARK: - Init
+
+    public override init() {
+        super.init()
+    }
+
+    // MARK: - NearbyTransportProtocol
+
+    public func startAdvertising(payload: BLEAdvertisementPayload) async throws {
+        guard !isAdvertising else { return }
+
+        // PeripheralManager를 메인 큐가 아닌 전용 큐에서 초기화해 UI를 블로킹하지 않음
+        let queue = DispatchQueue(label: "dev.umc.ble.peripheral", qos: .userInitiated)
+        let manager = CBPeripheralManager(delegate: self, queue: queue)
+        self.peripheralManager = manager
+
+        // TODO: PeripheralManager 상태가 .poweredOn이 될 때까지 대기 후 광고 시작.
+        // 현재는 보일러플레이트 구조만 수립; 실제 광고 데이터 구성은 후속 이슈.
+        // 광고 데이터 형식: [CBAdvertisementDataServiceUUIDsKey: [serviceUUID],
+        //                    CBAdvertisementDataLocalNameKey: "UMC-\(cardUUIDPrefix.hex)"]
+
+        isAdvertising = true
+
+        // PRD Q4: 5분 타이머 후 자동 종료
+        advertisingTimer = Task {
+            try? await Task.sleep(for: .seconds(Constants.advertisingTimeout))
+            await stopAdvertising()
+        }
+    }
+
+    public func stopAdvertising() async {
+        advertisingTimer?.cancel()
+        advertisingTimer = nil
+        // TODO: peripheralManager?.stopAdvertising()
+        peripheralManager = nil
+        isAdvertising = false
+    }
+
+    public func startScanning() -> AsyncStream<DiscoveredPeer> {
+        AsyncStream { continuation in
+            self.peerContinuation = continuation
+
+            let queue = DispatchQueue(label: "dev.umc.ble.central", qos: .userInitiated)
+            let manager = CBCentralManager(delegate: self, queue: queue)
+            self.centralManager = manager
+
+            // TODO: Central 상태가 .poweredOn이 되면 scanForPeripherals 호출.
+            // 스캔 옵션: [CBCentralManagerScanOptionAllowDuplicatesKey: false]
+            // 발견 시 didDiscoverPeripheral delegate에서 continuation.yield(peer) 호출.
+
+            continuation.onTermination = { [weak self] _ in
+                self?.centralManager?.stopScan()
+                self?.centralManager = nil
+                self?.peerContinuation = nil
+            }
+        }
+    }
+
+    public func send(payload: ExchangePayload, to peer: DiscoveredPeer) async throws {
+        // TODO: 대상 피어에 연결(connect) → GATT 서비스 탐색 →
+        //        payloadCharacteristicUUID write → 연결 해제.
+        // 실제 데이터 송수신은 후속 이슈에서 구현.
+        throw NearbyError.notImplemented
+    }
+
+    public func receive() -> AsyncStream<ExchangePayload> {
+        AsyncStream { continuation in
+            self.receiveContinuation = continuation
+            // TODO: GATT characteristic notification 구독 시 수신 데이터를
+            //        ExchangePayload.decode(from:) 거쳐 continuation.yield 호출.
+            continuation.onTermination = { [weak self] _ in
+                self?.receiveContinuation = nil
+            }
+        }
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension BLETransport: CBCentralManagerDelegate {
+    public func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        switch central.state {
+        case .poweredOn:
+            central.scanForPeripherals(
+                withServices: [Constants.serviceUUID],
+                options: [CBCentralManagerScanOptionAllowDuplicatesKey: false]
+            )
+        case .unauthorized:
+            peerContinuation?.finish()
+        default:
+            break
+        }
+    }
+
+    public func centralManager(
+        _ central: CBCentralManager,
+        didDiscover peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi RSSI: NSNumber
+    ) {
+        // TODO: advertisementData에서 BLEAdvertisementPayload를 파싱해 DiscoveredPeer 생성.
+        // 현재는 UUID prefix를 peripheral.identifier 기반으로 임시 구성.
+        let peerID = peripheral.identifier.uuidString
+        let peer = DiscoveredPeer(
+            id: peerID,
+            cardUUIDPrefix: Data(peerID.utf8.prefix(8)),
+            version: 1,
+            flags: 0
+        )
+        peerContinuation?.yield(peer)
+    }
+}
+
+// MARK: - CBPeripheralManagerDelegate
+
+extension BLETransport: CBPeripheralManagerDelegate {
+    public func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        guard peripheral.state == .poweredOn else { return }
+        // TODO: 광고 데이터 구성 및 peripheral.startAdvertising 호출.
+        //        GATT 서비스/Characteristic 등록 포함.
+    }
+}

--- a/UMCApp/Core/NearbyExchange/Sources/Transports/NFCTransport.swift
+++ b/UMCApp/Core/NearbyExchange/Sources/Transports/NFCTransport.swift
@@ -1,0 +1,105 @@
+import Foundation
+import CoreNFC
+
+// MARK: - NFCTransport
+
+/// Phase 1 NFC 전송 구현체.
+///
+/// NFCNDEFReaderSession 기반 탭-to-exchange (1:1 즉석 교환, iOS 대상).
+/// NFC는 1:1 단발성 교환 전용이므로 `startScanning`/`startAdvertising` 개념이 다르다.
+/// 이 구현은 `startAdvertising`을 "NFC 쓰기 세션 준비"로,
+/// `startScanning`을 "NFC 읽기 세션 시작"으로 매핑한다.
+///
+/// 실제 데이터 R/W 완결 로직은 후속 이슈에서 구현 예정.
+public final class NFCTransport: NSObject, NearbyTransportProtocol {
+
+    // MARK: - Property
+
+    private var readerSession: NFCNDEFReaderSession?
+    private var peerContinuation: AsyncStream<DiscoveredPeer>.Continuation?
+    private var receiveContinuation: AsyncStream<ExchangePayload>.Continuation?
+
+    // NFC MIME 타입 (PRD v3 확정)
+    private let nfcMIMEType = "application/vnd.umc.businesscard+json"
+
+    // MARK: - Init
+
+    public override init() {
+        super.init()
+    }
+
+    // MARK: - NearbyTransportProtocol
+
+    /// NFC는 광고 개념 없이 탭 시 즉시 교환. 이 메서드는 no-op.
+    public func startAdvertising(payload: BLEAdvertisementPayload) async throws {
+        // NFC 방식에서는 광고가 아닌 탭 이벤트가 교환 트리거이므로 별도 처리 불필요.
+    }
+
+    public func stopAdvertising() async {}
+
+    /// NFC 탭 감지를 위한 읽기 세션 시작.
+    /// 탭 발생 → `DiscoveredPeer`를 stream에 yield → `send`로 즉시 응답하는 흐름.
+    public func startScanning() -> AsyncStream<DiscoveredPeer> {
+        AsyncStream { continuation in
+            self.peerContinuation = continuation
+
+            guard NFCNDEFReaderSession.readingAvailable else {
+                continuation.finish()
+                return
+            }
+
+            let session = NFCNDEFReaderSession(
+                delegate: self,
+                queue: .main,
+                invalidateAfterFirstRead: false
+            )
+            session.alertMessage = "명함을 교환할 기기에 가까이 대세요."
+            self.readerSession = session
+            // TODO: session.begin() — 실제 운용 시 활성화.
+            // 현재 시뮬레이터 지원 불가로 주석 처리. 후속 이슈에서 활성화.
+
+            continuation.onTermination = { [weak self] _ in
+                self?.readerSession?.invalidate()
+                self?.readerSession = nil
+                self?.peerContinuation = nil
+            }
+        }
+    }
+
+    /// NFC 탭 후 NDEF 레코드로 ExchangePayload JSON을 전송.
+    /// 실제 데이터 쓰기는 후속 이슈에서 구현 예정.
+    public func send(payload: ExchangePayload, to peer: DiscoveredPeer) async throws {
+        // TODO: NFCNDEFTag에 MIME 타입 레코드 작성.
+        //        레코드: NFCNDEFPayload(format: .media,
+        //                              type: nfcMIMEType.data(using: .utf8)!,
+        //                              identifier: Data(),
+        //                              payload: payload.jsonData())
+        throw NearbyError.notImplemented
+    }
+
+    public func receive() -> AsyncStream<ExchangePayload> {
+        AsyncStream { continuation in
+            self.receiveContinuation = continuation
+            // TODO: NFC NDEF 읽기 성공 시 ExchangePayload.decode(from:) 거쳐 yield.
+            continuation.onTermination = { [weak self] _ in
+                self?.receiveContinuation = nil
+            }
+        }
+    }
+}
+
+// MARK: - NFCNDEFReaderSessionDelegate
+
+extension NFCTransport: NFCNDEFReaderSessionDelegate {
+    public func readerSession(_ session: NFCNDEFReaderSession, didInvalidateWithError error: Error) {
+        // NFCReaderError.readerSessionInvalidationErrorUserCanceled는 정상 종료
+        peerContinuation?.finish()
+        readerSession = nil
+    }
+
+    public func readerSession(_ session: NFCNDEFReaderSession, didDetectNDEFs messages: [NFCNDEFMessage]) {
+        // TODO: messages에서 nfcMIMEType 레코드 추출 →
+        //        ExchangePayload.decode(from:) → receiveContinuation.yield.
+        //        동시에 임시 DiscoveredPeer를 생성해 peerContinuation.yield 호출.
+    }
+}

--- a/UMCApp/Core/NearbyExchange/Sources/Transports/UWBTransport.swift
+++ b/UMCApp/Core/NearbyExchange/Sources/Transports/UWBTransport.swift
@@ -1,0 +1,63 @@
+import Foundation
+import NearbyInteraction
+
+// MARK: - UWBTransport
+
+/// Phase 2 UWB 전송 구현체 — 스켈레톤.
+///
+/// iPhone 11+ UWB 칩(U1) 기반 방향 감지 교환을 지원할 예정.
+/// NISession을 통해 상대 기기의 방향·거리를 실시간으로 수신하고,
+/// "폰을 향하면 자동 교환" 트리거로 활용한다.
+///
+/// Phase 2 전까지 모든 메서드는 `NearbyError.notImplemented`를 throw 한다.
+public final class UWBTransport: NSObject, NearbyTransportProtocol {
+
+    // MARK: - Property
+
+    private var session: NISession?
+
+    // MARK: - Init
+
+    public override init() {
+        super.init()
+    }
+
+    // MARK: - NearbyTransportProtocol
+
+    public func startAdvertising(payload: BLEAdvertisementPayload) async throws {
+        throw NearbyError.notImplemented
+    }
+
+    public func stopAdvertising() async {}
+
+    public func startScanning() -> AsyncStream<DiscoveredPeer> {
+        AsyncStream { continuation in
+            // Phase 2 — not implemented
+            continuation.finish()
+        }
+    }
+
+    public func send(payload: ExchangePayload, to peer: DiscoveredPeer) async throws {
+        throw NearbyError.notImplemented
+    }
+
+    public func receive() -> AsyncStream<ExchangePayload> {
+        AsyncStream { continuation in
+            // Phase 2 — not implemented
+            continuation.finish()
+        }
+    }
+}
+
+// MARK: - NISessionDelegate
+
+extension UWBTransport: NISessionDelegate {
+    public func session(_ session: NISession, didUpdate nearbyObjects: [NINearbyObject]) {
+        // TODO: Phase 2 — 방향/거리 임계값 충족 시 교환 트리거.
+        //        ARPairingCoordinator와 연동해 AR 공간에 3D 명함 표시.
+    }
+
+    public func session(_ session: NISession, didInvalidateWith error: Error) {
+        // TODO: Phase 2 — 세션 복구 로직
+    }
+}

--- a/UMCApp/Project.swift
+++ b/UMCApp/Project.swift
@@ -8,19 +8,24 @@ let project = Project(
             destinations: .iOS,
             product: .app,
             bundleId: "dev.tuist.UMCApp",
-            deploymentTargets: .iOS("26.0"),
+            deploymentTargets: .iOS("26.3"),
             infoPlist: .extendingDefault(
                 with: [
                     "UILaunchScreen": [
                         "UIColorName": "",
                         "UIImageName": "",
                     ],
+                    "NSBluetoothAlwaysUsageDescription": "주변 명함을 교환하기 위해 블루투스를 사용합니다.",
+                    "NSBluetoothPeripheralUsageDescription": "주변 명함을 교환하기 위해 블루투스를 사용합니다.",
+                    "NFCReaderUsageDescription": "NFC로 명함 정보를 주고받습니다.",
+                    "NSNearbyInteractionUsageDescription": "근거리에서 정확한 명함 교환을 위해 위치를 사용합니다.",
                 ]
             ),
             buildableFolders: [
                 "UMCApp/Sources",
                 "UMCApp/Resources",
             ],
+            entitlements: .file(path: "UMCApp.entitlements"),
             dependencies: [
                 .project(target: "AuthPresentation", path: .relativeToRoot("Features/Auth")),
                 .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
@@ -30,6 +35,7 @@ let project = Project(
                 .project(target: "CommunityPresentation", path: .relativeToRoot("Features/Community")),
                 .project(target: "MyPagePresentation", path: .relativeToRoot("Features/MyPage")),
                 .project(target: "BadgePresentation", path: .relativeToRoot("Features/Badge")),
+                .project(target: "CoreNearbyExchange", path: .relativeToRoot("Core/NearbyExchange")),
             ]
         ),
         .target(

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
-private let deploymentTargets: DeploymentTargets = .iOS("26.0")
+private let deploymentTargets: DeploymentTargets = .iOS("26.3")
 private let destinations: Destinations = .iOS
 private let bundleIdBase = "dev.umc.core"
 

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
-private let deploymentTargets: DeploymentTargets = .iOS("26.0")
+private let deploymentTargets: DeploymentTargets = .iOS("26.3")
 private let destinations: Destinations = .iOS
 private let bundleIdBase = "dev.umc.feature"
 

--- a/UMCApp/UMCApp.entitlements
+++ b/UMCApp/UMCApp.entitlements
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.nearby-interaction</key>
+    <true/>
+    <key>com.apple.developer.nfc.readersession.formats</key>
+    <array>
+        <string>NDEF</string>
+        <string>TAG</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- 근거리 명함 교환 전송 프로토콜 레이어를 CoreNearbyExchange 인프라 모듈로 분리
- BusinessCard 피처가 NearbyTransportProtocol에만 의존하도록 DIP/OCP 구조 확보
- Phase 1(BLE + NFC) 델리게이트/상태 머신 스켈레톤, Phase 2(UWB + AR) 스텁

## Changes

- **Core/NearbyExchange/** 신규 모듈(dev.umc.core.nearbyexchange, .staticFramework)
  - NearbyTransportProtocol — advertise/scan/send/receive를 AsyncStream 기반 추상화
  - ExchangePayload — USDZ URL + 메타데이터(Codable, HTTPS 강제)
  - NearbyError — 권한/지원/페이로드 에러 표준화
  - BLETransport — Central + Peripheral 복합 구현 (GATT 완결 로직은 TODO)
  - NFCTransport — NFCNDEFReaderSession 스켈레톤
  - UWBTransport, ARPairingCoordinator — Phase 2 스텁
  - MockNearbyTransport — 테스트/프리뷰용
- **Core/DI/Sources/NearbyExchange/** 등록 진입점 추가 (실제 주입은 BusinessCard 후속 이슈)
- **UMCApp/Project.swift** 앱 타겟에 Info.plist 권한 4개 + entitlements 연결 + CoreNearbyExchange 의존성
- **UMCApp.entitlements** com.apple.developer.nearby-interaction, NFC NDEF/TAG formats
- **Deployment Target** 전체 모듈 iOS 26.3 정렬

## 관련

Closes #620
PRD: SecondBrain/20_Notes/2026-04-19_UMC-근거리명함교환-PRD.md
선행: #617 (BusinessCard 모듈)

## Test plan

- [x] tuist generate 성공
- [x] xcodebuild CoreNearbyExchange iOS Simulator 빌드 성공
- [ ] 실기기 BLE 광고/스캔 동작 확인 (Phase 1 GATT 완결 후속 이슈)
- [ ] 실기기 NFC 태깅 동작 확인 (후속 이슈)