### PR TITLE
♻️ [Refactor] 공지사항 투표 응답 API 엔드포인트(noticeId 기반) 마이그레이션 (#652)

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/Mock/MockNoticeRepository.swift
@@ -45,11 +45,11 @@ final class MockNoticeRepository: NoticeRepositoryProtocol {
 
     func readNotice(noticeId: Int) async throws {}
 
-    func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws {
+    func submitVoteResponse(noticeId: Int, optionIds: [Int]) async throws {
         throw DomainError.insufficientPermission(required: "인증")
     }
 
-    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws {
+    func updateVoteResponse(noticeId: Int, optionIds: [Int]) async throws {
         throw DomainError.insufficientPermission(required: "인증")
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
@@ -192,9 +192,9 @@ struct NoticeRepository: NoticeRepositoryProtocol {
     }
 
     /// 투표 응답(사용자 선택 전송)
-    func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws {
+    func submitVoteResponse(noticeId: Int, optionIds: [Int]) async throws {
         let response = try await adapter.request(
-            NoticeRouter.submitVoteResponse(voteId: voteId, optionIds: optionIds)
+            NoticeRouter.submitVoteResponse(noticeId: noticeId, optionIds: optionIds)
         )
 
         let apiResponse = try JSONDecoder().decode(
@@ -205,9 +205,9 @@ struct NoticeRepository: NoticeRepositoryProtocol {
     }
 
     /// 투표 응답 수정
-    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws {
+    func updateVoteResponse(noticeId: Int, optionIds: [Int]) async throws {
         let response = try await adapter.request(
-            NoticeRouter.updateVoteResponse(voteId: voteId, optionIds: optionIds)
+            NoticeRouter.updateVoteResponse(noticeId: noticeId, optionIds: optionIds)
         )
 
         let apiResponse = try JSONDecoder().decode(

--- a/AppProduct/AppProduct/Features/Notice/Data/Router/NoticeRouter.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Router/NoticeRouter.swift
@@ -63,12 +63,12 @@ enum NoticeRouter: BaseTargetType {
     case readNotice(noticeId: Int)
     /// 투표 응답(사용자 선택 전송)
     case submitVoteResponse(
-        voteId: Int,
+        noticeId: Int,
         optionIds: [Int]
     )
     /// 투표 응답 수정
     case updateVoteResponse(
-        voteId: Int,
+        noticeId: Int,
         optionIds: [Int]
     )
     
@@ -122,10 +122,10 @@ enum NoticeRouter: BaseTargetType {
             return "/api/v1/notices/\(noticeId)/reminders"
         case .readNotice(let noticeId):
             return "/api/v1/notices/\(noticeId)/read"
-        case .submitVoteResponse(let voteId, _):
-            return "/api/v1/surveys/votes/\(voteId)/responses"
-        case .updateVoteResponse(let voteId, _):
-            return "/api/v1/surveys/votes/\(voteId)/responses"
+        case .submitVoteResponse(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/votes/responses"
+        case .updateVoteResponse(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/votes/responses"
         case .updateNotice(let noticeId, _):
             return "/api/v1/notices/\(noticeId)"
         case .updateLink(let noticeId, _):

--- a/AppProduct/AppProduct/Features/Notice/Domain/Interfaces/NoticeRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Interfaces/NoticeRepositoryProtocol.swift
@@ -43,10 +43,10 @@ protocol NoticeRepositoryProtocol {
     func readNotice(noticeId: Int) async throws
 
     /// 투표 응답(사용자 선택 전송)
-    func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws
+    func submitVoteResponse(noticeId: Int, optionIds: [Int]) async throws
 
     /// 투표 응답 수정
-    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws
+    func updateVoteResponse(noticeId: Int, optionIds: [Int]) async throws
     
     // MARK: - 공지 수정
     /// 공지사항 수정 (제목, 본문)

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift
@@ -171,22 +171,22 @@ final class NoticeUseCase: NoticeUseCaseProtocol {
     }
 
     /// 투표 응답(사용자 선택 전송)
-    func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws {
-        guard voteId > 0 else {
-            throw DomainError.custom(message: "유효하지 않은 투표입니다")
+    func submitVoteResponse(noticeId: Int, optionIds: [Int]) async throws {
+        guard noticeId > 0 else {
+            throw DomainError.custom(message: "유효하지 않은 공지입니다")
         }
         guard !optionIds.isEmpty else {
             throw DomainError.custom(message: "선택한 항목이 없습니다")
         }
-        try await repository.submitVoteResponse(voteId: voteId, optionIds: optionIds)
+        try await repository.submitVoteResponse(noticeId: noticeId, optionIds: optionIds)
     }
 
     /// 투표 응답 수정 (빈 배열 전송 시 투표 해제)
-    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws {
-        guard voteId > 0 else {
-            throw DomainError.custom(message: "유효하지 않은 투표입니다")
+    func updateVoteResponse(noticeId: Int, optionIds: [Int]) async throws {
+        guard noticeId > 0 else {
+            throw DomainError.custom(message: "유효하지 않은 공지입니다")
         }
-        try await repository.updateVoteResponse(voteId: voteId, optionIds: optionIds)
+        try await repository.updateVoteResponse(noticeId: noticeId, optionIds: optionIds)
     }
     
     /// 미확인 대상에게 공지 리마인더 발송

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeUseCaseProtocol.swift
@@ -81,15 +81,15 @@ protocol NoticeUseCaseProtocol {
 
     /// 투표 응답(사용자 선택 전송)
     /// - Parameters:
-    ///   - voteId: 투표 ID
+    ///   - noticeId: 공지 ID
     ///   - optionIds: 선택한 옵션 ID 목록
-    func submitVoteResponse(voteId: Int, optionIds: [Int]) async throws
+    func submitVoteResponse(noticeId: Int, optionIds: [Int]) async throws
 
     /// 투표 응답 수정
     /// - Parameters:
-    ///   - voteId: 투표 ID
-    ///   - optionIds: 수정할 옵션 ID 목록
-    func updateVoteResponse(voteId: Int, optionIds: [Int]) async throws
+    ///   - noticeId: 공지 ID
+    ///   - optionIds: 수정할 옵션 ID 목록 (빈 배열 전송 시 응답 취소)
+    func updateVoteResponse(noticeId: Int, optionIds: [Int]) async throws
     
     // MARK: - 리마인더 (POST)
     

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -598,7 +598,7 @@ extension NoticeDetailViewModel {
     ///
     /// 선택 옵션을 서버로 전송한 뒤 공지 상세를 재조회하여 최신 투표 상태를 반영합니다.
     @MainActor
-    func handleVote(voteId: String, optionIds: [String]) async {
+    func handleVote(optionIds: [String]) async {
         guard case .loaded = noticeState else {
             return
         }
@@ -608,17 +608,13 @@ extension NoticeDetailViewModel {
             isSubmittingVote = true
             defer { isSubmittingVote = false }
 
-            guard let resolvedVoteId = Int(voteId) else {
-                throw DomainError.custom(message: "유효하지 않은 투표 ID입니다.")
-            }
-
             let resolvedOptionIds = optionIds.compactMap(Int.init)
             guard !resolvedOptionIds.isEmpty else {
                 throw DomainError.custom(message: "유효한 투표 항목이 없습니다.")
             }
 
             try await noticeUseCase.submitVoteResponse(
-                voteId: resolvedVoteId,
+                noticeId: noticeID,
                 optionIds: resolvedOptionIds
             )
 
@@ -637,7 +633,7 @@ extension NoticeDetailViewModel {
                     retryAction: { [weak self] in
                         guard let self = self else { return }
                         Task {
-                            await self.handleVote(voteId: voteId, optionIds: optionIds)
+                            await self.handleVote(optionIds: optionIds)
                         }
                     }
                 )
@@ -652,7 +648,7 @@ extension NoticeDetailViewModel {
                     retryAction: { [weak self] in
                         guard let self = self else { return }
                         Task {
-                            await self.handleVote(voteId: voteId, optionIds: optionIds)
+                            await self.handleVote(optionIds: optionIds)
                         }
                     }
                 )
@@ -679,10 +675,7 @@ extension NoticeDetailViewModel {
                         retryAction: { [weak self] in
                             guard let self = self else { return }
                             Task {
-                                await self.handleVote(
-                                    voteId: voteId,
-                                    optionIds: optionIds
-                                )
+                                await self.handleVote(optionIds: optionIds)
                             }
                         }
                     )
@@ -698,7 +691,7 @@ extension NoticeDetailViewModel {
                     retryAction: { [weak self] in
                         guard let self = self else { return }
                         Task {
-                            await self.handleVote(voteId: voteId, optionIds: optionIds)
+                            await self.handleVote(optionIds: optionIds)
                         }
                     }
                 )
@@ -709,8 +702,9 @@ extension NoticeDetailViewModel {
     /// 투표 응답 수정 처리
     ///
     /// 기존 투표를 수정(PUT)한 뒤 공지 상세를 재조회하여 최신 투표 상태를 반영합니다.
+    /// 빈 배열 전송 시 기존 응답이 취소(삭제)됩니다.
     @MainActor
-    func handleUpdateVote(voteId: String, optionIds: [String]) async {
+    func handleUpdateVote(optionIds: [String]) async {
         guard case .loaded = noticeState else { return }
         guard !isSubmittingVote else { return }
 
@@ -718,14 +712,10 @@ extension NoticeDetailViewModel {
             isSubmittingVote = true
             defer { isSubmittingVote = false }
 
-            guard let resolvedVoteId = Int(voteId) else {
-                throw DomainError.custom(message: "유효하지 않은 투표 ID입니다.")
-            }
-
             let resolvedOptionIds = optionIds.compactMap(Int.init)
 
             try await noticeUseCase.updateVoteResponse(
-                voteId: resolvedVoteId,
+                noticeId: noticeID,
                 optionIds: resolvedOptionIds
             )
 
@@ -742,7 +732,7 @@ extension NoticeDetailViewModel {
                     action: "handleUpdateVote",
                     retryAction: { [weak self] in
                         guard let self else { return }
-                        Task { await self.handleUpdateVote(voteId: voteId, optionIds: optionIds) }
+                        Task { await self.handleUpdateVote(optionIds: optionIds) }
                     }
                 )
             )
@@ -755,7 +745,7 @@ extension NoticeDetailViewModel {
                     action: "handleUpdateVote",
                     retryAction: { [weak self] in
                         guard let self else { return }
-                        Task { await self.handleUpdateVote(voteId: voteId, optionIds: optionIds) }
+                        Task { await self.handleUpdateVote(optionIds: optionIds) }
                     }
                 )
             )
@@ -781,10 +771,7 @@ extension NoticeDetailViewModel {
                         retryAction: { [weak self] in
                             guard let self else { return }
                             Task {
-                                await self.handleUpdateVote(
-                                    voteId: voteId,
-                                    optionIds: optionIds
-                                )
+                                await self.handleUpdateVote(optionIds: optionIds)
                             }
                         }
                     )
@@ -800,10 +787,7 @@ extension NoticeDetailViewModel {
                     retryAction: { [weak self] in
                         guard let self else { return }
                         Task {
-                            await self.handleUpdateVote(
-                                voteId: voteId,
-                                optionIds: optionIds
-                            )
+                            await self.handleUpdateVote(optionIds: optionIds)
                         }
                     }
                 )

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -227,15 +227,12 @@ struct NoticeDetailView: View {
                     container: di,
                     onVote: { optionIds in
                         Task {
-                            await viewModel.handleVote(voteId: vote.id, optionIds: optionIds)
+                            await viewModel.handleVote(optionIds: optionIds)
                         }
                     },
                     onUpdateVote: { optionIds in
                         Task {
-                            await viewModel.handleUpdateVote(
-                                voteId: vote.id,
-                                optionIds: optionIds
-                            )
+                            await viewModel.handleUpdateVote(optionIds: optionIds)
                         }
                     }
                 )


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 서버 도메인 재정비에 따른 공지사항 투표 응답 API 엔드포인트 마이그레이션

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음. 네트워크/도메인 레이어 마이그레이션 + ViewModel API 단순화입니다.

## 🛠️ 작업내용

- **Router**: `submitVoteResponse` / `updateVoteResponse` path를 `/api/v1/surveys/votes/{voteId}/responses` → `/api/v1/notices/{noticeId}/votes/responses` 로 변경, associated value를 `noticeId` 로 rename
- **Repository / Mock / Protocol**: 메서드 시그니처 `voteId` → `noticeId` 통일
- **UseCase / Protocol**: 시그니처 + validation 메시지(`유효하지 않은 공지입니다`) + DocC 주석 갱신
- **ViewModel**: `handleVote(optionIds:)` / `handleUpdateVote(optionIds:)` 로 파라미터 단순화 — ViewModel 내부의 `noticeID` 를 직접 사용하도록 정리 (View에서 `vote.id` 를 잘못 전달할 위험 제거)
- **View(`NoticeDetailView`)**: 호출부에서 `vote.id` 인자 제거

### 사전 검증 후 스킵

- `NoticeDetailContentDTO` — 이미 `startsAt` / `endsAtExclusive` 만 사용 중이라 `startDateKst` / `endDateKst` 제거 영향 없음 (이슈 본문 명시)
- 에러 코드 매핑 레이어 — 클라이언트에 `SURVEY-00xx` / `NOTICE-CONTENTS-00xx` 코드별 매핑 자체가 없음(grep 0건). 현재는 NetworkError catch에서 서버 `message` 필드를 그대로 노출하는 구조라 신규 코드(`SURVEY_NOT_PUBLISHED` 등)는 자동 반영됨

## 📋 추후 진행 상황

- 코드 기반 분기(특정 에러 코드별 다른 UX)가 필요해지면 `DomainError` 케이스 추가하는 별도 이슈로 진행

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Features/Notice/Data/Router/NoticeRouter.swift` — 새 path 및 associated value 변경 확인
- `AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift` — Router 호출부에 `noticeId` 정상 전달되는지
- `AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift` — `noticeId > 0` validation 의미 변경 확인
- `AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift` — `handleVote` / `handleUpdateVote` 가 `noticeID` 를 사용하도록 단순화된 흐름 확인 (retry 클로저 포함)
- `AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift` — `onVote` / `onUpdateVote` 호출부의 인자 변경

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

resolves #652