### PR TITLE
♻️ Refactor: Tuist 모듈 구조에 Widget Extension 타겟 + CoreWidgetShared 모듈 추가 (#618)

### DIFF
--- a/UMCApp/Core/WidgetShared/Project.swift
+++ b/UMCApp/Core/WidgetShared/Project.swift
@@ -1,0 +1,10 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = coreProject(
+    name: "CoreWidgetShared",
+    bundleIdSuffix: "widgetshared",
+    dependencies: [
+        .sdk(name: "WidgetKit", type: .framework, status: .required),
+    ]
+)

--- a/UMCApp/Core/WidgetShared/Sources/Entries/WidgetAttendanceEntry.swift
+++ b/UMCApp/Core/WidgetShared/Sources/Entries/WidgetAttendanceEntry.swift
@@ -1,0 +1,40 @@
+import WidgetKit
+import Foundation
+
+public struct WidgetAttendanceEntry: TimelineEntry {
+
+    // MARK: - Property
+
+    public let date: Date
+    public let status: AttendanceStatus
+    public let sessionTitle: String
+
+    // MARK: - Init
+
+    public init(
+        date: Date,
+        status: AttendanceStatus,
+        sessionTitle: String
+    ) {
+        self.date = date
+        self.status = status
+        self.sessionTitle = sessionTitle
+    }
+
+    public static var placeholder: WidgetAttendanceEntry {
+        WidgetAttendanceEntry(
+            date: .now,
+            status: .pending,
+            sessionTitle: "정기 세션"
+        )
+    }
+}
+
+// MARK: - AttendanceStatus
+
+public enum AttendanceStatus: String, Codable, Sendable {
+    case attended
+    case absent
+    case late
+    case pending
+}

--- a/UMCApp/Core/WidgetShared/Sources/Entries/WidgetNoticeEntry.swift
+++ b/UMCApp/Core/WidgetShared/Sources/Entries/WidgetNoticeEntry.swift
@@ -1,0 +1,35 @@
+import WidgetKit
+import Foundation
+
+public struct WidgetNoticeEntry: TimelineEntry {
+
+    // MARK: - Property
+
+    public let date: Date
+    public let noticeTitle: String
+    public let noticeBody: String
+    public let postedAt: Date?
+
+    // MARK: - Init
+
+    public init(
+        date: Date,
+        noticeTitle: String,
+        noticeBody: String,
+        postedAt: Date? = nil
+    ) {
+        self.date = date
+        self.noticeTitle = noticeTitle
+        self.noticeBody = noticeBody
+        self.postedAt = postedAt
+    }
+
+    public static var placeholder: WidgetNoticeEntry {
+        WidgetNoticeEntry(
+            date: .now,
+            noticeTitle: "공지사항",
+            noticeBody: "최신 공지를 확인해보세요.",
+            postedAt: .now
+        )
+    }
+}

--- a/UMCApp/Core/WidgetShared/Sources/Entries/WidgetScheduleEntry.swift
+++ b/UMCApp/Core/WidgetShared/Sources/Entries/WidgetScheduleEntry.swift
@@ -1,0 +1,35 @@
+import WidgetKit
+import Foundation
+
+public struct WidgetScheduleEntry: TimelineEntry {
+
+    // MARK: - Property
+
+    public let date: Date
+    public let scheduleTitle: String
+    public let scheduleTime: Date?
+    public let location: String?
+
+    // MARK: - Init
+
+    public init(
+        date: Date,
+        scheduleTitle: String,
+        scheduleTime: Date? = nil,
+        location: String? = nil
+    ) {
+        self.date = date
+        self.scheduleTitle = scheduleTitle
+        self.scheduleTime = scheduleTime
+        self.location = location
+    }
+
+    public static var placeholder: WidgetScheduleEntry {
+        WidgetScheduleEntry(
+            date: .now,
+            scheduleTitle: "오늘의 일정",
+            scheduleTime: .now,
+            location: nil
+        )
+    }
+}

--- a/UMCApp/Core/WidgetShared/Sources/Storage/WidgetStorage.swift
+++ b/UMCApp/Core/WidgetShared/Sources/Storage/WidgetStorage.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// App Group 기반 위젯 공유 스토리지 래퍼
+///
+/// `group.dev.umc.appproduct.widget` App Group을 통해
+/// 메인 앱과 Widget Extension 간 데이터를 공유합니다.
+public final class WidgetStorage: Sendable {
+
+    // MARK: - Property
+
+    public static let shared = WidgetStorage()
+
+    private static let appGroupSuiteName = "group.dev.umc.appproduct.widget"
+
+    nonisolated(unsafe) private let defaults: UserDefaults?
+
+    // MARK: - Init
+
+    public init() {
+        self.defaults = UserDefaults(suiteName: Self.appGroupSuiteName)
+    }
+
+    // MARK: - Function
+
+    public func save<T: Encodable>(_ value: T, forKey key: WidgetStorageKey) {
+        guard let defaults else { return }
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(value) else { return }
+        defaults.set(data, forKey: key.rawValue)
+    }
+
+    public func load<T: Decodable>(_ type: T.Type, forKey key: WidgetStorageKey) -> T? {
+        guard let defaults,
+              let data = defaults.data(forKey: key.rawValue) else { return nil }
+        let decoder = JSONDecoder()
+        return try? decoder.decode(type, from: data)
+    }
+
+    public func remove(forKey key: WidgetStorageKey) {
+        defaults?.removeObject(forKey: key.rawValue)
+    }
+}
+
+// MARK: - WidgetStorageKey
+
+public enum WidgetStorageKey: String, Sendable {
+    case scheduleEntry = "widget.scheduleEntry"
+    case attendanceEntry = "widget.attendanceEntry"
+    case noticeEntry = "widget.noticeEntry"
+}

--- a/UMCApp/Project.swift
+++ b/UMCApp/Project.swift
@@ -36,6 +36,7 @@ let project = Project(
                 .project(target: "MyPagePresentation", path: .relativeToRoot("Features/MyPage")),
                 .project(target: "BadgePresentation", path: .relativeToRoot("Features/Badge")),
                 .project(target: "CoreNearbyExchange", path: .relativeToRoot("Core/NearbyExchange")),
+                .project(target: "UMCAppWidget", path: "UMCAppWidget"),
             ]
         ),
         .target(
@@ -43,7 +44,7 @@ let project = Project(
             destinations: .iOS,
             product: .unitTests,
             bundleId: "dev.tuist.UMCAppTests",
-            deploymentTargets: .iOS("26.0"),
+            deploymentTargets: .iOS("26.3"),
             infoPlist: .default,
             buildableFolders: [
                 "UMCApp/Tests",

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WidgetExtension.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WidgetExtension.swift
@@ -1,0 +1,44 @@
+import ProjectDescription
+
+private let deploymentTargets: DeploymentTargets = .iOS("26.3")
+private let destinations: Destinations = .iOS
+
+/// Widget Extension 타겟용 Project 생성 헬퍼
+///
+/// Widget Extension은 단일 appExtension 타겟으로 구성됩니다.
+/// WidgetKit extension에 필요한 Info.plist 항목을 자동으로 포함합니다.
+///
+/// - Parameters:
+///   - name: 타겟 이름 (예: "UMCAppWidget")
+///   - bundleId: 완전한 번들 ID — 반드시 호스트 앱 번들 ID를 prefix로 포함해야 합니다
+///   - entitlements: entitlements 파일 경로 (기본값 nil)
+///   - dependencies: 의존성 목록
+public func widgetExtensionProject(
+    name: String,
+    bundleId: String,
+    entitlements: Entitlements? = nil,
+    dependencies: [TargetDependency] = []
+) -> Project {
+    Project(
+        name: name,
+        targets: [
+            .target(
+                name: name,
+                destinations: destinations,
+                product: .appExtension,
+                bundleId: bundleId,
+                deploymentTargets: deploymentTargets,
+                infoPlist: .extendingDefault(
+                    with: [
+                        "NSExtension": [
+                            "NSExtensionPointIdentifier": "com.apple.widgetkit-extension",
+                        ],
+                    ]
+                ),
+                sources: ["Sources/**"],
+                entitlements: entitlements,
+                dependencies: dependencies
+            )
+        ]
+    )
+}

--- a/UMCApp/UMCAppWidget/Project.swift
+++ b/UMCApp/UMCAppWidget/Project.swift
@@ -1,0 +1,11 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = widgetExtensionProject(
+    name: "UMCAppWidget",
+    bundleId: "dev.tuist.UMCApp.widget",
+    entitlements: .file(path: "UMCAppWidget.entitlements"),
+    dependencies: [
+        .project(target: "CoreWidgetShared", path: .relativeToRoot("Core/WidgetShared")),
+    ]
+)

--- a/UMCApp/UMCAppWidget/Sources/UMCAppWidget.swift
+++ b/UMCApp/UMCAppWidget/Sources/UMCAppWidget.swift
@@ -1,0 +1,15 @@
+import WidgetKit
+import SwiftUI
+
+struct UMCHomeWidget: Widget {
+    let kind: String = "UMCHomeWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: UMCHomeWidgetProvider()) { entry in
+            UMCHomeWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("UMC")
+        .description("UMC 동아리 정보를 홈 화면에서 확인하세요.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}

--- a/UMCApp/UMCAppWidget/Sources/UMCAppWidgetBundle.swift
+++ b/UMCApp/UMCAppWidget/Sources/UMCAppWidgetBundle.swift
@@ -1,0 +1,9 @@
+import WidgetKit
+import SwiftUI
+
+@main
+struct UMCAppWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        UMCHomeWidget()
+    }
+}

--- a/UMCApp/UMCAppWidget/Sources/UMCAppWidgetEntryView.swift
+++ b/UMCApp/UMCAppWidget/Sources/UMCAppWidgetEntryView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct UMCHomeWidgetEntryView: View {
+
+    // MARK: - Property
+
+    let entry: UMCHomeWidgetEntry
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("UMC")
+                .font(.headline)
+            Text("위젯 준비 중입니다.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+    }
+}

--- a/UMCApp/UMCAppWidget/Sources/UMCAppWidgetProvider.swift
+++ b/UMCApp/UMCAppWidget/Sources/UMCAppWidgetProvider.swift
@@ -1,0 +1,21 @@
+import WidgetKit
+
+struct UMCHomeWidgetEntry: TimelineEntry {
+    let date: Date
+}
+
+struct UMCHomeWidgetProvider: TimelineProvider {
+    func placeholder(in context: Context) -> UMCHomeWidgetEntry {
+        UMCHomeWidgetEntry(date: .now)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (UMCHomeWidgetEntry) -> Void) {
+        completion(UMCHomeWidgetEntry(date: .now))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<UMCHomeWidgetEntry>) -> Void) {
+        let entry = UMCHomeWidgetEntry(date: .now)
+        let timeline = Timeline(entries: [entry], policy: .never)
+        completion(timeline)
+    }
+}

--- a/UMCApp/UMCAppWidget/UMCAppWidget.entitlements
+++ b/UMCApp/UMCAppWidget/UMCAppWidget.entitlements
@@ -2,13 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.developer.nearby-interaction</key>
-    <true/>
-    <key>com.apple.developer.nfc.readersession.formats</key>
-    <array>
-        <string>NDEF</string>
-        <string>TAG</string>
-    </array>
     <key>com.apple.security.application-groups</key>
     <array>
         <string>group.dev.umc.appproduct.widget</string>

--- a/UMCApp/Workspace.swift
+++ b/UMCApp/Workspace.swift
@@ -6,5 +6,6 @@ let workspace = Workspace(
         ".",
         "Core/*",
         "Features/*",
+        "UMCAppWidget",
     ]
 )


### PR DESCRIPTION
## Summary

홈 화면 위젯 기능 구현의 선행 인프라 작업으로, Tuist 모듈 구조에 Widget Extension 타겟과 앱-위젯 공유 Core 모듈을 추가합니다.

- **Core/WidgetShared** 신규 모듈: \`WidgetScheduleEntry\` / \`WidgetAttendanceEntry\` / \`WidgetNoticeEntry\` (TimelineEntry 준수) + App Group 기반 \`WidgetStorage\` 래퍼
- **UMCAppWidget** Widget Extension 타겟 신규 추가 — 플레이스홀더 \`UMCHomeWidget\` 1개 포함 (빌드 성공을 위한 최소 구현)
- **Project+WidgetExtension.swift** 헬퍼 추가 — \`.appExtension\` product + \`NSExtensionPointIdentifier\` Info.plist 자동 주입, 재사용 가능 형태
- App Group \`group.dev.umc.appproduct.widget\` entitlement을 앱/위젯 양쪽 타겟에 적용
- \`Project.swift\` / \`Workspace.swift\`에 신규 타겟 연결

## 주요 설계 메모

- **Widget 번들 ID는 호스트 앱 prefix 규칙**을 따라 \`dev.tuist.UMCApp.widget\`로 설정 (App Extension의 Apple 제약). 헬퍼 시그니처도 \`bundleIdSuffix\` 대신 완전한 \`bundleId\`를 직접 받는 방식으로 설계해 호출부에서 규칙이 명시적으로 드러나도록 했습니다.
- **타겟명 vs. 타입명 충돌 회피**: 타겟 이름이 \`UMCAppWidget\`이므로 Widget struct는 \`UMCHomeWidget\`으로 분리해 같은 모듈 내 \`UMCAppWidget()\` 호출이 모듈명으로 해석되는 스코프 충돌을 제거했습니다.
- **실제 위젯 데이터 덤프 로직은 Out of Scope** — Features/Home, Activity, Notice Presentation 수정은 이슈 원문대로 별도 이슈에서 다룹니다.

## Test plan

- [x] \`tuist generate\` 성공
- [x] \`xcodebuild -workspace UMCApp.xcworkspace -scheme UMCApp -configuration Debug build\` 성공
- [x] 빌드 결과물에 \`UMCApp.app/PlugIns/UMCAppWidget.appex\` 정상 임베드 + \`ValidateEmbeddedBinary\` 통과
- [x] Widget Extension 스킴 \`UMCAppWidget\` / Core 모듈 스킴 \`CoreWidgetShared\` \`xcodebuild -list\`에서 확인

Close #618