### PR TITLE
🐛 [Fix] Stella 엔드포인트 화면 레이아웃 + 컬럼 폭 조절

### DIFF
--- a/Stella/Sources/StellaApp/EndpointsView.swift
+++ b/Stella/Sources/StellaApp/EndpointsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 import StellaCore
@@ -16,7 +17,10 @@ struct EndpointsView: View {
     @Bindable var model: ScanModel
     @State private var selection: EndpointRow.ID?
     @State private var draggingColumn: EndpointColumn?
+    @State private var columnWidths: [EndpointColumn: CGFloat] = [:]
+    @State private var resizeAnchor: (column: EndpointColumn, startWidth: CGFloat)?
     @AppStorage("endpointColumnOrder") private var columnOrderRaw = EndpointColumn.defaultOrderRaw
+    @AppStorage("endpointColumnWidths") private var columnWidthsRaw = ""
 
     var body: some View {
         if model.snapshot == nil {
@@ -43,7 +47,10 @@ struct EndpointsView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .onAppear { selectFirstRowIfNeeded() }
+            .onAppear {
+                selectFirstRowIfNeeded()
+                loadColumnWidths()
+            }
             .onChange(of: rows.map(\.id)) { _, _ in selectFirstRowIfNeeded() }
         }
     }
@@ -99,22 +106,24 @@ struct EndpointsView: View {
     }
 
     private var table: some View {
-        ScrollView([.vertical, .horizontal]) {
-            VStack(alignment: .leading, spacing: 0) {
-                endpointHeader
-                ForEach(rows) { row in
-                    endpointRow(row)
-                        .id(row.id)
+        GeometryReader { geometry in
+            ScrollView([.vertical, .horizontal]) {
+                VStack(alignment: .leading, spacing: 0) {
+                    endpointHeader(containerWidth: geometry.size.width)
+                    ForEach(rows) { row in
+                        endpointRow(row, containerWidth: geometry.size.width)
+                            .id(row.id)
+                    }
                 }
+                .frame(minWidth: max(tableMinWidth, geometry.size.width), alignment: .topLeading)
             }
-            .frame(minWidth: tableMinWidth, maxWidth: .infinity, alignment: .topLeading)
+            .defaultScrollAnchor(.topLeading)
+            .background(.background)
         }
-        .defaultScrollAnchor(.topLeading)
-        .background(.background)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
-    private var endpointHeader: some View {
+    private func endpointHeader(containerWidth: CGFloat) -> some View {
         HStack(spacing: 0) {
             ForEach(orderedColumns) { column in
                 HStack(spacing: 6) {
@@ -127,13 +136,18 @@ struct EndpointsView: View {
                         .foregroundStyle(.tertiary)
                 }
                 .padding(.horizontal, 10)
-                .frame(width: column.width, alignment: .leading)
+                .frame(width: widthForColumn(column, containerWidth: containerWidth), alignment: .leading)
                 .frame(height: 30)
                 .background(.background)
                 .overlay(alignment: .trailing) {
                     Rectangle()
                         .fill(.separator)
                         .frame(width: 1)
+                }
+                .overlay(alignment: .trailing) {
+                    if !isLastOrdered(column) {
+                        resizeHandle(for: column)
+                    }
                 }
                 .contextMenu {
                     Button("왼쪽으로 이동") { moveColumn(column, offset: -1) }
@@ -142,6 +156,7 @@ struct EndpointsView: View {
                         .disabled(isLastColumn(column))
                     Divider()
                     Button("기본 순서로") { resetColumnOrder() }
+                    Button("폭 초기화") { resetColumnWidths() }
                 }
                 .opacity(draggingColumn == column ? 0.45 : 1)
                 .onDrag {
@@ -165,7 +180,7 @@ struct EndpointsView: View {
         }
     }
 
-    private func endpointRow(_ row: EndpointRow) -> some View {
+    private func endpointRow(_ row: EndpointRow, containerWidth: CGFloat) -> some View {
         Button {
             selection = row.id
         } label: {
@@ -173,7 +188,7 @@ struct EndpointsView: View {
                 ForEach(orderedColumns) { column in
                     columnCell(column, row: row)
                         .padding(.horizontal, 10)
-                        .frame(width: column.width, alignment: .leading)
+                        .frame(width: widthForColumn(column, containerWidth: containerWidth), alignment: .leading)
                         .frame(height: 30)
                 }
             }
@@ -187,6 +202,35 @@ struct EndpointsView: View {
             }
         }
         .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func resizeHandle(for column: EndpointColumn) -> some View {
+        Color.clear
+            .frame(width: 8)
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.resizeLeftRight.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .highPriorityGesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .local)
+                    .onChanged { value in
+                        if resizeAnchor == nil {
+                            resizeAnchor = (column, currentColumnWidth(column))
+                        }
+                        guard let anchor = resizeAnchor, anchor.column == column else { return }
+                        let proposed = anchor.startWidth + value.translation.width
+                        columnWidths[column] = max(column.minWidth, proposed)
+                    }
+                    .onEnded { _ in
+                        resizeAnchor = nil
+                        saveColumnWidths()
+                    }
+            )
     }
 
     @ViewBuilder
@@ -261,7 +305,50 @@ struct EndpointsView: View {
     }
 
     private var tableMinWidth: CGFloat {
-        orderedColumns.reduce(CGFloat.zero) { $0 + $1.width }
+        orderedColumns.reduce(CGFloat.zero) { $0 + currentColumnWidth($1) }
+    }
+
+    private func currentColumnWidth(_ column: EndpointColumn) -> CGFloat {
+        columnWidths[column] ?? column.defaultWidth
+    }
+
+    private func widthForColumn(_ column: EndpointColumn, containerWidth: CGFloat) -> CGFloat {
+        guard isLastOrdered(column) else {
+            return currentColumnWidth(column)
+        }
+        let usedByOthers = orderedColumns
+            .filter { $0 != column }
+            .reduce(CGFloat.zero) { $0 + currentColumnWidth($1) }
+        let remaining = containerWidth - usedByOthers
+        return max(currentColumnWidth(column), remaining)
+    }
+
+    private func isLastOrdered(_ column: EndpointColumn) -> Bool {
+        orderedColumns.last == column
+    }
+
+    private func loadColumnWidths() {
+        var result: [EndpointColumn: CGFloat] = [:]
+        for pair in columnWidthsRaw.split(separator: ",") {
+            let parts = pair.split(separator: ":")
+            guard parts.count == 2,
+                  let column = EndpointColumn(rawValue: String(parts[0])),
+                  let value = Double(parts[1]) else { continue }
+            result[column] = max(column.minWidth, CGFloat(value))
+        }
+        columnWidths = result
+    }
+
+    private func saveColumnWidths() {
+        columnWidthsRaw = columnWidths
+            .sorted { $0.key.rawValue < $1.key.rawValue }
+            .map { "\($0.key.rawValue):\(Int($0.value))" }
+            .joined(separator: ",")
+    }
+
+    private func resetColumnWidths() {
+        columnWidths = [:]
+        columnWidthsRaw = ""
     }
 
     private func persistColumnOrder(_ columns: [EndpointColumn]) {
@@ -360,7 +447,7 @@ private enum EndpointColumn: String, CaseIterable, Identifiable {
         }
     }
 
-    var width: CGFloat {
+    var defaultWidth: CGFloat {
         switch self {
         case .method: return 90
         case .path: return 360
@@ -368,6 +455,17 @@ private enum EndpointColumn: String, CaseIterable, Identifiable {
         case .tag: return 250
         case .owner: return 170
         case .connections: return 260
+        }
+    }
+
+    var minWidth: CGFloat {
+        switch self {
+        case .method: return 60
+        case .path: return 160
+        case .summary: return 120
+        case .tag: return 120
+        case .owner: return 100
+        case .connections: return 140
         }
     }
 }

--- a/Stella/Sources/StellaApp/EndpointsView.swift
+++ b/Stella/Sources/StellaApp/EndpointsView.swift
@@ -100,18 +100,16 @@ struct EndpointsView: View {
 
     private var table: some View {
         ScrollView([.vertical, .horizontal]) {
-            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                Section {
-                    ForEach(rows) { row in
-                        endpointRow(row)
-                            .id(row.id)
-                    }
-                } header: {
-                    endpointHeader
+            VStack(alignment: .leading, spacing: 0) {
+                endpointHeader
+                ForEach(rows) { row in
+                    endpointRow(row)
+                        .id(row.id)
                 }
             }
             .frame(minWidth: tableMinWidth, maxWidth: .infinity, alignment: .topLeading)
         }
+        .defaultScrollAnchor(.topLeading)
         .background(.background)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -515,6 +513,7 @@ private struct EndpointDetailView: View {
                 }
             }
             .padding(16)
+            .padding(.bottom, 44)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
@@ -544,6 +543,7 @@ private struct EndpointDetailView: View {
                 }
             }
             .padding(16)
+            .padding(.bottom, 44)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
     }


### PR DESCRIPTION
## ✨ PR 유형

Fix / Feat — Stella(엔드포인트 뷰어) UI 버그 수정 + 컬럼 폭 조절 기능 추가

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경이라 캡처/녹화 첨부 부탁드립니다. 확인 포인트:
1. 필터로 결과가 1-2건만 남아도 헤더+행이 표 영역 최상단에 붙는지
2. 윈도우를 가로로 늘렸을 때 마지막 컬럼이 남는 폭을 흡수해 좌우 여백이 사라지는지
3. 헤더 우측 가장자리에 마우스를 올리면 좌우 화살표 커서로 바뀌고 드래그로 폭 조절이 되는지
4. 상세 패널 높이를 작게 줄였을 때 개요/스펙 탭의 마지막 콘텐츠가 잘리지 않는지 -->

## 🛠️ 작업내용

### 🐛 레이아웃 버그 수정 (1836be78)
- 테이블을 `LazyVStack(pinnedViews: [.sectionHeaders])` + `Section/header` 구조에서 `VStack(alignment: .leading)` 평면 구성으로 단순화
  - 컬럼 가운데 정렬로 인한 좌우 여백 어긋남 해소
  - 필터 결과가 적을 때 sticky 헤더가 행 아래에 그려지던 layout 버그 해소
- `ScrollView` 에 `defaultScrollAnchor(.topLeading)` 추가 → 컨텐츠가 작을 때도 상단 고정
- 상세 패널 `overviewPane` / `specPane` ScrollView 에 `.padding(.bottom, 44)` 추가 → 패널 높이 축소 시 마지막 콘텐츠 잘림 해소 (testPane 은 기존에 이미 적용되어 있던 패턴 통일)

### ✨ 컬럼 폭 조절 + 풀폭 채우기 (945ed51b)
- 헤더 우측 가장자리에 8pt invisible 드래그 핸들 추가 — hover 시 `NSCursor.resizeLeftRight`, 드래그로 폭 조절
- `GeometryReader` 로 컨테이너 폭 측정 → **마지막 컬럼이 남는 가로 공간을 흡수**해서 표가 좌우 여백 없이 컨테이너를 꽉 채움. 컨테이너가 좁으면 가로 스크롤 그대로 유지
- 조절된 폭은 `@AppStorage("endpointColumnWidths")` 로 영속화. 컨텍스트 메뉴에 **"폭 초기화"** 항목 추가
- `EndpointColumn.width` → `defaultWidth` 로 명명 변경하고 컬럼별 `minWidth` 하한 추가 (너무 좁히지 못하도록)
- 컬럼 reorder 드래그(`.onDrag`)와 충돌 방지로 resize 핸들은 `.highPriorityGesture` 사용 — 가장자리 8pt 영역에서는 resize 우선, 그 외 영역은 reorder

## 📋 추후 진행 상황

- 진짜 sticky 헤더가 필요하면 outer ScrollView + 외부 헤더 분리 패턴으로 별도 구현 필요 (이번 PR 에서는 sticky 자체를 제거)
- 컬럼 폭 외에 행 높이/폰트 크기 조절도 향후 옵션화 검토 가능

## 📌 리뷰 포인트

- `Stella/Sources/StellaApp/EndpointsView.swift`
  - `table` (~L107): `GeometryReader` + `defaultScrollAnchor(.topLeading)` 조합과, `frame(minWidth: max(tableMinWidth, geometry.size.width))` 로직
  - `widthForColumn(_:containerWidth:)`: 마지막 컬럼이 잔여 폭을 흡수하는 계산
  - `resizeHandle(for:)`: 8pt 트레일링 히트영역 + `NSCursor` 토글 + `.highPriorityGesture` 로 reorder 드래그와의 우선순위 처리
  - `loadColumnWidths` / `saveColumnWidths`: `@AppStorage` 직렬화 포맷 (`column:width,...`) 의 안정성 — 잘못된 값은 무시하고 default 사용
  - `EndpointColumn.minWidth`: 컬럼별 최소 폭 하한 값이 적절한지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)