### PR TITLE
✨ [Feat] 스터디 그룹 일정 생성 V2 마이그레이션 (2단계 호출 + 본인 참여자 제외) (#656)

### DIFF
--- a/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
+++ b/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
@@ -233,6 +233,9 @@ extension DIContainer {
                 ),
                 classifierRepository: container.resolve(
                     ScheduleClassifierRepository.self
+                ),
+                scheduleRepository: container.resolve(
+                    ScheduleRepositoryProtocol.self
                 )
             )
         }

--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/StudyGroupScheduleCreateRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/StudyGroupScheduleCreateRequestDTO.swift
@@ -7,58 +7,14 @@
 
 import Foundation
 
-/// 스터디 그룹 일정 생성 Request DTO
+/// 스터디 그룹 일정 연결 Request DTO (V2 2단계 호출)
 ///
-/// `POST /api/v1/schedules/study-group`
-struct StudyGroupScheduleCreateRequestDTO: Encodable {
-    let name: String
-    let startsAt: Date
-    let endsAt: Date
-    let isAllDay: Bool
-    let locationName: String
-    let latitude: Double
-    let longitude: Double
-    let description: String
-    let tags: [String]
+/// `POST /api/v1/study-groups/schedules`
+///
+/// 1단계 V2 일정 생성(`POST /api/v2/schedules`)으로 받아온 `scheduleId`를
+/// 스터디 그룹과 주차 커리큘럼에 연결합니다.
+struct StudyGroupScheduleCreateRequestDTO: Encodable, Equatable {
+    let scheduleId: Int
     let studyGroupId: Int
-    let gisuId: Int
-    let requiresApproval: Bool
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case startsAt
-        case endsAt
-        case isAllDay
-        case locationName
-        case latitude
-        case longitude
-        case description
-        case tags
-        case studyGroupId
-        case gisuId
-        case requiresApproval
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(name, forKey: .name)
-        try container.encode(isAllDay, forKey: .isAllDay)
-        try container.encode(locationName, forKey: .locationName)
-        try container.encode(latitude, forKey: .latitude)
-        try container.encode(longitude, forKey: .longitude)
-        try container.encode(description, forKey: .description)
-        try container.encode(tags, forKey: .tags)
-        try container.encode(studyGroupId, forKey: .studyGroupId)
-        try container.encode(gisuId, forKey: .gisuId)
-        try container.encode(requiresApproval, forKey: .requiresApproval)
-
-        try container.encode(
-            ServerDateTimeConverter.toUTCDateTimeString(startsAt),
-            forKey: .startsAt
-        )
-        try container.encode(
-            ServerDateTimeConverter.toUTCDateTimeString(endsAt),
-            forKey: .endsAt
-        )
-    }
+    let weeklyCurriculumId: Int
 }

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockStudyRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockStudyRepository.swift
@@ -168,6 +168,17 @@ final class MockStudyRepository: StudyRepositoryProtocol {
         return Array(1...10)
     }
 
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption] {
+        try await Task.sleep(for: .milliseconds(200))
+        return missions.map {
+            WeeklyCurriculumOption(
+                weeklyCurriculumId: $0.week,
+                weekNo: $0.week,
+                title: $0.title
+            )
+        }
+    }
+
     func resolveChallengerId(
         memberId: Int,
         preferredGeneration: Int?
@@ -270,30 +281,14 @@ final class MockStudyRepository: StudyRepositoryProtocol {
         try await Task.sleep(for: .milliseconds(200))
     }
 
-    func createStudyGroupSchedule(
-        name: String,
-        startsAt: Date,
-        endsAt: Date,
-        isAllDay: Bool,
-        locationName: String,
-        latitude: Double,
-        longitude: Double,
-        description: String,
+    func linkStudyGroupSchedule(
+        scheduleId: Int,
         studyGroupId: Int,
-        gisuId: Int,
-        requiresApproval: Bool
+        weeklyCurriculumId: Int
     ) async throws {
-        _ = name
-        _ = startsAt
-        _ = endsAt
-        _ = isAllDay
-        _ = locationName
-        _ = latitude
-        _ = longitude
-        _ = description
+        _ = scheduleId
         _ = studyGroupId
-        _ = gisuId
-        _ = requiresApproval
+        _ = weeklyCurriculumId
         try await Task.sleep(for: .milliseconds(300))
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
@@ -62,6 +62,30 @@ final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
         try await fetchCurriculumData(weekNo: nil).missions
     }
 
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption] {
+        guard let gisuId = preferredGisuId, gisuId > 0 else {
+            throw DomainError.curriculumUnavailableForGeneration
+        }
+        let part = resolvedPartAPIValue
+        let response = try await adapter.request(
+            StudyRouter.getCurriculum(gisuId: gisuId, part: part, weekNo: nil)
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<CurriculumDTO>.self,
+            from: response.data
+        )
+        let dto = try apiResponse.unwrap()
+        return dto.weeks
+            .sorted { $0.weekNo < $1.weekNo }
+            .map {
+                WeeklyCurriculumOption(
+                    weeklyCurriculumId: $0.weeklyCurriculumId,
+                    weekNo: $0.weekNo,
+                    title: $0.title
+                )
+            }
+    }
+
     // MARK: - 운영진 스터디 관리 (Fallback)
 
     func fetchStudyMembers(
@@ -388,43 +412,31 @@ final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
         }
     }
 
-    func createStudyGroupSchedule(
-        name: String,
-        startsAt: Date,
-        endsAt: Date,
-        isAllDay: Bool,
-        locationName: String,
-        latitude: Double,
-        longitude: Double,
-        description: String,
+    func linkStudyGroupSchedule(
+        scheduleId: Int,
         studyGroupId: Int,
-        gisuId: Int,
-        requiresApproval: Bool
+        weeklyCurriculumId: Int
     ) async throws {
         let response = try await adapter.request(
-            StudyRouter.createStudyGroupSchedule(
+            StudyRouter.linkStudyGroupSchedule(
                 body: StudyGroupScheduleCreateRequestDTO(
-                    name: name,
-                    startsAt: startsAt,
-                    endsAt: endsAt,
-                    isAllDay: isAllDay,
-                    locationName: locationName,
-                    latitude: latitude,
-                    longitude: longitude,
-                    description: description,
-                    tags: ["STUDY"],
+                    scheduleId: scheduleId,
                     studyGroupId: studyGroupId,
-                    gisuId: gisuId,
-                    requiresApproval: requiresApproval
+                    weeklyCurriculumId: weeklyCurriculumId
                 )
             )
         )
 
-        let apiResponse = try decoder.decode(
-            APIResponse<String>.self,
+        if response.data.isEmpty {
+            return
+        }
+
+        if let apiResponse = try? decoder.decode(
+            APIResponse<EmptyResult>.self,
             from: response.data
-        )
-        try apiResponse.validateSuccess()
+        ) {
+            try apiResponse.validateSuccess()
+        }
     }
 
     func updateStudyGroup(

--- a/AppProduct/AppProduct/Features/Activity/Data/Router/StudyRouter.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Router/StudyRouter.swift
@@ -13,7 +13,7 @@ import Moya
 enum StudyRouter {
     case getCurriculum(gisuId: Int, part: String, weekNo: Int?)
     case getCurriculumWeeks(part: String)
-    case createStudyGroupSchedule(body: StudyGroupScheduleCreateRequestDTO)
+    case linkStudyGroupSchedule(body: StudyGroupScheduleCreateRequestDTO)
     case getMyStudyGroups(cursor: Int?, size: Int)
     case getStudyGroupNames
     case getStudyGroupDetail(groupId: Int)
@@ -49,8 +49,8 @@ extension StudyRouter: BaseTargetType {
             return "/api/v2/curriculums/overview"
         case .getCurriculumWeeks:
             return "/api/v1/curriculums/weeks"
-        case .createStudyGroupSchedule:
-            return "/api/v1/schedules/study-group"
+        case .linkStudyGroupSchedule:
+            return "/api/v1/study-groups/schedules"
         case .getMyStudyGroups:
             return "/api/v1/study-groups/managed"
         case .getStudyGroupNames:
@@ -104,7 +104,7 @@ extension StudyRouter: BaseTargetType {
             return .delete
         case .searchChallengersOffset:
             return .get
-        case .createStudyGroupSchedule:
+        case .linkStudyGroupSchedule:
             return .post
         case .updateStudyGroup:
             return .patch
@@ -149,7 +149,7 @@ extension StudyRouter: BaseTargetType {
                 parameters: ["part": part],
                 encoding: URLEncoding.queryString
             )
-        case .createStudyGroupSchedule(let body):
+        case .linkStudyGroupSchedule(let body):
             return .requestJSONEncodable(body)
         case .getMyStudyGroups(let cursor, let size):
             var parameters: [String: Any] = [

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/StudyRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/StudyRepositoryProtocol.swift
@@ -61,6 +61,15 @@ protocol StudyRepositoryProtocol {
     /// - Throws: 네트워크 오류 또는 파싱 오류
     func fetchWeeks() async throws -> [Int]
 
+    /// 주차 커리큘럼 옵션 목록을 가져옵니다.
+    ///
+    /// 스터디 그룹 일정을 특정 주차 커리큘럼에 연결할 때 (`POST /api/v1/study-groups/schedules`)
+    /// 사용자가 선택할 수 있는 주차 정보(weeklyCurriculumId · weekNo · title)를 반환합니다.
+    ///
+    /// - Returns: 주차 커리큘럼 옵션 배열 (서버 응답 순서를 유지)
+    /// - Throws: 네트워크 오류 또는 파싱 오류
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption]
+
     /// 멤버 ID로 챌린저 ID를 조회합니다.
     /// - Parameters:
     ///   - memberId: 멤버 ID
@@ -175,32 +184,19 @@ protocol StudyRepositoryProtocol {
     /// - Throws: 네트워크 오류 또는 파싱 오류
     func deleteStudyGroup(groupId: Int) async throws
 
-    /// 스터디 그룹 일정을 생성합니다.
+    /// 1단계 V2 일정 생성으로 받은 `scheduleId` 를 스터디 그룹/주차 커리큘럼에 연결합니다.
+    ///
+    /// `POST /api/v1/study-groups/schedules` 엔드포인트의 단순 래퍼입니다.
+    /// 1단계 일정 생성은 `ScheduleRepositoryProtocol.generateSchedule(...)` 으로 호출합니다.
     ///
     /// - Parameters:
-    ///   - name: 일정 이름
-    ///   - startsAt: 시작 일시
-    ///   - endsAt: 종료 일시
-    ///   - isAllDay: 종일 여부
-    ///   - locationName: 장소명
-    ///   - latitude: 위도
-    ///   - longitude: 경도
-    ///   - description: 일정 설명
+    ///   - scheduleId: 1단계에서 생성된 일정 ID
     ///   - studyGroupId: 스터디 그룹 ID
-    ///   - gisuId: 기수 ID
-    ///   - requiresApproval: 승인 필요 여부
-    /// - Throws: 네트워크 오류 또는 파싱 오류
-    func createStudyGroupSchedule(
-        name: String,
-        startsAt: Date,
-        endsAt: Date,
-        isAllDay: Bool,
-        locationName: String,
-        latitude: Double,
-        longitude: Double,
-        description: String,
+    ///   - weeklyCurriculumId: 주차 커리큘럼 ID
+    /// - Throws: 네트워크 오류 또는 파싱 오류 (`SCHEDULE-0009`, `ORGANIZAITON-0023`, `CURRICULUM-0014` 등)
+    func linkStudyGroupSchedule(
+        scheduleId: Int,
         studyGroupId: Int,
-        gisuId: Int,
-        requiresApproval: Bool
+        weeklyCurriculumId: Int
     ) async throws
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/WeeklyCurriculumOption.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Study/WeeklyCurriculumOption.swift
@@ -1,0 +1,21 @@
+//
+//  WeeklyCurriculumOption.swift
+//  AppProduct
+//
+//  Created by jaewon Lee on 5/6/26.
+//
+
+import Foundation
+
+/// 주차 커리큘럼 선택 옵션 도메인 모델
+///
+/// 스터디 그룹 일정을 특정 주차 커리큘럼과 연결할 때 (`POST /api/v1/study-groups/schedules`)
+/// 사용자가 선택할 수 있는 주차 정보 한 줄을 표현합니다.
+struct WeeklyCurriculumOption: Hashable, Identifiable, Sendable {
+
+    let weeklyCurriculumId: Int
+    let weekNo: Int
+    let title: String
+
+    var id: Int { weeklyCurriculumId }
+}

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchStudyMembersUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchStudyMembersUseCaseProtocol.swift
@@ -31,6 +31,11 @@ protocol FetchStudyMembersUseCaseProtocol {
     /// 스터디 주차 목록 조회
     func fetchWeeks() async throws -> [Int]
 
+    /// 주차 커리큘럼 옵션(weeklyCurriculumId · weekNo · title) 목록 조회
+    ///
+    /// 스터디 그룹 일정 등록 화면에서 어느 주차 커리큘럼에 연결할지 선택할 때 사용합니다.
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption]
+
     /// 멤버 ID를 챌린저 ID로 변환
     func resolveChallengerId(
         memberId: Int,
@@ -95,18 +100,23 @@ protocol FetchStudyMembersUseCaseProtocol {
     /// - Throws: 네트워크 오류 또는 파싱 오류
     func deleteStudyGroup(groupId: Int) async throws
 
-    /// 스터디 그룹 일정 생성
-    func createStudyGroupSchedule(
-        name: String,
-        startsAt: Date,
-        endsAt: Date,
-        isAllDay: Bool,
-        locationName: String,
-        latitude: Double,
-        longitude: Double,
-        description: String,
+    /// 스터디 그룹 일정 — 1단계 V2 일정 생성
+    ///
+    /// `POST /api/v2/schedules` 를 호출해 일반 일정을 만들고 `scheduleId` 를 반환합니다.
+    /// 본 메서드는 호출자가 참여자에서 본인을 제외한 멤버 ID 와 출석 정책 등을 채워서 전달합니다.
+    func createStudySchedule(
+        request: GenerateScheduleRequetDTO
+    ) async throws -> Int
+
+    /// 스터디 그룹 일정 — 2단계 스터디 그룹/주차 커리큘럼 연결
+    ///
+    /// `POST /api/v1/study-groups/schedules`
+    func linkStudyGroupSchedule(
+        scheduleId: Int,
         studyGroupId: Int,
-        gisuId: Int,
-        requiresApproval: Bool
+        weeklyCurriculumId: Int
     ) async throws
+
+    /// 일정 단순 삭제 (스터디 그룹 일정 2단계 실패 시 베스트 에포트 롤백 용)
+    func deleteSchedule(scheduleId: Int) async throws
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchStudyMembersUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchStudyMembersUseCase.swift
@@ -15,11 +15,16 @@ final class FetchStudyMembersUseCase: FetchStudyMembersUseCaseProtocol {
     // MARK: - Property
 
     private let repository: StudyRepositoryProtocol
+    private let scheduleRepository: ScheduleRepositoryProtocol
 
     // MARK: - Init
 
-    init(repository: StudyRepositoryProtocol) {
+    init(
+        repository: StudyRepositoryProtocol,
+        scheduleRepository: ScheduleRepositoryProtocol
+    ) {
         self.repository = repository
+        self.scheduleRepository = scheduleRepository
     }
 
     // MARK: - Function
@@ -54,6 +59,10 @@ final class FetchStudyMembersUseCase: FetchStudyMembersUseCaseProtocol {
 
     func fetchWeeks() async throws -> [Int] {
         try await repository.fetchWeeks()
+    }
+
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption] {
+        try await repository.fetchWeeklyCurriculumOptions()
     }
 
     func resolveChallengerId(
@@ -142,31 +151,25 @@ final class FetchStudyMembersUseCase: FetchStudyMembersUseCaseProtocol {
         try await repository.deleteStudyGroup(groupId: groupId)
     }
 
-    func createStudyGroupSchedule(
-        name: String,
-        startsAt: Date,
-        endsAt: Date,
-        isAllDay: Bool,
-        locationName: String,
-        latitude: Double,
-        longitude: Double,
-        description: String,
+    func createStudySchedule(
+        request: GenerateScheduleRequetDTO
+    ) async throws -> Int {
+        try await scheduleRepository.generateSchedule(schedule: request)
+    }
+
+    func linkStudyGroupSchedule(
+        scheduleId: Int,
         studyGroupId: Int,
-        gisuId: Int,
-        requiresApproval: Bool
+        weeklyCurriculumId: Int
     ) async throws {
-        try await repository.createStudyGroupSchedule(
-            name: name,
-            startsAt: startsAt,
-            endsAt: endsAt,
-            isAllDay: isAllDay,
-            locationName: locationName,
-            latitude: latitude,
-            longitude: longitude,
-            description: description,
+        try await repository.linkStudyGroupSchedule(
+            scheduleId: scheduleId,
             studyGroupId: studyGroupId,
-            gisuId: gisuId,
-            requiresApproval: requiresApproval
+            weeklyCurriculumId: weeklyCurriculumId
         )
+    }
+
+    func deleteSchedule(scheduleId: Int) async throws {
+        try await scheduleRepository.deleteSchedule(scheduleId: scheduleId)
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Provider/ActivityUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Provider/ActivityUseCaseProvider.swift
@@ -58,7 +58,8 @@ final class ActivityUseCaseProvider: ActivityUseCaseProviding {
 
     init(
         repositoryProvider: ActivityRepositoryProviding,
-        classifierRepository: ScheduleClassifierRepository
+        classifierRepository: ScheduleClassifierRepository,
+        scheduleRepository: ScheduleRepositoryProtocol
     ) {
         self.fetchSessionsUseCase = FetchSessionsUseCase(
             repository: repositoryProvider.activityRepository
@@ -79,7 +80,8 @@ final class ActivityUseCaseProvider: ActivityUseCaseProviding {
             repository: repositoryProvider.studyRepository
         )
         self.fetchStudyMembersUseCase = FetchStudyMembersUseCase(
-            repository: repositoryProvider.studyRepository
+            repository: repositoryProvider.studyRepository,
+            scheduleRepository: scheduleRepository
         )
         self.fetchMembersUseCase = FetchMembersUseCase(
             repository: repositoryProvider.memberRepository

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/StudyScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/StudyScheduleRegistrationViewModel.swift
@@ -8,6 +8,11 @@
 import Foundation
 
 /// 스터디 일정 등록 화면의 상태를 관리하는 뷰 모델
+///
+/// V2 일정 API 마이그레이션에 따라 두 단계로 호출합니다.
+/// 1. `POST /api/v2/schedules` 로 일반 일정 생성 (본인은 참여자에서 제외, 태그 `["STUDY"]` 자동, 출석 정책 필수)
+/// 2. 받아온 `scheduleId` 를 `POST /api/v1/study-groups/schedules` 로 스터디 그룹·주차 커리큘럼에 연결
+/// 2단계가 실패하면 ``alertPrompt`` 로 재시도/취소를 노출하고, 취소 시 1단계 일정을 베스트 에포트로 삭제합니다.
 @Observable
 final class StudyScheduleRegistrationViewModel {
 
@@ -21,7 +26,7 @@ final class StudyScheduleRegistrationViewModel {
 
     /// 선택된 장소
     var place: PlaceSearchInfo = .init(name: "", address: "", coordinate: .init(latitude: 0.0, longitude: 0.0))
-    
+
     /// 스터디명 (초기값은 스터디 그룹 이름)
     var studyName: String
 
@@ -30,6 +35,18 @@ final class StudyScheduleRegistrationViewModel {
 
     /// 종료 일시
     var endDate: Date = .now.addingTimeInterval(7200)
+
+    /// 주차 커리큘럼 옵션 목록 (서버 조회 결과)
+    private(set) var weeklyOptions: [WeeklyCurriculumOption] = []
+
+    /// 선택된 주차 커리큘럼
+    var selectedWeeklyOption: WeeklyCurriculumOption?
+
+    /// 주차 옵션 로딩 상태
+    private(set) var weeklyOptionsState: Loadable<[WeeklyCurriculumOption]> = .idle
+
+    /// 2단계 실패 시 재시도/취소 다이얼로그
+    var alertPrompt: AlertPrompt?
 
     // MARK: - DatePicker Toggle State
 
@@ -50,45 +67,7 @@ final class StudyScheduleRegistrationViewModel {
             && !place.name.trimmingCharacters(in: .whitespaces).isEmpty
             && studyGroupId > 0
             && endDate >= startDate
-    }
-
-    /// 스케줄 등록 실행
-    @MainActor
-    func submitSchedule() async -> Bool {
-        guard canSubmit else {
-            return false
-        }
-
-        let gisuId = UserDefaults.standard.integer(forKey: AppStorageKey.gisuId)
-        guard gisuId > 0 else {
-            return false
-        }
-
-        do {
-            try await useCase.createStudyGroupSchedule(
-                name: studyName.trimmingCharacters(in: .whitespacesAndNewlines),
-                startsAt: startDate,
-                endsAt: endDate,
-                isAllDay: false,
-                locationName: place.name,
-                latitude: place.coordinate.latitude,
-                longitude: place.coordinate.longitude,
-                description: "",
-                studyGroupId: studyGroupId,
-                gisuId: gisuId,
-                requiresApproval: true
-            )
-            return true
-        } catch {
-            errorHandler.handle(error, context: ErrorContext(
-                feature: "Activity",
-                action: "createStudyGroupSchedule",
-                retryAction: { [weak self] in
-                    _ = await self?.submitSchedule()
-                }
-            ))
-            return false
-        }
+            && selectedWeeklyOption != nil
     }
 
     // MARK: - Init
@@ -108,5 +87,154 @@ final class StudyScheduleRegistrationViewModel {
         self.studyGroupId = studyGroupId
         self.useCase = useCase
         self.errorHandler = errorHandler
+    }
+
+    // MARK: - Function
+
+    /// 주차 커리큘럼 옵션 목록을 서버에서 불러옵니다.
+    @MainActor
+    func loadWeeklyOptions() async {
+        if case .loading = weeklyOptionsState { return }
+        weeklyOptionsState = .loading
+        do {
+            let options = try await useCase.fetchWeeklyCurriculumOptions()
+            weeklyOptions = options
+            weeklyOptionsState = .loaded(options)
+            if selectedWeeklyOption == nil {
+                selectedWeeklyOption = options.first
+            }
+        } catch let error as DomainError {
+            weeklyOptionsState = .failed(.domain(error))
+        } catch let error as AppError {
+            weeklyOptionsState = .failed(error)
+        } catch {
+            weeklyOptionsState = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    /// 스케줄 등록 실행 (2단계 V2 호출)
+    /// - Returns: 두 단계 모두 성공한 경우에만 `true`
+    @MainActor
+    func submitSchedule() async -> Bool {
+        guard canSubmit, let weeklyOption = selectedWeeklyOption else {
+            return false
+        }
+
+        let request = makeScheduleRequest()
+
+        let scheduleId: Int
+        do {
+            scheduleId = try await useCase.createStudySchedule(request: request)
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "createStudySchedule",
+                retryAction: { [weak self] in
+                    _ = await self?.submitSchedule()
+                }
+            ))
+            return false
+        }
+
+        return await linkSchedule(
+            scheduleId: scheduleId,
+            weeklyCurriculumId: weeklyOption.weeklyCurriculumId
+        )
+    }
+
+    // MARK: - Private
+
+    /// 1단계 V2 일정 요청 페이로드를 구성합니다.
+    ///
+    /// - 본인은 참여자에서 제외 (이슈 #656 요구사항) → `participantMemberIds = []`
+    /// - 태그는 `[.study]` 로 하드코딩
+    /// - 출석 정책은 시작/종료 시간을 기준으로 `AttendanceGeofenceConstants` 임계값에서 도출
+    private func makeScheduleRequest() -> GenerateScheduleRequetDTO {
+        let onTimeThreshold = TimeInterval(AttendanceGeofenceConstants.onTimeThresholdMinutes * 60)
+        let lateThreshold = TimeInterval(AttendanceGeofenceConstants.lateThresholdMinutes * 60)
+
+        let policy = V2AttendancePolicyDTO(
+            domain: AttendancePolicy(
+                checkInStartAt: startDate.addingTimeInterval(-onTimeThreshold),
+                onTimeEndAt: startDate.addingTimeInterval(onTimeThreshold),
+                lateEndAt: startDate.addingTimeInterval(lateThreshold)
+            )
+        )
+
+        let location = V2LocationDTO(
+            latitude: place.coordinate.latitude,
+            longitude: place.coordinate.longitude,
+            locationName: place.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+
+        return GenerateScheduleRequetDTO(
+            name: studyName.trimmingCharacters(in: .whitespacesAndNewlines),
+            description: "",
+            startsAt: startDate,
+            endsAt: endDate,
+            location: location,
+            participantMemberIds: [],
+            tags: [.study],
+            attendancePolicy: policy
+        )
+    }
+
+    /// 2단계 — 스터디 그룹/주차 커리큘럼 연결.
+    /// 실패 시 `AlertPrompt` 로 재시도/취소를 묻고, 취소 시 1단계 일정을 베스트 에포트로 삭제합니다.
+    @MainActor
+    private func linkSchedule(
+        scheduleId: Int,
+        weeklyCurriculumId: Int
+    ) async -> Bool {
+        do {
+            try await useCase.linkStudyGroupSchedule(
+                scheduleId: scheduleId,
+                studyGroupId: studyGroupId,
+                weeklyCurriculumId: weeklyCurriculumId
+            )
+            return true
+        } catch {
+            await presentLinkFailureAlert(
+                scheduleId: scheduleId,
+                weeklyCurriculumId: weeklyCurriculumId
+            )
+            return false
+        }
+    }
+
+    @MainActor
+    private func presentLinkFailureAlert(
+        scheduleId: Int,
+        weeklyCurriculumId: Int
+    ) async {
+        alertPrompt = AlertPrompt(
+            title: "스터디 일정 연결 실패",
+            message: "일정은 생성됐지만 스터디 그룹과 연결하는 데 실패했어요.\n다시 시도하시겠어요?",
+            positiveBtnTitle: "재시도",
+            positiveBtnAction: { [weak self] in
+                Task { @MainActor [weak self] in
+                    _ = await self?.linkSchedule(
+                        scheduleId: scheduleId,
+                        weeklyCurriculumId: weeklyCurriculumId
+                    )
+                }
+            },
+            negativeBtnTitle: "취소",
+            negativeBtnAction: { [weak self] in
+                Task { @MainActor [weak self] in
+                    await self?.rollbackSchedule(scheduleId: scheduleId)
+                }
+            }
+        )
+    }
+
+    /// 베스트 에포트 롤백 — 실패해도 사용자에게 노출하지 않습니다.
+    @MainActor
+    private func rollbackSchedule(scheduleId: Int) async {
+        do {
+            try await useCase.deleteSchedule(scheduleId: scheduleId)
+        } catch {
+            // 베스트 에포트 — 실패해도 화면 흐름을 막지 않음
+        }
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/StudyScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/StudyScheduleRegistrationView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// 스터디 일정 등록 화면
 ///
 /// 스터디 그룹 카드에서 "스터디 일정 등록하기" 버튼을 탭하면 푸시됩니다.
-/// 스터디명, 일시(시작/종료), 장소를 입력받습니다.
+/// 스터디명, 주차 커리큘럼, 일시(시작/종료), 장소를 입력받아 V2 일정 API 2단계로 호출합니다.
 struct StudyScheduleRegistrationView: View {
 
     // MARK: - Property
@@ -53,6 +53,10 @@ struct StudyScheduleRegistrationView: View {
                 studyNameField
             }
 
+            Section("주차 커리큘럼") {
+                weeklyCurriculumPicker
+            }
+
             Section {
                 dateTimeSection
             }
@@ -73,6 +77,10 @@ struct StudyScheduleRegistrationView: View {
                 isLoading: isSubmitting,
                 dismissOnTap: false
             )
+        }
+        .alertPrompt(item: $viewModel.alertPrompt)
+        .task {
+            await viewModel.loadWeeklyOptions()
         }
     }
 
@@ -104,6 +112,42 @@ struct StudyScheduleRegistrationView: View {
         .appFont(.body, color: .black)
         .submitLabel(.next)
         .tint(.indigo500)
+    }
+
+    /// 주차 커리큘럼 선택 Picker
+    @ViewBuilder
+    private var weeklyCurriculumPicker: some View {
+        switch viewModel.weeklyOptionsState {
+        case .idle, .loading:
+            HStack {
+                Text("주차 목록 불러오는 중…")
+                    .appFont(.body, color: .grey500)
+                Spacer()
+                ProgressView()
+            }
+        case .failed:
+            HStack {
+                Text("주차 목록을 불러오지 못했어요")
+                    .appFont(.body, color: .grey500)
+                Spacer()
+                Button("재시도") {
+                    Task { await viewModel.loadWeeklyOptions() }
+                }
+                .appFont(.footnote, color: .indigo500)
+            }
+        case .loaded(let options) where options.isEmpty:
+            Text("등록된 주차 커리큘럼이 없어요")
+                .appFont(.body, color: .grey500)
+        case .loaded(let options):
+            Picker("주차 커리큘럼", selection: $viewModel.selectedWeeklyOption) {
+                ForEach(options) { option in
+                    Text("\(option.weekNo)주차 · \(option.title)")
+                        .tag(Optional(option))
+                }
+            }
+            .pickerStyle(.menu)
+            .tint(.indigo500)
+        }
     }
 
     /// 시작/종료 날짜·시간 선택 섹션

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
@@ -58,7 +58,7 @@ final class MockHomeRepository: HomeRepositoryProtocol {
 /// 프리뷰 및 테스트용 Schedule Repository Mock 구현체
 final class MockScheduleRepository: ScheduleRepositoryProtocol {
 
-    func generateSchedule(schedule: GenerateScheduleRequetDTO) async throws {
+    func generateSchedule(schedule: GenerateScheduleRequetDTO) async throws -> Int {
         throw DomainError.insufficientPermission(required: "인증")
     }
 
@@ -67,6 +67,10 @@ final class MockScheduleRepository: ScheduleRepositoryProtocol {
     }
 
     func deleteScheduleWithAttendance(scheduleId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "인증")
+    }
+
+    func deleteSchedule(scheduleId: Int) async throws {
         throw DomainError.insufficientPermission(required: "인증")
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/ScheduleRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/ScheduleRepository.swift
@@ -42,13 +42,35 @@ final class ScheduleRepository: ScheduleRepositoryProtocol, @unchecked Sendable 
     /// 출석 포함 일정을 생성합니다.
     ///
     /// - Parameter schedule: 일정 생성 요청 DTO
+    /// - Returns: 생성된 일정 ID (V2 응답의 `result.scheduleId`)
     /// - Throws: 서버 에러 또는 네트워크 에러
+    @discardableResult
     func generateSchedule(
         schedule: GenerateScheduleRequetDTO
-    ) async throws {
+    ) async throws -> Int {
         let response = try await adapter.request(
             ScheduleV2Router.postSchedule(request: schedule)
         )
+        let apiResponse = try decoder.decode(
+            APIResponse<Int>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap()
+    }
+
+    /// 일정을 단순 삭제합니다.
+    ///
+    /// - Parameter scheduleId: 삭제할 일정 ID
+    /// - Throws: 서버 에러 또는 네트워크 에러
+    func deleteSchedule(
+        scheduleId: Int
+    ) async throws {
+        let response = try await adapter.request(
+            ScheduleV2Router.deleteSchedule(scheduleId: scheduleId)
+        )
+        if response.data.isEmpty {
+            return
+        }
         let apiResponse = try decoder.decode(
             APIResponse<EmptyResult>.self,
             from: response.data

--- a/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleV2Router.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleV2Router.swift
@@ -26,6 +26,8 @@ enum ScheduleV2Router {
     case postSchedule(request: GenerateScheduleRequetDTO)
     /// 일정 수정 (부분 갱신)
     case patchSchedule(scheduleId: Int, request: UpdateScheduleRequestDTO)
+    /// 일정 삭제 (스터디 그룹 일정 2단계 실패 시 베스트 에포트 롤백 등)
+    case deleteSchedule(scheduleId: Int)
 }
 
 extension ScheduleV2Router: BaseTargetType {
@@ -44,6 +46,8 @@ extension ScheduleV2Router: BaseTargetType {
             return "/api/v2/schedules"
         case .patchSchedule(let scheduleId, _):
             return "/api/v2/schedules/\(scheduleId)"
+        case .deleteSchedule(let scheduleId):
+            return "/api/v2/schedules/\(scheduleId)"
         }
     }
 
@@ -57,6 +61,8 @@ extension ScheduleV2Router: BaseTargetType {
             return .post
         case .patchSchedule:
             return .patch
+        case .deleteSchedule:
+            return .delete
         }
     }
 
@@ -64,7 +70,7 @@ extension ScheduleV2Router: BaseTargetType {
 
     var task: Moya.Task {
         switch self {
-        case .getCapabilities, .getScheduleDetail:
+        case .getCapabilities, .getScheduleDetail, .deleteSchedule:
             return .requestPlain
         case .getMySchedules(let from, let to, let isAttendanceRequired):
             return .requestParameters(

--- a/AppProduct/AppProduct/Features/Home/Domain/Interface/ScheduleRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Interface/ScheduleRepositoryProtocol.swift
@@ -18,9 +18,21 @@ protocol ScheduleRepositoryProtocol: Sendable {
     /// 출석 포함 일정을 생성합니다.
     ///
     /// - Parameter schedule: 일정 생성 요청 DTO (제목, 날짜, 장소, 참여자 등)
+    /// - Returns: 생성된 일정 ID (V2 응답의 `result.scheduleId`)
     /// - Throws: 서버 에러 또는 네트워크 에러
+    @discardableResult
     func generateSchedule(
         schedule: GenerateScheduleRequetDTO
+    ) async throws -> Int
+
+    /// 일정을 단순 삭제합니다 (출석부 연동 없이).
+    ///
+    /// 스터디 그룹 일정 2단계 호출 실패 시 베스트 에포트 롤백 등에 사용합니다.
+    ///
+    /// - Parameter scheduleId: 삭제할 일정 ID
+    /// - Throws: 서버 에러 또는 네트워크 에러
+    func deleteSchedule(
+        scheduleId: Int
     ) async throws
 
     /// 일정 정보를 부분 수정합니다.

--- a/AppProduct/AppProduct/Features/Home/Domain/UseCases/GenerateScheduleUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/UseCases/GenerateScheduleUseCaseProtocol.swift
@@ -11,5 +11,7 @@ import Foundation
 protocol GenerateScheduleUseCaseProtocol {
     /// 일정 생성
     /// - Parameter schedule: 일정 생성 요청 DTO
-    func execute(schedule: GenerateScheduleRequetDTO) async throws
+    /// - Returns: 생성된 일정 ID (V2 응답의 `result.scheduleId`)
+    @discardableResult
+    func execute(schedule: GenerateScheduleRequetDTO) async throws -> Int
 }

--- a/AppProduct/AppProduct/Features/Home/Domain/UseCases/Implementations/GenerateScheduleUseCase.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/UseCases/Implementations/GenerateScheduleUseCase.swift
@@ -26,7 +26,8 @@ final class GenerateScheduleUseCase: GenerateScheduleUseCaseProtocol {
 
     // MARK: - Function
 
-    func execute(schedule: GenerateScheduleRequetDTO) async throws {
+    @discardableResult
+    func execute(schedule: GenerateScheduleRequetDTO) async throws -> Int {
         try await repository.generateSchedule(schedule: schedule)
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Feature + Refactor — 스터디 그룹 일정 생성 흐름을 V2 일정 API 2단계 호출 구조로 마이그레이션하고, 본인 참여자 제외 / 출석 정책 기본값 자동 산출 / 주차 커리큘럼 Picker UI 등을 도입합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 스터디 일정 등록 화면에 "주차 커리큘럼" 섹션이 추가되어 화면 캡처가 필요합니다 -->

## 🛠️ 작업내용

- **V2 일정 생성 2단계 흐름 구현**
    - 1단계: `POST /api/v2/schedules` 로 일반 일정 생성 → `scheduleId` 수신
    - 2단계: `POST /api/v1/study-groups/schedules` 로 `{scheduleId, studyGroupId, weeklyCurriculumId}` 연결
- **본인 참여자 제외** (`participantMemberIds: []`) — 이슈 #656 요구사항
- **태그 `[STUDY]` 자동 부여** (`tags: [.study]` 하드코딩)
- **출석 정책 기본값 자동 산출** — 시작/종료 시각을 기준으로 `AttendanceGeofenceConstants` (10분 정시, 30분 지각) 임계값으로부터 도출
- **2단계 실패 시 AlertPrompt 재시도/취소 분기**
    - 재시도 → `linkSchedule` 재호출
    - 취소 → 베스트 에포트로 1단계 일정 삭제 (`DELETE /api/v2/schedules/{id}`)
- **주차 커리큘럼 선택 UI** 추가
    - `WeeklyCurriculumOption` 도메인 모델 신설
    - `fetchWeeklyCurriculumOptions()` UseCase / Repository 메서드 추가 (기존 커리큘럼 엔드포인트 재사용 + ID 보존)
    - `Loadable<[WeeklyCurriculumOption]>` 상태로 로딩/실패/빈 상태 표현
- **레거시 잔재 정리**
    - `requiresApproval` / `isAllDay` 하드코딩 제거
    - `StudyGroupScheduleCreateRequestDTO` V1 연결 전용으로 슬림화
    - `ScheduleRepository.generateSchedule` 응답 디코딩을 `APIResponse<Int>` 로 단순화

## 📋 추후 진행 상황

- 2단계 PR 단계 전환 시 사용자 화면 흐름(로딩 인디케이터/토스트) UX 다듬기
- `weeklyCurriculumId` 가 없는 기수/파트 케이스 처리 정책 확정
- ScheduleV2 마이그레이션 후속 — 일정 수정/삭제 화면도 V2 어댑테이션 검토

## 📌 리뷰 포인트

- `Features/Activity/Presentation/ViewModels/Operation/StudyScheduleRegistrationViewModel.swift` — 2단계 흐름, AlertPrompt 분기, 베스트 에포트 롤백 로직
- `Features/Activity/Presentation/Views/Operation/StudyScheduleRegistrationView.swift` — `weeklyOptionsState` 분기 렌더링 / Picker tag(Optional) 처리
- `Features/Activity/Domain/UseCases/Implementations/FetchStudyMembersUseCase.swift` — `createStudySchedule` / `linkStudyGroupSchedule` / `deleteSchedule` UseCase 흐름
- `Features/Activity/Data/Repositories/StudyRepository.swift` — 기존 커리큘럼 엔드포인트 재사용으로 `WeeklyCurriculumOption` 매핑
- `Features/Home/Data/Repository/ScheduleRepository.swift` — `APIResponse<Int>` 직접 디코딩 (응답 result 가 raw Int)
- `Core/DIContainer/DIContainer.swift` — `ScheduleRepositoryProtocol` 의존성 주입 추가

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)