### PR TITLE
✨ [Feat] 공지사항 상세 vote 응답 신규 필드(status / totalParticipants / voteRate) 반영

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailContentDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailContentDTO.swift
@@ -16,6 +16,8 @@ struct NoticeDetailVoteDTO: Codable {
     let endsAtExclusive: String
     let options: [NoticeDetailVoteOptionDTO]
     let mySelectedOptionIds: [String]
+    let status: String?
+    let totalParticipants: Int?
 
     private enum CodingKeys: String, CodingKey {
         case voteId
@@ -26,6 +28,8 @@ struct NoticeDetailVoteDTO: Codable {
         case endsAtExclusive
         case options
         case mySelectedOptionIds
+        case status
+        case totalParticipants
     }
 
     init(from decoder: Decoder) throws {
@@ -38,18 +42,28 @@ struct NoticeDetailVoteDTO: Codable {
         self.endsAtExclusive = try container.decode(String.self, forKey: .endsAtExclusive)
         self.options = try container.decode([NoticeDetailVoteOptionDTO].self, forKey: .options)
         self.mySelectedOptionIds = try container.decodeStringArrayFlexible(forKey: .mySelectedOptionIds)
+        self.status = try container.decodeIfPresent(String.self, forKey: .status)
+        self.totalParticipants = try container.decodeIntFlexibleIfPresent(forKey: .totalParticipants)
     }
 
     func toDomain() -> NoticeVote {
-        NoticeVote(
+        let startDate = parseISO8601(startsAt)
+        let endDate = parseISO8601(endsAtExclusive)
+        let resolvedStatus: VoteStatus = status
+            .flatMap { VoteStatus(rawValue: $0) }
+            ?? VoteStatus.fallback(now: .now, startsAt: startDate, endsAt: endDate)
+
+        return NoticeVote(
             id: voteId,
             question: title,
             options: options.map { $0.toDomain() },
-            startDate: parseISO8601(startsAt),
-            endDate: parseISO8601(endsAtExclusive),
+            startDate: startDate,
+            endDate: endDate,
             allowMultipleChoices: allowMultipleChoice,
             isAnonymous: isAnonymous,
-            userVotedOptionIds: mySelectedOptionIds
+            userVotedOptionIds: mySelectedOptionIds,
+            status: resolvedStatus,
+            totalParticipants: totalParticipants
         )
     }
 }
@@ -59,12 +73,14 @@ struct NoticeDetailVoteOptionDTO: Codable {
     let content: String
     let voteCount: String
     let selectedMemberIds: [String]
+    let voteRate: Double?
 
     private enum CodingKeys: String, CodingKey {
         case optionId
         case content
         case voteCount
         case selectedMemberIds
+        case voteRate
     }
 
     init(from decoder: Decoder) throws {
@@ -73,6 +89,7 @@ struct NoticeDetailVoteOptionDTO: Codable {
         self.content = try container.decode(String.self, forKey: .content)
         self.voteCount = try container.decodeStringFlexible(forKey: .voteCount)
         self.selectedMemberIds = (try? container.decodeStringArrayFlexible(forKey: .selectedMemberIds)) ?? []
+        self.voteRate = try container.decodeDoubleFlexibleIfPresent(forKey: .voteRate)
     }
 
     func toDomain() -> VoteOption {
@@ -80,7 +97,8 @@ struct NoticeDetailVoteOptionDTO: Codable {
             id: optionId,
             title: content,
             voteCount: Int(voteCount) ?? 0,
-            selectedMemberIds: selectedMemberIds
+            selectedMemberIds: selectedMemberIds,
+            voteRate: voteRate
         )
     }
 }
@@ -151,6 +169,32 @@ private extension KeyedDecodingContainer {
             return values.map(String.init)
         }
         return []
+    }
+
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if let value = try? decodeIfPresent(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try? decodeIfPresent(Double.self, forKey: key) {
+            return Int(value)
+        }
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return Int(value)
+        }
+        return nil
+    }
+
+    func decodeDoubleFlexibleIfPresent(forKey key: Key) throws -> Double? {
+        if let value = try? decodeIfPresent(Double.self, forKey: key) {
+            return value
+        }
+        if let value = try? decodeIfPresent(Int.self, forKey: key) {
+            return Double(value)
+        }
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return Double(value)
+        }
+        return nil
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift
@@ -295,27 +295,52 @@ struct NoticeVote: Equatable, Identifiable, Hashable {
     let isAnonymous: Bool
     /// 현재 사용자가 투표한 옵션 ID 목록
     let userVotedOptionIds: [String]
-    
-    /// 전체 투표 수
+    /// 투표 상태 (서버 제공)
+    let status: VoteStatus
+    /// 전체 참여자 수 (서버 제공) — 복수 선택 시 voteCount 합과 다를 수 있음
+    let totalParticipants: Int
+
+    init(
+        id: String,
+        question: String,
+        options: [VoteOption],
+        startDate: Date,
+        endDate: Date,
+        allowMultipleChoices: Bool,
+        isAnonymous: Bool,
+        userVotedOptionIds: [String],
+        status: VoteStatus? = nil,
+        totalParticipants: Int? = nil
+    ) {
+        self.id = id
+        self.question = question
+        self.options = options
+        self.startDate = startDate
+        self.endDate = endDate
+        self.allowMultipleChoices = allowMultipleChoices
+        self.isAnonymous = isAnonymous
+        self.userVotedOptionIds = userVotedOptionIds
+        self.status = status
+            ?? VoteStatus.fallback(now: .now, startsAt: startDate, endsAt: endDate)
+        self.totalParticipants = totalParticipants
+            ?? options.reduce(0) { $0 + $1.voteCount }
+    }
+
+    /// 옵션별 voteCount 합계 (복수 선택 시 totalParticipants와 다름)
     var totalVotes: Int {
         options.reduce(0) { $0 + $1.voteCount }
     }
-    
+
     /// 투표 종료 여부
     var isEnded: Bool {
-        Date() > endDate
+        status == .ended
     }
-    
-    /// 투표 상태
-    var status: VoteStatus {
-        isEnded ? .ended : .active
-    }
-    
+
     /// 사용자 투표 여부
     var hasUserVoted: Bool {
         !userVotedOptionIds.isEmpty
     }
-    
+
     /// 날짜 포맷 (MM.dd - MM.dd)
     var formattedPeriod: String {
         startDate.dateRange(to: endDate)
@@ -328,25 +353,43 @@ struct VoteOption: Equatable, Identifiable, Hashable {
     let title: String
     let voteCount: Int
     let selectedMemberIds: [String]
+    /// 옵션 득표율 (서버 계산값, 0.0 ~ 100.0)
+    let voteRate: Double
 
-    init(id: String, title: String, voteCount: Int, selectedMemberIds: [String] = []) {
+    init(
+        id: String,
+        title: String,
+        voteCount: Int,
+        selectedMemberIds: [String] = [],
+        voteRate: Double? = nil
+    ) {
         self.id = id
         self.title = title
         self.voteCount = voteCount
         self.selectedMemberIds = selectedMemberIds
+        self.voteRate = voteRate ?? 0
     }
 
-    /// 투표율 계산
+    /// 투표율 — 서버 voteRate 우선, 없으면 클라이언트 계산
     func percentage(totalVotes: Int) -> Double {
+        if voteRate > 0 { return voteRate }
         guard totalVotes > 0 else { return 0 }
         return Double(voteCount) / Double(totalVotes) * 100
     }
 }
 
-/// 투표 상태
-enum VoteStatus {
-    case active  // 진행 중
-    case ended   // 종료
+/// 투표 상태 (서버 enum 매핑)
+enum VoteStatus: String {
+    case notStarted = "NOT_STARTED"
+    case active = "OPEN"
+    case ended = "CLOSED"
+
+    /// 미정의 raw value 또는 서버 미제공 시 fallback (시작/종료 시각 기반)
+    static func fallback(now: Date, startsAt: Date, endsAt: Date) -> VoteStatus {
+        if now < startsAt { return .notStarted }
+        if now >= endsAt { return .ended }
+        return .active
+    }
 }
 
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeVoteCard.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeVoteCard.swift
@@ -121,6 +121,12 @@ struct NoticeVoteCard: View {
     private var statusBadge: some View {
         Group {
             switch vote.status {
+            case .notStarted:
+                Text("시작 전")
+                    .appFont(.footnoteEmphasis, color: .grey700)
+                    .padding(Constants.capsulePadding)
+                    .background(Color.grey400.opacity(Constants.capsuleOpacity))
+                    .clipShape(Capsule())
             case .active:
                 Text("진행중")
                     .appFont(.footnoteEmphasis, color: .green)
@@ -239,17 +245,17 @@ struct NoticeVoteCard: View {
                 }
             }
 
-            if !vote.isAnonymous && vote.totalVotes > 0 {
+            if !vote.isAnonymous && vote.totalParticipants > 0 {
                 Button(action: { showAllVotersSheet = true }) {
                     HStack(spacing: DefaultSpacing.spacing4) {
                         Image(systemName: "person.2.fill")
                             .font(.system(size: 11))
-                        Text("총 \(vote.totalVotes)명 참여")
+                        Text("총 \(vote.totalParticipants)명 참여")
                     }
                     .appFont(.footnote, color: .indigo500)
                 }
             } else {
-                Text("총 \(vote.totalVotes)명 참여")
+                Text("총 \(vote.totalParticipants)명 참여")
                     .appFont(.footnote, color: .grey600)
             }
         }


### PR DESCRIPTION
## ✨ PR 유형

Feature — `GET /api/v1/notices/{noticeId}` 응답의 `vote` / `vote.options[]` 신규 필드를 클라이언트 모델에 반영하여, 클라이언트가 직접 계산하던 값들을 서버 계산값으로 일원화합니다.

closes #653

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 시작 전(`NOT_STARTED`) 상태 배지 추가 외 가시 변경 미미 — 기존 동작 회귀 없음 -->

## 🛠️ 작업내용

### Data
- `NoticeDetailVoteDTO`에 `status: String?`, `totalParticipants: Int?` 디코딩 추가
- `NoticeDetailVoteOptionDTO`에 `voteRate: Double?` 디코딩 추가
- `decodeIntFlexibleIfPresent` / `decodeDoubleFlexibleIfPresent` flexible 디코딩 헬퍼 추가
- `toDomain()` 매핑 갱신 — 서버 `status` 미정의값 시 `VoteStatus.fallback(now:startsAt:endsAt:)` 적용

### Domain
- `VoteStatus` enum을 `String` raw value로 변경하고 서버 enum 매핑: `.notStarted = "NOT_STARTED"` / `.active = "OPEN"` / `.ended = "CLOSED"`
- `VoteStatus.fallback(now:startsAt:endsAt:)` 정적 헬퍼 추가
- `NoticeVote`에 `status`(stored), `totalParticipants` 필드 추가
- `NoticeVote.isEnded`를 `Date()` 시각 비교 → `status == .ended` 로 단순화
- `VoteOption`에 `voteRate: Double` 추가
- `VoteOption.percentage(totalVotes:)`는 서버 `voteRate` 우선, 미제공 시 클라이언트 계산 fallback

### Presentation
- `NoticeVoteCard.statusBadge`에 `.notStarted`("시작 전") 케이스 추가
- 참여자 라벨/링크 조건을 `vote.totalVotes` → `vote.totalParticipants`로 교체

### 하위 호환
- `NoticeVote` / `VoteOption` 신규 필드는 모두 옵셔널 default를 가지므로 기존 Mock/Preview 호출은 변경 없이 동작
- 서버가 신규 필드 미제공 시 fallback 로직으로 안전 처리

## 📋 추후 진행 상황

- 디자인 확정 시 `.notStarted` 상태의 옵션 영역 UX 보강 (현재는 상태 배지만 추가)
- 복수 선택 투표에서 `totalParticipants` vs `totalVotes` 사용처 분리 정합성 추가 점검

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeDetailContentDTO.swift` — 신규 필드 디코딩, `toDomain()` 매핑(미정의 status fallback)
- `AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeDetailModel.swift` — `VoteStatus` enum 확장과 fallback, `NoticeVote`/`VoteOption` 메모리와이즈 init 호환성
- `AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeVoteCard.swift` — `.notStarted` 분기, `totalParticipants` 라벨 교체

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)