### PR TITLE
♻️ [Refactor] Tuist 모듈 구조에 watchOS Companion App + featureProject destinations 확장

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ SwiftUI + iOS 26.2+ 기반 (Liquid Glass 지원)
 
 ## Build & Run
 
+프로젝트는 `AppProduct/`(레거시 xcodeproj)와 `UMCApp/`(Tuist 기반) **두 축**으로 관리됩니다.
+신규 작업은 `UMCApp/`를 기본으로 사용합니다.
+
+### AppProduct (xcodeproj)
+
 ```bash
 # Xcode로 빌드 (권장)
 open AppProduct/AppProduct.xcodeproj
@@ -26,36 +31,79 @@ xcodebuild -project AppProduct/AppProduct.xcodeproj -scheme AppProduct -configur
 xcodebuild -project AppProduct/AppProduct.xcodeproj -scheme AppProduct test
 ```
 
+### UMCApp (Tuist)
+
+Tuist 버전은 `UMCApp/mise.toml` 로 팀 전원 고정됩니다. Makefile이 `mise exec --` 래퍼를 제공하므로 **로컬 tuist 버전 차이가 발생하지 않습니다**.
+
+```bash
+cd UMCApp
+
+# 최초 1회 (신규 팀원)
+brew install mise      # mise가 없다면
+make bootstrap         # mise.toml 기반 tuist 설치
+make install           # SPM 의존성
+
+# 일상 작업
+make generate          # .xcworkspace 생성
+make open              # Xcode 열기 (없으면 자동 generate)
+make test              # xcodebuild 테스트
+make doctor            # 환경 진단 (mise/tuist/xcode 버전)
+make reset             # 꼬였을 때 전체 초기화
+make help              # 전체 타겟 목록
+```
+
+자세한 사용법은 `UMCApp/MAKEFILE_GUIDE.md` 참고.
+
 ## Tuist 모듈 구조 (UMCApp)
 
 `UMCApp/` 폴더는 Tuist 기반의 별도 모듈화 프로젝트입니다. `AppProduct/`와 병행하여 관리됩니다.
+
+### 버전 관리 & 빌드 래퍼
+
+| 파일 | 역할 |
+|------|------|
+| `mise.toml` | Tuist 버전 고정 (현재 `4.155.0`) — 팀 전원 동일 버전 보장 |
+| `Makefile` | `mise exec -- tuist …` 래퍼. 모든 Tuist/xcodebuild 명령의 **표준 진입점** |
+| `MAKEFILE_GUIDE.md` | 팀원용 사용 가이드 |
+
+> Tuist 버전을 올릴 때는 **`mise.toml` 만** 수정하고 PR 본문에 릴리스 노트를 첨부합니다.
+> Makefile / 로컬 tuist 설치는 손대지 않습니다.
 
 ### 전체 구조
 
 ```
 UMCApp/
+├── Makefile                       # 빌드/생성 래퍼 (mise exec 기반)
+├── MAKEFILE_GUIDE.md              # 팀원용 사용 가이드
+├── mise.toml                      # tuist 버전 고정
 ├── Project.swift                  # 앱 타겟 정의
-├── Workspace.swift                # 전체 워크스페이스 (Core/*, Features/* glob)
+├── Workspace.swift                # 전체 워크스페이스 (Core/*, Features/* glob + Widget/Watch)
 ├── Tuist.swift                    # Tuist 시스템 설정
 ├── Tuist/
 │   ├── Package.swift              # SPM 외부 의존성 (Moya, Kingfisher)
 │   └── ProjectDescriptionHelpers/
 │       ├── Project+Core.swift     # Core 모듈 공통 헬퍼
 │       └── Project+Feature.swift  # Feature 모듈 공통 헬퍼
-├── Core/                          # 5개 공유 인프라 모듈
+├── Core/                          # 8개 공유 인프라 모듈
 │   ├── Foundation/                # 기반 유틸리티, Config
 │   ├── Network/                   # 네트워크 레이어 (Moya)
 │   ├── DesignSystem/              # 디자인 토큰, 색상
 │   ├── UIComponents/              # 공용 UI 컴포넌트 (Kingfisher)
-│   └── DI/                        # 의존성 주입 컨테이너
-└── Features/                      # 7개 기능 모듈
-    ├── Activity/
-    ├── Auth/
-    ├── BusinessCard/              # 전자명함 (3D 렌더링 캡슐화 경계 모듈)
-    ├── Community/
-    ├── Home/
-    ├── MyPage/
-    └── Notice/
+│   ├── DI/                        # 의존성 주입 컨테이너
+│   ├── NearbyExchange/            # 근거리 명함 교환 인프라
+│   ├── WatchConnectivity/         # iOS ↔ watchOS 통신
+│   └── WidgetShared/              # Widget-App 공유 모델
+├── Features/                      # 8개 기능 모듈
+│   ├── Activity/
+│   ├── Auth/
+│   ├── Badge/
+│   ├── BusinessCard/              # 전자명함 (3D 렌더링 캡슐화 경계 모듈)
+│   ├── Community/
+│   ├── Home/
+│   ├── MyPage/
+│   └── Notice/
+├── UMCAppWidget/                  # Widget Extension 타겟
+└── UMCWatchApp/                   # watchOS Companion App 타겟
 ```
 
 ### 모듈 의존성 방향
@@ -115,10 +163,11 @@ featureProject(
 
 ### 주요 설정
 
-- **Deployment Target**: iOS 26.0 (전체 타겟 공통)
+- **Tuist 버전**: `UMCApp/mise.toml` 고정 (`4.155.0`)
+- **Deployment Target**: iOS 26.3 (`Project.swift` 기준, 전체 타겟 공통)
 - **Product Type**: 모든 모듈 `.staticFramework`
 - **Bundle ID**: Core → `dev.umc.core.*` / Feature → `dev.umc.feature.*.*`
-- **Workspace**: glob 패턴(`Core/*`, `Features/*`)으로 서브프로젝트 자동 포함
+- **Workspace**: glob(`Core/*`, `Features/*`) + `UMCAppWidget`, `UMCWatchApp` 명시 포함
 
 ---
 

--- a/UMCApp/Core/Foundation/Project.swift
+++ b/UMCApp/Core/Foundation/Project.swift
@@ -3,5 +3,8 @@ import ProjectDescriptionHelpers
 
 let project = coreProject(
     name: "UMCFoundation",
-    bundleIdSuffix: "foundation"
+    bundleIdSuffix: "foundation",
+    destinations: [.iPhone, .appleWatch],
+    deploymentTargets: .multiplatform(iOS: "26.3", watchOS: "26.3")
 )
+

--- a/UMCApp/Core/NearbyExchange/Project.swift
+++ b/UMCApp/Core/NearbyExchange/Project.swift
@@ -9,7 +9,7 @@ let project = Project(
             destinations: .iOS,
             product: .staticFramework,
             bundleId: "dev.umc.core.nearbyexchange",
-            deploymentTargets: .iOS("26.0"),
+            deploymentTargets: .iOS("26.3"),
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),

--- a/UMCApp/Core/WatchConnectivity/Project.swift
+++ b/UMCApp/Core/WatchConnectivity/Project.swift
@@ -1,0 +1,12 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = coreProject(
+    name: "CoreWatchConnectivity",
+    bundleIdSuffix: "watchconnectivity",
+    destinations: [.iPhone, .appleWatch],
+    deploymentTargets: .multiplatform(iOS: "26.3", watchOS: "26.3"),
+    dependencies: [
+        .sdk(name: "WatchConnectivity", type: .framework, status: .required),
+    ]
+)

--- a/UMCApp/Core/WatchConnectivity/Sources/WatchMessenger.swift
+++ b/UMCApp/Core/WatchConnectivity/Sources/WatchMessenger.swift
@@ -1,0 +1,47 @@
+//
+//  WatchMessenger.swift
+//  CoreWatchConnectivity
+//
+//  Created by euijjang97 on 4/24/26.
+//
+
+#if canImport(WatchConnectivity)
+import WatchConnectivity
+
+/// iOS ↔ watchOS 간 메시지 송수신 인터페이스
+///
+/// 실제 도메인 페이로드 정의는 후속 이슈에서 추가됩니다.
+/// 현재는 WCSession 기반 통신 인프라만 제공합니다.
+public protocol WatchMessengerProtocol: Sendable {
+    /// 상대방이 reachable 상태일 때 메시지를 즉시 전송합니다.
+    func sendMessage(_ message: [String: Any]) async throws
+
+    /// 애플리케이션 컨텍스트를 업데이트합니다.
+    /// 상대방이 활성화되지 않은 경우에도 최신 상태를 전달할 수 있습니다.
+    func updateApplicationContext(_ context: [String: Any]) throws
+}
+
+/// `WatchMessengerProtocol`의 `WCSession` 기반 구현체
+public final class WatchMessenger: WatchMessengerProtocol {
+
+    // MARK: - Property
+
+    private let coordinator: WatchSessionCoordinator
+
+    // MARK: - Init
+
+    public init(coordinator: WatchSessionCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    // MARK: - Function
+
+    public func sendMessage(_ message: [String: Any]) async throws {
+        try await coordinator.sendMessage(message)
+    }
+
+    public func updateApplicationContext(_ context: [String: Any]) throws {
+        try coordinator.updateApplicationContext(context)
+    }
+}
+#endif

--- a/UMCApp/Core/WatchConnectivity/Sources/WatchSessionCoordinator.swift
+++ b/UMCApp/Core/WatchConnectivity/Sources/WatchSessionCoordinator.swift
@@ -1,0 +1,85 @@
+//
+//  WatchSessionCoordinator.swift
+//  CoreWatchConnectivity
+//
+//  Created by euijjang97 on 4/24/26.
+//
+
+#if canImport(WatchConnectivity)
+import WatchConnectivity
+
+/// WCSession 활성화 및 상태 관리 코디네이터
+///
+/// - `activate()` 호출 후 세션이 준비됩니다.
+/// - reachability / activation 상태는 내부에서 WCSessionDelegate를 통해 관리합니다.
+@Observable
+public final class WatchSessionCoordinator: NSObject, WCSessionDelegate {
+
+    // MARK: - Property
+
+    public private(set) var isReachable: Bool = false
+    public private(set) var isActivated: Bool = false
+
+    private var session: WCSession { .default }
+
+    // MARK: - Init
+
+    public override init() {
+        super.init()
+    }
+
+    // MARK: - Function
+
+    /// WCSession을 활성화합니다. 앱 시작 시 한 번 호출합니다.
+    public func activate() {
+        guard WCSession.isSupported() else { return }
+        session.delegate = self
+        session.activate()
+    }
+
+    /// 상대방이 reachable 상태일 때 메시지를 즉시 전송합니다.
+    public func sendMessage(_ message: [String: Any]) async throws {
+        guard session.isReachable else {
+            throw WatchConnectivityError.notReachable
+        }
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            session.sendMessage(message, replyHandler: nil) { error in
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    /// 애플리케이션 컨텍스트를 업데이트합니다.
+    public func updateApplicationContext(_ context: [String: Any]) throws {
+        try session.updateApplicationContext(context)
+    }
+
+    // MARK: - WCSessionDelegate
+
+    public func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        isActivated = activationState == .activated
+    }
+
+    public func sessionReachabilityDidChange(_ session: WCSession) {
+        isReachable = session.isReachable
+    }
+
+#if os(iOS)
+    public func sessionDidBecomeInactive(_ session: WCSession) {}
+    public func sessionDidDeactivate(_ session: WCSession) {
+        session.activate()
+    }
+#endif
+}
+
+// MARK: - Error
+
+public enum WatchConnectivityError: Error {
+    case notReachable
+    case sessionNotActivated
+}
+#endif

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -3,6 +3,8 @@ import ProjectDescriptionHelpers
 
 let project = featureProject(
     name: "Activity",
+    domainDestinations: [.iPhone, .appleWatch],
+    domainDeploymentTargets: .multiplatform(iOS: "26.3", watchOS: "26.3"),
     presentationExtraDependencies: [
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
     ]

--- a/UMCApp/MAKEFILE_GUIDE.md
+++ b/UMCApp/MAKEFILE_GUIDE.md
@@ -1,0 +1,164 @@
+# UMCApp Makefile 사용 가이드
+
+팀원 전원이 **동일한 Tuist 버전**으로 작업할 수 있도록 만든 래퍼입니다.
+`mise.toml` 에 고정된 Tuist 버전을 `mise exec --` 로 감싸 실행합니다.
+
+> 모든 명령은 `UMCApp/` 디렉터리에서 실행합니다.
+> ```bash
+> cd UMCApp
+> ```
+
+---
+
+## 1. 최초 환경 구축 (신규 팀원용)
+
+### Step 1. mise 설치 (이미 설치됐으면 생략)
+
+```bash
+brew install mise
+```
+
+설치 후 셸 설정(최초 1회):
+
+```bash
+# zsh
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+공식 문서: https://mise.jdx.dev/getting-started.html
+
+### Step 2. Tuist 설치 + 프로젝트 생성
+
+```bash
+cd UMCApp
+make bootstrap   # mise.toml 기반으로 tuist 4.155.0 자동 설치
+make install     # SPM 의존성 설치
+make generate    # .xcworkspace / .xcodeproj 생성
+make open        # Xcode 실행
+```
+
+이후 일상 작업은 **Step 2 만 반복**하면 됩니다.
+
+---
+
+## 2. 자주 쓰는 명령
+
+| 명령 | 설명 | 언제 쓰나 |
+|------|------|-----------|
+| `make generate` | 워크스페이스 생성 | `Project.swift` / 모듈 구조 변경 후 |
+| `make gen` | `generate` 별칭 | |
+| `make open` | Xcode 워크스페이스 열기 (없으면 자동 generate) | 개발 시작할 때 |
+| `make install` | SPM 의존성 설치 | `Tuist/Package.swift` 변경 후 |
+| `make edit` | Tuist 매니페스트 편집 모드 | `Project+Feature.swift` 등 수정 시 |
+| `make graph` | 의존성 그래프(`graph.png`) 생성 | 구조 리뷰할 때 |
+| `make test` | 테스트 실행 | CI 재현 / 로컬 검증 |
+| `make build` | Debug 빌드 | 빌드 가능 여부만 확인할 때 |
+| `make doctor` | 환경 진단 (mise/tuist/xcode 버전) | 다른 팀원과 증상이 다를 때 |
+| `make help` | 전체 타겟 목록 | 까먹었을 때 |
+
+---
+
+## 3. 정리 / 초기화
+
+| 명령 | 설명 |
+|------|------|
+| `make clean` | `Derived/`, `Tuist/.build`, 생성된 `*.xcodeproj` / `*.xcworkspace`, `graph.*` 제거 |
+| `make clean-dd` | 로컬 DerivedData (`.local-derived-data-*`) 제거 |
+| `make reset` | `clean + clean-dd` 동시 실행 (전체 초기화) |
+
+**초기화 후에는 반드시 `make generate` 를 다시 실행하세요.**
+
+### 뭔가 꼬였을 때 복구 순서
+
+```bash
+make reset
+make install
+make generate
+make open
+```
+
+---
+
+## 4. 환경 변수 오버라이드
+
+기본값은 Makefile 상단에 정의되어 있습니다. 필요 시 명령줄에서 덮어쓸 수 있습니다.
+
+| 변수 | 기본값 | 예시 |
+|------|--------|------|
+| `SCHEME` | `UMCApp` | `make test SCHEME=AuthTests` |
+| `CONFIGURATION` | `Debug` | `make build CONFIGURATION=Release` |
+| `DESTINATION` | `platform=iOS Simulator,name=iPhone 16 Pro` | `make test DESTINATION='platform=iOS Simulator,name=iPhone 15'` |
+
+예시:
+
+```bash
+# Release 빌드
+make build CONFIGURATION=Release
+
+# 다른 시뮬레이터에서 테스트
+make test DESTINATION='platform=iOS Simulator,name=iPhone 15 Pro'
+```
+
+---
+
+## 5. 버전 업그레이드 규칙
+
+Tuist 버전을 올릴 때는 **`mise.toml` 만** 수정합니다. Makefile은 건드리지 않습니다.
+
+```toml
+# UMCApp/mise.toml
+[tools]
+tuist = "4.155.0"   # ← 이 값만 변경
+```
+
+변경 후 팀원들은 각자:
+
+```bash
+cd UMCApp
+make bootstrap    # 새 버전 자동 설치
+make reset
+make generate
+```
+
+버전 변경은 별도 PR로 올리고, PR 본문에 **릴리스 노트 링크**를 첨부하세요.
+
+---
+
+## 6. 트러블슈팅
+
+### `mise: command not found`
+→ `brew install mise` 후 셸 재시작.
+
+### `tuist not found` (make 실행 시)
+→ `make bootstrap` 다시 실행. 여전히 실패하면 `mise install` 로그 확인.
+
+### `make generate` 후에도 Xcode가 옛 구조를 보임
+→ `make reset && make generate`.
+
+### 다른 팀원과 빌드 결과가 다름
+→ `make doctor` 출력을 공유. `mise` / `tuist` / `Xcode` 버전이 일치하는지 확인.
+
+### 워크스페이스가 이미 열려 있는 상태로 `make generate` 했더니 이상함
+→ Xcode 완전 종료(⌘Q) → `make reset` → `make generate` → `make open`.
+
+---
+
+## 7. 파일 구조 참고
+
+```
+UMCApp/
+├── Makefile              # ← 이 가이드가 설명하는 파일
+├── MAKEFILE_GUIDE.md     # ← 이 문서
+├── mise.toml             # tuist 버전 고정
+├── Tuist.swift
+├── Workspace.swift
+├── Project.swift
+├── Tuist/
+│   ├── Package.swift     # SPM 외부 의존성
+│   └── ProjectDescriptionHelpers/
+├── Core/                 # 공유 인프라 모듈
+└── Features/             # 기능 모듈
+```
+
+모듈 구조 자체에 대한 설명은 루트 `CLAUDE.md` 의 **"Tuist 모듈 구조 (UMCApp)"** 섹션을 참고하세요.

--- a/UMCApp/Makefile
+++ b/UMCApp/Makefile
@@ -1,0 +1,145 @@
+# UMCApp Tuist Makefile
+#
+# 팀 전원이 동일한 Tuist 버전(mise.toml 고정)으로 작업하기 위한 래퍼입니다.
+# mise가 tuist 버전을 관리하므로, 모든 tuist 호출은 `mise exec --` 로 감쌉니다.
+#
+# 사용법:
+#   cd UMCApp
+#   make bootstrap   # 최초 1회: mise + tuist 설치
+#   make generate    # 프로젝트 생성 (가장 자주 쓰는 커맨드)
+#   make help        # 전체 타겟 목록
+
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+SCHEME ?= UMCApp
+WORKSPACE := UMCApp.xcworkspace
+DESTINATION ?= platform=iOS Simulator,name=iPhone 16 Pro
+CONFIGURATION ?= Debug
+
+MISE ?= mise
+TUIST := $(MISE) exec -- tuist
+
+# ──────────────────────────────────────────────────────────────
+# Help
+# ──────────────────────────────────────────────────────────────
+
+.PHONY: help
+help: ## 이 도움말 출력
+	@awk 'BEGIN {FS = ":.*?## "; printf "\nUMCApp Makefile — 사용 가능한 타겟:\n\n"} \
+		/^[a-zA-Z_-]+:.*?## / { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 } \
+		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	@echo ""
+	@echo "환경 변수 오버라이드 예시:"
+	@echo "  make test DESTINATION='platform=iOS Simulator,name=iPhone 15'"
+	@echo "  make build CONFIGURATION=Release"
+	@echo ""
+
+##@ 환경 설정
+
+.PHONY: bootstrap
+bootstrap: check-mise ## 최초 환경 구축 (mise로 tuist 설치)
+	@echo "▶︎ mise.toml 도구 설치 중..."
+	@$(MISE) install
+	@echo "▶︎ tuist 버전 확인"
+	@$(TUIST) version
+	@echo "bootstrap 완료. 이제 'make generate' 를 실행하세요."
+
+.PHONY: check-mise
+check-mise: ## mise 설치 여부 확인
+	@if ! command -v $(MISE) >/dev/null 2>&1; then \
+		echo "mise 가 설치되어 있지 않습니다."; \
+		echo "설치: brew install mise"; \
+		echo "셸 설정: https://mise.jdx.dev/getting-started.html"; \
+		exit 1; \
+	fi
+
+.PHONY: doctor
+doctor: check-mise ## 개발 환경 진단
+	@echo "── mise ──"; $(MISE) --version
+	@echo "── tuist ──"; $(TUIST) version
+	@echo "── xcodebuild ──"; xcodebuild -version
+	@echo "── mise.toml ──"; cat mise.toml
+
+##@ Tuist
+
+.PHONY: install
+install: ## SPM 의존성 설치 (tuist install)
+	@$(TUIST) install
+
+.PHONY: generate
+generate: ## 워크스페이스/프로젝트 생성
+	@$(TUIST) generate --no-open
+
+.PHONY: gen
+gen: generate ## generate 별칭
+
+.PHONY: generate-open
+generate-open: ## 생성 후 Xcode로 열기
+	@$(TUIST) generate
+
+.PHONY: edit
+edit: ## Tuist 매니페스트 편집 모드
+	@$(TUIST) edit
+
+.PHONY: graph
+graph: ## 의존성 그래프(graph.png) 생성
+	@$(TUIST) graph --format png --output-path .
+
+.PHONY: cache-warm
+cache-warm: ## Tuist 바이너리 캐시 워밍업
+	@$(TUIST) cache
+
+##@ Xcode
+
+.PHONY: open
+open: ## Xcode 워크스페이스 열기
+	@if [ ! -d "$(WORKSPACE)" ]; then \
+		echo "⚠️  $(WORKSPACE) 없음 → 먼저 'make generate' 실행"; \
+		$(MAKE) generate; \
+	fi
+	@open $(WORKSPACE)
+
+.PHONY: build
+build: ## 빌드 ($(CONFIGURATION))
+	@xcodebuild \
+		-workspace $(WORKSPACE) \
+		-scheme $(SCHEME) \
+		-configuration $(CONFIGURATION) \
+		-destination "$(DESTINATION)" \
+		build
+
+.PHONY: test
+test: ## 테스트 실행
+	@xcodebuild \
+		-workspace $(WORKSPACE) \
+		-scheme $(SCHEME) \
+		-configuration $(CONFIGURATION) \
+		-destination "$(DESTINATION)" \
+		test
+
+##@ 정리
+
+.PHONY: clean
+clean: ## Tuist Derived/빌드 산출물 제거
+	@echo "▶︎ Tuist 생성물 제거"
+	@rm -rf Derived
+	@rm -rf */Derived
+	@rm -rf */*/Derived
+	@rm -rf Tuist/.build
+	@rm -f graph.dot graph.png
+	@echo "▶︎ 생성된 xcodeproj/xcworkspace 제거"
+	@find . -maxdepth 3 -name "*.xcodeproj" -not -path "./Tuist/*" -exec rm -rf {} + 2>/dev/null || true
+	@find . -maxdepth 3 -name "*.xcworkspace" -not -path "./Tuist/*" -exec rm -rf {} + 2>/dev/null || true
+	@echo "clean 완료"
+
+.PHONY: clean-dd
+clean-dd: ## 로컬 DerivedData 제거
+	@rm -rf .local-derived-data-*
+	@echo "로컬 DerivedData 제거 완료"
+
+.PHONY: reset
+reset: clean clean-dd ## 전체 초기화 (clean + clean-dd)
+	@echo "전체 리셋 완료. 'make generate' 로 다시 생성하세요."
+
+## 제작자 : 제옹

--- a/UMCApp/Project.swift
+++ b/UMCApp/Project.swift
@@ -37,6 +37,7 @@ let project = Project(
                 .project(target: "BadgePresentation", path: .relativeToRoot("Features/Badge")),
                 .project(target: "CoreNearbyExchange", path: .relativeToRoot("Core/NearbyExchange")),
                 .project(target: "UMCAppWidget", path: "UMCAppWidget"),
+                .project(target: "UMCWatchApp", path: "UMCWatchApp"),
             ]
         ),
         .target(

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
@@ -1,7 +1,5 @@
 import ProjectDescription
 
-private let deploymentTargets: DeploymentTargets = .iOS("26.3")
-private let destinations: Destinations = .iOS
 private let bundleIdBase = "dev.umc.core"
 
 /// Core 모듈용 Project 생성 헬퍼
@@ -11,10 +9,14 @@ private let bundleIdBase = "dev.umc.core"
 /// - Parameters:
 ///   - name: 타겟 이름 (예: "CoreNetwork", "UMCFoundation")
 ///   - bundleIdSuffix: bundleId 접미사 (예: "network", "foundation")
+///   - destinations: 지원 플랫폼 (기본값: `.iOS`)
+///   - deploymentTargets: 배포 대상 (기본값: iOS 26.3)
 ///   - dependencies: 의존성 목록
 public func coreProject(
     name: String,
     bundleIdSuffix: String,
+    destinations: Destinations = .iOS,
+    deploymentTargets: DeploymentTargets = .iOS("26.3"),
     dependencies: [TargetDependency] = []
 ) -> Project {
     Project(

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
@@ -1,7 +1,5 @@
 import ProjectDescription
 
-private let deploymentTargets: DeploymentTargets = .iOS("26.3")
-private let destinations: Destinations = .iOS
 private let bundleIdBase = "dev.umc.feature"
 
 /// Feature 모듈용 Project 생성 헬퍼
@@ -13,11 +11,15 @@ private let bundleIdBase = "dev.umc.feature"
 ///
 /// - Parameters:
 ///   - name: Feature 이름 (예: "Auth", "Home"). 타겟명 및 bundleId 생성에 사용됩니다.
+///   - domainDestinations: Domain 타겟의 지원 플랫폼 (기본값: `.iOS`). watchOS 공유가 필요한 경우 `[.iPhone, .appleWatch]`로 지정.
+///   - domainDeploymentTargets: Domain 타겟의 배포 대상 (기본값: iOS 26.3). watchOS 공유 시 `.multiplatform(iOS:watchOS:)` 로 지정.
 ///   - domainExtraDependencies: Domain 타겟에 추가할 의존성
 ///   - dataExtraDependencies: Data 타겟에 추가할 의존성
 ///   - presentationExtraDependencies: Presentation 타겟에 추가할 의존성
 public func featureProject(
     name: String,
+    domainDestinations: Destinations = .iOS,
+    domainDeploymentTargets: DeploymentTargets = .iOS("26.3"),
     domainExtraDependencies: [TargetDependency] = [],
     dataExtraDependencies: [TargetDependency] = [],
     presentationExtraDependencies: [TargetDependency] = []
@@ -29,10 +31,10 @@ public func featureProject(
         targets: [
             .target(
                 name: "\(name)Domain",
-                destinations: destinations,
+                destinations: domainDestinations,
                 product: .staticFramework,
                 bundleId: "\(bundleIdBase).\(nameLowered).domain",
-                deploymentTargets: deploymentTargets,
+                deploymentTargets: domainDeploymentTargets,
                 sources: ["Domain/Sources/**"],
                 dependencies: [
                     .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
@@ -40,10 +42,10 @@ public func featureProject(
             ),
             .target(
                 name: "\(name)Data",
-                destinations: destinations,
+                destinations: .iOS,
                 product: .staticFramework,
                 bundleId: "\(bundleIdBase).\(nameLowered).data",
-                deploymentTargets: deploymentTargets,
+                deploymentTargets: .iOS("26.3"),
                 sources: ["Data/Sources/**"],
                 dependencies: [
                     .target(name: "\(name)Domain"),
@@ -53,10 +55,10 @@ public func featureProject(
             ),
             .target(
                 name: "\(name)Presentation",
-                destinations: destinations,
+                destinations: .iOS,
                 product: .staticFramework,
                 bundleId: "\(bundleIdBase).\(nameLowered).presentation",
-                deploymentTargets: deploymentTargets,
+                deploymentTargets: .iOS("26.3"),
                 sources: ["Presentation/Sources/**"],
                 dependencies: [
                     .target(name: "\(name)Domain"),

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WatchApp.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WatchApp.swift
@@ -1,0 +1,45 @@
+import ProjectDescription
+
+private let companionBundleId = "dev.umc.appproduct"
+
+/// Watch 앱 타겟용 Project 생성 헬퍼
+///
+/// watchOS App 타겟 1개를 구성합니다.
+/// WKCompanionAppBundleIdentifier는 호스트 iOS 앱 번들 ID로 자동 설정됩니다.
+///
+/// - Parameters:
+///   - name: 타겟 이름 (예: "UMCWatchApp")
+///   - bundleId: Watch 앱 번들 ID
+///   - entitlements: entitlements 파일 경로 (기본값 nil)
+///   - dependencies: 의존성 목록
+public func watchAppProject(
+    name: String,
+    bundleId: String,
+    entitlements: Entitlements? = nil,
+    dependencies: [TargetDependency] = []
+) -> Project {
+    Project(
+        name: name,
+        targets: [
+            .target(
+                name: name,
+                destinations: [.appleWatch],
+                product: .app,
+                bundleId: bundleId,
+                deploymentTargets: .watchOS("26.3"),
+                infoPlist: .extendingDefault(
+                    with: [
+                        "WKCompanionAppBundleIdentifier": .string(companionBundleId),
+                        "UISupportedInterfaceOrientations": .array([
+                            .string("UIInterfaceOrientationPortrait"),
+                        ]),
+                    ]
+                ),
+                sources: ["Sources/**"],
+                resources: ["Resources/**"],
+                entitlements: entitlements,
+                dependencies: dependencies
+            )
+        ]
+    )
+}

--- a/UMCApp/UMCApp.entitlements
+++ b/UMCApp/UMCApp.entitlements
@@ -13,5 +13,9 @@
     <array>
         <string>group.dev.umc.appproduct.widget</string>
     </array>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)dev.umc.shared</string>
+    </array>
 </dict>
 </plist>

--- a/UMCApp/UMCWatchApp/Project.swift
+++ b/UMCApp/UMCWatchApp/Project.swift
@@ -1,0 +1,11 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = watchAppProject(
+    name: "UMCWatchApp",
+    bundleId: "dev.umc.appproduct.watchkitapp",
+    entitlements: .file(path: "UMCWatchApp.entitlements"),
+    dependencies: [
+        .project(target: "CoreWatchConnectivity", path: .relativeToRoot("Core/WatchConnectivity")),
+    ]
+)

--- a/UMCApp/UMCWatchApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/UMCApp/UMCWatchApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "44x44"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "50x50"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "86x86"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "98x98"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "108x108"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "194x194"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UMCApp/UMCWatchApp/Resources/Assets.xcassets/Contents.json
+++ b/UMCApp/UMCWatchApp/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UMCApp/UMCWatchApp/Sources/ContentView.swift
+++ b/UMCApp/UMCWatchApp/Sources/ContentView.swift
@@ -1,0 +1,17 @@
+//
+//  ContentView.swift
+//  UMCWatchApp
+//
+//  Created by euijjang97 on 4/24/26.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+
+    // MARK: - Body
+
+    var body: some View {
+        Text("Hello Watch")
+    }
+}

--- a/UMCApp/UMCWatchApp/Sources/UMCWatchApp.swift
+++ b/UMCApp/UMCWatchApp/Sources/UMCWatchApp.swift
@@ -1,0 +1,17 @@
+//
+//  UMCWatchApp.swift
+//  UMCWatchApp
+//
+//  Created by euijjang97 on 4/24/26.
+//
+
+import SwiftUI
+
+@main
+struct UMCWatchApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/UMCApp/UMCWatchApp/UMCWatchApp.entitlements
+++ b/UMCApp/UMCWatchApp/UMCWatchApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)dev.umc.shared</string>
+    </array>
+</dict>
+</plist>

--- a/UMCApp/Workspace.swift
+++ b/UMCApp/Workspace.swift
@@ -7,5 +7,6 @@ let workspace = Workspace(
         "Core/*",
         "Features/*",
         "UMCAppWidget",
+        "UMCWatchApp",
     ]
 )


### PR DESCRIPTION
## ✨ PR 유형

Refactor — Apple Watch 출석 기능(PRD §9.1) 구현을 위한 Tuist 모듈 구조 확장. watchOS Companion App 타겟과 WatchConnectivity 인프라 모듈을 추가하고, Core/Feature 헬퍼가 multiplatform destinations를 받을 수 있도록 일반화했습니다. **실제 Watch UI/비즈니스 로직은 후속 이슈에서 진행**하며 본 PR은 인프라 스캐폴딩만 포함합니다.

추가로 확장된 Tuist 구조를 팀 전원이 동일하게 사용할 수 있도록 **mise + Makefile 기반 빌드 래퍼**와 한글 사용 가이드를 함께 포함합니다.

Closes #621

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (Tuist 빌드 구조 리팩토링 전용). Watch 앱은 "Hello Watch" 스켈레톤만 포함.

## 🛠️ 작업내용

### Tuist 헬퍼 확장
- `Project+Core.swift` — `destinations` / `deploymentTargets` 파라미터 추가 (기본값 `.iOS` / `iOS 26.3`)
- `Project+Feature.swift` — `domainDestinations` / `domainDeploymentTargets` 파라미터 추가 (Data·Presentation은 iOS 전용 유지, Domain만 멀티플랫폼 선택 가능)
- `Project+WatchApp.swift` 신규 — watchOS Companion App 타겟 생성 헬퍼 (Bundle ID `dev.umc.appproduct.watchkitapp`, `WKCompanionAppBundleIdentifier` 세팅 포함)

### 신규 모듈/타겟
- `Core/WatchConnectivity/` — iOS + watchOS 양쪽 destinations를 갖는 staticFramework. `WatchMessenger`, `WatchSessionCoordinator`로 WCSession 래핑 최소 구현
- `UMCWatchApp/` — watchOS 앱 타겟 (Assets, Info.plist, entitlements, ContentView 스켈레톤)

### 기존 모듈 조정
- `Core/Foundation/Project.swift` — `UMCFoundation`을 `[.iPhone, .appleWatch]` + `.multiplatform(iOS: 26.3, watchOS: 26.3)`으로 확장 (소스 코드는 `import Foundation`만 쓰므로 무수정 호환)
- `Features/Activity/Project.swift` — `ActivityDomain`만 watchOS 공유 설정 (Data/Presentation은 iOS 전용 유지)
- `UMCApp/Project.swift` / `Workspace.swift` — `UMCWatchApp` 의존성·경로 추가 (위젯과 동일 embed 패턴)
- `UMCApp.entitlements` / `UMCWatchApp.entitlements` — 공유 Keychain Access Group `$(AppIdentifierPrefix)dev.umc.shared` 양쪽에 적용

### 버전 통일
- `Core/NearbyExchange/Project.swift`의 `iOS 26.0` → `26.3`으로 조정, UMCApp 하위 모든 Tuist manifest의 deployment target을 26.3으로 통일

### 빌드 래퍼 & 문서 (추가 커밋)
- `UMCApp/Makefile` 신규 — `mise exec -- tuist …` 기반 표준 진입점
    - `bootstrap` / `install` / `generate` / `open` / `build` / `test` / `doctor` / `clean` / `reset` 등 타겟 제공
    - `mise.toml` 에 고정된 tuist 4.155.0 을 팀 전원이 강제로 사용하도록 래핑
    - `SCHEME` / `CONFIGURATION` / `DESTINATION` 환경변수 오버라이드 지원
- `UMCApp/MAKEFILE_GUIDE.md` 신규 — 팀원용 한글 가이드 (환경 구축, 명령 테이블, 버전 업그레이드 규칙, 트러블슈팅)
- `CLAUDE.md` 업데이트
    - Build & Run 섹션을 AppProduct / UMCApp 두 축으로 분리, Makefile 워크플로 반영
    - Tuist 섹션에 **버전 관리 & 빌드 래퍼** 서브섹션 신설
    - 전체 구조 트리 현실화 (Core 5→**8개**, Features 7→**8개**, `UMCAppWidget` / `UMCWatchApp` 타겟 노출)
    - Deployment Target 기재값 `26.0` → `26.3` 정정

## 📋 추후 진행 상황

- Watch 앱 UI (출석 원탭 흐름, PRD §5.1)
- WatchConnectivity 도메인 페이로드 정의 및 iPhone ↔ Watch 상태 동기화
- Apple Watch용 `ActivityDomain` UseCase 실제 사용
- Complication / 알림 연동 (PRD §9.1 후속)
- CI(GitHub Actions)에서 `make generate` / `make test` 호출로 전환 검토

## 📌 리뷰 포인트

- `UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift` — Feature 헬퍼에서 Domain만 선택적으로 multiplatform이 되도록 파라미터를 분리한 방식이 합리적인지 (Data/Presentation까지 기본 multiplatform으로 하면 불필요한 검증 비용이 생김)
- `UMCApp/Tuist/ProjectDescriptionHelpers/Project+WatchApp.swift` — watchOS 앱 타겟 구성 (Bundle ID, `WKCompanionAppBundleIdentifier`, deployment target)
- `UMCApp/Core/WatchConnectivity/Sources/WatchSessionCoordinator.swift` — `#if canImport(WatchConnectivity)` 가드 및 WCSession activation/상태 관리 최소 구현이 후속 확장에 적합한지
- `UMCApp/Core/Foundation/Project.swift` — `UMCFoundation`을 multiplatform으로 열어도 현재 소스들이 watchOS에서 빌드되는지 (현재 `import Foundation`만 사용)
- `UMCApp/Features/Activity/Project.swift` — `ActivityDomain`만 watchOS 공유로 제한, Data/Presentation은 iOS로 유지한 경계 설정
- `UMCApp/Project.swift` / `UMCApp.entitlements` — 위젯과 동일 패턴의 embed 및 Keychain Access Group 공유
- `UMCApp/Makefile` — `mise exec --` 래핑 전략과 기본 타겟 집합이 팀 워크플로에 충분한지
- `UMCApp/MAKEFILE_GUIDE.md` — 신규 팀원 온보딩 흐름이 실제로 막히는 지점이 없는지
- `CLAUDE.md` — 문서 상 Deployment Target / 모듈 개수가 현행 매니페스트와 일치하는지

### 검증 상태
- `tuist generate`: 성공
- iPhone (`UMCApp` scheme, `generic/platform=iOS`): **BUILD SUCCEEDED**
- Watch (`UMCWatchApp`): 로컬 머신에 watchOS 26.x 플랫폼 컴포넌트 미설치라 `xcodebuild` destination 없음 → `xcrun --sdk watchsimulator26.4 swiftc -parse`로 Watch 소스 파싱 오류 없음 확인. 리뷰어는 Xcode > Settings > Components에서 watchOS 설치 후 스킴 빌드 권장
- `make help` / `make doctor`: 로컬 실행 확인 (tuist 4.155.0 / Xcode 26.4.1 인식)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)