### PR TITLE
♻️ [Refactor] AppFont Emphasis 제거 및 AppColor 토큰 enum 도입 (#632)

### DIFF
--- a/UMCApp/Core/DesignSystem/Sources/Colors/AppColor.swift
+++ b/UMCApp/Core/DesignSystem/Sources/Colors/AppColor.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+public enum AppColor {
+
+    // MARK: - Grey
+
+    case grey000, grey100, grey200, grey300, grey400
+    case grey500, grey600, grey700, grey800, grey900
+
+    // MARK: - Primary (Indigo)
+
+    case indigo100, indigo200, indigo300, indigo400, indigo500
+    case indigo600, indigo700, indigo800, indigo900
+
+    // MARK: - Accent (Orange)
+
+    case orange100, orange200, orange300, orange400, orange500
+    case orange600, orange700, orange800, orange900
+
+    // MARK: - Semantic
+
+    case red100, red300, red500, red700, red900
+    case green100, green300, green500, green700, green900
+    case yellow100, yellow300, yellow500, yellow700, yellow900
+
+    // MARK: - ETC
+
+    case kakao
+    case etc000
+
+    public var swiftUIColor: Color {
+        switch self {
+        case .grey000:   return .grey000
+        case .grey100:   return .grey100
+        case .grey200:   return .grey200
+        case .grey300:   return .grey300
+        case .grey400:   return .grey400
+        case .grey500:   return .grey500
+        case .grey600:   return .grey600
+        case .grey700:   return .grey700
+        case .grey800:   return .grey800
+        case .grey900:   return .grey900
+
+        case .indigo100: return .indigo100
+        case .indigo200: return .indigo200
+        case .indigo300: return .indigo300
+        case .indigo400: return .indigo400
+        case .indigo500: return .indigo500
+        case .indigo600: return .indigo600
+        case .indigo700: return .indigo700
+        case .indigo800: return .indigo800
+        case .indigo900: return .indigo900
+
+        case .orange100: return .orange100
+        case .orange200: return .orange200
+        case .orange300: return .orange300
+        case .orange400: return .orange400
+        case .orange500: return .orange500
+        case .orange600: return .orange600
+        case .orange700: return .orange700
+        case .orange800: return .orange800
+        case .orange900: return .orange900
+
+        case .red100:    return .red100
+        case .red300:    return .red300
+        case .red500:    return .red500
+        case .red700:    return .red700
+        case .red900:    return .red900
+
+        case .green100:  return .green100
+        case .green300:  return .green300
+        case .green500:  return .green500
+        case .green700:  return .green700
+        case .green900:  return .green900
+
+        case .yellow100: return .yellow100
+        case .yellow300: return .yellow300
+        case .yellow500: return .yellow500
+        case .yellow700: return .yellow700
+        case .yellow900: return .yellow900
+
+        case .kakao:     return .kakao
+        case .etc000:    return .etc000
+        }
+    }
+}

--- a/UMCApp/Core/DesignSystem/Sources/Styles/ButtonStyles.swift
+++ b/UMCApp/Core/DesignSystem/Sources/Styles/ButtonStyles.swift
@@ -42,7 +42,7 @@ public struct SecondaryButtonStyle: ButtonStyle {
 
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .appFont(.bodyEmphasis)
+            .appFont(.body, weight: .semibold)
             .foregroundStyle(
                 isEnabled
                     ? (configuration.isPressed ? Color.indigo600 : Color.indigo500)
@@ -76,7 +76,7 @@ public struct DestructiveButtonStyle: ButtonStyle {
 
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .appFont(.bodyEmphasis)
+            .appFont(.body, weight: .semibold)
             .foregroundStyle(Color.grey000)
             .frame(maxWidth: .infinity)
             .frame(height: ButtonConstants.height)

--- a/UMCApp/Core/DesignSystem/Sources/Tokens/TypographyTokens.swift
+++ b/UMCApp/Core/DesignSystem/Sources/Tokens/TypographyTokens.swift
@@ -14,80 +14,40 @@ public enum AppFont {
     case caption1
     case caption2
 
-    case largeTitleEmphasis
-    case title1Emphasis
-    case title2Emphasis
-    case title3Emphasis
-    case bodyEmphasis
-    case calloutEmphasis
-    case subheadlineEmphasis
-    case footnoteEmphasis
-    case caption1Emphasis
-    case caption2Emphasis
-
-    private var baseStyle: AppFont {
-        switch self {
-        case .largeTitleEmphasis:  return .largeTitle
-        case .title1Emphasis:      return .title1
-        case .title2Emphasis:      return .title2
-        case .title3Emphasis:      return .title3
-        case .bodyEmphasis:        return .body
-        case .calloutEmphasis:     return .callout
-        case .subheadlineEmphasis: return .subheadline
-        case .footnoteEmphasis:    return .footnote
-        case .caption1Emphasis:    return .caption1
-        case .caption2Emphasis:    return .caption2
-        default:                   return self
-        }
-    }
-
-    public var isEmphasis: Bool {
-        switch self {
-        case .largeTitleEmphasis, .title1Emphasis, .title2Emphasis, .title3Emphasis,
-             .bodyEmphasis, .calloutEmphasis, .subheadlineEmphasis,
-             .footnoteEmphasis, .caption1Emphasis, .caption2Emphasis:
-            return true
-        default:
-            return false
-        }
-    }
-
     public var size: CGFloat {
         switch self {
-        case .largeTitle, .largeTitleEmphasis:     return 34
-        case .title1, .title1Emphasis:             return 28
-        case .title2, .title2Emphasis:             return 22
-        case .title3, .title3Emphasis:             return 20
-        case .body, .bodyEmphasis:                 return 17
-        case .callout, .calloutEmphasis:           return 16
-        case .subheadline, .subheadlineEmphasis:   return 15
-        case .footnote, .footnoteEmphasis:         return 13
-        case .caption1, .caption1Emphasis:         return 12
-        case .caption2, .caption2Emphasis:         return 11
+        case .largeTitle:  return 34
+        case .title1:      return 28
+        case .title2:      return 22
+        case .title3:      return 20
+        case .body:        return 17
+        case .callout:     return 16
+        case .subheadline: return 15
+        case .footnote:    return 13
+        case .caption1:    return 12
+        case .caption2:    return 11
         }
     }
 
-    public var lineHeightMultiplier: CGFloat {
-        switch baseStyle {
-        case .largeTitle:  return 1.21
-        case .title1:      return 1.21
-        case .title2:      return 1.27
-        case .title3:      return 1.25
-        case .body:        return 1.38
-        case .callout:     return 1.31
-        case .subheadline: return 1.33
-        case .footnote:    return 1.38
-        case .caption1:    return 1.33
-        case .caption2:    return 1.18
-        default:           return 1.0
+    public var lineHeight: CGFloat {
+        switch self {
+        case .largeTitle:  return 41.14
+        case .title1:      return 33.88
+        case .title2:      return 27.94
+        case .title3:      return 25.00
+        case .body:        return 23.46
+        case .callout:     return 20.96
+        case .subheadline: return 19.95
+        case .footnote:    return 17.94
+        case .caption1:    return 15.96
+        case .caption2:    return 12.98
         }
     }
 
-    public var lineHeight: CGFloat { size * lineHeightMultiplier }
     public var lineSpacing: CGFloat { lineHeight - size }
 
     public var textStyle: Font.TextStyle {
-        switch baseStyle {
+        switch self {
         case .largeTitle:  return .largeTitle
         case .title1:      return .title
         case .title2:      return .title2
@@ -98,7 +58,6 @@ public enum AppFont {
         case .footnote:    return .footnote
         case .caption1:    return .caption
         case .caption2:    return .caption2
-        default:           return .body
         }
     }
 }
@@ -130,9 +89,8 @@ public enum AppFontWeight {
 // MARK: - Font Extension
 
 public extension Font {
-    static func app(_ style: AppFont, weight: AppFontWeight? = nil) -> Font {
-        let finalWeight = weight ?? (style.isEmphasis ? .semibold : .regular)
-        return .custom(finalWeight.fontName, size: style.size, relativeTo: style.textStyle)
+    static func app(_ style: AppFont, weight: AppFontWeight = .regular) -> Font {
+        .custom(weight.fontName, size: style.size, relativeTo: style.textStyle)
     }
 
     static func app(size: CGFloat, weight: AppFontWeight = .medium) -> Font {
@@ -146,16 +104,27 @@ public extension View {
     @ViewBuilder
     func appFont(
         _ style: AppFont,
-        weight: AppFontWeight? = nil,
-        color: Color? = nil
+        weight: AppFontWeight = .regular,
+        color: AppColor? = nil
     ) -> some View {
         let view = self
             .font(.app(style, weight: weight))
             .lineSpacing(style.lineSpacing)
         if let color {
-            view.foregroundStyle(color)
+            view.foregroundStyle(color.swiftUIColor)
         } else {
             view
         }
+    }
+
+    func appFont(
+        _ style: AppFont,
+        weight: AppFontWeight = .regular,
+        color: Color
+    ) -> some View {
+        self
+            .font(.app(style, weight: weight))
+            .lineSpacing(style.lineSpacing)
+            .foregroundStyle(color)
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 디자인 시스템 Typography 토큰 단순화 및 Color 토큰 enum 추상화

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (디자인 시스템 내부 API 정리). 호출부에서 weight 표기만 명시적으로 바뀌므로 시각적 결과는 동일합니다.

## 🛠️ 작업내용

**Typography 단순화 (`TypographyTokens.swift`)**
- `*Emphasis` 케이스 10개 제거 (`largeTitleEmphasis` ~ `caption2Emphasis`)
- `isEmphasis`, `baseStyle` 분기 제거 → `AppFont` enum이 size/lineHeight/textStyle 단일 책임만 가지도록 정리
- `lineHeightMultiplier` 곱셈 계산을 제거하고 디자인 스펙의 `lineHeight` 값을 직접 매핑
- `Font.app(_:weight:)` 시그니처에서 옵셔널 weight 분기 삭제 → 호출부에서 weight 명시
- `appFont` modifier에 `AppColor` 오버로드 추가 (디자인 토큰 컬러 직접 주입 가능)

**Color 토큰 enum 도입 (`AppColor.swift`)**
- 기존 `Color.grey500` 같은 정적 확장을 `AppColor` enum으로 캡슐화
- Grey / Indigo / Orange / Semantic(Red·Green·Yellow) / Kakao·Etc 그룹화
- `swiftUIColor` 계산 프로퍼티로 SwiftUI `Color`에 매핑

**호출부 정리 (`ButtonStyles.swift`)**
- `.appFont(.bodyEmphasis)` → `.appFont(.body, weight: .semibold)` 으로 전환
- Secondary / Destructive 버튼 스타일에 동일 패턴 적용

## 📋 추후 진행 상황

- 다른 Feature 모듈에서 사용 중인 `*Emphasis` 호출부를 일괄 치환하는 후속 PR 예정
- `AppColor` enum을 컴포넌트 props 단위로 도입(예: `MainButton`, `Section`)하여 색상 토큰화 진행

## 📌 리뷰 포인트

- `UMCApp/Core/DesignSystem/Sources/Tokens/TypographyTokens.swift`
  - `lineHeight` 값이 디자인 시스템 스펙과 일치하는지 (기존 `size * multiplier` 결과와 비교 시 미세한 반올림 차이 있음)
  - `appFont` 두 오버로드(AppColor / SwiftUI Color)의 중복이 의도된 것인지 — 기존 호출부 호환을 위해 함께 유지
- `UMCApp/Core/DesignSystem/Sources/Colors/AppColor.swift`
  - 케이스 누락 여부 (특히 `etc000`, `kakao` 같은 ETC 토큰)
- `UMCApp/Core/DesignSystem/Sources/Styles/ButtonStyles.swift`
  - `.body + weight: .semibold` 변환이 기존 `.bodyEmphasis`와 시각적으로 동일한지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    - 해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)