### PR TITLE
🐛 [Fix] 카카오톡 미설치 시 문의하기 버튼 웹 폴백

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ GoogleService-Info.plist
 # Superpowers / brainstorming local caches
 .superpowers/
 docs/superpowers/
+
+# Git worktrees
+.worktrees/

--- a/AppProduct/AppProduct/Core/Manager/Auth/KakaoPlusManager.swift
+++ b/AppProduct/AppProduct/Core/Manager/Auth/KakaoPlusManager.swift
@@ -7,17 +7,18 @@
 
 import Foundation
 import KakaoSDKTalk
+import UIKit
 
 /// 카카오톡 채널(플러스친구)과의 상호작용을 처리하는 매니저입니다.
 ///
 /// UMC 동아리의 카카오톡 채널 채팅방을 여는 기능을 제공합니다.
-///
-/// - Important: 카카오톡 앱이 설치되어 있어야 합니다.
+/// 카카오톡 앱이 설치되어 있지 않은 환경(예: App Store 심사)에서는
+/// 웹 채팅 URL(`https://pf.kakao.com/{channelId}/chat`)로 자동 폴백합니다.
 ///
 /// - Usage:
 /// ```swift
-/// let kakaoPlusManager = KakaoPlusManager()
-/// kakaoPlusManager.openKakaoChannel()  // 카카오톡 채널 채팅방 열기
+/// let manager = KakaoPlusManager()
+/// manager.openKakaoChannel(errorHandler: errorHandler)
 /// ```
 class KakaoPlusManager {
     // MARK: - Property
@@ -26,24 +27,80 @@ class KakaoPlusManager {
     ///
     /// - Note: 채널 관리자 페이지에서 확인 가능한 고유 ID입니다.
     let channelId = "_MDxhqX"
-    
+
+    /// 카카오톡 미설치 시 사용할 웹 채팅 URL
+    private var webChatURL: URL? {
+        URL(string: "https://pf.kakao.com/\(channelId)/chat")
+    }
+
     // MARK: - Function
 
     /// UMC 카카오톡 채널 채팅방을 엽니다.
     ///
-    /// 카카오톡 앱이 실행되며 UMC 채널과의 1:1 채팅방이 열립니다.
-    /// 사용자 문의, 공지사항 확인 등에 활용됩니다.
+    /// 다음 순서로 채널을 엽니다:
+    /// 1. ``TalkApi/isKakaoTalkChannelAvailable(path:)`` 로 카카오톡 채널 연결 가능 여부를 확인합니다.
+    /// 2. 사용 가능하면 ``TalkApi/chatChannel(channelPublicId:completion:)`` 로 카카오톡 채팅방을 엽니다.
+    /// 3. 카카오톡 미설치이거나 SDK 호출이 실패하면 웹 채팅 URL을 외부 브라우저로 엽니다.
+    /// 4. 웹 URL 마저 열 수 없는 극한 케이스에서는 ``ErrorHandler`` 로 사용자 Alert 을 표시합니다.
     ///
-    /// - Note:
-    ///   - 카카오톡 미설치 시 자동으로 App Store로 이동합니다.
-    ///   - 채널 추가 여부와 관계없이 채팅방이 열립니다.
-    func openKakaoChannel() {
-        TalkApi.shared.chatChannel(channelPublicId: channelId, completion: { error in
-            if let error = error {
-                print("채널 열기 에러: \(error)")
-            } else {
-                print("카카오톡 채널 채팅 열기 성공")
+    /// - Parameter errorHandler: 모든 폴백이 실패했을 때 사용자에게 안내할 핸들러.
+    ///   `nil` 이면 안내 없이 로그만 남깁니다.
+    ///
+    /// - Important: SDK 의 채널 가용성 검사는 `kakaoplus://` 스킴에 대한 `canOpenURL` 호출을 포함하므로,
+    ///   Info.plist 의 `LSApplicationQueriesSchemes` 에 `kakaoplus` 가 등록되어 있어야 합니다.
+    @MainActor
+    func openKakaoChannel(errorHandler: ErrorHandler? = nil) {
+        let chatPath = "plusfriend/talk/chat/\(channelId)"
+
+        guard TalkApi.isKakaoTalkChannelAvailable(path: chatPath) else {
+            openWebChat(errorHandler: errorHandler)
+            return
+        }
+
+        TalkApi.shared.chatChannel(channelPublicId: channelId) { [weak self] error in
+            guard let self else { return }
+            if let error {
+                print("카카오톡 채널 열기 에러: \(error). 웹으로 폴백합니다.")
+                Task { @MainActor in
+                    self.openWebChat(errorHandler: errorHandler)
+                }
             }
-        })
+        }
+    }
+
+    // MARK: - Private
+
+    /// 웹 채팅 URL을 외부 브라우저로 엽니다.
+    ///
+    /// URL을 만들 수 없거나 시스템이 열기를 거부하면 ``reportFailure(errorHandler:)``로 안내합니다.
+    @MainActor
+    private func openWebChat(errorHandler: ErrorHandler?) {
+        guard let url = webChatURL else {
+            reportFailure(errorHandler: errorHandler)
+            return
+        }
+
+        UIApplication.shared.open(url) { [weak self] success in
+            guard !success else { return }
+            Task { @MainActor in
+                self?.reportFailure(errorHandler: errorHandler)
+            }
+        }
+    }
+
+    /// 카카오톡 / 웹 폴백이 모두 실패한 경우 ``ErrorHandler``로 안내합니다.
+    @MainActor
+    private func reportFailure(errorHandler: ErrorHandler?) {
+        guard let errorHandler else {
+            print("카카오톡 채널/웹 모두 열기 실패")
+            return
+        }
+        errorHandler.handle(
+            DomainError.custom(message: "카카오톡 문의 채널을 열 수 없습니다. 잠시 후 다시 시도해주세요."),
+            context: ErrorContext(
+                feature: "KakaoPlusManager",
+                action: "openKakaoChannel"
+            )
+        )
     }
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift
@@ -223,7 +223,7 @@ struct FailedVerificationUMC: View {
 
     /// 카카오톡 문의 채널을 엽니다.
     private func openInquiryChannel() {
-        kakaoPlusManager.openKakaoChannel()
+        kakaoPlusManager.openKakaoChannel(errorHandler: errorHandler)
     }
 
     /// 승인 대기 화면에서 로그아웃 확인 프롬프트를 표시합니다.

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/HelpSection.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/HelpSection.swift
@@ -12,6 +12,7 @@ struct HelpSection: View {
     // MARK: - Property
 
     @Environment(\.di) var di
+    @Environment(ErrorHandler.self) private var errorHandler
     /// 섹션의 타입 (헤더 타이틀로 사용됨)
     let sectionType: MyPageSectionType
     let kakaoPlusManager: KakaoPlusManager = .init()
@@ -61,7 +62,7 @@ struct HelpSection: View {
     private func sectionAction(_ help: HelpType) {
         switch help {
         case .inquery:
-            kakaoPlusManager.openKakaoChannel()
+            kakaoPlusManager.openKakaoChannel(errorHandler: errorHandler)
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
+++ b/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
@@ -213,11 +213,13 @@ fileprivate struct CommunityAccessoryView: View {
 
 /// 마이페이지 탭 하단 액세서리 - 문의하기 버튼
 fileprivate struct MyPageAccessoryView: View {
+    @Environment(ErrorHandler.self) private var errorHandler
+
     private let kakaoPlusManager: KakaoPlusManager = .init()
 
     var body: some View {
         Button(action: {
-            kakaoPlusManager.openKakaoChannel()
+            kakaoPlusManager.openKakaoChannel(errorHandler: errorHandler)
         }) {
             HStack(spacing: DefaultSpacing.spacing8) {
                 Spacer()

--- a/AppProduct/Info.plist
+++ b/AppProduct/Info.plist
@@ -23,6 +23,7 @@
 	<array>
 		<string>kakaokompassauth</string>
 		<string>kakaoplus</string>
+		<string>kakaotalk</string>
 	</array>
 	<key>UIAppFonts</key>
 	<array>


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix — 카카오톡 미설치 환경(특히 App Store 심사)에서 **문의하기** 버튼이 무반응이던 문제를 웹 채팅 URL 폴백으로 해결합니다. (closes #637)

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음. (수동 QA 필요 — 카카오톡 설치/미설치 두 환경에서 진입점 3곳 동작 확인)

## 🛠️ 작업내용

### `KakaoPlusManager` 폴백 체인 도입
- `openKakaoChannel(errorHandler: ErrorHandler? = nil)` 로 시그니처 확장 (선택 파라미터 — 기존 호출부 호환)
- `TalkApi.isKakaoTalkChannelAvailable(path:)` 로 카카오톡 채널 연결 가능 여부 분기
  - SDK 현재 버전에 `isKakaoTalkInstalled()` 가 없어 채널 전용 가용성 검사 API 사용 (`kakaoplus://` 스킴 `canOpenURL`)
- 미설치/SDK 호출 실패 → `https://pf.kakao.com/{channelId}/chat` 을 `UIApplication.shared.open` 으로 오픈
- 웹 URL 마저 실패하는 극한 케이스 → `ErrorHandler.handle(...)` 으로 Alert 안내 (`DomainError.custom`)
- 메서드/타입 모두 `@MainActor` 격리

### 호출 3개 지점에 `errorHandler` 전달
- `HelpSection.swift` — `@Environment(ErrorHandler.self)` 추가 후 매니저에 전달
- `FailedVerificationUMC.swift` — 기존 환경값 그대로 전달
- `UmcBottonAccessoryView.swift` (`MyPageAccessoryView`) — `@Environment` 추가 후 전달

### Info.plist
- `LSApplicationQueriesSchemes` 에 `kakaotalk` 추가 (KakaoSDK 권장 스킴 보강)

## 📋 추후 진행 상황

- 카카오톡 설치/미설치 환경 수동 QA 통과 후 머지
- 필요 시 `KakaoPlusManager` 단위 테스트 추가 (URL 빌드 / 폴백 분기)

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Core/Manager/Auth/KakaoPlusManager.swift` — 폴백 체인 (가용성 검사 → SDK 호출 → 웹 URL → ErrorHandler) 흐름 및 `@MainActor` 격리, `[weak self]` 사용
- `AppProduct/Info.plist` — `LSApplicationQueriesSchemes` 항목 (`kakaokompassauth`, `kakaoplus`, `kakaotalk`)
- `AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/HelpSection.swift` — `ErrorHandler` 환경 주입 추가
- `AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift` — `MyPageAccessoryView` 의 `ErrorHandler` 주입 위치 (fileprivate View 내부)
- `AppProduct/AppProduct/Features/Auth/Presentation/Views/FailedVerificationUMC.swift` — 기존 환경값 전달 라인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)