### PR TITLE
refactor: Attendance 도메인 모델 ActivityDomain 모듈 이관

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorContext.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorContext.swift
@@ -1,0 +1,78 @@
+//
+//  ErrorContext.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 에러가 발생한 위치와 재시도 정보를 담는 컨텍스트.
+///
+/// 동일한 에러라도 발생 위치에 따라 다른 처리가 필요합니다:
+/// - 공지사항 조회 중 네트워크 에러 → "공지사항을 불러올 수 없습니다"
+/// - 출석 체크 중 네트워크 에러 → "출석 체크에 실패했습니다"
+///
+/// ## Usage
+///
+/// ```swift
+/// errorHandler.handle(error, context: ErrorContext(
+///     feature: "Notice",
+///     action: "fetchList",
+///     retryAction: { [weak self] in
+///         await self?.fetchNotices()
+///     }
+/// ))
+/// ```
+///
+/// - SeeAlso: ``ErrorHandler``, ``PresentableError``
+public struct ErrorContext: Equatable {
+
+    // MARK: - Property
+
+    /// 에러가 발생한 Feature 이름.
+    ///
+    /// Feature 폴더명과 일치시키는 것을 권장합니다.
+    ///
+    /// - Note: PascalCase 사용 (예: `"Notice"`, `"Auth"`, `"Attendance"`)
+    public let feature: String
+
+    /// 에러가 발생한 액션 이름.
+    ///
+    /// 해당 Feature 내에서 어떤 작업 중 에러가 발생했는지를 나타냅니다.
+    ///
+    /// - Note: camelCase, 동사로 시작 (예: `"fetchList"`, `"login"`, `"submitAttendance"`)
+    public let action: String
+
+    /// 에러 발생 시 재시도할 수 있는 클로저.
+    ///
+    /// 이 값이 `nil`이면 UI에서 재시도 버튼이 표시되지 않습니다.
+    ///
+    /// - Important: 클로저 내부에서 `[weak self]`를 사용하여 순환 참조를 방지하세요.
+    public let retryAction: (() async -> Void)?
+
+    // MARK: - Init
+
+    /// 새로운 ErrorContext를 생성합니다.
+    ///
+    /// - Parameters:
+    ///   - feature: 에러가 발생한 Feature 이름.
+    ///   - action: 에러가 발생한 액션 이름.
+    ///   - retryAction: 재시도 클로저. 기본값은 `nil`.
+    public init(
+        feature: String,
+        action: String,
+        retryAction: (() async -> Void)? = nil
+    ) {
+        self.feature = feature
+        self.action = action
+        self.retryAction = retryAction
+    }
+
+    // MARK: - Equatable
+
+    /// 두 ErrorContext가 같은 위치를 나타내는지 비교합니다.
+    public static func == (lhs: ErrorContext, rhs: ErrorContext) -> Bool {
+        lhs.feature == rhs.feature && lhs.action == rhs.action
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorHandler.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorHandler.swift
@@ -1,0 +1,294 @@
+//
+//  ErrorHandler.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+import os.log
+
+/// 앱 전역에서 발생하는 에러를 중앙 집중식으로 처리하는 핸들러.
+///
+/// Mediator 패턴을 적용하여 여러 ViewModel에서 발생하는 에러를 한 곳에서 수집하고 처리합니다.
+///
+/// ErrorHandler의 역할:
+/// 1. 에러 변환: `MoyaError`, `URLError` 등을 ``AppError``로 통합
+/// 2. 로깅: `os.log`를 사용하여 에러 정보 기록
+/// 3. 분석: Firebase, Sentry 등 외부 서비스로 에러 데이터 전송
+/// 4. 특수 처리: 401 Unauthorized → 자동 로그아웃
+/// 5. UI 바인딩: ``currentError``를 통해 View에서 Alert 표시
+///
+/// ## Usage
+///
+/// **App에서 Environment로 주입:**
+///
+/// ```swift
+/// @main
+/// struct AppProductApp: App {
+///     @State private var errorHandler = ErrorHandler()
+///
+///     var body: some Scene {
+///         WindowGroup {
+///             ContentView()
+///                 .environment(errorHandler)
+///                 .globalErrorAlert(errorHandler: errorHandler)
+///         }
+///     }
+/// }
+/// ```
+///
+/// **ViewModel에서 에러 처리:**
+///
+/// ```swift
+/// func fetchNotices() async {
+///     do {
+///         notices = try await useCase.execute()
+///     } catch {
+///         errorHandler.handle(error, context: ErrorContext(
+///             feature: "Notice",
+///             action: "fetchList",
+///             retryAction: { [weak self] in await self?.fetchNotices() }
+///         ))
+///     }
+/// }
+/// ```
+///
+/// - Important: 에러 처리 방식은 UX 관점에서 결정하세요.
+///   - **ErrorHandler**: 작업 흐름 중단, 즉각적인 사용자 액션이 필요한 경우 (Alert)
+///   - **Loadable**: 데이터 상태와 함께 관리, 화면 내 상태 변화 표시 (인라인)
+///
+///   예시:
+///   - 세션 만료, 권한 필요, 네트워크 오류 → ErrorHandler
+///   - 리스트 로딩 실패, 폼 검증 실패, 범위 벗어남 → Loadable
+///
+/// - Warning: 현재 특수 에러 처리는 `NotificationCenter`를 사용합니다.
+///   추후 `AppState + Environment` 패턴으로 리팩터링 예정입니다.
+///
+/// - SeeAlso: ``ErrorContext``, ``AppError``, ``PresentableError``, ``Loadable``
+@Observable
+public final class ErrorHandler {
+
+    // MARK: - Property
+
+    /// 현재 표시해야 할 에러.
+    ///
+    /// View에서 이 값을 관찰하여 에러 Alert을 표시합니다.
+    /// `nil`이면 에러가 없는 상태입니다.
+    ///
+    /// - Note: 외부에서 직접 수정할 수 없습니다. ``handle(_:context:)``를 사용하세요.
+    public private(set) var currentError: PresentableError?
+
+    /// 에러 로깅에 사용되는 Logger.
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "AppProduct",
+        category: "ErrorHandler"
+    )
+
+    // MARK: - Init
+
+    /// ErrorHandler를 초기화합니다.
+    ///
+    /// App 레벨에서 한 번만 생성하고 Environment로 주입합니다.
+    public init() {}
+
+    // MARK: - Public Methods
+
+    /// 에러를 처리합니다.
+    ///
+    /// 에러 처리의 단일 진입점입니다. 다음 순서로 처리합니다:
+    /// 1. `Error` → ``AppError`` 변환
+    /// 2. os.log로 로깅
+    /// 3. Analytics 전송
+    /// 4. 특수 케이스 처리 (401 → 로그아웃)
+    /// 5. ``currentError`` 설정 → View에서 Alert 표시
+    ///
+    /// - Parameters:
+    ///   - error: 발생한 에러. ``AppError``, `MoyaError`, `URLError` 등 모든 `Error` 타입 가능.
+    ///   - context: 에러 발생 위치와 재시도 정보를 담은 컨텍스트.
+    ///
+    /// - Precondition: Main Thread에서 호출해야 합니다.
+    public func handle(_ error: Error, context: ErrorContext) {
+        let appError = convert(error)
+
+        log(appError, context: context)
+        trackError(appError, context: context)
+
+        if handleSpecialCases(appError, context: context) {
+            return
+        }
+
+        currentError = PresentableError(
+            error: appError,
+            context: context,
+            dismissAction: { [weak self] in
+                self?.clearError()
+            },
+            retryAction: context.retryAction
+        )
+    }
+
+    /// 현재 표시 중인 에러를 초기화합니다.
+    ///
+    /// 에러 Alert이 닫힐 때 자동으로 호출됩니다.
+    public func clearError() {
+        currentError = nil
+    }
+
+    // MARK: - Private Methods
+
+    /// 임의의 Error를 AppError로 변환합니다.
+    ///
+    /// - Parameter error: 변환할 에러.
+    /// - Returns: 통합된 ``AppError``.
+    ///
+    /// - Note: 지원 타입: `AppError`, `NetworkError`, `RepositoryError`, `AuthError`,
+    ///   `ValidationError`, `DomainError`, `MoyaError`, `URLError`, `DecodingError`
+    private func convert(_ error: Error) -> AppError {
+        // 1. AppError는 그대로 반환
+        if let appError = error as? AppError {
+            return appError
+        }
+
+        // 2. NetworkError → AppError.network (Actor 기반 네트워크 클라이언트)
+        if let networkError = error as? NetworkError {
+            return .network(networkError)
+        }
+
+        // 3. RepositoryError
+        if let repositoryError = error as? RepositoryError {
+            return .repository(repositoryError)
+        }
+
+        // 4. ValidationError
+        if let validationError = error as? ValidationError {
+            return .validation(validationError)
+        }
+
+        // 5. AuthError
+        if let authError = error as? AuthError {
+            return .auth(authError)
+        }
+
+        // 6. DomainError
+        if let domainError = error as? DomainError {
+            return .domain(domainError)
+        }
+
+        // 7. URLError → NetworkError 변환
+        if let urlError = error as? URLError {
+            return .network(convertURLError(urlError))
+        }
+
+        // 8. DecodingError → RepositoryError 변환
+        if let decodingError = error as? DecodingError {
+            return .repository(.decodingError(detail: describeDecodingError(decodingError)))
+        }
+
+        // 9. 알 수 없는 에러
+        return .unknown(message: error.localizedDescription)
+    }
+
+    private func convertURLError(_ error: URLError) -> NetworkError {
+        switch error.code {
+        case .notConnectedToInternet, .networkConnectionLost:
+            return .noNetwork
+        case .timedOut:
+            return .timeout
+        default:
+            return .requestFailed(statusCode: error.errorCode, data: nil)
+        }
+    }
+
+    private func describeDecodingError(_ error: DecodingError) -> String {
+        switch error {
+        case .keyNotFound(let key, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            let location = path.isEmpty ? key.stringValue : "\(path).\(key.stringValue)"
+            return "Missing key: \(location)"
+        case .typeMismatch(let type, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "Type mismatch: expected \(type) at \(path)"
+        case .valueNotFound(let type, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "Value not found: \(type) at \(path)"
+        case .dataCorrupted(let context):
+            return "Data corrupted: \(context.debugDescription)"
+        @unknown default:
+            return "Unknown decoding error"
+        }
+    }
+
+    // MARK: - Logging
+
+    /// 에러를 os.log로 기록합니다.
+    ///
+    /// 로그 레벨은 에러의 ``AppError/severity``에 따라 결정됩니다.
+    private func log(_ error: AppError, context: ErrorContext) {
+        let message = """
+        [Error] \(context.feature)/\(context.action)
+        - Error: \(error.errorDescription ?? "Unknown")
+        - Severity: \(error.severity)
+        - Retryable: \(error.isRetryable)
+        """
+
+        switch error.severity {
+        case .info:
+            logger.info("\(message)")
+        case .warning:
+            logger.warning("\(message)")
+        case .critical:
+            logger.error("\(message)")
+        }
+    }
+
+    // MARK: - Analytics
+
+    /// 에러를 외부 분석 서비스로 전송합니다.
+    ///
+    /// - Todo: Firebase Analytics, Sentry 등 연동
+    private func trackError(_ error: AppError, context: ErrorContext) {
+        // TODO: Firebase Analytics, Sentry 등 연동 - [25.01.07] 이재원
+    }
+
+    // MARK: - Special Cases
+
+    // TODO: [Refactor] NotificationCenter → AppState + Environment 패턴으로 리팩터링 예정 - [25.01.07] 이재원
+    // 현재: NotificationCenter 사용 (타입 안전하지 않음)
+    // 개선: AppState를 주입받아 직접 상태 변경 (DIContainer 구현 후)
+
+    /// 특수 에러를 처리합니다.
+    ///
+    /// Alert 표시 대신 앱 전체 상태 변경이 필요한 에러를 처리합니다.
+    ///
+    /// - Parameters:
+    ///   - error: 처리할 에러.
+    ///   - context: 에러 컨텍스트.
+    /// - Returns: 특수 처리가 수행되었으면 `true`.
+    ///
+    /// - Warning: 현재 `NotificationCenter`를 사용합니다. 추후 리팩터링 필요.
+    private func handleSpecialCases(_ error: AppError, context: ErrorContext) -> Bool {
+        switch error {
+        // 인증 만료 → 자동 로그아웃
+        case .auth(.sessionExpired):
+            NotificationCenter.default.post(name: .authSessionExpired, object: nil)
+            return true
+
+        // NetworkError 인증 관련 에러 → 자동 로그아웃
+        case .network(.unauthorized),
+             .network(.tokenRefreshFailed),
+             .network(.noRefreshToken),
+             .network(.maxRetryExceeded):
+            NotificationCenter.default.post(name: .authSessionExpired, object: nil)
+            return true
+
+        // 승인 대기 상태 → 대기 화면으로 이동
+        case .auth(.pendingApproval):
+            NotificationCenter.default.post(name: .navigateToPendingApproval, object: nil)
+            return true
+
+        default:
+            return false
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Handler/Notification+Error.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Handler/Notification+Error.swift
@@ -1,0 +1,30 @@
+//
+//  Notification+Error.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+// MARK: - Error Notification Names
+
+// TODO: [Refactor] AppState 도입 후 제거 예정 - [25.01.07] 이재원
+extension Notification.Name {
+    /// 인증 세션이 만료되었을 때 발송되는 알림.
+    ///
+    /// 이 알림을 받으면 저장된 토큰을 삭제하고 로그인 화면으로 이동해야 합니다.
+    public static let authSessionExpired = Notification.Name("authSessionExpired")
+
+    /// 승인 대기 상태일 때 발송되는 알림.
+    ///
+    /// 이 알림을 받으면 승인 대기 안내 화면으로 이동해야 합니다.
+    public static let navigateToPendingApproval = Notification.Name("navigateToPendingApproval")
+
+    /// 출석 승인/반려 상태 변경 알림.
+    ///
+    /// 운영진이 출석을 승인/반려하면 발송됩니다.
+    /// 챌린저 ViewModel이 수신하여 `myHistory`를 갱신합니다.
+    public static let attendanceStatusChanged = Notification.Name("attendanceStatusChanged")
+
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Handler/PresentableError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Handler/PresentableError.swift
@@ -1,0 +1,64 @@
+//
+//  PresentableError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// View에 표시할 에러 정보
+public struct PresentableError: Identifiable, Equatable {
+    // MARK: - Property
+
+    public let id: UUID
+    public let error: AppError
+    public let context: ErrorContext
+    public let dismissAction: () -> Void
+    public let retryAction: (() async -> Void)?
+
+    // MARK: - Computed Property
+
+    /// Alert 타이틀
+    public var title: String {
+        switch error.severity {
+        case .info:
+            return "알림"
+        case .warning:
+            return "오류"
+        case .critical:
+            return "문제 발생"
+        }
+    }
+
+    /// 사용자에게 표시할 메시지
+    public var message: String {
+        error.userMessage
+    }
+
+    /// 재시도 버튼 표시 여부
+    public var showRetry: Bool {
+        error.isRetryable && retryAction != nil
+    }
+
+    // MARK: - Init
+
+    public init(
+        error: AppError,
+        context: ErrorContext,
+        dismissAction: @escaping () -> Void,
+        retryAction: (() async -> Void)? = nil
+    ) {
+        self.id = UUID()
+        self.error = error
+        self.context = context
+        self.dismissAction = dismissAction
+        self.retryAction = retryAction
+    }
+
+    // MARK: - Equatable
+
+    public static func == (lhs: PresentableError, rhs: PresentableError) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Loadable/Loadable.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Loadable/Loadable.swift
@@ -1,0 +1,227 @@
+//
+//  Loadable.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 비동기 데이터 로딩 상태를 나타내는 열거형.
+///
+/// ViewModel에서 API 호출 결과를 관리할 때 사용합니다.
+/// 단일 데이터 소스의 상태를 명시적으로 표현하여
+/// View에서 각 상태에 맞는 UI를 렌더링할 수 있습니다.
+///
+/// ## Usage
+///
+/// **ViewModel에서 상태 관리:**
+///
+/// ```swift
+/// @Observable
+/// final class NoticeListViewModel {
+///     private(set) var notices: Loadable<[Notice]> = .idle
+///
+///     func fetchNotices() async {
+///         notices = .loading
+///         do {
+///             let result = try await useCase.execute()
+///             notices = .loaded(result)
+///         } catch let error as AppError {
+///             notices = .failed(error)
+///         } catch {
+///             notices = .failed(.unknown(message: error.localizedDescription))
+///         }
+///     }
+/// }
+/// ```
+///
+/// **View에서 상태별 UI 렌더링:**
+///
+/// ```swift
+/// struct NoticeListView: View {
+///     @State private var viewModel: NoticeListViewModel
+///
+///     var body: some View {
+///         switch viewModel.notices {
+///         case .idle:
+///             Color.clear.task { await viewModel.fetchNotices() }
+///         case .loading:
+///             ProgressView()
+///         case .loaded(let notices):
+///             List(notices) { NoticeRow(notice: $0) }
+///         case .failed(let error):
+///             ErrorView(error: error, retryAction: { Task { await viewModel.fetchNotices() } })
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## ErrorHandler vs Loadable 선택 기준
+///
+/// | 기준 | ErrorHandler (Alert) | Loadable (인라인) |
+/// |------|---------------------|-------------------|
+/// | **사용자 액션** | 즉각적인 액션 필요 | 화면 내에서 해결 가능 |
+/// | **작업 흐름** | 중단해야 함 | 유지 가능 |
+/// | **에러 예시** | 세션 만료, 네트워크 오류 | 범위 밖, 이미 제출됨 |
+///
+/// ## 에러 타입별 catch 분기 패턴
+///
+/// ```swift
+/// do {
+///     let result = try await useCase.execute()
+///     state = .loaded(result)
+///
+/// } catch let error as DomainError {
+///     // 도메인 에러 → Loadable (인라인)
+///     state = .failed(.domain(error))
+///
+/// } catch {
+///     // 기타 에러 → ErrorHandler (Alert) + 상태 복구
+///     state = .loaded(initialData)  // 또는 .idle
+///     errorHandler.handle(error, context: ...)
+/// }
+/// ```
+///
+/// - SeeAlso: ``AppError``, ``ErrorHandler``, ``DomainError``
+public enum Loadable<T: Equatable>: Equatable {
+
+    // MARK: - Cases
+
+    /// 초기 상태.
+    ///
+    /// 아직 데이터 로딩이 시작되지 않은 상태입니다.
+    /// View가 나타날 때 `.onAppear`에서 로딩을 시작하는 트리거로 사용합니다.
+    case idle
+
+    /// 로딩 중 상태.
+    ///
+    /// 데이터를 요청 중이며 응답을 기다리는 상태입니다.
+    /// `ProgressView`나 스켈레톤 UI를 표시하세요.
+    case loading
+
+    /// 로딩 성공 상태.
+    ///
+    /// 데이터 로딩이 성공적으로 완료된 상태입니다.
+    ///
+    /// - Parameter value: 로드된 데이터.
+    case loaded(T)
+
+    /// 로딩 실패 상태.
+    ///
+    /// 데이터 로딩 중 에러가 발생한 상태입니다.
+    /// 에러 메시지와 재시도 버튼을 표시하세요.
+    ///
+    /// - Parameter error: 발생한 에러.
+    case failed(AppError)
+
+    // MARK: - Computed Property
+
+    /// 로드된 값.
+    ///
+    /// `.loaded` 상태일 때만 값을 반환하고, 그 외에는 `nil`을 반환합니다.
+    ///
+    /// ```swift
+    /// if let notices = viewModel.notices.value {
+    ///     // notices 사용
+    /// }
+    /// ```
+    public var value: T? {
+        if case .loaded(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    /// 발생한 에러.
+    ///
+    /// `.failed` 상태일 때만 에러를 반환하고, 그 외에는 `nil`을 반환합니다.
+    ///
+    /// ```swift
+    /// if let error = viewModel.notices.error {
+    ///     print(error.errorDescription)
+    /// }
+    /// ```
+    public var error: AppError? {
+        if case .failed(let error) = self {
+            return error
+        }
+        return nil
+    }
+
+    /// 로딩 중 여부.
+    ///
+    /// `ProgressView` 표시 조건으로 사용합니다.
+    ///
+    /// ```swift
+    /// if viewModel.notices.isLoading {
+    ///     ProgressView()
+    /// }
+    /// ```
+    public var isLoading: Bool {
+        if case .loading = self {
+            return true
+        }
+        return false
+    }
+
+    /// 로드 완료 여부.
+    ///
+    /// 성공(`.loaded`) 또는 실패(`.failed`) 상태인지 확인합니다.
+    /// 최초 로딩이 완료되었는지 판단할 때 사용합니다.
+    public var isComplete: Bool {
+        switch self {
+        case .loaded, .failed:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// 초기 상태 여부.
+    ///
+    /// 아직 로딩이 시작되지 않았는지 확인합니다.
+    /// `.task`에서 최초 로딩 트리거 조건으로 사용합니다.
+    ///
+    /// ```swift
+    /// .task {
+    ///     if viewModel.notices.isIdle {
+    ///        await viewModel.fetchNotices()
+    ///     }
+    /// }
+    /// ```
+    public var isIdle: Bool {
+        if case .idle = self {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Mapping
+
+    /// 로드된 값을 다른 타입으로 변환합니다.
+    ///
+    /// 함수형 프로그래밍의 `map` 패턴을 적용하여
+    /// 상태를 유지하면서 내부 값만 변환합니다.
+    ///
+    /// ```swift
+    /// let noticeCount: Loadable<Int> = viewModel.notices.map { $0.count }
+    /// ```
+    ///
+    /// - Parameter transform: 값을 변환하는 클로저.
+    /// - Returns: 변환된 값을 담은 새로운 `Loadable`.
+    ///
+    /// - Note: `.idle`, `.loading`, `.failed` 상태는 그대로 유지됩니다.
+    public func map<U: Equatable>(_ transform: (T) -> U) -> Loadable<U> {
+        switch self {
+        case .idle:
+            return .idle
+        case .loading:
+            return .loading
+        case .loaded(let value):
+            return .loaded(transform(value))
+        case .failed(let error):
+            return .failed(error)
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/LocationError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/LocationError.swift
@@ -1,0 +1,28 @@
+//
+//  LocationError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/6/26.
+//
+
+import Foundation
+
+public enum LocationError: LocalizedError {
+    case notAuthorized
+    case locationFailed(String)
+    case timeout
+    case geocodingFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notAuthorized:
+            return "위치 권한이 필요합니다."
+        case .locationFailed(let message):
+            return "위치를 가져올 수 없습니다. \(message)"
+        case .timeout:
+            return "위치 요청 시간이 초과되었습니다."
+        case .geocodingFailed(let message):
+            return "주소를 가져올 수 없습니다. \(message)"
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/AppError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/AppError.swift
@@ -1,0 +1,151 @@
+//
+//  AppError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 앱 전체에서 사용하는 통합 에러 타입.
+///
+/// 모든 에러를 래핑하여 일관된 처리를 제공합니다.
+/// ViewModel에서 에러 발생 시 이 타입으로 변환하여 처리합니다.
+///
+/// ## Usage
+///
+/// **ViewModel에서 에러 타입별 분기 처리:**
+///
+/// ```swift
+/// @MainActor
+/// func submit() async {
+///     state = .loading
+///
+///     do {
+///         let result = try await useCase.execute()
+///         state = .loaded(result)
+///
+///     } catch let error as DomainError {
+///         // 도메인 에러 → Loadable
+///         state = .failed(.domain(error))
+///
+///     } catch {
+///         // 기타 에러 → ErrorHandler (Alert) + 상태 복구
+///         state = .loaded(initialData)
+///         errorHandler.handle(error, context: .init(
+///             feature: "Feature",
+///             action: "submit",
+///             retryAction: { [weak self] in await self?.submit() }
+///         ))
+///     }
+/// }
+/// ```
+///
+/// **View에서 인라인 에러 표시:**
+///
+/// ```swift
+/// if let error = viewModel.state.error {
+///     Text(error.userMessage)
+///         .foregroundStyle(.red)
+/// }
+/// ```
+///
+/// - SeeAlso: ``ErrorHandler``, ``Loadable``, ``DomainError``
+public enum AppError: Error, LocalizedError, Equatable {
+    /// Repository 계층 에러 (서버 비즈니스 에러)
+    case repository(RepositoryError)
+
+    /// 네트워크 계층 에러 (Actor 기반 NetworkClient)
+    case network(NetworkError)
+
+    /// 입력 유효성 검증 에러
+    case validation(ValidationError)
+
+    /// 인증 관련 에러
+    case auth(AuthError)
+
+    /// 도메인(비즈니스) 에러
+    case domain(DomainError)
+
+    /// 알 수 없는 에러
+    case unknown(message: String)
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .repository(let error):
+            return error.errorDescription
+        case .network(let error):
+            return error.errorDescription
+        case .validation(let error):
+            return error.errorDescription
+        case .auth(let error):
+            return error.errorDescription
+        case .domain(let error):
+            return error.errorDescription
+        case .unknown(let message):
+            return message
+        }
+    }
+
+    // MARK: - User Message
+
+    /// 사용자에게 표시할 친화적 메시지
+    public var userMessage: String {
+        switch self {
+        case .repository(let error):
+            return error.userMessage
+        case .network(let error):
+            return error.userMessage
+        case .validation(let error):
+            return error.userMessage
+        case .auth(let error):
+            return error.userMessage
+        case .domain(let error):
+            return error.userMessage
+        case .unknown:
+            return "일시적인 오류가 발생했습니다. 다시 시도해주세요."
+        }
+    }
+
+    // MARK: - Severity
+
+    /// 에러 심각도 (표시 방식 결정에 사용)
+    public var severity: ErrorSeverity {
+        switch self {
+        case .repository:
+            return .warning
+        case .network(let error):
+            return error.severity
+        case .validation:
+            return .warning
+        case .auth:
+            return .critical
+        case .domain:
+            return .info
+        case .unknown:
+            return .warning
+        }
+    }
+
+    // MARK: - Retryable
+
+    /// 재시도 가능 여부
+    public var isRetryable: Bool {
+        switch self {
+        case .repository(let error):
+            return error.isRetryable
+        case .network(let error):
+            return error.isRetryable
+        case .validation:
+            return false
+        case .auth:
+            return false
+        case .domain:
+            return false
+        case .unknown:
+            return true
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/AuthError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/AuthError.swift
@@ -1,0 +1,86 @@
+//
+//  AuthError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 인증 관련 에러
+public enum AuthError: Error, LocalizedError, Equatable {
+    /// 로그인되지 않음
+    case notLoggedIn
+
+    /// 세션 만료
+    case sessionExpired
+
+    /// 인증 정보 오류 (아이디/비밀번호)
+    case invalidCredentials
+
+    /// 소셜 로그인 실패
+    case socialLoginFailed(provider: String, reason: String?)
+
+    /// 계정 정지
+    case accountSuspended(reason: String?)
+
+    /// 가입 승인 대기 중
+    case pendingApproval
+
+    /// 가입 거절됨
+    case rejected(reason: String?)
+
+    /// 등록되지 않은 사용자 (챌린저로 등록되지 않음)
+    case notRegisteredMember
+
+    /// 인증 코드 오류
+    case invalidVerificationCode
+
+    /// 인증 코드 만료
+    case verificationCodeExpired
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .notLoggedIn:
+            return "로그인이 필요합니다."
+        case .sessionExpired:
+            return "세션이 만료되었습니다."
+        case .invalidCredentials:
+            return "인증 정보가 올바르지 않습니다."
+        case .socialLoginFailed(let provider, let reason):
+            return "\(provider) 로그인 실패\(reason.map { ": \($0)" } ?? "")"
+        case .accountSuspended(let reason):
+            return "계정이 정지되었습니다.\(reason.map { " (\($0))" } ?? "")"
+        case .pendingApproval:
+            return "가입 승인 대기 중입니다."
+        case .rejected(let reason):
+            return "가입이 거절되었습니다.\(reason.map { " (\($0))" } ?? "")"
+        case .notRegisteredMember:
+            return "등록된 챌린저가 아닙니다."
+        case .invalidVerificationCode:
+            return "인증 번호가 올바르지 않습니다."
+        case .verificationCodeExpired:
+            return "인증 번호가 만료되었습니다."
+        }
+    }
+
+    /// 사용자에게 표시할 친화적 메시지
+    public var userMessage: String {
+        switch self {
+        case .sessionExpired:
+            return "다시 로그인해주세요."
+        case .pendingApproval:
+            return "운영진의 승인을 기다리고 있어요."
+        case .notRegisteredMember:
+            return "등록된 챌린저 정보가 없어요. 운영진에게 문의해주세요."
+        case .invalidVerificationCode:
+            return "인증 번호를 다시 확인해주세요."
+        case .verificationCodeExpired:
+            return "인증 번호가 만료되었어요. 다시 요청해주세요."
+        default:
+            return errorDescription ?? ""
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
@@ -1,0 +1,162 @@
+//
+//  DomainError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 도메인(비즈니스 로직) 관련 에러.
+///
+/// UMC 앱의 비즈니스 규칙 위반 시 발생하는 에러입니다.
+/// 일반적으로 **Loadable** 방식으로 처리합니다.
+///
+/// ## 처리 원칙
+///
+/// DomainError는 대부분 **화면을 유지**하면서 사용자에게 안내해야 합니다:
+/// - 출석 범위 밖 → 위치 이동 유도
+/// - 이미 제출됨 → 단순 안내
+/// - 사유 입력 필요 → 입력 유도
+///
+/// ## Usage
+///
+/// **UseCase에서 throw:**
+///
+/// ```swift
+/// func requestGPSAttendance() async throws -> Attendance {
+///     guard locationManager.isInsideGeofence else {
+///         throw DomainError.attendanceOutOfRange
+///     }
+///     // ...
+/// }
+/// ```
+///
+/// **ViewModel에서 catch:**
+///
+/// ```swift
+/// do {
+///     let result = try await useCase.requestGPSAttendance()
+///     state = .loaded(result)
+/// } catch let error as DomainError {
+///     // Loadable로 인라인 표시
+///     state = .failed(.domain(error))
+/// }
+/// ```
+///
+/// **View에서 인라인 표시:**
+///
+/// ```swift
+/// if let error = viewModel.state.error {
+///     Text(error.userMessage)
+///         .font(.caption)
+///         .foregroundStyle(.red)
+/// }
+/// ```
+///
+/// - Important: DomainError는 ErrorHandler가 아닌 Loadable로 처리하세요.
+///   사용자가 화면에서 직접 문제를 해결할 수 있어야 합니다.
+///
+/// - SeeAlso: ``AppError``, ``Loadable``
+public enum DomainError: Error, LocalizedError, Equatable {
+    // MARK: - 공지사항
+
+    /// 공지사항을 찾을 수 없음
+    case noticeNotFound
+
+    /// 공지사항 수정 불가
+    case cannotEditNotice
+
+    // MARK: - 출석
+
+    /// 출석 가능 범위 벗어남 (GPS)
+    case attendanceOutOfRange
+
+    /// 이미 출석 완료
+    case attendanceAlreadySubmitted
+
+    /// 출석 시간 만료
+    case attendanceTimeExpired
+
+    /// 출석 사유 입력 필요
+    case attendanceReasonRequired
+
+    // MARK: - 워크북/과제
+
+    /// 제출 기한 초과
+    case workbookDeadlinePassed
+
+    /// 이미 제출됨
+    case workbookAlreadySubmitted
+
+    /// 미션을 찾을 수 없음
+    case missionNotFound
+
+    /// 미션 링크 입력 필요
+    case missionLinkRequired
+
+    // MARK: - 커리큘럼
+
+    /// 현재 운영 중이 아닌 기수라 커리큘럼 조회 불가
+    case curriculumUnavailableForGeneration
+
+    // MARK: - 커뮤니티
+
+    /// 게시글을 찾을 수 없음
+    case postNotFound
+
+    /// 게시글 삭제 불가
+    case cannotDeletePost
+
+    // MARK: - 권한
+
+    /// 권한 부족
+    case insufficientPermission(required: String)
+
+    // MARK: - 기타
+
+    /// 커스텀 에러 메시지
+    case custom(message: String)
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .noticeNotFound:
+            return "공지사항을 찾을 수 없습니다."
+        case .cannotEditNotice:
+            return "공지사항을 수정할 수 없습니다."
+        case .attendanceOutOfRange:
+            return "출석 가능 범위를 벗어났습니다."
+        case .attendanceAlreadySubmitted:
+            return "이미 출석을 완료했습니다."
+        case .attendanceTimeExpired:
+            return "출석 시간이 지났습니다."
+        case .attendanceReasonRequired:
+            return "출석 사유를 입력해주세요."
+        case .workbookDeadlinePassed:
+            return "제출 기한이 지났습니다."
+        case .workbookAlreadySubmitted:
+            return "이미 제출한 워크북입니다."
+        case .missionNotFound:
+            return "미션을 찾을 수 없습니다."
+        case .missionLinkRequired:
+            return "링크를 입력해주세요."
+        case .curriculumUnavailableForGeneration:
+            return "현재 운영중인 기수가 아니어서 커리큘럼을 조회할 수 없습니다."
+        case .postNotFound:
+            return "게시글을 찾을 수 없습니다."
+        case .cannotDeletePost:
+            return "게시글을 삭제할 수 없습니다."
+        case .insufficientPermission(let required):
+            return "\(required) 권한이 필요합니다."
+        case .custom(let message):
+            return message
+        }
+    }
+
+    /// 사용자에게 표시할 메시지
+    public var userMessage: String {
+        errorDescription ?? ""
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/ErrorSeverity.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/ErrorSeverity.swift
@@ -1,0 +1,21 @@
+//
+//  ErrorSeverity.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 에러 심각도
+/// - 표시 방식 결정에 사용
+public enum ErrorSeverity {
+    /// 정보성 알림 (Toast로 표시)
+    case info
+
+    /// 경고 (Alert로 표시)
+    case warning
+
+    /// 심각 (강제 액션 필요 - 로그아웃 등)
+    case critical
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/NetworkError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/NetworkError.swift
@@ -1,0 +1,244 @@
+//
+//  NetworkError.swift
+//  UMCFoundation
+//
+//  Created by euijjang97 on 1/9/26.
+//
+
+import Foundation
+
+// MARK: - NetworkError
+
+/// 네트워크 계층에서 발생하는 모든 에러를 정의하는 열거형입니다.
+///
+/// NetworkClient, TokenStore, TokenRefreshService에서 발생 가능한 에러를 타입 안전하게 표현합니다.
+///
+/// - Important:
+///   - **Sendable**: Actor 간 안전한 에러 전파
+///   - **Equatable**: Loadable<T: Equatable> 상태 관리 지원
+///   - **LocalizedError**: 사용자 친화적 에러 메시지 제공
+///
+/// - Usage:
+/// ```swift
+/// do {
+///     let data = try await networkClient.request(urlRequest)
+/// } catch NetworkError.unauthorized {
+///     // 로그아웃 처리
+/// } catch NetworkError.tokenRefreshFailed {
+///     // 재로그인 유도
+/// } catch NetworkError.requestFailed(let statusCode, _) {
+///     // 서버 에러 처리
+/// }
+/// ```
+public enum NetworkError: Error, Sendable, Equatable {
+    // MARK: - Cases
+
+    /// 인증이 필요한 요청에 토큰이 없음 (401 Unauthorized)
+    ///
+    /// - 발생 시점: 로그인하지 않은 상태에서 인증 필요 API 호출
+    /// - 해결 방법: 로그인 화면으로 이동
+    case unauthorized
+
+    /// 리프레시 토큰을 사용한 토큰 갱신 실패
+    ///
+    /// - Parameter reason: 갱신 실패 원인 설명 (네트워크 에러, 서버 에러 등)
+    ///
+    /// - 발생 시점:
+    ///   - 리프레시 토큰 만료
+    ///   - 서버 토큰 갱신 API 호출 실패
+    ///   - 네트워크 연결 끊김
+    ///
+    /// - 해결 방법: 재로그인 필요
+    ///
+    /// - Note: Equatable 준수를 위해 Error? → String?로 변경
+    case tokenRefreshFailed(reason: String?)
+
+    /// 저장소에 리프레시 토큰이 없음
+    ///
+    /// - 발생 시점:
+    ///   - 로그아웃 상태
+    ///   - Keychain 데이터 손실
+    ///
+    /// - 해결 방법: 로그인 화면으로 이동
+    case noRefreshToken
+
+    /// API 요청 실패 (2xx 이외의 상태 코드)
+    ///
+    /// - Parameters:
+    ///   - statusCode: HTTP 상태 코드 (400, 403, 404, 500 등)
+    ///   - data: 서버 응답 데이터 (에러 메시지 파싱 가능)
+    ///
+    /// - 발생 시점:
+    ///   - 잘못된 요청 (400 Bad Request)
+    ///   - 권한 없음 (403 Forbidden)
+    ///   - 리소스 없음 (404 Not Found)
+    ///   - 서버 에러 (500 Internal Server Error)
+    ///
+    /// - 해결 방법: 상태 코드별 적절한 에러 처리
+    ///
+    /// - Note: Data는 Equatable이 아니므로 비교 시 제외
+    case requestFailed(statusCode: Int, data: Data?)
+
+    /// 서버 응답이 HTTPURLResponse가 아님
+    ///
+    /// - 발생 시점: 네트워크 설정 오류, 프록시 에러 등
+    /// - 해결 방법: 네트워크 연결 확인
+    case invalidResponse
+
+    /// 토큰 갱신 재시도 횟수 초과
+    ///
+    /// - 발생 시점: 401 에러 발생 후 재시도 횟수(기본 1회) 초과
+    /// - 해결 방법: 재로그인 필요
+    case maxRetryExceeded
+
+    /// 네트워크 연결 없음
+    ///
+    /// - 발생 시점: 인터넷 연결이 끊긴 상태에서 API 호출
+    /// - 해결 방법: 네트워크 연결 확인 후 재시도
+    case noNetwork
+
+    /// 요청 시간 초과
+    ///
+    /// - 발생 시점: 서버 응답이 timeout 시간 내에 오지 않음
+    /// - 해결 방법: 네트워크 상태 확인 후 재시도
+    case timeout
+
+    // MARK: - Equatable
+
+    /// Equatable 비교 구현
+    ///
+    /// - Note: requestFailed의 Data는 비교에서 제외 (Equatable 아님)
+    public static func == (lhs: NetworkError, rhs: NetworkError) -> Bool {
+        switch (lhs, rhs) {
+        case (.unauthorized, .unauthorized):
+            return true
+        case (.tokenRefreshFailed(let lReason), .tokenRefreshFailed(let rReason)):
+            return lReason == rReason
+        case (.noRefreshToken, .noRefreshToken):
+            return true
+        case (.requestFailed(let lCode, _), .requestFailed(let rCode, _)):
+            return lCode == rCode  // Data는 비교 제외
+        case (.invalidResponse, .invalidResponse):
+            return true
+        case (.maxRetryExceeded, .maxRetryExceeded):
+            return true
+        case (.noNetwork, .noNetwork):
+            return true
+        case (.timeout, .timeout):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - NetworkError + LocalizedError
+
+extension NetworkError: LocalizedError {
+    /// 사용자에게 표시할 에러 메시지를 반환합니다.
+    ///
+    /// - Returns: 에러 유형에 맞는 한글 에러 메시지
+    public var errorDescription: String? {
+        switch self {
+        case .unauthorized:
+            return "인증이 필요합니다."
+        case .tokenRefreshFailed(let reason):
+            return "토큰 갱신 실패: \(reason ?? "알 수 없음")"
+        case .noRefreshToken:
+            return "리프레시 토큰이 없습니다."
+        case .requestFailed(let statusCode, _):
+            return "요청 실패 status: \(statusCode)"
+        case .invalidResponse:
+            return "잘못된 서버 응답"
+        case .maxRetryExceeded:
+            return "최대 재시도 횟수 초과"
+        case .noNetwork:
+            return "네트워크 연결이 없습니다."
+        case .timeout:
+            return "요청 시간이 초과되었습니다."
+        }
+    }
+
+    /// 사용자에게 표시할 친화적 메시지
+    ///
+    /// ErrorHandler와의 일관성을 위해 제공됩니다.
+    public var userMessage: String {
+        switch self {
+        case .unauthorized:
+            return "로그인이 필요합니다."
+        case .tokenRefreshFailed, .noRefreshToken, .maxRetryExceeded:
+            return "세션이 만료되었습니다. 다시 로그인해주세요."
+        case .requestFailed(let statusCode, let data):
+            if let serverMessage = Self.parseServerMessage(from: data) {
+                return serverMessage
+            }
+            switch statusCode {
+            case 400...499:
+                return "요청을 처리할 수 없습니다. 다시 시도해주세요."
+            case 500...599:
+                return "서버에 일시적인 오류가 발생했습니다."
+            default:
+                return "네트워크 연결이 원활하지 않습니다."
+            }
+        case .invalidResponse:
+            return "네트워크 연결이 원활하지 않습니다."
+        case .noNetwork:
+            return "인터넷 연결을 확인해주세요."
+        case .timeout:
+            return "서버 응답이 늦어지고 있어요. 잠시 후 다시 시도해주세요."
+        }
+    }
+
+    /// 서버 응답 데이터에서 에러 메시지를 추출합니다.
+    private static func parseServerMessage(from data: Data?) -> String? {
+        guard let data else { return nil }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let message = json["message"] as? String,
+              !message.isEmpty else {
+            return nil
+        }
+        return message
+    }
+
+    /// 에러 심각도
+    ///
+    /// 로깅 및 알림 우선순위 결정에 사용됩니다.
+    public var severity: ErrorSeverity {
+        switch self {
+        case .unauthorized, .tokenRefreshFailed, .noRefreshToken, .maxRetryExceeded:
+            return .critical  // 즉시 로그아웃/재로그인 필요
+        case .requestFailed(let statusCode, _):
+            switch statusCode {
+            case 500...599:
+                return .critical  // 서버 에러
+            default:
+                return .warning   // 클라이언트 에러
+            }
+        case .invalidResponse:
+            return .warning
+        case .noNetwork, .timeout:
+            return .warning
+        }
+    }
+
+    /// 재시도 가능 여부
+    ///
+    /// ErrorHandler의 재시도 버튼 표시 여부 결정에 사용됩니다.
+    public var isRetryable: Bool {
+        switch self {
+        case .unauthorized, .tokenRefreshFailed, .noRefreshToken, .maxRetryExceeded:
+            return false  // 로그인 필요
+        case .requestFailed(let statusCode, _):
+            switch statusCode {
+            case 500...599:
+                return true  // 서버 에러는 재시도 가능
+            default:
+                return false // 클라이언트 에러는 재시도 불가
+            }
+        case .invalidResponse:
+            return true  // 네트워크 연결 재시도 가능
+        case .noNetwork, .timeout:
+            return true
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/RepositoryError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/RepositoryError.swift
@@ -1,0 +1,78 @@
+//
+//  RepositoryError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 2/3/26.
+//
+
+import Foundation
+
+/// Repository 계층에서 발생하는 에러
+///
+/// 서버 응답의 `isSuccess: false` 또는 데이터 변환 실패 시 발생합니다.
+///
+/// ## 사용 예시
+/// ```swift
+/// func getUser() async throws -> User {
+///     let response = try await adapter.request(UserAPI.getMe)
+///     let dto = try JSONDecoder().decode(CommonDTO<UserDTO>.self, from: response.data)
+///
+///     guard dto.isSuccess, let userDTO = dto.result else {
+///         throw RepositoryError.serverError(code: dto.code, message: dto.message)
+///     }
+///
+///     return userDTO.toDomain()
+/// }
+/// ```
+public enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
+
+    // MARK: - Cases
+
+    /// 서버에서 실패 응답 반환 (isSuccess: false)
+    ///
+    /// - Parameters:
+    ///   - code: 에러 코드 (e.g., "AUTH001", "USER404")
+    ///   - message: 에러 메시지
+    case serverError(code: String?, message: String?)
+
+    /// 응답 데이터 디코딩 실패
+    case decodingError(detail: String?)
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .serverError(_, let message):
+            return message ?? "서버 오류가 발생했습니다"
+        case .decodingError(let detail):
+            return "데이터 파싱 실패: \(detail ?? "알 수 없는 오류")"
+        }
+    }
+
+    // MARK: - Properties
+
+    /// 에러 코드 (서버 에러인 경우)
+    public var code: String? {
+        switch self {
+        case .serverError(let code, _):
+            return code
+        default:
+            return nil
+        }
+    }
+
+    /// 사용자에게 표시할 메시지
+    public var userMessage: String {
+        errorDescription ?? "알 수 없는 오류가 발생했습니다"
+    }
+
+    /// 재시도 가능 여부
+    public var isRetryable: Bool {
+        switch self {
+        case .serverError:
+            return true
+        case .decodingError:
+            return false
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/ValidationError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/ValidationError.swift
@@ -1,0 +1,58 @@
+//
+//  ValidationError.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/7/25.
+//
+
+import Foundation
+
+/// 입력 유효성 검증 에러
+public enum ValidationError: Error, LocalizedError, Equatable {
+    /// 필수 입력값 누락
+    case empty(field: String)
+
+    /// 형식 오류 (이메일, 전화번호 등)
+    case invalidFormat(field: String, expected: String)
+
+    /// 최소 길이 미달
+    case tooShort(field: String, minLength: Int)
+
+    /// 최대 길이 초과
+    case tooLong(field: String, maxLength: Int)
+
+    /// 유효하지 않은 값
+    case invalidValue(field: String, reason: String)
+
+    /// 두 필드 값 불일치 (비밀번호 확인 등)
+    case mismatch(field1: String, field2: String)
+
+    /// 이미 사용 중인 값 (이메일 등)
+    case alreadyInUse(field: String)
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .empty(let field):
+            return "\(field)을(를) 입력해주세요."
+        case .invalidFormat(let field, let expected):
+            return "\(field)의 형식이 올바르지 않습니다. (\(expected))"
+        case .tooShort(let field, let minLength):
+            return "\(field)은(는) 최소 \(minLength)자 이상이어야 합니다."
+        case .tooLong(let field, let maxLength):
+            return "\(field)은(는) \(maxLength)자를 초과할 수 없습니다."
+        case .invalidValue(let field, let reason):
+            return "\(field): \(reason)"
+        case .mismatch(let field1, let field2):
+            return "\(field1)와(과) \(field2)이(가) 일치하지 않습니다."
+        case .alreadyInUse(let field):
+            return "이미 사용 중인 \(field)입니다."
+        }
+    }
+
+    /// 사용자에게 표시할 메시지 (errorDescription과 동일)
+    public var userMessage: String {
+        errorDescription ?? ""
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/ActivityDomain.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/ActivityDomain.swift
@@ -1,1 +1,0 @@
-public protocol ActivityUseCase {}

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceStatus.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceStatus.swift
@@ -1,0 +1,52 @@
+//
+//  AttendanceStatus.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+public enum AttendanceStatus: String, CaseIterable {
+    case beforeAttendance = "pending"
+    case pendingApproval
+    case present
+    case late
+    case absent
+
+    /// 배지/버튼에 표시할 텍스트
+    public var displayText: String {
+        switch self {
+        case .beforeAttendance: return "출석 전"
+        case .pendingApproval: return "승인 대기"
+        case .present: return "출석"
+        case .late: return "지각"
+        case .absent: return "결석"
+        }
+    }
+}
+
+// MARK: - Server Status Mapping
+extension AttendanceStatus {
+    /// 서버 API 상태 문자열 → Domain enum 변환
+    ///
+    /// - Parameter serverStatus: 서버 응답 status 필드
+    ///   (e.g., "PRESENT", "LATE", "ABSENT", "PENDING",
+    ///    "PRESENT_PENDING", "LATE_PENDING", "EXCUSED",
+    ///    "EXCUSED_PENDING")
+    public init(serverStatus: String) {
+        switch serverStatus {
+        case "PRESENT", "EXCUSED": self = .present
+        case "LATE": self = .late
+        case "ABSENT": self = .absent
+        case "PENDING": self = .beforeAttendance
+        case "PRESENT_PENDING", "LATE_PENDING", "EXCUSED_PENDING": self = .pendingApproval
+        default:
+            if serverStatus.hasSuffix("_PENDING") {
+                self = .pendingApproval
+            } else {
+                self = .beforeAttendance
+            }
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceTimeWindow.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceTimeWindow.swift
@@ -1,0 +1,25 @@
+//
+//  AttendanceTimeWindow.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 출석 시간대 상태 (시간 체크 전용)
+///
+/// `isWithinAttendanceTime(session:)`에서 현재 시간이 어느 시간대에 속하는지 반환합니다.
+public enum AttendanceTimeWindow {
+    /// 출석 시간 전 (아직 출석 체크 불가)
+    case tooEarly
+
+    /// 정시 출석 가능 시간대 (GPS 출석 가능)
+    case onTime
+
+    /// 지각 시간대 (사유 제출 필요)
+    case lateWindow
+
+    /// 마감됨 (결석 사유 제출 필요)
+    case expired
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/MyAttendanceItemStatus.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/MyAttendanceItemStatus.swift
@@ -1,0 +1,39 @@
+//
+//  MyAttendanceItemStatus.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+public enum MyAttendanceItemStatus: Equatable {
+    case pendingApproval
+    case present
+    case late
+    case absent
+
+    /// 배지/버튼에 표시할 텍스트
+    public var text: String {
+        switch self {
+        case .pendingApproval: return "승인 대기"
+        case .present: return "출석"
+        case .late: return "지각"
+        case .absent: return "결석"
+        }
+    }
+}
+
+extension MyAttendanceItemStatus {
+    /// AttendanceStatus에서 변환
+    /// - Note: beforeAttendance 상태는 nil 반환 (리스트에 표시 안함)
+    public init?(from status: AttendanceStatus) {
+        switch status {
+        case .pendingApproval: self = .pendingApproval
+        case .present: self = .present
+        case .late: self = .late
+        case .absent: self = .absent
+        case .beforeAttendance: return nil
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/Attendance.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/Attendance.swift
@@ -1,0 +1,79 @@
+//
+//  Attendance.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 출석 Domain 핵심 엔티티
+///
+/// GPS 출석과 사유 출석을 모두 표현하며,
+/// 불변 값 타입으로 상태 변경 시 `copy` 기반 빌더 메서드를 제공합니다.
+public struct Attendance: Identifiable, Equatable {
+    public let id: UUID
+    public let sessionId: SessionID
+    public let userId: UserID
+    public let type: AttendanceType
+    public let status: AttendanceStatus
+    public let locationVerification: LocationVerification?
+    public let reason: String?
+    public let createdAt: Date
+
+    public init(
+        id: UUID = .init(),
+        sessionId: SessionID,
+        userId: UserID,
+        type: AttendanceType,
+        status: AttendanceStatus,
+        locationVerification: LocationVerification? = nil,
+        reason: String? = nil,
+        createdAt: Date = .now
+    ) {
+        self.id = id
+        self.sessionId = sessionId
+        self.userId = userId
+        self.type = type
+        self.status = status
+        self.locationVerification = locationVerification
+        self.reason = reason
+        self.createdAt = createdAt
+    }
+
+    public func approved(with verification: LocationVerification) -> Self {
+        copy(status: .present, locationVerification: verification)
+    }
+
+    public func beforeAttendance() -> Self {
+        copy(status: .beforeAttendance)
+    }
+
+    public func rejected(status: AttendanceStatus) -> Self {
+        copy(status: status)
+    }
+
+    public func late(reason: String) -> Self {
+        copy(status: .late, reason: reason)
+    }
+
+    public func absent(reason: String) -> Self {
+        copy(status: .absent, reason: reason)
+    }
+
+    private func copy(
+        type: AttendanceType? = nil,
+        status: AttendanceStatus? = nil,
+        reason: String? = nil,
+        locationVerification: LocationVerification? = nil
+    ) -> Self {
+        .init(
+            sessionId: self.sessionId,
+            userId: self.userId,
+            type: type ?? self.type,
+            status: status ?? self.status,
+            locationVerification: locationVerification ?? self.locationVerification,
+            reason: reason ?? self.reason
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceHistoryItem.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceHistoryItem.swift
@@ -1,0 +1,50 @@
+//
+//  AttendanceHistoryItem.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+/// 출석 이력 항목 Domain 모델
+///
+/// `GET /api/v1/attendances/history` 및
+/// `GET /api/v1/attendances/challenger/{challengerId}/history` 응답 매핑
+
+import Foundation
+
+public struct AttendanceHistoryItem: Equatable, Identifiable {
+    public let id: UUID
+    public let attendanceId: Int
+    public let scheduleId: Int
+    public let scheduleName: String
+    public let tags: [String]
+    public let scheduledDate: String
+    public let startTime: String
+    public let endTime: String
+    public let status: AttendanceStatus
+    public let statusDisplay: String
+
+    public init(
+        id: UUID = .init(),
+        attendanceId: Int,
+        scheduleId: Int,
+        scheduleName: String,
+        tags: [String],
+        scheduledDate: String,
+        startTime: String,
+        endTime: String,
+        status: AttendanceStatus,
+        statusDisplay: String
+    ) {
+        self.id = id
+        self.attendanceId = attendanceId
+        self.scheduleId = scheduleId
+        self.scheduleName = scheduleName
+        self.tags = tags
+        self.scheduledDate = scheduledDate
+        self.startTime = startTime
+        self.endTime = endTime
+        self.status = status
+        self.statusDisplay = statusDisplay
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendancePolicy.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendancePolicy.swift
@@ -1,0 +1,23 @@
+//
+//  AttendancePolicy.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+import CoreLocation
+
+/// 출석 정책 상수
+///
+/// GPS 출석의 지오펜스 반경과 시간 기준(정시/지각/결석)을 정의합니다.
+public enum AttendancePolicy {
+    /// GPS 출석 유효 반경 (미터)
+    public static let geofenceRadius: CLLocationDistance = 50.0
+
+    /// 정시 출석 허용 시간 (분) — 세션 시작 후 이 시간 내 출석 시 '출석'
+    public static let onTimeThresholdMinutes: Int = 10
+
+    /// 지각 허용 시간 (분) — 정시 이후 이 시간 내 출석 시 '지각'
+    public static let lateThresholdMinutes: Int = 30
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceRecord.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceRecord.swift
@@ -1,0 +1,34 @@
+//
+//  AttendanceRecord.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+/// 출석 기록 상세 Domain 모델
+///
+/// `GET /api/v1/attendances/{recordId}` 응답 매핑
+
+import Foundation
+
+public struct AttendanceRecord: Equatable, Identifiable {
+    public let id: Int
+    public let attendanceSheetId: Int
+    public let memberId: String
+    public let status: AttendanceStatus
+    public let memo: String?
+
+    public init(
+        id: Int,
+        attendanceSheetId: Int,
+        memberId: String,
+        status: AttendanceStatus,
+        memo: String?
+    ) {
+        self.id = id
+        self.attendanceSheetId = attendanceSheetId
+        self.memberId = memberId
+        self.status = status
+        self.memo = memo
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceType.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceType.swift
@@ -1,0 +1,19 @@
+//
+//  AttendanceType.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 출석 방식
+///
+/// GPS 위치 인증 출석과 사유 기반 출석 두 가지를 구분합니다.
+public enum AttendanceType: String {
+    /// GPS 위치 인증을 통한 출석
+    case gps
+
+    /// 사유 제출을 통한 출석 (지각/결석 사유)
+    case reason
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AvailableAttendanceSchedule.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AvailableAttendanceSchedule.swift
@@ -1,0 +1,52 @@
+//
+//  AvailableAttendanceSchedule.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+/// 출석 가능 일정 Domain 모델
+///
+/// `GET /api/v1/attendances/available` 응답 매핑
+
+import Foundation
+
+public struct AvailableAttendanceSchedule: Equatable, Identifiable {
+    public let id: UUID
+    public let scheduleId: Int
+    public let scheduleName: String
+    public let tags: [String]
+    public let startTime: String
+    public let endTime: String
+    public let sheetId: Int
+    public let recordId: Int?
+    public let status: AttendanceStatus
+    public let statusDisplay: String
+    public let locationVerified: Bool
+
+    public init(
+        id: UUID = .init(),
+        scheduleId: Int,
+        scheduleName: String,
+        tags: [String],
+        startTime: String,
+        endTime: String,
+        sheetId: Int,
+        recordId: Int?,
+        status: AttendanceStatus,
+        statusDisplay: String,
+        locationVerified: Bool
+    ) {
+        self.id = id
+        self.scheduleId = scheduleId
+        self.scheduleName = scheduleName
+        self.tags = tags
+        self.startTime = startTime
+        self.endTime = endTime
+        self.sheetId = sheetId
+        self.recordId = recordId
+        self.status = status
+        self.statusDisplay = statusDisplay
+        self.locationVerified = locationVerified
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/LocationVerification.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/LocationVerification.swift
@@ -1,0 +1,30 @@
+//
+//  LocationVerification.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// GPS 출석 위치 인증 결과
+///
+/// 사용자의 GPS 좌표가 세션 장소 지오펜스 내에 있는지 검증한 결과를 담습니다.
+public struct LocationVerification: Equatable {
+    public let isVerified: Bool
+    public let coordinate: Coordinate
+    public let address: Address
+    public let verifiedAt: Date
+
+    public init(
+        isVerified: Bool,
+        coordinate: Coordinate,
+        address: Address,
+        verifiedAt: Date
+    ) {
+        self.isVerified = isVerified
+        self.coordinate = coordinate
+        self.address = address
+        self.verifiedAt = verifiedAt
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/MemberAttendanceRecord.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/MemberAttendanceRecord.swift
@@ -1,0 +1,38 @@
+//
+//  MemberAttendanceRecord.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+/// 멤버 출석/활동 기록
+///
+/// 멤버 상세 화면에서 출석 이력을 표시하기 위한 모델입니다.
+/// SessionInfo의 title과 Attendance 정보를 포함합니다.
+
+import Foundation
+
+public struct MemberAttendanceRecord: Identifiable, Equatable {
+    public let id: UUID
+
+    /// 세션 제목
+    public let sessionTitle: String
+
+    /// 주차 (예: 1, 2, 3...)
+    public let week: Int
+
+    /// 출석 정보
+    public let status: AttendanceStatus
+
+    public init(
+        id: UUID = UUID(),
+        sessionTitle: String,
+        week: Int,
+        status: AttendanceStatus
+    ) {
+        self.id = id
+        self.sessionTitle = sessionTitle
+        self.week = week
+        self.status = status
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/PendingAttendanceRecord.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/PendingAttendanceRecord.swift
@@ -1,0 +1,48 @@
+//
+//  PendingAttendanceRecord.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 승인 대기 출석 항목 Domain 모델
+///
+/// `GET /api/v1/attendances/pending/{scheduleId}` 응답 매핑
+public struct PendingAttendanceRecord: Equatable, Identifiable {
+    public let id: UUID
+    public let attendanceId: Int
+    public let memberId: String
+    public let memberName: String
+    public let nickname: String
+    public let profileImageLink: URL?
+    public let schoolName: String
+    public let status: AttendanceStatus
+    public let reason: String?
+    public let requestedAt: Date
+
+    public init(
+        id: UUID = .init(),
+        attendanceId: Int,
+        memberId: String,
+        memberName: String,
+        nickname: String,
+        profileImageLink: URL?,
+        schoolName: String,
+        status: AttendanceStatus,
+        reason: String?,
+        requestedAt: Date
+    ) {
+        self.id = id
+        self.attendanceId = attendanceId
+        self.memberId = memberId
+        self.memberName = memberName
+        self.nickname = nickname
+        self.profileImageLink = profileImageLink
+        self.schoolName = schoolName
+        self.status = status
+        self.reason = reason
+        self.requestedAt = requestedAt
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Identifier/Identifier.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Identifier/Identifier.swift
@@ -1,0 +1,43 @@
+//
+//  Identifier.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+// MARK: - Identifier
+// 서버 API 통신용 식별자 타입들
+// - 타입 안전성: String 간 혼동 방지 (SessionID vs UserID)
+// - SwiftUI Identifiable용 UUID와는 별개 (UUID는 ForEach/List diffing 전용)
+
+/// 세션(스터디/세미나) 식별자
+/// - 출석 요청, 세션 조회 등 서버 API 호출 시 사용
+public struct SessionID: Hashable, Codable {
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+}
+
+/// 사용자 식별자
+/// - 출석 요청, 사용자 정보 조회 등 서버 API 호출 시 사용
+public struct UserID: Hashable, Codable {
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+}
+
+/// 출석 기록 식별자
+/// - 출석 상태 변경, 출석 기록 조회 등 서버 API 호출 시 사용
+public struct AttendanceID: Hashable, Codable {
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Map/Address.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Map/Address.swift
@@ -1,0 +1,23 @@
+//
+//  Address.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 주소 정보
+///
+/// 지오코딩 결과로 얻은 주소를 전체/시/구 단위로 구분하여 저장합니다.
+public struct Address: Equatable {
+    public let fullAddress: String
+    public let city: String
+    public let district: String
+
+    public init(fullAddress: String, city: String, district: String) {
+        self.fullAddress = fullAddress
+        self.city = city
+        self.district = district
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Map/Coordinate.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Map/Coordinate.swift
@@ -1,0 +1,21 @@
+//
+//  Coordinate.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 위경도 좌표
+///
+/// GPS 출석, 지도 표시 등에서 사용하는 위치 좌표 값 타입입니다.
+public struct Coordinate: Hashable, Codable, Sendable {
+    public let latitude: Double
+    public let longitude: Double
+
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Map/Geofence.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Map/Geofence.swift
@@ -1,0 +1,22 @@
+//
+//  Geofence.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+import CoreLocation
+
+/// 지오펜스 영역
+///
+/// 세션 장소를 중심으로 한 원형 영역으로, GPS 출석 유효 범위를 정의합니다.
+public struct Geofence {
+    public let center: Coordinate
+    public let radiusInMeters: CLLocationDistance
+
+    public init(center: Coordinate, radiusInMeters: CLLocationDistance) {
+        self.center = center
+        self.radiusInMeters = radiusInMeters
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorPendingMember.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorPendingMember.swift
@@ -1,0 +1,72 @@
+//
+//  OperatorPendingMember.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 승인 대기 중인 멤버 정보
+///
+/// 출석 승인을 기다리고 있는 멤버의 정보를 담습니다.
+public struct OperatorPendingMember: Identifiable, Equatable {
+    public let id: UUID
+    public let serverID: String?
+    public let name: String
+    public let nickname: String?
+    public let university: String
+    public let requestTime: Date
+    public let reason: String?
+    public let profileImageURL: String?
+
+    public init(
+        id: UUID = .init(),
+        serverID: String? = nil,
+        name: String,
+        nickname: String? = nil,
+        university: String,
+        requestTime: Date,
+        reason: String? = nil,
+        profileImageURL: String? = nil
+    ) {
+        self.id = id
+        self.serverID = serverID
+        self.name = name
+        self.nickname = nickname
+        self.university = university
+        self.requestTime = requestTime
+        self.reason = reason
+        self.profileImageURL = profileImageURL
+    }
+
+    /// 사유가 있는지 여부
+    public var hasReason: Bool {
+        reason != nil && !(reason?.isEmpty ?? true)
+    }
+
+    /// 표시용 이름 (닉네임/이름 또는 이름만)
+    public var displayName: String {
+        if let nickname = nickname {
+            return "\(nickname)/\(name)"
+        }
+        return name
+    }
+}
+
+// MARK: - Domain → Presentation 변환
+
+extension OperatorPendingMember {
+    /// PendingAttendanceRecord(Domain) → OperatorPendingMember(Presentation) 변환
+    public init(from record: PendingAttendanceRecord) {
+        self.init(
+            serverID: String(record.attendanceId),
+            name: record.memberName,
+            nickname: record.nickname,
+            university: record.schoolName,
+            requestTime: record.requestedAt,
+            reason: record.reason,
+            profileImageURL: record.profileImageLink?.absoluteString
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceStats.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceStats.swift
@@ -1,0 +1,49 @@
+//
+//  ScheduleAttendanceStats.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 4/14/26.
+//
+
+import Foundation
+
+/// 일정별 출석 통계
+///
+/// `GET /api/v1/schedules` 응답에서 출석 집계 필드만 추출한 모델.
+/// `attendanceRate`는 0.0-1.0 범위 (DTO에서 변환 완료).
+public struct ScheduleAttendanceStats: Equatable, Sendable {
+    public let scheduleId: Int
+    public let name: String
+    public let date: String
+    public let startTime: String
+    public let endTime: String
+    public let locationName: String
+    public let totalCount: Int
+    public let presentCount: Int
+    public let pendingCount: Int
+    public let attendanceRate: Double
+
+    public init(
+        scheduleId: Int,
+        name: String,
+        date: String,
+        startTime: String,
+        endTime: String,
+        locationName: String,
+        totalCount: Int,
+        presentCount: Int,
+        pendingCount: Int,
+        attendanceRate: Double
+    ) {
+        self.scheduleId = scheduleId
+        self.name = name
+        self.date = date
+        self.startTime = startTime
+        self.endTime = endTime
+        self.locationName = locationName
+        self.totalCount = totalCount
+        self.presentCount = presentCount
+        self.pendingCount = pendingCount
+        self.attendanceRate = attendanceRate
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

♻️ 리팩토링 — `refactor/589` 브랜치에 머지된 #605 변경사항을 develop으로 반영 (#628 위에 stack)

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (Domain 모델 이관)

## 🛠️ 작업내용

#605 (`refactor/590 → refactor/589`)에서 머지된 변경사항을 develop으로 통합합니다.

- Attendance 관련 도메인 모델/열거형 18개 파일을 `ActivityDomain` Tuist 모듈로 이관
- SwiftUI 의존성 완전 제거 (`AttendanceStatus`, `MyAttendanceItemStatus`의 Color 프로퍼티)
- `memberId` 타입을 `Int` → `String`으로 변경 (서버 응답 타입과 일치)
- `SessionID`, `UserID`, `AttendanceID` 강타입 Identifier wrapper 이관
- 보조 타입 함께 이관: `Coordinate`, `Address`, `Geofence`, `OperatorPendingMember`
- `MyAttendanceItemModel`, `OperatorSessionAttendance`는 Session 의존으로 제외 (#604)
- 총 19개 파일, 719줄 추가

resolves #590

## 📋 추후 진행 상황

- [ ] #604 — Session 모델 + 잔여 Attendance 모델 ActivityDomain 이관
- [ ] Color 매핑 Presentation extension 복원 (#604에 포함)
- [ ] Identifier 타입 UMCFoundation 승격 검토 (크로스 Feature 사용 시)
- [ ] `AlertPrompt` + `View.alertPrompt(item:)` 이관 (별도 티켓)

## 🔗 머지 의존성

이 PR은 #628 (`refactor/588 → develop`, Loadable + ErrorHandler 이관) 위에 stack 되어 있습니다.

머지 순서: **#628 → #629** 순서로 Squash and Merge 권장
- #628 머지 후 develop이 업데이트되면, GitHub이 본 PR의 diff를 자동 재계산하여 Attendance Domain 19개 파일만 남게 됩니다.

## 📌 리뷰 포인트

- `Domain/Sources/Enums/Attendance/` — SwiftUI Color 프로퍼티 제거가 적절한지
- `Domain/Sources/Models/Attendance/AttendanceRecord.swift`, `PendingAttendanceRecord.swift` — `memberId: Int → String` 타입 변경
- `Domain/Sources/Models/Identifier/Identifier.swift` — 강타입 ID wrapper 구조
- 모든 타입의 `public` 접근제어자 + `public init` 적용 확인

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] develop과 머지 충돌 없음 (사전 dry-run 검증)