### PR TITLE
♻️ [Refactor] 내 스터디 그룹 목록 API 엔드포인트 변경 및 createdAt 필드 추가 (#651)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/StudyGroupNamesDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/StudyGroupNamesDTO.swift
@@ -20,11 +20,13 @@ struct StudyGroupNamesDTO: Codable, Sendable, Equatable {
 struct StudyGroupNameItemDTO: Codable, Sendable, Equatable {
     let groupId: Int
     let name: String
+    let createdAt: String?
 
     private enum CodingKeys: String, CodingKey {
         case groupId
         case id
         case name
+        case createdAt
     }
 
     init(from decoder: Decoder) throws {
@@ -34,12 +36,14 @@ struct StudyGroupNameItemDTO: Codable, Sendable, Equatable {
             ?? container.decodeIntFlexibleIfPresent(forKey: .id)
             ?? 0
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt)
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(groupId, forKey: .groupId)
         try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(createdAt, forKey: .createdAt)
     }
 }
 

--- a/AppProduct/AppProduct/Features/Activity/Data/Router/StudyRouter.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Router/StudyRouter.swift
@@ -52,7 +52,7 @@ extension StudyRouter: BaseTargetType {
         case .createStudyGroupSchedule:
             return "/api/v1/schedules/study-group"
         case .getMyStudyGroups:
-            return "/api/v1/study-groups"
+            return "/api/v1/study-groups/managed"
         case .getStudyGroupNames:
             return "/api/v1/study-groups/names"
         case .getStudyGroupDetail(let groupId):


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor — 서버 API 변경(엔드포인트 + 응답 스키마)에 따른 클라이언트 동기화

Closes #651

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음 (네트워크 레이어 변경, UI 변경 없음)

## 🛠️ 작업내용

- `StudyRouter.getMyStudyGroups` path 변경: `/api/v1/study-groups` → `/api/v1/study-groups/managed`
- `StudyGroupNameItemDTO`에 `createdAt: String?` 옵셔널 프로퍼티 추가
    - `CodingKeys` / `init(from:)` / `encode(to:)` 모두 반영
    - 같은 항목 DTO를 재사용하는 `getStudyGroupNames`(`/api/v1/study-groups/names`) 응답 호환을 위해 옵셔널로 둠
- 프로젝트 컨벤션(`MemberManagementProfileDTO`, `StudyGroupDetailDTO`)에 맞춰 DTO는 `String?`으로 받고, 향후 도메인 변환 시 `ServerDateTimeConverter`로 파싱 가능하도록 raw string 유지

## 📋 추후 진행 상황

현 시점 후속 작업 없음.

`createdAt`은 서버 응답에서 받기만 하고, 현재 앱의 어떤 뷰에서도 표시/정렬/필터링에 사용하지 않습니다(`StudyGroupItem`의 유일한 사용처인 `ToolBarCollection.StudyGroupFilter` Picker는 그룹 이름만 렌더링). 추후 `createdAt`을 활용하는 구체적인 UI 요구가 생기면 별도 이슈로 분리해 도메인 모델(`StudyGroupItem`) 확장과 함께 진행합니다.

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Features/Activity/Data/Router/StudyRouter.swift` — `getMyStudyGroups` path만 변경, method/task/sampleData 등 다른 부분 무변경 확인
- `AppProduct/AppProduct/Features/Activity/Data/DTOs/StudyGroupNamesDTO.swift` — `createdAt` 옵셔널 디코딩 처리, `/names` 호출(응답에 `createdAt` 부재)에서 디코딩 실패하지 않는지 확인
- `AppProduct/AppProduct/Features/Activity/Data/DTOs/MyStudyGroupsPageDTO.swift` — 항목 DTO만 수정해도 페이징 래퍼(`cursor`/`content`/`studyGroups` 3종 포맷 흡수)는 자동 반영되는지 확인 (변경 없음)
- 호출 체인(`StudyRepository` → `FetchStudyMembersUseCase` → `OperatorStudyManagementViewModel` → `ToolBarCollection.StudyGroupFilter`) 무영향 검토

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    - 해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)