### PR TITLE
♻️ [Refactor] CoreNetwork JWT 인증 NetworkClient 도입 + 공통 응답/빌드 설정 통합 (#597)

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
@@ -79,7 +79,7 @@ final class NoticeViewModel {
     var isFetchingFirstPage: Bool = false
 
     /// Error Handler
-    private let errorHandler: ErrorHandler
+    let errorHandler: ErrorHandler
 
     /// 페이징 진행 상태 (무한 스크롤 인디케이터 노출용)
     var isLoadingMore: Bool {

--- a/AppProductTestServer/Makefile
+++ b/AppProductTestServer/Makefile
@@ -1,0 +1,74 @@
+# AppProductTestServer Makefile
+#
+# CoreNetwork / 앱 통합 테스트용 로컬 Vapor 서버를 손쉽게 띄우고 내릴 수 있는 래퍼입니다.
+# 별도 PostgreSQL 없이도 정의된 라우트는 모두 동작합니다 (라우트가 DB를 사용하지 않음).
+
+HOST    ?= 127.0.0.1
+PORT    ?= 8080
+PIDFILE := .server.pid
+LOGFILE := .server.log
+
+.PHONY: help build run start stop restart logs status health clean test integration
+
+help: ## 사용 가능한 타겟 목록 표시
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+	  | awk 'BEGIN {FS=":.*?## "} {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+build: ## swift build (Debug)
+	swift build
+
+run: ## 포그라운드로 서버 실행 (Ctrl+C로 종료)
+	swift run AppProductTestServer serve --hostname $(HOST) --port $(PORT)
+
+start: ## 백그라운드로 서버 실행
+	@if [ -f $(PIDFILE) ] && kill -0 $$(cat $(PIDFILE)) 2>/dev/null; then \
+	  echo "이미 실행 중 (PID: $$(cat $(PIDFILE)))"; \
+	else \
+	  swift build > /dev/null && \
+	  nohup swift run AppProductTestServer serve --hostname $(HOST) --port $(PORT) \
+	    > $(LOGFILE) 2>&1 & echo $$! > $(PIDFILE); \
+	  sleep 2; \
+	  echo "서버 시작 (PID: $$(cat $(PIDFILE))) — http://$(HOST):$(PORT)"; \
+	fi
+
+stop: ## 백그라운드 서버 종료
+	@-pkill -9 -f "AppProductTestServer.*serve" 2>/dev/null || true
+	@-pkill -9 -f "AppProductTestServer/debug/AppProductTestServer" 2>/dev/null || true
+	@if [ -f $(PIDFILE) ]; then kill -9 $$(cat $(PIDFILE)) 2>/dev/null || true; rm -f $(PIDFILE); fi
+	@if lsof -i :$(PORT) >/dev/null 2>&1; then \
+	  echo "포트 $(PORT) 점유 프로세스 강제 종료"; \
+	  lsof -ti :$(PORT) | xargs kill -9 2>/dev/null || true; \
+	fi
+	@echo "서버 종료"
+
+restart: stop start ## 서버 재시작
+
+logs: ## 백그라운드 서버 로그 tail
+	@if [ -f $(LOGFILE) ]; then tail -f $(LOGFILE); else echo "$(LOGFILE) 없음 — make start 먼저"; fi
+
+status: ## 서버 상태 확인
+	@if [ -f $(PIDFILE) ] && kill -0 $$(cat $(PIDFILE)) 2>/dev/null; then \
+	  echo "✅ 실행 중 (PID: $$(cat $(PIDFILE))) — http://$(HOST):$(PORT)"; \
+	else \
+	  echo "❌ 실행 중 아님"; \
+	fi
+
+health: ## 주요 엔드포인트 핑 (서버 살아있는지 확인)
+	@echo "GET / →" && curl -sf http://$(HOST):$(PORT)/ && echo
+	@echo "GET /test →" && curl -sf http://$(HOST):$(PORT)/test && echo
+	@echo "GET /protected (Bearer A) →" \
+	  && curl -sf -H "Authorization: Bearer A" http://$(HOST):$(PORT)/protected && echo
+
+test: ## swift test
+	swift test
+
+clean: stop ## 서버 종료 + 빌드/로그 정리
+	rm -f $(PIDFILE) $(LOGFILE)
+	swift package clean
+
+integration: ## 서버 start → UMCApp CoreNetwork 통합 테스트 → 서버 stop (원샷)
+	@$(MAKE) start
+	@echo "▶︎ CoreNetwork 통합 테스트 실행 (TEST_SERVER_URL=http://$(HOST):$(PORT))"
+	@cd ../UMCApp && $(MAKE) test-network TEST_SERVER_URL=http://$(HOST):$(PORT); STATUS=$$?; \
+	  cd ../AppProductTestServer && $(MAKE) stop; \
+	  exit $$STATUS

--- a/AppProductTestServer/Sources/AppProductTestServer/DTOs/CommonDTO.swift
+++ b/AppProductTestServer/Sources/AppProductTestServer/DTOs/CommonDTO.swift
@@ -8,6 +8,10 @@
 
 import Vapor
 
+/// UMC 백엔드의 `ApiResponse<T>` 계약을 흉내내는 공통 응답 래퍼입니다.
+///
+/// JSON 직렬화 시 `isSuccess` 프로퍼티는 `success` 키로 인코딩되어
+/// 클라이언트(CoreNetwork `APIResponse<T>`) 와 형태가 일치합니다.
 struct CommonDTO<T: Content>: Content {
     let isSuccess: Bool
     let code: String?
@@ -27,6 +31,13 @@ struct CommonDTO<T: Content>: Content {
 
     static func failure(code: String, message: String) -> CommonDTO<T> {
         CommonDTO(isSuccess: false, code: code, message: message, result: nil)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case isSuccess = "success"
+        case code
+        case message
+        case result
     }
 }
 

--- a/UMCApp/Core/Foundation/Sources/Alert/AlertPrompt.swift
+++ b/UMCApp/Core/Foundation/Sources/Alert/AlertPrompt.swift
@@ -2,7 +2,7 @@
 //  AlertPrompt.swift
 //  UMCFoundation
 //
-//  Created by JEONG on 4/25/26.
+//  Created by euijjang97 on 4/25/26.
 //
 
 import Foundation

--- a/UMCApp/Core/Foundation/Sources/Alert/View+AlertPrompt.swift
+++ b/UMCApp/Core/Foundation/Sources/Alert/View+AlertPrompt.swift
@@ -2,7 +2,7 @@
 //  View+AlertPrompt.swift
 //  UMCFoundation
 //
-//  Created by JEONG on 4/25/26.
+//  Created by euijjang97 on 4/25/26.
 //
 
 import SwiftUI

--- a/UMCApp/Core/Foundation/Sources/Error/Types/APIError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/APIError.swift
@@ -1,0 +1,29 @@
+//
+//  APIError.swift
+//  UMCFoundation
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+
+/// 서버가 비즈니스 레벨 실패를 응답한 경우(`isSuccess == false`) 던져지는 에러입니다.
+///
+/// `APIResponse.unwrap()` / `validateSuccess()`가 이 에러를 throw 하며,
+/// 호출 측 Repository에서 catch 후 도메인 에러(`RepositoryError` 등)로 변환합니다.
+///
+/// - Note: HTTP 전송 계층 에러는 `NetworkError`, 서버 응답 비즈니스 에러는 `APIError`로 분리.
+public enum APIError: Error, LocalizedError, Equatable, Sendable {
+    
+    /// 서버 비즈니스 에러 응답 (`isSuccess == false` 또는 result 누락)
+    /// - Parameters:
+    ///   - code: 서버 정의 에러 코드 (예: "AUTH001")
+    ///   - message: 서버 메시지
+    case serverError(code: String?, message: String?)
+    public var errorDescription: String? {
+        switch self {
+        case .serverError(let code, let message):
+            return "[\(code ?? "UNKNOWN")] \(message ?? "알 수 없는 오류가 발생했습니다")"
+        }
+    }
+}

--- a/UMCApp/Core/NearbyExchange/Project.swift
+++ b/UMCApp/Core/NearbyExchange/Project.swift
@@ -3,6 +3,7 @@ import ProjectDescriptionHelpers
 
 let project = Project(
     name: "CoreNearbyExchange",
+    settings: recommendedProjectSettings,
     targets: [
         .target(
             name: "CoreNearbyExchange",

--- a/UMCApp/Core/Network/Project.swift
+++ b/UMCApp/Core/Network/Project.swift
@@ -7,5 +7,10 @@ let project = coreProject(
     dependencies: [
         .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
         .external(name: "Moya"),
+        .sdk(name: "Security", type: .framework),
+    ],
+    includesTests: true,
+    testDependencies: [
+        .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
     ]
 )

--- a/UMCApp/Core/Network/Sources/Auth/KeychainTokenStore.swift
+++ b/UMCApp/Core/Network/Sources/Auth/KeychainTokenStore.swift
@@ -1,0 +1,165 @@
+//
+//  KeychainTokenStore.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import Security
+
+/// Keychain을 사용한 토큰 저장소
+///
+/// Actor로 구현하여 thread-safety를 보장합니다.
+/// 액세스 토큰과 리프레시 토큰을 iOS Keychain에 안전하게 저장하며,
+/// 메모리 캐시를 사용해 반복적인 Keychain 접근을 줄입니다.
+///
+/// - Important:
+///   - **Thread-safety**: Actor 격리로 동시 접근 안전
+///   - **Accessibility**: `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` 사용
+///     (디바이스 잠금 해제 후 접근 가능, 백업·동기화 안 됨)
+///   - **메모리 캐시**: 첫 조회 시 Keychain에서 로드 후 캐싱
+public actor KeychainTokenStore: TokenStore {
+
+    // MARK: - Property
+
+    private let service: String
+    private let accessTokenKey: String
+    private let refreshTokenKey: String
+
+    private var cachedAccessToken: String?
+    private var cachedRefreshToken: String?
+    private var isCacheLoaded: Bool = false
+
+    // MARK: - Init
+
+    public init(
+        service: String = "com.ump.product",
+        accessTokenKey: String = "accessToken",
+        refreshTokenKey: String = "refreshToken"
+    ) {
+        self.service = service
+        self.accessTokenKey = accessTokenKey
+        self.refreshTokenKey = refreshTokenKey
+    }
+
+    // MARK: - TokenStore
+
+    public func getAccessToken() async -> String? {
+        await loadCached()
+        return cachedAccessToken
+    }
+
+    public func getRefreshToken() async -> String? {
+        await loadCached()
+        return cachedRefreshToken
+    }
+
+    public func save(accessToken: String, refreshToken: String) async throws {
+        try saveToKeychain(key: accessTokenKey, value: accessToken)
+        try saveToKeychain(key: refreshTokenKey, value: refreshToken)
+
+        cachedAccessToken = accessToken
+        cachedRefreshToken = refreshToken
+
+        #if DEBUG
+        print("토큰 저장 완료")
+        print("[Auth] saved accessToken: \(accessToken)")
+        print("[Auth] saved refreshToken: \(refreshToken)")
+        #endif
+    }
+
+    public func clear() async throws {
+        deleteFromKeychain(key: accessTokenKey)
+        deleteFromKeychain(key: refreshTokenKey)
+
+        cachedAccessToken = nil
+        cachedRefreshToken = nil
+
+        #if DEBUG
+        print("토큰 삭제 완료")
+        #endif
+    }
+
+    // MARK: - Private Methods
+
+    private func loadCached() async {
+        guard !isCacheLoaded else { return }
+
+        cachedAccessToken = loadFromKeychain(key: accessTokenKey)
+        cachedRefreshToken = loadFromKeychain(key: refreshTokenKey)
+        isCacheLoaded = true
+    }
+
+    private func saveToKeychain(key: String, value: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.encodingFailed
+        }
+
+        deleteFromKeychain(key: key)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+
+        guard status == errSecSuccess else {
+            throw KeychainError.saveFailed(status: status)
+        }
+    }
+
+    private func loadFromKeychain(key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return string
+    }
+
+    private func deleteFromKeychain(key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+// MARK: - KeychainError
+
+public enum KeychainError: Error, LocalizedError {
+    case encodingFailed
+    case saveFailed(status: OSStatus)
+    case loadFailed(status: OSStatus)
+
+    public var errorDescription: String? {
+        switch self {
+        case .encodingFailed:
+            return "토큰 인코딩 실패"
+        case .saveFailed(let status):
+            return "Keychain 저장 실패 (status: \(status))"
+        case .loadFailed(let status):
+            return "Keychain 로드 실패 (status: \(status))"
+        }
+    }
+}

--- a/UMCApp/Core/Network/Sources/Base/APIResponse.swift
+++ b/UMCApp/Core/Network/Sources/Base/APIResponse.swift
@@ -1,0 +1,126 @@
+//
+//  APIResponse.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 서버 공통 응답 DTO
+///
+/// Spring 백엔드의 `ApiResponse<T>` 형식과 매핑됩니다.
+///
+/// ## 서버 응답 형식
+/// ```json
+/// {
+///   "success": true,
+///   "code": "200",
+///   "message": "성공",
+///   "result": { ... }
+/// }
+/// ```
+///
+/// ## 사용 예시
+/// ```swift
+/// let response = try JSONDecoder().decode(
+///     APIResponse<UserDTO>.self,
+///     from: data
+/// )
+///
+/// guard response.isSuccess, let user = response.result else {
+///     throw RepositoryError.serverError(
+///         code: response.code,
+///         message: response.message
+///     )
+/// }
+/// ```
+public struct APIResponse<T: Codable>: Codable {
+
+    // MARK: - Property
+
+    /// 요청 성공 여부
+    public let isSuccess: Bool
+
+    /// 응답 코드 (e.g., "200", "AUTH001")
+    public let code: String?
+
+    /// 응답 메시지 (e.g., "성공", "인증에 실패했습니다")
+    public let message: String?
+
+    /// 응답 데이터 (성공 시에만 존재)
+    public let result: T?
+
+    // MARK: - CodingKeys
+
+    /// Spring `@JsonProperty("success")` 매핑
+    private enum CodingKeys: String, CodingKey {
+        case isSuccess = "success"
+        case code
+        case message
+        case result
+    }
+
+    // MARK: - Init
+
+    public init(isSuccess: Bool, code: String?, message: String?, result: T?) {
+        self.isSuccess = isSuccess
+        self.code = code
+        self.message = message
+        self.result = result
+    }
+}
+
+// MARK: - Convenience
+
+extension APIResponse {
+
+    /// 성공 응답인지 확인하고 result를 반환
+    ///
+    /// - Throws: `RepositoryError.serverError` (실패 시)
+    /// - Returns: result 값
+    public func unwrap() throws -> T {
+        guard isSuccess else {
+            throw RepositoryError.serverError(code: code, message: message)
+        }
+
+        if let result {
+            return result
+        }
+
+        // result가 없는 성공 응답은 EmptyResult로 복구합니다.
+        if T.self == EmptyResult.self, let empty = EmptyResult() as? T {
+            return empty
+        }
+
+        throw RepositoryError.serverError(code: code, message: message)
+    }
+
+    /// 성공 여부만 검증합니다.
+    ///
+    /// `result`가 없는 성공 응답(PATCH/DELETE 등)을 처리할 때 사용합니다.
+    /// - Throws: `RepositoryError.serverError` (실패 시)
+    public func validateSuccess() throws {
+        guard isSuccess else {
+            throw RepositoryError.serverError(code: code, message: message)
+        }
+    }
+
+    /// 에러 메시지 (실패 시 사용)
+    public var errorMessage: String {
+        message ?? "알 수 없는 오류가 발생했습니다"
+    }
+
+    /// 에러 코드 (실패 시 사용)
+    public var errorCode: String {
+        code ?? "UNKNOWN"
+    }
+}
+
+// MARK: - Empty Result
+
+/// 결과 데이터가 없는 API 응답용 (DELETE 등)
+public struct EmptyResult: Codable, Sendable, Equatable {
+    public init() {}
+}

--- a/UMCApp/Core/Network/Sources/Base/BaseTargetType.swift
+++ b/UMCApp/Core/Network/Sources/Base/BaseTargetType.swift
@@ -6,4 +6,44 @@
 //
 
 import Foundation
+import Moya
 
+/// 모든 API Target이 채택해야 하는 공통 프로토콜.
+///
+/// Moya `TargetType`을 확장하여 `baseURL`, `headers`, `validationType`의
+/// 기본 구현을 제공합니다. 각 Feature의 Router는 이 프로토콜을 채택하고
+/// `path`, `method`, `task`만 정의하면 됩니다.
+///
+/// ## 사용 예시
+/// ```swift
+/// enum NoticeAPI: BaseTargetType {
+///     case fetchList(generation: Int)
+///
+///     var path: String {
+///         switch self {
+///         case .fetchList: return "/api/v1/notices"
+///         }
+///     }
+///
+///     var method: Moya.Method { .get }
+///     var task: Task { .requestPlain }
+/// }
+/// ```
+public protocol BaseTargetType: TargetType {}
+
+extension BaseTargetType {
+    /// 공통 base URL
+    public var baseURL: URL {
+        NetworkConfig.baseURL
+    }
+    
+    /// 공통 기본 헤더
+    public var headers: [String : String]? {
+        NetworkConfig.defaultHeaders
+    }
+    
+    /// 2x 응답만 성공으로 간주
+    public var validationType: ValidationType {
+        .successCodes
+    }
+}

--- a/UMCApp/Core/Network/Sources/Client/DefaultAuthenticationPolicy.swift
+++ b/UMCApp/Core/Network/Sources/Client/DefaultAuthenticationPolicy.swift
@@ -1,0 +1,31 @@
+//
+//  DefaultAuthenticationPolicy.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+
+/// 기본 인증 정책 구현체입니다.
+///
+/// 가장 일반적인 JWT 인증 방식을 따릅니다:
+/// - **모든 API 요청에 인증 필요** (로그인/회원가입 API도 포함)
+/// - **401 상태 코드를 인증 실패로 간주**
+public struct DefaultAuthenticationPolicy: AuthenticationPolicy, Sendable {
+    
+    // MARK: - Init
+    public nonisolated init() {}
+    
+    // MARK: - AuthenticationPolicy
+    
+    /// 모든 요청에 인증이 필요하다고 판단합니다.
+    public nonisolated func requireAuthentication(_ request: URLRequest) -> Bool {
+        true
+    }
+    
+    /// 401 Unthorized 응답을 인증 실패로 판단합니다.
+    public func isUnauthorizedResponse(_ response: HTTPURLResponse) -> Bool {
+        response.statusCode == 401
+    }
+}

--- a/UMCApp/Core/Network/Sources/Client/MoyaNetworkAdapter.swift
+++ b/UMCApp/Core/Network/Sources/Client/MoyaNetworkAdapter.swift
@@ -1,0 +1,447 @@
+//
+//  MoyaNetworkAdapter.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import Moya
+import UMCFoundation
+internal import Alamofire
+
+/// Moya의 TargetType을 NetworkClient와 연동하는 어댑터입니다.
+///
+/// Moya의 선언적 API 정의 방식(TargetType)을 사용하면서,
+/// NetworkClient의 JWT 인증 및 토큰 갱신 기능을 활용할 수 있습니다.
+///
+/// - Important:
+///   - **TargetType → URLRequest 변환**: Moya의 TargetType을 URLRequest로 변환
+///   - **NetworkClient 위임**: 실제 네트워크 요청은 NetworkClient가 처리
+///   - **Moya Response 반환**: Moya의 Response 타입으로 결과 반환
+public struct MoyaNetworkAdapter {
+    // MARK: - Property
+
+    private let networkClient: NetworkClient
+    private let baseURL: URL
+
+    // MARK: - Init
+
+    public init(networkClient: NetworkClient, baseURL: URL) {
+        self.networkClient = networkClient
+        self.baseURL = baseURL
+    }
+
+    // MARK: - Public API
+
+    /// Moya TargetType을 사용하여 API 요청을 수행합니다.
+    public func request<T: TargetType>(_ target: T) async throws -> Response {
+        let urlRequest = try buildURLRequest(target)
+        let requestID = NetworkVerboseLogger.makeRequestID()
+        let start = Date()
+        NetworkVerboseLogger.logTraceBegin(requestID: requestID, request: urlRequest, authRequired: true)
+        NetworkVerboseLogger.logRequest(urlRequest, authRequired: true, requestID: requestID)
+
+        do {
+            let (data, httpResponse) = try await networkClient.request(urlRequest)
+            let response = Response(
+                statusCode: httpResponse.statusCode,
+                data: data,
+                request: urlRequest,
+                response: httpResponse
+            )
+            NetworkVerboseLogger.logResponse(response, requestID: requestID)
+            NetworkVerboseLogger.logTraceEnd(requestID: requestID, result: "SUCCESS", startedAt: start)
+            return response
+        } catch {
+            NetworkVerboseLogger.logError(error, request: urlRequest, requestID: requestID)
+            NetworkVerboseLogger.logTraceEnd(requestID: requestID, result: "ERROR", startedAt: start)
+            throw error
+        }
+    }
+
+    /// 인증 없이 API 요청을 수행합니다 (로그인, 회원가입 등)
+    public func requestWithoutAuth<T: TargetType>(_ target: T) async throws -> Response {
+        let urlRequest = try buildURLRequest(target)
+        let requestID = NetworkVerboseLogger.makeRequestID()
+        let start = Date()
+        NetworkVerboseLogger.logTraceBegin(requestID: requestID, request: urlRequest, authRequired: false)
+        NetworkVerboseLogger.logRequest(urlRequest, authRequired: false, requestID: requestID)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: urlRequest)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw NetworkError.invalidResponse
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                throw NetworkError.requestFailed(
+                    statusCode: httpResponse.statusCode,
+                    data: data
+                )
+            }
+
+            let moyaResponse = Response(
+                statusCode: httpResponse.statusCode,
+                data: data,
+                request: urlRequest,
+                response: httpResponse
+            )
+            NetworkVerboseLogger.logResponse(moyaResponse, requestID: requestID)
+            NetworkVerboseLogger.logTraceEnd(requestID: requestID, result: "SUCCESS", startedAt: start)
+            return moyaResponse
+        } catch {
+            NetworkVerboseLogger.logError(error, request: urlRequest, requestID: requestID)
+            NetworkVerboseLogger.logTraceEnd(requestID: requestID, result: "ERROR", startedAt: start)
+            throw error
+        }
+    }
+}
+
+// MARK: - Private Methods
+
+extension MoyaNetworkAdapter {
+    private func buildURLRequest<T: TargetType>(_ target: T) throws -> URLRequest {
+        let url = target.baseURL.appending(path: target.path)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = target.method.rawValue
+
+        target.headers?.forEach {
+            request.setValue($1, forHTTPHeaderField: $0)
+        }
+
+        switch target.task {
+        case .requestPlain:
+            break
+
+        case .requestData(let data):
+            request.httpBody = data
+
+        case .requestJSONEncodable(let encodable):
+            request.httpBody = try JSONEncoder().encode(AnyEncodable(encodable))
+
+        case .requestCustomJSONEncodable(let encodable, let encoder):
+            request.httpBody = try encoder.encode(AnyEncodable(encodable))
+
+        case .requestParameters(let parameters, let encoding):
+            request = try encodeParameters(request, parameters: parameters, encoding: encoding)
+
+        case .requestCompositeData(let bodyData, let urlParameters):
+            request.httpBody = bodyData
+            request = try encodeURLParameters(request, parameters: urlParameters)
+
+        case .requestCompositeParameters(let bodyParameters, let bodyEncoding, let urlParameters):
+            request = try encodeParameters(request, parameters: bodyParameters, encoding: bodyEncoding)
+            request = try encodeURLParameters(request, parameters: urlParameters)
+
+        case .uploadFile(let url):
+            request.httpBody = try Data(contentsOf: url)
+
+        case .uploadMultipart:
+            let boundary = "Boundary-\(UUID().uuidString)"
+            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            // TODO: 서버 멀티파트 폼 요청 명세서 보고 request.httpBody 구성 필요
+
+        case .uploadCompositeMultipart:
+            break
+
+        case .downloadDestination, .downloadParameters:
+            break
+        }
+
+        return request
+    }
+
+    private func encodeParameters(
+        _ request: URLRequest,
+        parameters: [String: Any],
+        encoding: ParameterEncoding
+    ) throws -> URLRequest {
+        try encoding.encode(request, with: parameters)
+    }
+
+    private func encodeURLParameters(
+        _ request: URLRequest,
+        parameters: [String: Any]
+    ) throws -> URLRequest {
+        try URLEncoding.queryString.encode(request, with: parameters)
+    }
+}
+
+// MARK: - AnyEncodable
+
+/// 타입 정보를 지우고 Encodable 프로토콜만 유지하는 래퍼입니다.
+fileprivate struct AnyEncodable: Encodable {
+    private let _encode: (Encoder) throws -> Void
+
+    init<T: Encodable>(_ wrapped: T) {
+        let wrappedValue = wrapped
+        _encode = { encoder in
+            try wrappedValue.encode(to: encoder)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try _encode(encoder)
+    }
+}
+
+// MARK: - NetworkVerboseLogger
+
+private enum NetworkVerboseLogger {
+    private static let maxLineWidth = 120
+
+    static func makeRequestID() -> String {
+        String(UUID().uuidString.prefix(8))
+    }
+
+    static func logTraceBegin(requestID: String, request: URLRequest, authRequired: Bool) {
+        #if DEBUG
+        let method = request.httpMethod ?? "GET"
+        let path = request.url?.path ?? "/"
+        print("")
+        print("╔════════════ UMC_SWAGGER_TRACE_BEGIN [\(requestID)] ════════════")
+        print("║ method: \(method)  path: \(path)  auth: \(authRequired ? "required" : "none")")
+        print("╚══════════════════════════════════════════════════════════════════")
+        #endif
+    }
+
+    static func logTraceEnd(requestID: String, result: String, startedAt: Date) {
+        #if DEBUG
+        let elapsed = Date().timeIntervalSince(startedAt) * 1000
+        print("╔════════════ UMC_SWAGGER_TRACE_END [\(requestID)] ══════════════")
+        print("║ result: \(result)  elapsed: \(Int(elapsed))ms")
+        print("╚══════════════════════════════════════════════════════════════════")
+        print("")
+        #endif
+    }
+
+    static func logRequest(_ request: URLRequest, authRequired: Bool, requestID: String) {
+        #if DEBUG
+        let method = request.httpMethod ?? "GET"
+        let url = request.url?.absoluteString ?? "(invalid URL)"
+        let path = request.url?.path ?? "/"
+
+        print("")
+        print("-----------------UMC_SWAGGER_REQUEST_BEGIN [\(requestID)]-----------------")
+        print("time: \(timestamp())")
+        print("summary:")
+        print("  method: \(method)")
+        print("  path: \(path)")
+        print("  auth: \(authRequired ? "required" : "none")")
+        print("  url: \(url)")
+        printSection("headers", formatHeaders(request.allHTTPHeaderFields))
+
+        if let body = request.httpBody, !body.isEmpty {
+            printSection("body", formattedBody(from: body, shortenLongStrings: false))
+        } else {
+            printSection("body", "(empty)")
+        }
+
+        printSection("curl", curlString(for: request))
+        print("------------------UMC_SWAGGER_REQUEST_END [\(requestID)]------------------")
+        print("")
+        #endif
+    }
+
+    static func logResponse(_ response: Response, requestID: String) {
+        #if DEBUG
+        let method = response.request?.httpMethod ?? "GET"
+        let requestURL = response.response?.url?.absoluteString
+            ?? response.request?.url?.absoluteString
+            ?? "(unknown URL)"
+        let path = response.response?.url?.path
+            ?? response.request?.url?.path
+            ?? "/"
+
+        print("")
+        print("----------------UMC_SWAGGER_RESPONSE_BEGIN [\(requestID)]-----------------")
+        print("time: \(timestamp())")
+        print("summary:")
+        print("  method: \(method)")
+        print("  path: \(path)")
+        print("  status: \(response.statusCode)")
+        print("  url: \(requestURL)")
+
+        if let headers = response.response?.allHeaderFields, !headers.isEmpty {
+            let normalized = headers.reduce(into: [String: String]()) { partialResult, item in
+                partialResult[String(describing: item.key)] = String(describing: item.value)
+            }
+            printSection("headers", formatHeaders(normalized))
+        } else {
+            printSection("headers", "(none)")
+        }
+
+        if !response.data.isEmpty {
+            printSection("body", formattedBody(from: response.data, shortenLongStrings: true))
+        } else {
+            printSection("body", "(empty)")
+        }
+
+        print("-----------------UMC_SWAGGER_RESPONSE_END [\(requestID)]------------------")
+        print("")
+        #endif
+    }
+
+    static func logError(_ error: Error, request: URLRequest, requestID: String) {
+        #if DEBUG
+        let method = request.httpMethod ?? "GET"
+        let url = request.url?.absoluteString ?? "(invalid URL)"
+        let path = request.url?.path ?? "/"
+
+        print("")
+        print("------------------UMC_SWAGGER_ERROR_BEGIN [\(requestID)]------------------")
+        print("time: \(timestamp())")
+        print("summary:")
+        print("  method: \(method)")
+        print("  path: \(path)")
+        print("  url: \(url)")
+        printSection("error", String(describing: error))
+
+        if case let NetworkError.requestFailed(statusCode, data) = error {
+            print("  status: \(statusCode)")
+            if let data, !data.isEmpty {
+                printSection("error body", formattedBody(from: data, shortenLongStrings: true))
+            } else {
+                printSection("error body", "(empty)")
+            }
+        } else {
+            print("  status: (unavailable)")
+            printSection("error body", "(unavailable)")
+        }
+
+        print("-------------------UMC_SWAGGER_ERROR_END [\(requestID)]-------------------")
+        print("")
+        #endif
+    }
+
+    private static func formattedBody(from data: Data, shortenLongStrings: Bool) -> String {
+        if
+            let object = try? JSONSerialization.jsonObject(with: data),
+            let outputObject = shortenLongStrings ? compactLongText(in: object) : object,
+            let prettyData = try? JSONSerialization.data(withJSONObject: outputObject, options: [.prettyPrinted, .sortedKeys]),
+            let pretty = String(data: prettyData, encoding: .utf8)
+        {
+            return pretty
+        }
+
+        if let utf8 = String(data: data, encoding: .utf8), !utf8.isEmpty {
+            return shortenLongStrings ? abbreviateLongToken(in: utf8) : utf8
+        }
+
+        return "(binary \(data.count) bytes)"
+    }
+
+    private static func formatHeaders(_ headers: [String: String]?) -> String {
+        guard let headers, !headers.isEmpty else {
+            return "(none)"
+        }
+
+        return headers
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key): \($0.value)" }
+            .joined(separator: "\n")
+    }
+
+    private static func printSection(_ title: String, _ content: String) {
+        print("  \(title):")
+        if content.isEmpty {
+            print("    (empty)")
+            return
+        }
+
+        let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        for line in lines {
+            for wrapped in wrap(line, width: maxLineWidth - 4) {
+                print("    \(wrapped)")
+            }
+        }
+    }
+
+    private static func timestamp() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date())
+    }
+
+    private static func curlString(for request: URLRequest) -> String {
+        var lines: [String] = ["curl -v \\"]
+
+        if let method = request.httpMethod {
+            lines.append("  -X \(method) \\")
+        }
+
+        if let headers = request.allHTTPHeaderFields {
+            for (key, value) in headers.sorted(by: { $0.key < $1.key }) {
+                lines.append("  -H '\(key): \(abbreviateLongToken(in: value))' \\")
+            }
+        }
+
+        if let body = request.httpBody, !body.isEmpty {
+            if let bodyString = String(data: body, encoding: .utf8) {
+                let escaped = bodyString.replacingOccurrences(of: "'", with: "'\"'\"'")
+                lines.append("  --data '\(escaped)' \\")
+            } else {
+                lines.append("  --data-binary '<binary \(body.count) bytes>' \\")
+            }
+        }
+
+        lines.append("  '\(request.url?.absoluteString ?? "")'")
+        return lines.joined(separator: "\n")
+    }
+
+    private static func compactLongText(in object: Any) -> Any? {
+        if let dict = object as? [String: Any] {
+            var output: [String: Any] = [:]
+            for (key, value) in dict {
+                output[key] = compactLongText(in: value) ?? NSNull()
+            }
+            return output
+        }
+
+        if let array = object as? [Any] {
+            return array.map { compactLongText(in: $0) ?? NSNull() }
+        }
+
+        if let text = object as? String {
+            return abbreviateLongToken(in: text)
+        }
+
+        return object
+    }
+
+    private static func abbreviateLongToken(in text: String) -> String {
+        let threshold = 90
+        guard text.count > threshold else { return text }
+        let head = text.prefix(40)
+        let tail = text.suffix(20)
+        return "\(head)...<\(text.count) chars>...\(tail)"
+    }
+
+    private static func wrap(_ text: String, width: Int) -> [String] {
+        guard text.count > width else { return [text] }
+        var lines: [String] = []
+        var remaining = text[...]
+
+        while remaining.count > width {
+            let cutoffIndex = remaining.index(remaining.startIndex, offsetBy: width)
+            let candidate = remaining[..<cutoffIndex]
+
+            if let space = candidate.lastIndex(of: " ") {
+                lines.append(String(remaining[..<space]))
+                remaining = remaining[remaining.index(after: space)...]
+            } else {
+                lines.append(String(candidate))
+                remaining = remaining[cutoffIndex...]
+            }
+        }
+
+        if !remaining.isEmpty {
+            lines.append(String(remaining))
+        }
+
+        return lines
+    }
+}

--- a/UMCApp/Core/Network/Sources/Client/NetworkClient.swift
+++ b/UMCApp/Core/Network/Sources/Client/NetworkClient.swift
@@ -1,0 +1,161 @@
+//
+//  NetworkClient.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// JWT 인증 기반의 Thread-safe 네트워크 클라이언트입니다.
+///
+/// 주요 기능:
+/// 1. **자동 토큰 관리**: API 요청 시 자동으로 액세스 토큰을 Authorization 헤더에 추가
+/// 2. **자동 토큰 갱신**: 401 응답 수신 시 리프레시 토큰으로 자동 갱신 후 재요청
+/// 3. **토큰 갱신 중복 방지**: Actor를 사용하여 동시 다발적 401 발생 시에도 토큰 갱신은 1회만 실행
+/// 4. **타입 안전한 API 호출**: Codable을 사용한 자동 JSON 파싱
+public actor NetworkClient {
+    // MARK: - Dependencies
+
+    private let session: URLSession
+    private let tokenStore: TokenStore
+    private let refreshService: TokenRefreshService
+    private let authPolicy: AuthenticationPolicy
+    private let maxRetryCount: Int
+
+    /// 현재 진행 중인 토큰 갱신 Task
+    ///
+    /// - Important:
+    ///   - nil이 아니면 이미 토큰 갱신 중 (다른 요청은 이 Task를 대기)
+    ///   - nil이면 토큰 갱신 가능 (새 Task 생성)
+    ///   - Actor 격리로 Race Condition 방지
+    private var refreshTask: Task<TokenPair, Error>?
+
+    // MARK: - Init
+
+    public init(
+        session: URLSession = .shared,
+        tokenStore: TokenStore,
+        refreshService: TokenRefreshService,
+        authPolicy: AuthenticationPolicy = DefaultAuthenticationPolicy(),
+        maxRetryCount: Int = 1
+    ) {
+        self.session = session
+        self.tokenStore = tokenStore
+        self.refreshService = refreshService
+        self.authPolicy = authPolicy
+        self.maxRetryCount = maxRetryCount
+    }
+
+    // MARK: - Public API
+
+    /// API 요청을 실행하고 원시 데이터와 HTTP 응답을 반환합니다.
+    public func request(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        try await performRequst(urlRequest, retryCount: 0)
+    }
+
+    /// API 요청을 실행하고 응답을 자동으로 디코딩하여 반환합니다.
+    public func request<T: Decodable>(
+        _ urlRequest: URLRequest,
+        decoder: JSONDecoder = .init()
+    ) async throws -> T {
+        let (data, _) = try await request(urlRequest)
+        return try decoder.decode(T.self, from: data)
+    }
+
+    /// 강제로 토큰을 갱신합니다.
+    public func forceRefreshToken() async throws -> TokenPair {
+        try await refreshTokenIssue(force: true)
+    }
+
+    /// 로그아웃 처리를 수행합니다.
+    public func logout() async throws {
+        refreshTask?.cancel()
+        refreshTask = nil
+        try await tokenStore.clear()
+
+        #if DEBUG
+        print("로그아웃 완료")
+        #endif
+    }
+
+    /// 현재 로그인 상태를 확인합니다.
+    public func isLoggedIn() async -> Bool {
+        await tokenStore.getAccessToken() != nil
+    }
+}
+
+// MARK: - Private Methods
+
+extension NetworkClient {
+    private func performRequst(
+        _ urlRequest: URLRequest,
+        retryCount: Int
+    ) async throws -> (Data, HTTPURLResponse) {
+        var authenticatedRequest = urlRequest
+
+        // 1. 인증이 필요한 요청인지 확인
+        if authPolicy.requireAuthentication(urlRequest) {
+            if let token = await tokenStore.getAccessToken() {
+                authenticatedRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
+        }
+
+        // 2. 네트워크 요청 실행
+        let (data, response) = try await session.data(for: authenticatedRequest)
+
+        // 3. HTTPURLResponse로 형변환
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse
+        }
+
+        // 4. 인증 실패(401) 응답 처리
+        if authPolicy.isUnauthorizedResponse(httpResponse) {
+            guard retryCount < maxRetryCount else {
+                throw NetworkError.maxRetryExceeded
+            }
+
+            _ = try await refreshTokenIssue(force: true)
+
+            return try await performRequst(urlRequest, retryCount: retryCount + 1)
+        }
+
+        // 5. 성공 응답(2xx) 확인
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw NetworkError.requestFailed(statusCode: httpResponse.statusCode, data: data)
+        }
+
+        return (data, httpResponse)
+    }
+
+    private func refreshTokenIssue(force: Bool = false) async throws -> TokenPair {
+        // 이미 토큰 갱신 중인지 확인
+        if let existingTask = refreshTask {
+            return try await existingTask.value
+        }
+
+        // 새 토큰 갱신 Task 생성
+        let task = Task<TokenPair, Error> {
+            defer { refreshTask = nil }
+
+            guard let refreshToken = await tokenStore.getRefreshToken() else {
+                throw NetworkError.noRefreshToken
+            }
+
+            do {
+                let tokenPair = try await refreshService.refresh(refreshToken)
+                try await tokenStore.save(
+                    accessToken: tokenPair.accessToken,
+                    refreshToken: tokenPair.refreshToken
+                )
+                return tokenPair
+            } catch {
+                throw NetworkError.tokenRefreshFailed(reason: error.localizedDescription)
+            }
+        }
+
+        refreshTask = task
+        return try await task.value
+    }
+}

--- a/UMCApp/Core/Network/Sources/Client/TokenPair.swift
+++ b/UMCApp/Core/Network/Sources/Client/TokenPair.swift
@@ -1,0 +1,34 @@
+//
+//  TokenPair.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+
+// MARK: - TokenPair
+
+/// JWT 인증에 사용되는 액세스 토큰과 리프레시 토큰 쌍을 나타냅니다.
+///
+/// 서버로부터 받은 토큰 쌍을 안전하게 저장하고 전달하기 위한 불변(immutable) 구조체입니다.
+///
+/// - Important:
+///   - **Sendable**: 동시성 환경(async/await, Actor)에서 안전하게 사용 가능
+///   - **Codable**: JSON 직렬화/역직렬화 지원 (서버 응답 파싱에 사용)
+///   - **nonisolated**: Actor 격리 없이 어디서든 접근 가능
+public struct TokenPair: Sendable, Codable, Equatable {
+    // MARK: - Property
+    
+    /// API 요청 시 사용하는 액세스 토큰
+    public nonisolated let accessToken: String
+    
+    /// 액세스 토큰 갱신에 사용하는 리프레시 토큰
+    public nonisolated let refreshToken: String
+    
+    // MARK: - Init
+    public nonisolated init(accessToken: String, refreshToken: String) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+    }
+}

--- a/UMCApp/Core/Network/Sources/Client/TokenRefreshServiceImpl.swift
+++ b/UMCApp/Core/Network/Sources/Client/TokenRefreshServiceImpl.swift
@@ -1,0 +1,123 @@
+//
+//  TokenRefreshServiceImpl.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+
+/// TokenRefreshService 프로토콜의 실제 구현체입니다.
+///
+/// 서버의 `/api/v1/auth/token/renew` 엔드포인트를 호출하여 리프레시 토큰으로 새로운 토큰 쌍을 발급받습니다.
+///
+/// - Important:
+///   - **NetworkClient와 독립적**: NetworkClient를 사용하지 않음 (무한 루프 방지)
+///   - **APIResponse 사용**: 서버의 공통 응답 포맷 사용
+///   - **JSON Body 전송**: 서버 문서 스펙에 맞춰 리프레시 토큰을 Request Body에 전송
+struct TokenRefreshServiceImpl: TokenRefreshService {
+    // MARK: - Property
+
+    private let baseURL: URL
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
+    // MARK: - Init
+
+    nonisolated init(
+        baseURL: URL,
+        session: URLSession = .shared,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.decoder = decoder
+    }
+
+    // MARK: - TokenRefreshService
+
+    /// 리프레시 토큰으로 새로운 토큰 쌍을 발급받습니다.
+    ///
+    /// ## 요청 형식
+    /// ```
+    /// POST /api/v1/auth/token/renew
+    /// Content-Type: application/json
+    ///
+    /// { "refreshToken": "..." }
+    /// ```
+    func refresh(_ refreshToken: String) async throws -> TokenPair {
+        // 1. URL 생성
+        let url = baseURL.appending(path: "api/v1/auth/token/renew")
+
+        // 2. URLRequest 구성
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(
+            RefreshTokenRequestBody(refreshToken: refreshToken)
+        )
+
+        // 3. 네트워크 요청 실행
+        let (data, response) = try await session.data(for: request)
+
+        // 4. HTTPURLResponse 형변환
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw TokenRefreshError.invalidResponse
+        }
+
+        // 5. 상태 코드 확인 (2xx 성공)
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw TokenRefreshError.serverError(statusCode: httpResponse.statusCode)
+        }
+
+        // 6. 응답 디코딩 (APIResponse 사용)
+        let tokenResponse = try decoder.decode(APIResponse<TokenResult>.self, from: data)
+
+        // 7. 성공 여부 확인
+        guard tokenResponse.isSuccess, let result = tokenResponse.result else {
+            throw TokenRefreshError.refreshFailed(message: tokenResponse.message)
+        }
+
+        // 8. TokenPair 생성
+        return TokenPair(
+            accessToken: result.accessToken,
+            refreshToken: result.refreshToken
+        )
+    }
+}
+
+// MARK: - RefreshTokenRequestBody
+
+private struct RefreshTokenRequestBody: Encodable {
+    let refreshToken: String
+}
+
+// MARK: - TokenResult
+
+/// 토큰 갱신 API 응답의 result 필드를 파싱하는 내부 모델입니다.
+private struct TokenResult: Codable, Sendable {
+    let accessToken: String
+    let refreshToken: String
+}
+
+// MARK: - TokenRefreshError
+
+/// 토큰 갱신 과정에서 발생하는 에러를 정의하는 열거형입니다.
+///
+/// - Important: NetworkClient는 이 에러를 `NetworkError.tokenRefreshFailed`로 래핑합니다.
+enum TokenRefreshError: Error, LocalizedError {
+    case invalidResponse
+    case serverError(statusCode: Int)
+    case refreshFailed(message: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "잘못된 서버 응답"
+        case .serverError(let statusCode):
+            return "서버 에러 (status: \(statusCode))"
+        case .refreshFailed(let message):
+            return message ?? "토큰 갱신 실패"
+        }
+    }
+}

--- a/UMCApp/Core/Network/Sources/Client/TokenStoreProtocol.swift
+++ b/UMCApp/Core/Network/Sources/Client/TokenStoreProtocol.swift
@@ -1,0 +1,60 @@
+//
+//  TokenStoreProtocol.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+
+// MARK: - TokenStore
+
+/// JWT 토큰을 안전하게 저장하고 관리하는 저장소 프로토콜입니다.
+///
+/// 액세스 토큰과 리프레시 토큰을 영구 저장소(Keychain, UserDefaults 등)에 저장하고,
+/// NetworkClient가 인증이 필요한 API 호출 시 토큰을 제공합니다.
+///
+/// - Important:
+///   - **Sendable**: Actor와 안전하게 상호작용 가능
+///   - **async 메서드**: 저장소 접근은 비동기로 처리 (I/O 작업)
+///   - **Keychain 권장**: 민감한 토큰 정보는 Keychain에 저장 필수
+public protocol TokenStore: Sendable {
+    /// 저장된 액세스 토큰 반환
+    func getAccessToken() async -> String?
+    
+    /// 저장된 리프레시 토큰을 반환
+    func getRefreshToken() async -> String?
+    
+    /// 액세스 토큰과 리프레시 토큰을 저장
+    func save(accessToken: String, refreshToken: String) async throws
+    
+    /// 저장된 모든 토큰 삭제
+    func clear() async throws
+}
+
+// MARK: - TokenRefreshService
+
+/// 리프레시 토큰으로 새로운 토큰 쌍을 발급받는 서비스 프로토콜입니다.
+///
+/// 액세스 토큰 만료(401) 시 서버의 토큰 갱신 API를 호출하여
+/// 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다.
+public protocol TokenRefreshService: Sendable {
+    /// 리프레시 토큰으로 새로운 토큰 쌍을 발급받습니다.
+    ///
+    /// - Throws:
+    ///   - `NetworkError.tokenRefreshFailed`: 토큰 갱신 API 호출 실패
+    func refresh(_ refreshToken: String) async throws -> TokenPair
+}
+
+// MARK: - AuthenticationPolicy
+
+/// API 요청의 인증 정책을 정의하는 프로토콜입니다.
+///
+/// 어떤 요청에 인증이 필요한지, 어떤 응답이 인증 실패인지를 판단하는 로직을 제공합니다.
+public protocol AuthenticationPolicy: Sendable {
+    /// 주어진 요청에 인증(Authorization 헤더)이 필요한지 판단합니다.
+    nonisolated func requireAuthentication(_ request: URLRequest) -> Bool
+
+    /// 주어진 응답이 인증 실패(Unauthorized) 응답인지 판단합니다.
+    nonisolated func isUnauthorizedResponse(_ response: HTTPURLResponse) -> Bool
+}

--- a/UMCApp/Core/Network/Sources/DI/AuthSystemFactory.swift
+++ b/UMCApp/Core/Network/Sources/DI/AuthSystemFactory.swift
@@ -1,0 +1,78 @@
+//
+//  AuthSystemFactory.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+
+/// 인증 시스템 관련 의존성을 생성하는 팩토리입니다.
+///
+/// NetworkClient와 관련 의존성(TokenStore, TokenRefreshService)을 올바르게 조립하여 생성합니다.
+///
+/// - Important:
+///   - **프로덕션**: `makeNetworkClient(baseURL:)` 사용
+///   - **테스트**: `makeTestNetworkClient(tokenStore:refreshService:)` 사용
+///
+/// - Usage:
+/// ```swift
+/// // DIContainer에서 사용
+/// final class DIContainer {
+///     lazy var networkClient: NetworkClient = {
+///         AuthSystemFactory.makeNetworkClient(
+///             baseURL: NetworkConfig.baseURL
+///         )
+///     }()
+/// }
+/// ```
+public enum AuthSystemFactory {
+
+    // MARK: - Factory Methods
+
+    /// 프로덕션 환경용 NetworkClient를 생성합니다.
+    ///
+    /// 실제 서버와 통신하는 완전한 NetworkClient를 생성합니다.
+    ///
+    /// ## 구성 요소
+    ///
+    /// ```
+    /// NetworkClient
+    ///     ├── URLSession (.shared)
+    ///     ├── TokenStore (KeychainTokenStore)
+    ///     ├── TokenRefreshService (TokenRefreshServiceImpl)
+    ///     └── AuthenticationPolicy (DefaultAuthenticationPolicy)
+    /// ```
+    public static func makeNetworkClient(
+        baseURL: URL,
+        session: URLSession = .shared,
+        tokenStore: TokenStore? = nil
+    ) -> NetworkClient {
+        // 1. 토큰 저장소 (외부 주입 또는 Keychain 기반 생성)
+        let store = tokenStore ?? KeychainTokenStore()
+
+        // 2. 실제 서버 토큰 갱신 서비스 생성
+        let refreshService = TokenRefreshServiceImpl(baseURL: baseURL, session: session)
+
+        // 3. NetworkClient 생성 (모든 의존성 주입)
+        return NetworkClient(
+            session: session,
+            tokenStore: store,
+            refreshService: refreshService
+        )
+    }
+
+    /// 테스트 환경용 NetworkClient를 생성합니다.
+    ///
+    /// Mock TokenStore와 TokenRefreshService를 주입하여 테스트 가능한 NetworkClient를 생성합니다.
+    public static func makeTestNetworkClient(
+        tokenStore: TokenStore,
+        refreshService: TokenRefreshService
+    ) -> NetworkClient {
+        NetworkClient(
+            session: .shared,
+            tokenStore: tokenStore,
+            refreshService: refreshService
+        )
+    }
+}

--- a/UMCApp/Core/Network/Tests/APIResponseTests.swift
+++ b/UMCApp/Core/Network/Tests/APIResponseTests.swift
@@ -1,0 +1,178 @@
+//
+//  APIResponseTests.swift
+//  CoreNetworkTests
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import CoreNetwork
+
+@Suite("APIResponse")
+struct APIResponseTests {
+
+    // MARK: - Decoding
+
+    @Test("서버 응답 JSON을 success/code/message/result 키로 디코딩한다")
+    func decodesServerJSONKeys() throws {
+        let json = """
+        {
+            "success": true,
+            "code": "200",
+            "message": "성공",
+            "result": { "id": 42, "name": "정의재" }
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(APIResponse<UserDTO>.self, from: json)
+
+        #expect(response.isSuccess)
+        #expect(response.code == "200")
+        #expect(response.message == "성공")
+        #expect(response.result?.id == 42)
+        #expect(response.result?.name == "정의재")
+    }
+
+    @Test("실패 응답은 isSuccess=false, result=nil로 디코딩된다")
+    func decodesFailureResponse() throws {
+        let json = """
+        {
+            "success": false,
+            "code": "AUTH001",
+            "message": "인증에 실패했습니다",
+            "result": null
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(APIResponse<UserDTO>.self, from: json)
+
+        #expect(!response.isSuccess)
+        #expect(response.code == "AUTH001")
+        #expect(response.message == "인증에 실패했습니다")
+        #expect(response.result == nil)
+    }
+
+    // MARK: - unwrap()
+
+    @Test("unwrap()은 성공 응답일 때 result를 반환한다")
+    func unwrapReturnsResultOnSuccess() throws {
+        let response = APIResponse(
+            isSuccess: true,
+            code: "200",
+            message: "성공",
+            result: UserDTO(id: 1, name: "test")
+        )
+
+        let result = try response.unwrap()
+
+        #expect(result.id == 1)
+        #expect(result.name == "test")
+    }
+
+    @Test("unwrap()은 isSuccess=false이면 RepositoryError.serverError를 throw한다")
+    func unwrapThrowsServerErrorOnFailure() {
+        let response = APIResponse<UserDTO>(
+            isSuccess: false,
+            code: "AUTH001",
+            message: "인증 실패",
+            result: nil
+        )
+
+        #expect(throws: RepositoryError.serverError(code: "AUTH001", message: "인증 실패")) {
+            _ = try response.unwrap()
+        }
+    }
+
+    @Test("unwrap()은 result==nil이지만 EmptyResult 타입이면 빈 값을 반환한다")
+    func unwrapReturnsEmptyResultWhenNilResultButEmptyResultType() throws {
+        let response = APIResponse<EmptyResult>(
+            isSuccess: true,
+            code: "200",
+            message: "성공",
+            result: nil
+        )
+
+        let result = try response.unwrap()
+
+        #expect(result == EmptyResult())
+    }
+
+    @Test("unwrap()은 result==nil이고 EmptyResult가 아니면 serverError를 throw한다")
+    func unwrapThrowsWhenNilResultAndNotEmptyResultType() {
+        let response = APIResponse<UserDTO>(
+            isSuccess: true,
+            code: nil,
+            message: nil,
+            result: nil
+        )
+
+        #expect(throws: RepositoryError.serverError(code: nil, message: nil)) {
+            _ = try response.unwrap()
+        }
+    }
+
+    // MARK: - validateSuccess()
+
+    @Test("validateSuccess()는 isSuccess=true이면 throw하지 않는다")
+    func validateSuccessDoesNotThrow() throws {
+        let response = APIResponse<EmptyResult>(
+            isSuccess: true,
+            code: "200",
+            message: nil,
+            result: nil
+        )
+
+        try response.validateSuccess()
+    }
+
+    @Test("validateSuccess()는 isSuccess=false이면 RepositoryError.serverError를 throw한다")
+    func validateSuccessThrowsOnFailure() {
+        let response = APIResponse<EmptyResult>(
+            isSuccess: false,
+            code: "ERR",
+            message: "fail",
+            result: nil
+        )
+
+        #expect(throws: RepositoryError.serverError(code: "ERR", message: "fail")) {
+            try response.validateSuccess()
+        }
+    }
+
+    // MARK: - errorMessage / errorCode
+
+    @Test("errorMessage 기본값과 errorCode 기본값을 반환한다")
+    func defaultErrorFields() {
+        let response = APIResponse<EmptyResult>(
+            isSuccess: false,
+            code: nil,
+            message: nil,
+            result: nil
+        )
+
+        #expect(response.errorMessage == "알 수 없는 오류가 발생했습니다")
+        #expect(response.errorCode == "UNKNOWN")
+    }
+
+    @Test("errorMessage와 errorCode는 서버 값을 우선 사용한다")
+    func errorFieldsPreferServerValues() {
+        let response = APIResponse<EmptyResult>(
+            isSuccess: false,
+            code: "AUTH001",
+            message: "토큰 만료",
+            result: nil
+        )
+
+        #expect(response.errorMessage == "토큰 만료")
+        #expect(response.errorCode == "AUTH001")
+    }
+}
+
+// MARK: - Test Fixtures
+
+private struct UserDTO: Codable, Equatable {
+    let id: Int
+    let name: String
+}

--- a/UMCApp/Core/Network/Tests/AuthSystemFactoryTests.swift
+++ b/UMCApp/Core/Network/Tests/AuthSystemFactoryTests.swift
@@ -1,0 +1,54 @@
+//
+//  AuthSystemFactoryTests.swift
+//  CoreNetworkTests
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import Testing
+@testable import CoreNetwork
+
+@Suite("AuthSystemFactory")
+struct AuthSystemFactoryTests {
+
+    @Test("makeNetworkClient는 baseURL로 NetworkClient 인스턴스를 만든다")
+    func makesProductionClient() async {
+        let baseURL = URL(string: "https://api.umc.test")!
+        let client = AuthSystemFactory.makeNetworkClient(baseURL: baseURL)
+
+        // 토큰 미설정 상태 → 로그인 안 된 상태
+        let loggedIn = await client.isLoggedIn()
+        #expect(!loggedIn)
+    }
+
+    @Test("makeNetworkClient는 외부에서 주입한 tokenStore를 사용한다")
+    func makesProductionClientWithInjectedStore() async {
+        let baseURL = URL(string: "https://api.umc.test")!
+        let injected = MockTokenStore(accessToken: "INJECTED", refreshToken: "R")
+
+        let client = AuthSystemFactory.makeNetworkClient(
+            baseURL: baseURL,
+            tokenStore: injected
+        )
+
+        let loggedIn = await client.isLoggedIn()
+        #expect(loggedIn, "주입한 store에 토큰이 있으므로 로그인 상태여야 한다")
+    }
+
+    @Test("makeTestNetworkClient는 주입된 의존성으로 NetworkClient를 조립한다")
+    func makesTestClient() async {
+        let store = MockTokenStore(accessToken: "TEST", refreshToken: "R")
+        let refresh = MockTokenRefreshService(
+            behavior: .success(TokenPair(accessToken: "X", refreshToken: "Y"))
+        )
+
+        let client = AuthSystemFactory.makeTestNetworkClient(
+            tokenStore: store,
+            refreshService: refresh
+        )
+
+        let loggedIn = await client.isLoggedIn()
+        #expect(loggedIn)
+    }
+}

--- a/UMCApp/Core/Network/Tests/DefaultAuthenticationPolicyTests.swift
+++ b/UMCApp/Core/Network/Tests/DefaultAuthenticationPolicyTests.swift
@@ -1,0 +1,54 @@
+//
+//  DefaultAuthenticationPolicyTests.swift
+//  CoreNetworkTests
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import Testing
+@testable import CoreNetwork
+
+@Suite("DefaultAuthenticationPolicy")
+struct DefaultAuthenticationPolicyTests {
+
+    @Test("requireAuthentication은 모든 요청에 대해 true를 반환한다")
+    func requireAuthenticationAlwaysTrue() {
+        let policy = DefaultAuthenticationPolicy()
+
+        let withoutAuth = URLRequest(url: URL(string: "https://example.com/login")!)
+        var withAuth = URLRequest(url: URL(string: "https://example.com/me")!)
+        withAuth.setValue("Bearer test", forHTTPHeaderField: "Authorization")
+
+        #expect(policy.requireAuthentication(withoutAuth))
+        #expect(policy.requireAuthentication(withAuth))
+    }
+
+    @Test(
+        "isUnauthorizedResponse는 401일 때만 true를 반환한다",
+        arguments: [
+            (200, false),
+            (201, false),
+            (204, false),
+            (400, false),
+            (401, true),
+            (403, false),
+            (404, false),
+            (500, false),
+        ]
+    )
+    func isUnauthorizedResponseOnly401(statusCode: Int, expected: Bool) throws {
+        let policy = DefaultAuthenticationPolicy()
+        let url = URL(string: "https://example.com/me")!
+        let response = try #require(
+            HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )
+        )
+
+        #expect(policy.isUnauthorizedResponse(response) == expected)
+    }
+}

--- a/UMCApp/Core/Network/Tests/Integration/AppProductTestServerIntegrationTests.swift
+++ b/UMCApp/Core/Network/Tests/Integration/AppProductTestServerIntegrationTests.swift
@@ -1,0 +1,258 @@
+//
+//  AppProductTestServerIntegrationTests.swift
+//  CoreNetworkTests
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import CoreNetwork
+
+/// AppProductTestServer가 띄워져 있을 때만 실행되는 통합 테스트입니다.
+///
+/// ## 실행 방법
+///
+/// ```bash
+/// # 1. 서버 띄우기
+/// cd AppProductTestServer && make start
+///
+/// # 2. 통합 테스트 실행 (UMCApp 워크스페이스)
+/// cd UMCApp && TEST_SERVER_URL=http://127.0.0.1:8080 make test
+///
+/// # 3. 서버 내리기
+/// cd AppProductTestServer && make stop
+/// ```
+///
+/// `TEST_SERVER_URL` 환경 변수가 비어 있거나 서버가 응답하지 않으면 자동 스킵됩니다.
+@Suite("AppProductTestServer 통합", .serialized, .enabled(if: IntegrationConfig.isEnabled))
+struct AppProductTestServerIntegrationTests {
+
+    // MARK: - Public Endpoints
+
+    @Test("GET /test 는 CommonDTO 성공 래퍼로 문자열을 돌려준다")
+    func testEndpointReturnsSuccess() async throws {
+        let client = makeUnauthenticatedClient()
+
+        let request = URLRequest(url: IntegrationConfig.baseURL.appending(path: "/test"))
+        let (data, response) = try await client.request(request)
+
+        #expect(response.statusCode == 200)
+
+        let decoded = try JSONDecoder().decode(APIResponse<String>.self, from: data)
+        #expect(decoded.isSuccess)
+        #expect(try decoded.unwrap() == "테스트 성공")
+    }
+
+    // MARK: - Protected Endpoints
+
+    @Test("토큰이 있으면 GET /protected 가 200을 돌려준다")
+    func protectedEndpointWithToken() async throws {
+        let client = makeAuthenticatedClient(accessToken: "valid_token")
+
+        let request = URLRequest(url: IntegrationConfig.baseURL.appending(path: "/protected"))
+        let (data, response) = try await client.request(request)
+
+        #expect(response.statusCode == 200)
+        let decoded = try JSONDecoder().decode(APIResponse<String>.self, from: data)
+        #expect(try decoded.unwrap() == "보호 성공")
+    }
+
+    @Test("토큰이 없으면 GET /protected 가 NetworkError.maxRetryExceeded 로 끝난다")
+    func protectedEndpointWithoutTokenFails() async throws {
+        // accessToken=nil → Authorization 헤더 미전송 → 401 → refresh 시도 →
+        // refreshToken 도 없으므로 noRefreshToken 으로 종료
+        let client = makeUnauthenticatedClient()
+
+        let request = URLRequest(url: IntegrationConfig.baseURL.appending(path: "/protected"))
+
+        await #expect(throws: NetworkError.self) {
+            _ = try await client.request(request)
+        }
+    }
+
+    @Test("GET /user 는 UserDTO 형태의 result 를 반환한다")
+    func userEndpointDecodesUserDTO() async throws {
+        let client = makeAuthenticatedClient(accessToken: "valid_token")
+
+        let request = URLRequest(url: IntegrationConfig.baseURL.appending(path: "/user"))
+        let response: APIResponse<TestUserDTO> = try await client.request(request)
+
+        let user = try response.unwrap()
+        #expect(user.id == 1)
+        #expect(user.name == "Test User")
+        #expect(user.email == "test@jeong.com")
+    }
+
+    @Test("GET /users 는 UserDTO 배열을 반환한다")
+    func usersEndpointDecodesArray() async throws {
+        let client = makeAuthenticatedClient(accessToken: "valid_token")
+
+        let request = URLRequest(url: IntegrationConfig.baseURL.appending(path: "/users"))
+        let response: APIResponse<[TestUserDTO]> = try await client.request(request)
+
+        let users = try response.unwrap()
+        #expect(users.count == 3)
+        #expect(users[0].id == 1)
+    }
+
+    // MARK: - Token Refresh Flow
+
+    @Test("401 만료 토큰 → /auth/reissue 호출 → 새 토큰으로 재시도 → 200")
+    func endToEndRefreshFlow() async throws {
+        // 1) 만료된 access + 유효한 refresh 로 시작
+        let store = MockTokenStore(
+            accessToken: "expired_token",
+            refreshToken: "valid_refresh_token"
+        )
+
+        // 2) 실제 서버의 /auth/reissue 를 호출하는 RefreshService
+        let refreshService = AppProductTestServerRefreshService(
+            baseURL: IntegrationConfig.baseURL,
+            session: .shared
+        )
+
+        let client = NetworkClient(
+            session: .shared,
+            tokenStore: store,
+            refreshService: refreshService,
+            authPolicy: DefaultAuthenticationPolicy(),
+            maxRetryCount: 1
+        )
+
+        // 3) /protected 호출 — 첫 시도는 401, 자동 refresh 후 새 토큰으로 재시도
+        let request = URLRequest(url: IntegrationConfig.baseURL.appending(path: "/protected"))
+        let (_, response) = try await client.request(request)
+
+        #expect(response.statusCode == 200)
+
+        // 4) Mock store 에 새 토큰이 저장되었는지 확인
+        let savedAccess = await store.accessToken
+        #expect(savedAccess?.hasPrefix("new_access_token_") == true,
+                "새 액세스 토큰으로 갱신되어야 한다 (실제: \(savedAccess ?? "nil"))")
+    }
+
+    @Test("리프레시 토큰이 'expired_token' 이면 갱신 자체가 실패한다")
+    func expiredRefreshTokenFails() async throws {
+        let store = MockTokenStore(
+            accessToken: "expired_token",
+            refreshToken: "expired_token"
+        )
+        let refreshService = AppProductTestServerRefreshService(
+            baseURL: IntegrationConfig.baseURL,
+            session: .shared
+        )
+        let client = NetworkClient(
+            session: .shared,
+            tokenStore: store,
+            refreshService: refreshService,
+            authPolicy: DefaultAuthenticationPolicy(),
+            maxRetryCount: 1
+        )
+
+        let request = URLRequest(url: IntegrationConfig.baseURL.appending(path: "/protected"))
+
+        await #expect(throws: NetworkError.self) {
+            _ = try await client.request(request)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeUnauthenticatedClient() -> NetworkClient {
+        let store = MockTokenStore()
+        return NetworkClient(
+            session: .shared,
+            tokenStore: store,
+            refreshService: NoopRefreshService(),
+            authPolicy: DefaultAuthenticationPolicy(),
+            maxRetryCount: 0
+        )
+    }
+
+    private func makeAuthenticatedClient(accessToken: String) -> NetworkClient {
+        let store = MockTokenStore(accessToken: accessToken, refreshToken: "valid_refresh")
+        return NetworkClient(
+            session: .shared,
+            tokenStore: store,
+            refreshService: NoopRefreshService(),
+            authPolicy: DefaultAuthenticationPolicy(),
+            maxRetryCount: 0
+        )
+    }
+}
+
+// MARK: - DTOs (테스트 전용)
+
+private struct TestUserDTO: Codable, Equatable, Sendable {
+    let id: Int
+    let name: String
+    let email: String
+}
+
+// MARK: - Real Refresh Service
+
+/// 실제 AppProductTestServer 의 `POST /auth/reissue` 를 호출하는 TokenRefreshService 입니다.
+///
+/// 서버 스펙:
+/// - 헤더: `Authorization: Bearer <refreshToken>`
+/// - 응답: `CommonDTO<TokenPair>` (성공 시 새 access/refresh 쌍)
+private struct AppProductTestServerRefreshService: TokenRefreshService {
+    let baseURL: URL
+    let session: URLSession
+
+    func refresh(_ refreshToken: String) async throws -> TokenPair {
+        var request = URLRequest(url: baseURL.appending(path: "/auth/reissue"))
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(refreshToken)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw NetworkError.invalidResponse
+        }
+
+        let decoded = try JSONDecoder().decode(APIResponse<TokenPair>.self, from: data)
+        return try decoded.unwrap()
+    }
+}
+
+private struct NoopRefreshService: TokenRefreshService {
+    func refresh(_ refreshToken: String) async throws -> TokenPair {
+        throw NetworkError.tokenRefreshFailed(reason: "noop")
+    }
+}
+
+// MARK: - Configuration
+
+enum IntegrationConfig {
+    static let baseURL: URL = {
+        let raw = ProcessInfo.processInfo.environment["TEST_SERVER_URL"] ?? "http://127.0.0.1:8080"
+        return URL(string: raw)!
+    }()
+
+    /// 서버에 연결 가능할 때만 통합 테스트를 실행합니다.
+    /// 첫 호출 시 1회 동기 ping → 결과 캐싱.
+    nonisolated(unsafe) static let isEnabled: Bool = {
+        // TEST_SERVER_URL 이 명시적으로 설정된 경우에도, 서버가 살아있어야 의미가 있음
+        var request = URLRequest(url: baseURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 1.5
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var reachable = false
+
+        let task = URLSession.shared.dataTask(with: request) { _, response, _ in
+            if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
+                reachable = true
+            }
+            semaphore.signal()
+        }
+        task.resume()
+        _ = semaphore.wait(timeout: .now() + 2.0)
+        task.cancel()
+
+        return reachable
+    }()
+}

--- a/UMCApp/Core/Network/Tests/NetworkClientTests.swift
+++ b/UMCApp/Core/Network/Tests/NetworkClientTests.swift
@@ -1,0 +1,278 @@
+//
+//  NetworkClientTests.swift
+//  CoreNetworkTests
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import CoreNetwork
+
+@Suite("NetworkClient", .serialized)
+@MainActor
+struct NetworkClientTests {
+
+    // MARK: - Fixtures
+
+    private let testURL = URL(string: "https://api.umc.test/api/v1/me")!
+
+    private func makeClient(
+        store: MockTokenStore,
+        refresh: MockTokenRefreshService,
+        maxRetryCount: Int = 1
+    ) -> NetworkClient {
+        StubURLProtocol.reset()
+        let session = makeStubSession()
+        return NetworkClient(
+            session: session,
+            tokenStore: store,
+            refreshService: refresh,
+            authPolicy: DefaultAuthenticationPolicy(),
+            maxRetryCount: maxRetryCount
+        )
+    }
+
+    // MARK: - isLoggedIn / logout
+
+    @Test("토큰이 있으면 isLoggedIn이 true다")
+    func isLoggedInTrue() async {
+        let store = MockTokenStore(accessToken: "A", refreshToken: "R")
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = makeClient(store: store, refresh: refresh)
+
+        let loggedIn = await client.isLoggedIn()
+        #expect(loggedIn)
+    }
+
+    @Test("토큰이 없으면 isLoggedIn이 false다")
+    func isLoggedInFalse() async {
+        let store = MockTokenStore()
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = makeClient(store: store, refresh: refresh)
+
+        let loggedIn = await client.isLoggedIn()
+        #expect(!loggedIn)
+    }
+
+    @Test("logout 호출 시 tokenStore.clear()가 1회 호출된다")
+    func logoutClearsTokens() async throws {
+        let store = MockTokenStore(accessToken: "A", refreshToken: "R")
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = makeClient(store: store, refresh: refresh)
+
+        try await client.logout()
+
+        let clearCount = await store.clearCallCount
+        let access = await store.accessToken
+        #expect(clearCount == 1)
+        #expect(access == nil)
+    }
+
+    // MARK: - request: Authorization 주입
+
+    @Test("인증 정책이 true이고 액세스 토큰이 있으면 Authorization 헤더가 주입된다")
+    func injectsAuthorizationHeader() async throws {
+        let store = MockTokenStore(accessToken: "ACCESS123", refreshToken: "R")
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = makeClient(store: store, refresh: refresh)
+
+        StubURLProtocol.handler = { _ in (Data("{}".utf8), 200, nil) }
+
+        let request = URLRequest(url: testURL)
+        _ = try await client.request(request)
+
+        let captured = try #require(StubURLProtocol.capturedRequests.first)
+        #expect(captured.value(forHTTPHeaderField: "Authorization") == "Bearer ACCESS123")
+    }
+
+    // MARK: - 401 → refresh → retry
+
+    @Test("401 응답 시 refresh 후 새 액세스 토큰으로 재시도하고 200을 반환한다")
+    func refreshOn401AndRetry() async throws {
+        let store = MockTokenStore(accessToken: "OLD", refreshToken: "REFRESH")
+        let refresh = MockTokenRefreshService(
+            behavior: .success(TokenPair(accessToken: "NEW", refreshToken: "NEW_R"))
+        )
+        let client = makeClient(store: store, refresh: refresh)
+
+        // 1번째 호출: 401, 2번째 호출(refresh 후): 200
+        let callCount = LockedCounter()
+        StubURLProtocol.handler = { _ in
+            let n = callCount.increment()
+            if n == 1 {
+                return (Data(), 401, nil)
+            } else {
+                return (Data("{\"ok\":true}".utf8), 200, nil)
+            }
+        }
+
+        let request = URLRequest(url: testURL)
+        let (data, response) = try await client.request(request)
+
+        #expect(response.statusCode == 200)
+        #expect(String(data: data, encoding: .utf8) == "{\"ok\":true}")
+
+        let refreshCalls = await refresh.callCount
+        #expect(refreshCalls == 1)
+
+        let stored = await store.accessToken
+        #expect(stored == "NEW")
+
+        // 두 번째 요청에서 새 토큰이 헤더에 들어가야 한다
+        let secondRequest = StubURLProtocol.capturedRequests[1]
+        #expect(secondRequest.value(forHTTPHeaderField: "Authorization") == "Bearer NEW")
+    }
+
+    @Test("401이 재시도 후에도 다시 발생하면 maxRetryExceeded를 throw한다")
+    func maxRetryExceededAfterRetry() async {
+        let store = MockTokenStore(accessToken: "OLD", refreshToken: "REFRESH")
+        let refresh = MockTokenRefreshService(
+            behavior: .success(TokenPair(accessToken: "NEW", refreshToken: "NEW_R"))
+        )
+        let client = makeClient(store: store, refresh: refresh, maxRetryCount: 1)
+
+        StubURLProtocol.handler = { _ in (Data(), 401, nil) }
+
+        await #expect(throws: NetworkError.maxRetryExceeded) {
+            _ = try await client.request(URLRequest(url: self.testURL))
+        }
+    }
+
+    @Test("refresh가 실패하면 NetworkError.tokenRefreshFailed를 throw한다")
+    func refreshFailureWraps() async {
+        let store = MockTokenStore(accessToken: "OLD", refreshToken: "REFRESH")
+        let refresh = MockTokenRefreshService(behavior: .failure(.invalidRefreshToken))
+        let client = makeClient(store: store, refresh: refresh)
+
+        StubURLProtocol.handler = { _ in (Data(), 401, nil) }
+
+        await #expect(throws: NetworkError.self) {
+            _ = try await client.request(URLRequest(url: self.testURL))
+        }
+    }
+
+    @Test("리프레시 토큰이 없으면 NetworkError.noRefreshToken을 throw한다")
+    func noRefreshTokenError() async {
+        let store = MockTokenStore(accessToken: "OLD", refreshToken: nil)
+        let refresh = MockTokenRefreshService(
+            behavior: .success(TokenPair(accessToken: "NEW", refreshToken: "NEW_R"))
+        )
+        let client = makeClient(store: store, refresh: refresh)
+
+        StubURLProtocol.handler = { _ in (Data(), 401, nil) }
+
+        await #expect(throws: NetworkError.self) {
+            _ = try await client.request(URLRequest(url: self.testURL))
+        }
+    }
+
+    // MARK: - Single-flight refresh
+
+    @Test("동시 다발적 401에서도 토큰 갱신은 단 1회만 실행된다 (single-flight)")
+    func singleFlightRefresh() async throws {
+        let store = MockTokenStore(accessToken: "OLD", refreshToken: "REFRESH")
+        let refresh = MockTokenRefreshService(
+            behavior: .delayedSuccess(
+                TokenPair(accessToken: "NEW", refreshToken: "NEW_R"),
+                nanoseconds: 80_000_000  // 80ms
+            )
+        )
+        let client = makeClient(store: store, refresh: refresh)
+
+        // 첫 요청은 401, 이후엔 200
+        let callCount = LockedCounter()
+        StubURLProtocol.handler = { _ in
+            let n = callCount.increment()
+            if n <= 5 { // 처음 5개의 동시 요청은 모두 401
+                return (Data(), 401, nil)
+            } else {
+                return (Data("{}".utf8), 200, nil)
+            }
+        }
+
+        async let r1 = client.request(URLRequest(url: testURL))
+        async let r2 = client.request(URLRequest(url: testURL))
+        async let r3 = client.request(URLRequest(url: testURL))
+        async let r4 = client.request(URLRequest(url: testURL))
+        async let r5 = client.request(URLRequest(url: testURL))
+
+        let results = try await [r1, r2, r3, r4, r5]
+        #expect(results.allSatisfy { $0.1.statusCode == 200 })
+
+        let refreshCalls = await refresh.callCount
+        #expect(refreshCalls == 1, "동시 401에도 refresh는 1회만 호출되어야 한다 — 실제: \(refreshCalls)")
+    }
+
+    // MARK: - forceRefreshToken
+
+    @Test("forceRefreshToken은 새 토큰 쌍을 저장하고 반환한다")
+    func forceRefreshSavesAndReturns() async throws {
+        let store = MockTokenStore(accessToken: "OLD", refreshToken: "REFRESH")
+        let newPair = TokenPair(accessToken: "NEW_A", refreshToken: "NEW_R")
+        let refresh = MockTokenRefreshService(behavior: .success(newPair))
+        let client = makeClient(store: store, refresh: refresh)
+
+        let result = try await client.forceRefreshToken()
+
+        #expect(result == newPair)
+
+        let savedAccess = await store.accessToken
+        let savedRefresh = await store.refreshToken
+        #expect(savedAccess == "NEW_A")
+        #expect(savedRefresh == "NEW_R")
+    }
+
+    // MARK: - Decodable overload
+
+    @Test("Decodable 오버로드는 응답 JSON을 자동 디코딩한다")
+    func decodableOverloadDecodes() async throws {
+        let store = MockTokenStore(accessToken: "A", refreshToken: "R")
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = makeClient(store: store, refresh: refresh)
+
+        StubURLProtocol.handler = { _ in
+            (Data("{\"id\":7,\"name\":\"jeong\"}".utf8), 200, nil)
+        }
+
+        let dto: SampleDTO = try await client.request(URLRequest(url: testURL))
+
+        #expect(dto.id == 7)
+        #expect(dto.name == "jeong")
+    }
+
+    // MARK: - Non-2xx error
+
+    @Test("2xx 외 응답은 NetworkError.requestFailed로 변환된다")
+    func nonSuccessStatusCodeFails() async {
+        let store = MockTokenStore(accessToken: "A", refreshToken: "R")
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = makeClient(store: store, refresh: refresh)
+
+        StubURLProtocol.handler = { _ in (Data(), 500, nil) }
+
+        await #expect(throws: NetworkError.requestFailed(statusCode: 500, data: nil)) {
+            _ = try await client.request(URLRequest(url: self.testURL))
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private struct SampleDTO: Decodable, Equatable, Sendable {
+    let id: Int
+    let name: String
+}
+
+/// 동기화된 카운터 — handler 클로저가 multiple thread/queue에서 호출될 수 있으므로 락 필요
+private final class LockedCounter: @unchecked Sendable {
+    private var value = 0
+    private let lock = NSLock()
+
+    func increment() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        value += 1
+        return value
+    }
+}

--- a/UMCApp/Core/Network/Tests/Support/MockTokenStore.swift
+++ b/UMCApp/Core/Network/Tests/Support/MockTokenStore.swift
@@ -1,0 +1,81 @@
+//
+//  MockTokenStore.swift
+//  CoreNetworkTests
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+@testable import CoreNetwork
+
+/// 메모리 기반 Mock TokenStore — Keychain을 거치지 않고 동작 확인용
+actor MockTokenStore: TokenStore {
+
+    private(set) var accessToken: String?
+    private(set) var refreshToken: String?
+    private(set) var saveCallCount: Int = 0
+    private(set) var clearCallCount: Int = 0
+
+    init(accessToken: String? = nil, refreshToken: String? = nil) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+    }
+
+    func getAccessToken() async -> String? { accessToken }
+    func getRefreshToken() async -> String? { refreshToken }
+
+    func save(accessToken: String, refreshToken: String) async throws {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.saveCallCount += 1
+    }
+
+    func clear() async throws {
+        accessToken = nil
+        refreshToken = nil
+        clearCallCount += 1
+    }
+}
+
+/// 토큰 갱신 동작을 시나리오로 주입할 수 있는 Mock RefreshService
+actor MockTokenRefreshService: TokenRefreshService {
+
+    enum Behavior: Sendable {
+        case success(TokenPair)
+        case failure(MockRefreshError)
+        /// 호출 시 sleep 후 success — single-flight 테스트에 사용
+        case delayedSuccess(TokenPair, nanoseconds: UInt64)
+    }
+
+    private var behavior: Behavior
+    private(set) var callCount: Int = 0
+    private(set) var receivedRefreshTokens: [String] = []
+
+    init(behavior: Behavior) {
+        self.behavior = behavior
+    }
+
+    func updateBehavior(_ behavior: Behavior) {
+        self.behavior = behavior
+    }
+
+    func refresh(_ refreshToken: String) async throws -> TokenPair {
+        callCount += 1
+        receivedRefreshTokens.append(refreshToken)
+
+        switch behavior {
+        case .success(let pair):
+            return pair
+        case .failure(let error):
+            throw error
+        case .delayedSuccess(let pair, let nanoseconds):
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            return pair
+        }
+    }
+}
+
+enum MockRefreshError: Error, Sendable, Equatable {
+    case invalidRefreshToken
+    case networkUnavailable
+}

--- a/UMCApp/Core/Network/Tests/Support/StubURLProtocol.swift
+++ b/UMCApp/Core/Network/Tests/Support/StubURLProtocol.swift
@@ -1,0 +1,71 @@
+//
+//  StubURLProtocol.swift
+//  CoreNetworkTests
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+
+/// URLSession을 가로채 임의의 응답을 주입하기 위한 URLProtocol 구현체입니다.
+///
+/// - Note: `URLSessionConfiguration.ephemeral`에 등록한 후 사용합니다.
+final class StubURLProtocol: URLProtocol, @unchecked Sendable {
+
+    /// (request) → (data, statusCode, headers) 응답을 결정하는 핸들러
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, Int, [String: String]?))?
+
+    /// 가로챈 모든 요청 (검증용)
+    nonisolated(unsafe) static var capturedRequests: [URLRequest] = []
+    private static let lock = NSLock()
+
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        handler = nil
+        capturedRequests = []
+    }
+
+    static func record(_ request: URLRequest) {
+        lock.lock(); defer { lock.unlock() }
+        capturedRequests.append(request)
+    }
+
+    // MARK: - URLProtocol
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.record(request)
+
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (data, statusCode, headers) = try handler(request)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: headers
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+/// 테스트 전용 URLSession을 만듭니다.
+@MainActor
+func makeStubSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+}

--- a/UMCApp/Core/Network/Tests/TokenPairTests.swift
+++ b/UMCApp/Core/Network/Tests/TokenPairTests.swift
@@ -1,0 +1,59 @@
+//
+//  TokenPairTests.swift
+//  CoreNetworkTests
+//
+//  Created by euijjang97 on 4/25/26.
+//
+
+import Foundation
+import Testing
+@testable import CoreNetwork
+
+@Suite("TokenPair")
+struct TokenPairTests {
+
+    @Test("init으로 생성한 토큰의 프로퍼티가 그대로 노출된다")
+    func initSetsProperties() {
+        let pair = TokenPair(accessToken: "access-1", refreshToken: "refresh-1")
+
+        #expect(pair.accessToken == "access-1")
+        #expect(pair.refreshToken == "refresh-1")
+    }
+
+    @Test("Codable round-trip 시 동일한 값이 보존된다")
+    func codableRoundTrip() throws {
+        let original = TokenPair(accessToken: "AAA", refreshToken: "RRR")
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(TokenPair.self, from: data)
+
+        #expect(decoded == original)
+    }
+
+    @Test("서버 JSON 키(accessToken/refreshToken)로 디코딩된다")
+    func decodesServerJSON() throws {
+        let json = """
+        { "accessToken": "JWT.A", "refreshToken": "JWT.R" }
+        """.data(using: .utf8)!
+
+        let pair = try JSONDecoder().decode(TokenPair.self, from: json)
+
+        #expect(pair.accessToken == "JWT.A")
+        #expect(pair.refreshToken == "JWT.R")
+    }
+
+    @Test(
+        "Equatable 비교가 두 필드를 모두 검사한다",
+        arguments: [
+            (TokenPair(accessToken: "A", refreshToken: "R"),
+             TokenPair(accessToken: "A", refreshToken: "R"), true),
+            (TokenPair(accessToken: "A", refreshToken: "R"),
+             TokenPair(accessToken: "A2", refreshToken: "R"), false),
+            (TokenPair(accessToken: "A", refreshToken: "R"),
+             TokenPair(accessToken: "A", refreshToken: "R2"), false),
+        ]
+    )
+    func equatable(lhs: TokenPair, rhs: TokenPair, expected: Bool) {
+        #expect((lhs == rhs) == expected)
+    }
+}

--- a/UMCApp/MAKEFILE_GUIDE.md
+++ b/UMCApp/MAKEFILE_GUIDE.md
@@ -52,7 +52,8 @@ make open        # Xcode 실행
 | `make install` | SPM 의존성 설치 | `Tuist/Package.swift` 변경 후 |
 | `make edit` | Tuist 매니페스트 편집 모드 | `Project+Feature.swift` 등 수정 시 |
 | `make graph` | 의존성 그래프(`graph.png`) 생성 | 구조 리뷰할 때 |
-| `make test` | 테스트 실행 | CI 재현 / 로컬 검증 |
+| `make test` | 테스트 실행 (`SCHEME` = `UMCApp`) | CI 재현 / 로컬 검증 |
+| `make test-network` | CoreNetwork 단위+통합 테스트 (`TEST_SERVER_URL` 자동 전달) | 네트워크 레이어 변경 후 |
 | `make build` | Debug 빌드 | 빌드 가능 여부만 확인할 때 |
 | `make build SCHEME=…` | 특정 스킴(모듈)만 빌드 | 한 모듈만 빠르게 검증할 때 |
 | `make pick` | 스킴 목록에서 골라 빌드 (대화형) | 스킴 이름이 안 떠오를 때 |
@@ -91,6 +92,7 @@ make open
 | `SCHEME` | `UMCApp` | `make build SCHEME=AuthDomain` (모듈 단위 빌드) |
 | `CONFIGURATION` | `Debug` | `make build CONFIGURATION=Release` |
 | `DESTINATION` | `platform=iOS Simulator,name=iPhone 17 Pro` | `make test DESTINATION='platform=iOS Simulator,name=iPhone 17'` |
+| `TEST_SERVER_URL` | `http://127.0.0.1:8080` | `make test-network TEST_SERVER_URL=http://127.0.0.1:9090` |
 
 예시:
 
@@ -122,7 +124,64 @@ xcodebuild -workspace UMCApp.xcworkspace -list
 
 ---
 
-## 5. 버전 업그레이드 규칙
+## 5. CoreNetwork 통합 테스트
+
+`CoreNetwork` 모듈은 두 단계로 검증됩니다.
+
+| 계층 | 무엇 | 외부 의존 |
+|------|------|----------|
+| **단위 테스트** | URLProtocol 스텁 + actor Mock 으로 `NetworkClient`/`APIResponse`/`TokenPair` 검증 | 없음 — 항상 실행 |
+| **통합 테스트** | 실제 Vapor 테스트 서버(`AppProductTestServer/`) 의 `/test`, `/protected`, `/auth/reissue` 호출 | 서버 살아있어야 실행 (없으면 자동 스킵) |
+
+`make test-network` 한 번이면 두 계층이 동시에 돌아갑니다 — 통합 테스트는 `IntegrationConfig.isEnabled` 가 서버를 1.5초 ping 으로 감지해서 켜지므로 **서버를 띄워두고 돌리면 38개, 안 띄우면 31개** 가 통과합니다.
+
+### 한 줄로 끝내기 (`make integration`)
+
+레포 루트의 `AppProductTestServer/Makefile` 에 **start → UMCApp test-network → stop** 원샷이 있습니다.
+
+```bash
+cd AppProductTestServer
+make integration   # 서버 자동 기동 → CoreNetwork 통합 테스트 → 서버 자동 종료
+```
+
+테스트가 실패해도 종료 단계는 항상 실행되며, 종료 코드는 보존됩니다 (CI 안전).
+
+### 수동 흐름 (서버 띄워두고 반복 실행)
+
+```bash
+# 터미널 A — 서버 띄우기
+cd AppProductTestServer
+make start         # 백그라운드 + .server.pid / .server.log
+make logs          # tail -f
+make health        # / · /test · /protected 핑
+
+# 터미널 B — 테스트 반복
+cd UMCApp
+make test-network  # 서버 살아있으면 통합도 자동 포함
+
+# 끝
+cd AppProductTestServer && make stop
+```
+
+### 환경 변수
+
+| 변수 | 어디서 | 용도 |
+|------|--------|------|
+| `TEST_SERVER_URL` | `make test-network`, `make integration` | 테스트 코드(`IntegrationConfig.baseURL`) 가 읽는 베이스 URL |
+| `HOST`, `PORT` | `AppProductTestServer/Makefile` | 서버 바인딩 (`make start HOST=0.0.0.0 PORT=9090`) |
+
+### 트러블슈팅 — 포트 8080 점유
+
+```bash
+cd AppProductTestServer
+make stop          # PID 파일 + pkill 패턴 + lsof 폴백 3중 종료
+```
+
+여전히 점유 중이면 `lsof -ti :8080 | xargs kill -9`.
+
+---
+
+## 6. 버전 업그레이드 규칙
 
 Tuist 버전을 올릴 때는 **`mise.toml` 만** 수정합니다. Makefile은 건드리지 않습니다.
 
@@ -145,7 +204,7 @@ make generate
 
 ---
 
-## 6. 트러블슈팅
+## 7. 트러블슈팅
 
 ### `mise: command not found`
 → `brew install mise` 후 셸 재시작.
@@ -164,21 +223,25 @@ make generate
 
 ---
 
-## 7. 파일 구조 참고
+## 8. 파일 구조 참고
 
 ```
-UMCApp/
-├── Makefile              # ← 이 가이드가 설명하는 파일
-├── MAKEFILE_GUIDE.md     # ← 이 문서
-├── mise.toml             # tuist 버전 고정
-├── Tuist.swift
-├── Workspace.swift
-├── Project.swift
-├── Tuist/
-│   ├── Package.swift     # SPM 외부 의존성
-│   └── ProjectDescriptionHelpers/
-├── Core/                 # 공유 인프라 모듈
-└── Features/             # 기능 모듈
+umc-product-iOS/
+├── UMCApp/
+│   ├── Makefile              # ← 이 가이드가 설명하는 파일
+│   ├── MAKEFILE_GUIDE.md     # ← 이 문서
+│   ├── mise.toml             # tuist 버전 고정
+│   ├── Tuist.swift
+│   ├── Workspace.swift
+│   ├── Project.swift
+│   ├── Tuist/
+│   │   ├── Package.swift     # SPM 외부 의존성
+│   │   └── ProjectDescriptionHelpers/
+│   ├── Core/                 # 공유 인프라 모듈
+│   └── Features/             # 기능 모듈
+└── AppProductTestServer/     # CoreNetwork 통합 테스트용 Vapor 서버
+    ├── Makefile              # start / stop / integration 원샷
+    └── Sources/AppProductTestServer/
 ```
 
 모듈 구조 자체에 대한 설명은 루트 `CLAUDE.md` 의 **"Tuist 모듈 구조 (UMCApp)"** 섹션을 참고하세요.

--- a/UMCApp/MAKEFILE_GUIDE.md
+++ b/UMCApp/MAKEFILE_GUIDE.md
@@ -54,6 +54,8 @@ make open        # Xcode 실행
 | `make graph` | 의존성 그래프(`graph.png`) 생성 | 구조 리뷰할 때 |
 | `make test` | 테스트 실행 | CI 재현 / 로컬 검증 |
 | `make build` | Debug 빌드 | 빌드 가능 여부만 확인할 때 |
+| `make build SCHEME=…` | 특정 스킴(모듈)만 빌드 | 한 모듈만 빠르게 검증할 때 |
+| `make pick` | 스킴 목록에서 골라 빌드 (대화형) | 스킴 이름이 안 떠오를 때 |
 | `make doctor` | 환경 진단 (mise/tuist/xcode 버전) | 다른 팀원과 증상이 다를 때 |
 | `make help` | 전체 타겟 목록 | 까먹었을 때 |
 
@@ -86,9 +88,9 @@ make open
 
 | 변수 | 기본값 | 예시 |
 |------|--------|------|
-| `SCHEME` | `UMCApp` | `make test SCHEME=AuthTests` |
+| `SCHEME` | `UMCApp` | `make build SCHEME=AuthDomain` (모듈 단위 빌드) |
 | `CONFIGURATION` | `Debug` | `make build CONFIGURATION=Release` |
-| `DESTINATION` | `platform=iOS Simulator,name=iPhone 16 Pro` | `make test DESTINATION='platform=iOS Simulator,name=iPhone 15'` |
+| `DESTINATION` | `platform=iOS Simulator,name=iPhone 17 Pro` | `make test DESTINATION='platform=iOS Simulator,name=iPhone 17'` |
 
 예시:
 
@@ -97,7 +99,25 @@ make open
 make build CONFIGURATION=Release
 
 # 다른 시뮬레이터에서 테스트
-make test DESTINATION='platform=iOS Simulator,name=iPhone 15 Pro'
+make test DESTINATION='platform=iOS Simulator,name=iPhone 17'
+
+# 특정 모듈만 빌드 (Tuist가 모듈마다 스킴을 자동 생성)
+make build SCHEME=AuthDomain
+make build SCHEME=NoticePresentation
+make build SCHEME=CoreNetwork
+
+# 스킴 이름이 기억 안 날 때 — 대화형으로 선택
+make pick
+```
+
+> **`make pick`**: `xcodebuild -workspace … -list` 결과를 동적으로 읽어와 선택지를 띄웁니다.
+> `fzf` 가 설치돼 있으면 fuzzy 검색, 없으면 bash `select` 로 번호 선택 메뉴가 뜹니다.
+> 모듈을 추가/삭제해도 별도 동기화가 필요 없습니다.
+
+### 사용 가능한 스킴 확인
+
+```bash
+xcodebuild -workspace UMCApp.xcworkspace -list
 ```
 
 ---

--- a/UMCApp/Makefile
+++ b/UMCApp/Makefile
@@ -14,7 +14,7 @@ SHELL := /bin/bash
 
 SCHEME ?= UMCApp
 WORKSPACE := UMCApp.xcworkspace
-DESTINATION ?= platform=iOS Simulator,name=iPhone 16 Pro
+DESTINATION ?= platform=iOS Simulator,name=iPhone 17 Pro
 CONFIGURATION ?= Debug
 
 MISE ?= mise
@@ -31,8 +31,13 @@ help: ## 이 도움말 출력
 		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
 	@echo ""
 	@echo "환경 변수 오버라이드 예시:"
-	@echo "  make test DESTINATION='platform=iOS Simulator,name=iPhone 15'"
+	@echo "  make pick                                     # 스킴 골라서 빌드 (대화형)"
+	@echo "  make build SCHEME=AuthDomain                  # 모듈 단위 빌드"
+	@echo "  make test  DESTINATION='platform=iOS Simulator,name=iPhone 17'"
 	@echo "  make build CONFIGURATION=Release"
+	@echo ""
+	@echo "사용 가능한 스킴 목록:"
+	@echo "  xcodebuild -workspace $(WORKSPACE) -list"
 	@echo ""
 
 ##@ 환경 설정
@@ -108,6 +113,34 @@ build: ## 빌드 ($(CONFIGURATION))
 		-configuration $(CONFIGURATION) \
 		-destination "$(DESTINATION)" \
 		build
+
+.PHONY: pick
+pick: ## 스킴을 골라 빌드 (fzf 있으면 fuzzy, 없으면 번호 선택)
+	@if [ ! -d "$(WORKSPACE)" ]; then \
+		echo "⚠️  $(WORKSPACE) 없음 → 먼저 'make generate' 실행"; \
+		exit 1; \
+	fi
+	@SCHEMES=$$(xcodebuild -workspace $(WORKSPACE) -list 2>/dev/null \
+		| awk '/Schemes:/{found=1; next} found && NF{sub(/^[[:space:]]+/, ""); print}'); \
+	if [ -z "$$SCHEMES" ]; then \
+		echo "스킴을 찾지 못했습니다."; exit 1; \
+	fi; \
+	if command -v fzf >/dev/null 2>&1; then \
+		SCHEME=$$(echo "$$SCHEMES" | fzf --prompt="빌드할 스킴 > " --height=40% --reverse); \
+	else \
+		echo ""; \
+		echo "빌드할 스킴을 선택하세요 (번호 입력, Ctrl+C 취소):"; \
+		PS3="> "; \
+		IFS=$$'\n'; \
+		select s in $$SCHEMES; do \
+			SCHEME=$$s; break; \
+		done; \
+	fi; \
+	if [ -z "$$SCHEME" ]; then \
+		echo "선택 취소"; exit 1; \
+	fi; \
+	echo "▶︎ '$$SCHEME' 빌드 시작"; \
+	$(MAKE) build SCHEME="$$SCHEME"
 
 .PHONY: test
 test: ## 테스트 실행

--- a/UMCApp/Makefile
+++ b/UMCApp/Makefile
@@ -151,6 +151,17 @@ test: ## 테스트 실행
 		-destination "$(DESTINATION)" \
 		test
 
+TEST_SERVER_URL ?= http://127.0.0.1:8080
+
+.PHONY: test-network
+test-network: ## CoreNetwork 단위+통합 테스트 (서버 살아있으면 통합도 자동 실행)
+	@TEST_SERVER_URL="$(TEST_SERVER_URL)" xcodebuild \
+		-workspace $(WORKSPACE) \
+		-scheme CoreNetwork \
+		-configuration $(CONFIGURATION) \
+		-destination "$(DESTINATION)" \
+		test
+
 ##@ 정리
 
 .PHONY: clean

--- a/UMCApp/Project.swift
+++ b/UMCApp/Project.swift
@@ -1,7 +1,9 @@
 import ProjectDescription
+import ProjectDescriptionHelpers
 
 let project = Project(
     name: "UMCApp",
+    settings: recommendedProjectSettings,
     targets: [
         .target(
             name: "UMCApp",

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
@@ -5,33 +5,57 @@ private let bundleIdBase = "dev.umc.core"
 /// Core 모듈용 Project 생성 헬퍼
 ///
 /// Core 모듈은 단일 staticFramework 타겟으로 구성됩니다.
+/// `includesTests: true`인 경우 `{name}Tests` unitTests 타겟이 함께 생성됩니다.
 ///
 /// - Parameters:
 ///   - name: 타겟 이름 (예: "CoreNetwork", "UMCFoundation")
 ///   - bundleIdSuffix: bundleId 접미사 (예: "network", "foundation")
 ///   - destinations: 지원 플랫폼 (기본값: `.iOS`)
 ///   - deploymentTargets: 배포 대상 (기본값: iOS 26.3)
-///   - dependencies: 의존성 목록
+///   - dependencies: 메인 타겟 의존성 목록
+///   - includesTests: `true`이면 `Tests/**` 소스를 사용하는 unitTests 타겟을 함께 생성
+///   - testDependencies: 테스트 타겟에 추가로 주입할 의존성 (메인 타겟은 자동 포함)
+///   - testEntitlements: 테스트 타겟용 entitlements 파일 (Keychain access 등)
 public func coreProject(
     name: String,
     bundleIdSuffix: String,
     destinations: Destinations = .iOS,
     deploymentTargets: DeploymentTargets = .iOS("26.3"),
-    dependencies: [TargetDependency] = []
+    dependencies: [TargetDependency] = [],
+    includesTests: Bool = false,
+    testDependencies: [TargetDependency] = [],
+    testEntitlements: Path? = nil
 ) -> Project {
-    Project(
+    var targets: [Target] = [
+        .target(
+            name: name,
+            destinations: destinations,
+            product: .staticFramework,
+            bundleId: "\(bundleIdBase).\(bundleIdSuffix)",
+            deploymentTargets: deploymentTargets,
+            sources: ["Sources/**"],
+            dependencies: dependencies
+        )
+    ]
+
+    if includesTests {
+        targets.append(
+            .target(
+                name: "\(name)Tests",
+                destinations: destinations,
+                product: .unitTests,
+                bundleId: "\(bundleIdBase).\(bundleIdSuffix).tests",
+                deploymentTargets: deploymentTargets,
+                sources: ["Tests/**"],
+                entitlements: testEntitlements.map(Entitlements.file(path:)),
+                dependencies: [.target(name: name)] + testDependencies
+            )
+        )
+    }
+
+    return Project(
         name: name,
         settings: recommendedProjectSettings,
-        targets: [
-            .target(
-                name: name,
-                destinations: destinations,
-                product: .staticFramework,
-                bundleId: "\(bundleIdBase).\(bundleIdSuffix)",
-                deploymentTargets: deploymentTargets,
-                sources: ["Sources/**"],
-                dependencies: dependencies
-            )
-        ]
+        targets: targets
     )
 }

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
@@ -21,6 +21,7 @@ public func coreProject(
 ) -> Project {
     Project(
         name: name,
+        settings: recommendedProjectSettings,
         targets: [
             .target(
                 name: name,

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
@@ -28,6 +28,7 @@ public func featureProject(
 
     return Project(
         name: name,
+        settings: recommendedProjectSettings,
         targets: [
             .target(
                 name: "\(name)Domain",

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WatchApp.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WatchApp.swift
@@ -20,6 +20,7 @@ public func watchAppProject(
 ) -> Project {
     Project(
         name: name,
+        settings: recommendedProjectSettings,
         targets: [
             .target(
                 name: name,

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WidgetExtension.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WidgetExtension.swift
@@ -21,6 +21,7 @@ public func widgetExtensionProject(
 ) -> Project {
     Project(
         name: name,
+        settings: recommendedProjectSettings,
         targets: [
             .target(
                 name: name,

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Settings+Recommended.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Settings+Recommended.swift
@@ -1,0 +1,26 @@
+import ProjectDescription
+
+/// Xcode가 권장하는 최신 빌드 설정 모음
+///
+/// Xcode `Issue Navigator > Update to recommended settings` 다이얼로그에서 제안하는 항목 중
+/// 프로젝트 전역으로 적용해도 안전한 설정을 모아둡니다.
+///
+/// Tuist는 매 generate 시 `.xcodeproj`을 재생성하므로, 이 설정은 반드시 매니페스트에서 관리해야
+/// 다이얼로그가 다시 뜨지 않습니다.
+///
+/// 적용 항목:
+/// - `ENABLE_MODULE_VERIFIER`: Clang 모듈 헤더 검증
+/// - `ENABLE_USER_SCRIPT_SANDBOXING`: Run Script Phase 샌드박스
+/// - `LOCALIZED_STRING_SWIFTUI_SUPPORT` / `STRING_CATALOG_GENERATE_SYMBOLS`: String Catalog 심볼 생성
+public let recommendedSettings: SettingsDictionary = [
+    "ENABLE_MODULE_VERIFIER": "YES",
+    "MODULE_VERIFIER_SUPPORTED_LANGUAGES": "objective-c objective-c++",
+    "MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS": "gnu17 gnu++20",
+    "ENABLE_USER_SCRIPT_SANDBOXING": "YES",
+    "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+]
+
+/// 프로젝트 전역에 권장 빌드 설정을 적용한 Settings
+public let recommendedProjectSettings: Settings = .settings(
+    base: recommendedSettings
+)


### PR DESCRIPTION
## ✨ PR 유형

Refactor — CoreNetwork 모듈에 JWT 인증 기반 Actor `NetworkClient`를 도입하고, 공통 API 응답 모델·권장 빌드 설정·Tests 타겟 헬퍼까지 함께 정비합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (인프라/모듈 구조 리팩토링).

## 🛠️ 작업내용

### 1. JWT 인증 NetworkClient 도입
- `NetworkClient` Actor로 토큰 자동 첨부 / 401 자동 갱신 / **Single Refresh Task** 패턴 구현 (동시 401 발생 시 토큰 갱신 1회만 실행)
- 추상화 프로토콜 분리: `TokenStore`, `TokenRefreshService`, `AuthenticationPolicy`
- `DefaultAuthenticationPolicy` (모든 요청 인증 + 401 처리), `KeychainTokenStore` (Keychain 기반 토큰 저장), `TokenRefreshServiceImpl`, `MoyaNetworkAdapter` 구현체 추가
- `AuthSystemFactory` DI 등록 진입점 신설

### 2. 네트워크 공통 응답 처리 + 권장 빌드 설정 통합
- 서버 표준 응답 래퍼(`APIResponse`) + `BaseTargetType` 도입으로 디코딩 경로 단일화
- `APIError` 도메인 에러 추가
- `Settings+Recommended` 추가로 전 모듈에 권장 빌드 설정 일괄 적용 (`coreProject`/`featureProject`/`watchAppProject`/`widgetExtensionProject` + `App` 타겟)

### 3. coreProject 헬퍼 Tests 타겟 옵션화
- `coreProject`에 `includesTests`, `testDependencies`, `testEntitlements` 파라미터 추가 → Core 모듈 단위 unitTests 타겟 자동 생성 지원
- `CoreNetwork`에 `Security.framework` SDK 의존성과 Tests 타겟 활성화
- 테스트 7개 파일 추가:
  - `NetworkClientTests` (토큰 자동 첨부/401 재시도/Single Refresh)
  - `APIResponseTests`, `TokenPairTests`, `DefaultAuthenticationPolicyTests`, `AuthSystemFactoryTests`
  - `MockTokenStore`, `StubURLProtocol` 테스트 지원 유틸

### 4. Makefile 모듈 단위 빌드 워크플로
- `make build SCHEME=…` 모듈 단위 빌드 지원
- `make pick` 대화형 스킴 선택 타겟 (fzf 우선, 미설치 시 bash `select`)
- 시뮬레이터 기본 디바이스 iPhone 17 Pro로 갱신, `MAKEFILE_GUIDE.md` 동기화

## 📋 추후 진행 상황

- 기존 Feature Data 레이어를 `NetworkClient` 기반으로 단계적 마이그레이션
- 401 후속 처리(세션 만료 → AppRouter 로그인 화면 분기) 통합
- Refresh Token 만료/무효화 시나리오 E2E 검증

## 📌 리뷰 포인트

- `Core/Network/Sources/Client/NetworkClient.swift` — Actor 격리로 `refreshTask`를 보호해 동시 401 요청에서도 토큰 갱신이 1회만 실행되는지, `performRequst` 재시도 분기 안전성
- `Core/Network/Sources/Client/TokenStoreProtocol.swift` — `TokenStore`/`TokenRefreshService`/`AuthenticationPolicy` 책임 분리가 적절한지
- `Core/Network/Sources/Client/DefaultAuthenticationPolicy.swift` — "모든 요청 인증 + 401 = 미인증" 기본 정책이 우리 서버 스펙과 맞는지 (예외 엔드포인트가 있다면 별도 정책 필요)
- `Core/Network/Sources/Auth/KeychainTokenStore.swift` — Keychain 접근 옵션(`kSecAttrAccessible`) 및 에러 처리 정책
- `Core/Network/Sources/DI/AuthSystemFactory.swift` — DIContainer 등록 시점/싱글톤 보장 방식
- `Core/Network/Sources/Base/APIResponse.swift`, `BaseTargetType.swift` — 응답 래퍼/공통 TargetType 시그니처가 모든 도메인에서 재사용 가능한지
- `Tuist/ProjectDescriptionHelpers/Project+Core.swift` — `includesTests` 옵션이 다른 Core 모듈에 전파될 때 부작용 없는지
- `Tuist/ProjectDescriptionHelpers/Settings+Recommended.swift` — Release/Debug 양쪽에서 권장 설정이 의도대로 적용되는지
- `Core/Network/Tests/NetworkClientTests.swift` — Single Refresh Task 검증 케이스의 실제 동시성 시나리오 커버리지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)