### PR TITLE
✨[Feat] 일정 생성/수정 화면 출석 정책 입력 UI 추가 (#657)

### DIFF
--- a/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
+++ b/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
@@ -297,6 +297,9 @@ extension DIContainer {
                 ),
                 challengerSearchRepository: container.resolve(
                     ChallengerSearchRepositoryProtocol.self
+                ),
+                scheduleCapabilitiesRepository: container.resolve(
+                    ScheduleCapabilitiesRepositoryProtocol.self
                 )
             )
         }

--- a/AppProduct/AppProduct/Features/Home/Domain/Models/Schedule/AttendancePolicyError.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/Schedule/AttendancePolicyError.swift
@@ -1,0 +1,42 @@
+//
+//  AttendancePolicyError.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 5/6/26.
+//
+
+import Foundation
+
+/// 출석 정책 입력 폼의 인라인 검증 에러
+///
+/// 일정 생성/수정 화면의 출석 정책 섹션에서 사용자 입력을 검증할 때 사용합니다.
+/// 단조 증가(checkInStartAt < onTimeEndAt < lateEndAt) 와
+/// 일정 종료 범위(lateEndAt ≤ endsAt) 위반 케이스를 표현합니다.
+enum AttendancePolicyError: Equatable, Sendable {
+
+    /// 시각 순서가 단조 증가가 아님
+    case invalidOrder(OrderField)
+
+    /// 지각 종료 시각이 일정 종료 시각을 초과함
+    case lateExceedsEnd
+
+    /// 단조 증가 위반 위치
+    enum OrderField: Equatable, Sendable {
+        /// 체크인 시작 ≥ 정시 종료
+        case checkInVsOnTime
+        /// 정시 종료 ≥ 지각 종료
+        case onTimeVsLate
+    }
+
+    /// 화면에 노출할 한국어 메시지
+    var message: String {
+        switch self {
+        case .invalidOrder(.checkInVsOnTime):
+            return "체크인 시작은 정시 종료보다 빨라야 합니다."
+        case .invalidOrder(.onTimeVsLate):
+            return "정시 종료는 지각 종료보다 빨라야 합니다."
+        case .lateExceedsEnd:
+            return "지각 종료는 일정 종료 시각을 넘을 수 없습니다."
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
@@ -29,6 +29,8 @@ protocol HomeUseCaseProviding {
     var classifyScheduleUseCase: ClassifyScheduleUseCase { get }
     /// 챌린저 검색 UseCase
     var searchChallengersUseCase: SearchChallengersUseCaseProtocol { get }
+    /// 일정 생성/수정 권한 조회 UseCase
+    var fetchScheduleCapabilitiesUseCase: FetchScheduleCapabilitiesUseCaseProtocol { get }
 }
 
 /// Home UseCase Provider 구현
@@ -49,6 +51,7 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
     let deleteScheduleUseCase: DeleteScheduleUseCaseProtocol
     let classifyScheduleUseCase: ClassifyScheduleUseCase
     let searchChallengersUseCase: SearchChallengersUseCaseProtocol
+    let fetchScheduleCapabilitiesUseCase: FetchScheduleCapabilitiesUseCaseProtocol
 
     // MARK: - Init
 
@@ -56,7 +59,8 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
         homeRepository: HomeRepositoryProtocol,
         scheduleRepository: ScheduleRepositoryProtocol,
         classifierRepository: ScheduleClassifierRepository,
-        challengerSearchRepository: ChallengerSearchRepositoryProtocol
+        challengerSearchRepository: ChallengerSearchRepositoryProtocol,
+        scheduleCapabilitiesRepository: ScheduleCapabilitiesRepositoryProtocol
     ) {
         self.fetchMyProfileUseCase = FetchMyProfileUseCase(
             repository: homeRepository
@@ -87,6 +91,9 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
         )
         self.searchChallengersUseCase = SearchChallengersUseCase(
             repository: challengerSearchRepository
+        )
+        self.fetchScheduleCapabilitiesUseCase = FetchScheduleCapabilitiesUseCase(
+            repository: scheduleCapabilitiesRepository
         )
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -24,6 +24,8 @@ class ScheduleRegistrationViewModel {
     private let classifyScheduleUseCase: ClassifyScheduleUseCase
     /// 챌린저 검색 UseCase (수정 모드 참여자 조회용)
     private let searchChallengersUseCase: SearchChallengersUseCaseProtocol
+    /// 일정 생성/수정 권한 조회 UseCase
+    private let fetchScheduleCapabilitiesUseCase: FetchScheduleCapabilitiesUseCaseProtocol
 
     /// 전역 에러 핸들러 (실패 시 Alert 표시용)
     private let errorHandler: ErrorHandler
@@ -73,6 +75,45 @@ class ScheduleRegistrationViewModel {
     /// 인라인 에러 메시지 (예: 시작된 일정 수정 차단 SCHEDULE-0028)
     private(set) var inlineErrorMessage: String?
 
+    // MARK: - Attendance Policy
+
+    /// 일정 생성/수정 권한 조회 상태
+    private(set) var capabilitiesState: Loadable<ScheduleCapabilities> = .idle
+
+    /// 출석 필수 일정 토글 상태
+    var isAttendanceRequired: Bool = false
+
+    /// 출석 체크인 시작 시각
+    var attendanceCheckInStartAt: Date = .now
+
+    /// 정시 출석 종료 시각 (= 지각 시작)
+    var attendanceOnTimeEndAt: Date = .now
+
+    /// 지각 종료 시각 (= 결석 시작)
+    var attendanceLateEndAt: Date = .now
+
+    /// 출석 정책 인라인 검증 에러
+    private(set) var attendancePolicyError: AttendancePolicyError?
+
+    /// 사용자가 출석 정책 시각을 직접 수정한 적이 있는지 여부 (자동 prefill 차단용)
+    private var isAttendancePolicyDirty: Bool = false
+
+    /// 수정 모드 진입 시점의 `isAttendanceRequired` 값 (PATCH 전환 플래그 산출용)
+    private var initialIsAttendanceRequired: Bool = false
+
+    /// 체크인 시작 날짜 DatePicker 표시 여부
+    var showCheckInStartDatePicker: Bool = false
+    /// 체크인 시작 시간 DatePicker 표시 여부
+    var showCheckInStartTimePicker: Bool = false
+    /// 정시 종료 날짜 DatePicker 표시 여부
+    var showOnTimeEndDatePicker: Bool = false
+    /// 정시 종료 시간 DatePicker 표시 여부
+    var showOnTimeEndTimePicker: Bool = false
+    /// 지각 종료 날짜 DatePicker 표시 여부
+    var showLateEndDatePicker: Bool = false
+    /// 지각 종료 시간 DatePicker 표시 여부
+    var showLateEndTimePicker: Bool = false
+
     /// 장소를 포함한 필수 입력 충족 여부
     ///
     /// 비대면 일정(`isOnline == true`) 인 경우 장소 검증을 건너뜁니다.
@@ -104,6 +145,7 @@ class ScheduleRegistrationViewModel {
             updateScheduleUseCase: provider.updateScheduleUseCase,
             classifyScheduleUseCase: provider.classifyScheduleUseCase,
             searchChallengersUseCase: provider.searchChallengersUseCase,
+            fetchScheduleCapabilitiesUseCase: provider.fetchScheduleCapabilitiesUseCase,
             errorHandler: errorHandler
         )
     }
@@ -113,12 +155,14 @@ class ScheduleRegistrationViewModel {
         updateScheduleUseCase: UpdateScheduleUseCaseProtocol,
         classifyScheduleUseCase: ClassifyScheduleUseCase,
         searchChallengersUseCase: SearchChallengersUseCaseProtocol,
+        fetchScheduleCapabilitiesUseCase: FetchScheduleCapabilitiesUseCaseProtocol,
         errorHandler: ErrorHandler
     ) {
         self.generateScheduleUseCase = generateScheduleUseCase
         self.updateScheduleUseCase = updateScheduleUseCase
         self.classifyScheduleUseCase = classifyScheduleUseCase
         self.searchChallengersUseCase = searchChallengersUseCase
+        self.fetchScheduleCapabilitiesUseCase = fetchScheduleCapabilitiesUseCase
         self.errorHandler = errorHandler
     }
 
@@ -155,6 +199,18 @@ class ScheduleRegistrationViewModel {
             .filter { !$0.isDeprecated }
         isTagManuallyOverridden = !tag.isEmpty
         prefillMemberIds = Set(detail.participantMemberIds)
+
+        if let policy = detail.attendancePolicy {
+            isAttendanceRequired = true
+            attendanceCheckInStartAt = policy.checkInStartAt
+            attendanceOnTimeEndAt = policy.onTimeEndAt
+            attendanceLateEndAt = policy.lateEndAt
+            isAttendancePolicyDirty = true
+        } else {
+            isAttendanceRequired = false
+        }
+        initialIsAttendanceRequired = isAttendanceRequired
+
         initialEditSnapshot = currentEditSnapshot
     }
 
@@ -268,12 +324,140 @@ class ScheduleRegistrationViewModel {
         isTagManuallyOverridden = !sanitized.isEmpty
     }
 
-    /// 일정을 서버에 생성합니다 (V2).
+    // MARK: - Attendance Policy Function
+
+    /// 일정 생성/수정 권한을 조회하여 출석 정책 섹션 노출 여부를 결정합니다.
     ///
-    /// 출석 정책(`attendancePolicy`) 입력 UI 는 본 마이그레이션 범위 밖이므로
-    /// 항상 `nil` 로 송신합니다.
+    /// 호출 실패 시에는 안전 기본값으로 권한 미보유로 간주하여 섹션이 노출되지 않도록 합니다.
+    @MainActor
+    func loadCapabilities() async {
+        capabilitiesState = .loading
+        do {
+            let capabilities = try await fetchScheduleCapabilitiesUseCase.execute()
+            capabilitiesState = .loaded(capabilities)
+            if !capabilities.canCreateAttendanceRequiredSchedule {
+                isAttendanceRequired = false
+            }
+            prefillAttendancePolicyIfNeeded()
+        } catch {
+            capabilitiesState = .idle
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Home",
+                action: "loadCapabilities"
+            ))
+        }
+    }
+
+    /// 일정 시작/종료 시각을 기준으로 출석 정책 기본값을 자동으로 채웁니다.
+    ///
+    /// - 일반 일정: `startsAt - 20분 / startsAt / startsAt + 60분`
+    /// - 하루종일 일정: 출석 정책 섹션 자체를 비노출하므로 prefill 생략
+    /// - 사용자가 한 번이라도 직접 시각을 수정한 경우(`isAttendancePolicyDirty == true`)에는 덮어쓰지 않습니다.
+    func prefillAttendancePolicyIfNeeded() {
+        guard !isAttendancePolicyDirty else { return }
+        guard !isAllDay else { return }
+        let startsAt = dataRange.startDate
+        attendanceCheckInStartAt = startsAt.addingTimeInterval(-20 * 60)
+        attendanceOnTimeEndAt = startsAt
+        attendanceLateEndAt = startsAt.addingTimeInterval(60 * 60)
+    }
+
+    /// 사용자가 출석 정책 시각 중 하나라도 직접 수정했음을 기록합니다.
+    ///
+    /// 이후 일정 시작 시각이 변경되어도 자동 prefill 로 덮어쓰지 않습니다.
+    func markAttendancePolicyDirty() {
+        isAttendancePolicyDirty = true
+    }
+
+    /// 출석 필수 토글 변경 시 dirty 플래그를 리셋하고 즉시 prefill 합니다.
+    ///
+    /// OFF -> ON 전환은 사용자가 새로 정책을 부여하려는 명확한 의도이므로
+    /// 이전 dirty 상태를 무효화하고 일정 시각 기준 기본값으로 채웁니다.
+    @MainActor
+    func attendanceToggleChanged(to newValue: Bool) {
+        if newValue {
+            isAttendancePolicyDirty = false
+            prefillAttendancePolicyIfNeeded()
+        }
+        attendancePolicyError = validateAttendancePolicy()
+    }
+
+    /// 출석 정책 입력 폼을 검증합니다.
+    ///
+    /// - Returns: 검증 위반이 있으면 ``AttendancePolicyError``, 없으면 `nil`
+    private func validateAttendancePolicy() -> AttendancePolicyError? {
+        guard isAttendanceRequired else { return nil }
+        guard attendanceCheckInStartAt < attendanceOnTimeEndAt else {
+            return .invalidOrder(.checkInVsOnTime)
+        }
+        guard attendanceOnTimeEndAt < attendanceLateEndAt else {
+            return .invalidOrder(.onTimeVsLate)
+        }
+        guard attendanceLateEndAt <= dataRange.endDate else {
+            return .lateExceedsEnd
+        }
+        return nil
+    }
+
+    /// 출석 정책 시각 변경 시 dirty 표시 + 검증을 갱신합니다.
+    @MainActor
+    func attendanceTimesChanged() {
+        markAttendancePolicyDirty()
+        attendancePolicyError = validateAttendancePolicy()
+    }
+
+    /// 송신용 출석 정책 DTO 를 생성합니다.
+    ///
+    /// 출석 토글이 OFF 이거나 하루종일 일정인 경우 `nil` 을 반환합니다.
+    private func makeAttendancePolicyDTOForSubmit() -> V2AttendancePolicyDTO? {
+        guard isAttendanceRequired, !isAllDay else { return nil }
+        return V2AttendancePolicyDTO(
+            domain: AttendancePolicy(
+                checkInStartAt: attendanceCheckInStartAt,
+                onTimeEndAt: attendanceOnTimeEndAt,
+                lateEndAt: attendanceLateEndAt
+            )
+        )
+    }
+
+    /// 수정 모드에서 PATCH 송신용 `isAttendanceRequired` 전환 플래그를 산출합니다.
+    ///
+    /// 진입 시점 상태와 현재 토글값을 비교해 다음 규칙으로 결정합니다:
+    /// - 변화 없음 → `nil` (필드 미송신, 백엔드 기존 상태 유지)
+    /// - OFF → ON → `true` (`attendancePolicy` 필수 동반 송신)
+    /// - ON → OFF → `false` (백엔드가 기존 출석 정책 자동 삭제)
+    private var attendanceRequiredTransitionFlag: Bool? {
+        if initialIsAttendanceRequired == isAttendanceRequired {
+            return nil
+        }
+        return isAttendanceRequired
+    }
+
+    /// 수정 모드에서 PATCH 송신용 `attendancePolicy` 값을 산출합니다.
+    ///
+    /// - 토글 OFF: `nil` (필드 자체 미송신 — 전환 플래그 `false` 가 삭제 처리)
+    /// - 토글 ON: 현재 폼의 3개 시각 DTO
+    /// - 하루종일: `nil`
+    private func makeAttendancePolicyDTOForUpdate() -> V2AttendancePolicyDTO? {
+        guard isAttendanceRequired, !isAllDay else { return nil }
+        return V2AttendancePolicyDTO(
+            domain: AttendancePolicy(
+                checkInStartAt: attendanceCheckInStartAt,
+                onTimeEndAt: attendanceOnTimeEndAt,
+                lateEndAt: attendanceLateEndAt
+            )
+        )
+    }
+
+    /// 일정을 서버에 생성합니다 (V2).
     @MainActor
     func submitSchedule() async {
+        attendancePolicyError = validateAttendancePolicy()
+        guard attendancePolicyError == nil else {
+            submitState = .idle
+            return
+        }
+
         submitState = .loading
         inlineErrorMessage = nil
         let memberIds = sanitizedParticipantMemberIds()
@@ -285,7 +469,7 @@ class ScheduleRegistrationViewModel {
             location: locationDTOForSubmit(),
             participantMemberIds: memberIds,
             tags: sanitizedTags,
-            attendancePolicy: nil
+            attendancePolicy: makeAttendancePolicyDTOForSubmit()
         )
         do {
             try await generateScheduleUseCase.execute(schedule: dto)
@@ -413,6 +597,12 @@ class ScheduleRegistrationViewModel {
             return
         }
 
+        attendancePolicyError = validateAttendancePolicy()
+        guard attendancePolicyError == nil else {
+            submitState = .idle
+            return
+        }
+
         submitState = .loading
         inlineErrorMessage = nil
 
@@ -425,9 +615,9 @@ class ScheduleRegistrationViewModel {
             location: locationDTOForSubmit(),
             participantMemberIds: participantMemberIds,
             tags: sanitizedTags,
-            attendancePolicy: nil,
+            attendancePolicy: makeAttendancePolicyDTOForUpdate(),
             isOnline: isOnlineDiff,
-            isAttendanceRequired: nil
+            isAttendanceRequired: attendanceRequiredTransitionFlag
         )
         do {
             try await updateScheduleUseCase.execute(

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -71,11 +71,7 @@ struct ScheduleRegistrationView: View {
             .scrollDismissesKeyboard(.immediately)
             .navigation(naviTitle: navigationTitle, displayMode: .inline)
             .toolbar { toolbarContent }
-            .onChange(of: viewModel.showStartDatePicker) { dismissKeyboard() }
-            .onChange(of: viewModel.showStartTimePicker) { dismissKeyboard() }
-            .onChange(of: viewModel.showEndDatePicker) { dismissKeyboard() }
-            .onChange(of: viewModel.showEndTimePicker) { dismissKeyboard() }
-            .onChange(of: viewModel.isAllDay) { dismissKeyboard() }
+            .modifier(KeyboardDismissOnPickerToggle(viewModel: viewModel))
             .onChange(of: viewModel.submitState) {
                 if case .loaded = viewModel.submitState {
                     dismiss()
@@ -85,6 +81,13 @@ struct ScheduleRegistrationView: View {
                 if mode == .edit {
                     await viewModel.fetchPrefillParticipants()
                 }
+                await viewModel.loadCapabilities()
+            }
+            .onChange(of: viewModel.dataRange.startDate) {
+                viewModel.prefillAttendancePolicyIfNeeded()
+            }
+            .onChange(of: viewModel.isAllDay) {
+                viewModel.prefillAttendancePolicyIfNeeded()
             }
     }
 
@@ -96,6 +99,7 @@ struct ScheduleRegistrationView: View {
             inlineErrorSection
             section(.title, .place)
             section(.allDay, .date)
+            AttendancePolicySection(viewModel: viewModel)
             section(.participation)
             section(.tag)
             section(.memo)
@@ -612,6 +616,243 @@ fileprivate struct ParticipantSection: View {
         })
     }
     
+}
+
+// MARK: - Keyboard Dismiss On Picker Toggle
+
+/// 일정 / 출석 정책의 모든 picker 토글과 `isAllDay` 변경 시 키보드를 내리는 ViewModifier.
+///
+/// `body` 의 `.onChange` 체인이 길어져 컴파일러 type-check 가 타임아웃되는 문제를 회피하기 위해
+/// 별도 `ViewModifier` 로 분리했습니다.
+fileprivate struct KeyboardDismissOnPickerToggle: ViewModifier {
+
+    let viewModel: ScheduleRegistrationViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: viewModel.showStartDatePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showStartTimePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showEndDatePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showEndTimePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showCheckInStartDatePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showCheckInStartTimePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showOnTimeEndDatePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showOnTimeEndTimePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showLateEndDatePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.showLateEndTimePicker) { dismissKeyboard() }
+            .onChange(of: viewModel.isAllDay) { dismissKeyboard() }
+    }
+
+    private func dismissKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
+    }
+}
+
+// MARK: - Attendance Policy Time Section
+
+/// 출석 정책 3개 시각(체크인 시작 / 정시 종료 / 지각 종료) 입력 섹션입니다.
+///
+/// `DateTimeRow` 패턴을 그대로 재사용하며, 시각 변경 시 `onTimesChanged` 콜백으로
+/// ViewModel 의 dirty flag 토글과 검증 갱신을 트리거합니다.
+fileprivate struct AttendancePolicyTimeSection: View {
+
+    @Binding var checkInStartAt: Date
+    @Binding var onTimeEndAt: Date
+    @Binding var lateEndAt: Date
+
+    @Binding var showCheckInDatePicker: Bool
+    @Binding var showCheckInTimePicker: Bool
+    @Binding var showOnTimeDatePicker: Bool
+    @Binding var showOnTimeTimePicker: Bool
+    @Binding var showLateDatePicker: Bool
+    @Binding var showLateTimePicker: Bool
+
+    let onTimesChanged: () -> Void
+
+    var body: some View {
+        Group {
+            row(
+                title: "체크인 시작",
+                date: $checkInStartAt,
+                isDateActive: showCheckInDatePicker,
+                isTimeActive: showCheckInTimePicker,
+                dateTap: {
+                    withAnimation {
+                        showCheckInDatePicker.toggle()
+                        closeOthers(except: .checkInDate)
+                    }
+                },
+                timeTap: {
+                    withAnimation {
+                        showCheckInTimePicker.toggle()
+                        closeOthers(except: .checkInTime)
+                    }
+                }
+            )
+            picker(condition: showCheckInDatePicker, date: $checkInStartAt, isTime: false)
+            picker(condition: showCheckInTimePicker, date: $checkInStartAt, isTime: true)
+
+            row(
+                title: "정시 종료",
+                date: $onTimeEndAt,
+                isDateActive: showOnTimeDatePicker,
+                isTimeActive: showOnTimeTimePicker,
+                dateTap: {
+                    withAnimation {
+                        showOnTimeDatePicker.toggle()
+                        closeOthers(except: .onTimeDate)
+                    }
+                },
+                timeTap: {
+                    withAnimation {
+                        showOnTimeTimePicker.toggle()
+                        closeOthers(except: .onTimeTime)
+                    }
+                }
+            )
+            picker(condition: showOnTimeDatePicker, date: $onTimeEndAt, isTime: false)
+            picker(condition: showOnTimeTimePicker, date: $onTimeEndAt, isTime: true)
+
+            row(
+                title: "지각 종료",
+                date: $lateEndAt,
+                isDateActive: showLateDatePicker,
+                isTimeActive: showLateTimePicker,
+                dateTap: {
+                    withAnimation {
+                        showLateDatePicker.toggle()
+                        closeOthers(except: .lateDate)
+                    }
+                },
+                timeTap: {
+                    withAnimation {
+                        showLateTimePicker.toggle()
+                        closeOthers(except: .lateTime)
+                    }
+                }
+            )
+            picker(condition: showLateDatePicker, date: $lateEndAt, isTime: false)
+            picker(condition: showLateTimePicker, date: $lateEndAt, isTime: true)
+        }
+        .onChange(of: checkInStartAt) { onTimesChanged() }
+        .onChange(of: onTimeEndAt) { onTimesChanged() }
+        .onChange(of: lateEndAt) { onTimesChanged() }
+    }
+
+    /// 단일 시각 입력 행
+    private func row(
+        title: String,
+        date: Binding<Date>,
+        isDateActive: Bool,
+        isTimeActive: Bool,
+        dateTap: @escaping () -> Void,
+        timeTap: @escaping () -> Void
+    ) -> some View {
+        DateTimeRow(
+            title: title,
+            date: date.wrappedValue,
+            isAllDay: false,
+            isDatePickerActive: isDateActive,
+            isTimePickerActive: isTimeActive,
+            dateTap: dateTap,
+            timeTap: timeTap
+        )
+        .equatable()
+    }
+
+    /// 날짜 또는 시간 피커
+    @ViewBuilder
+    private func picker(condition: Bool, date: Binding<Date>, isTime: Bool) -> some View {
+        if condition {
+            if isTime {
+                TimePickerRow(date: date, range: nil)
+            } else {
+                DatePickerRow(date: date, range: nil)
+            }
+        }
+    }
+
+    /// 한 번에 하나의 picker 만 열리도록 다른 picker 들을 닫습니다.
+    private func closeOthers(except keep: PickerSlot) {
+        if keep != .checkInDate { showCheckInDatePicker = false }
+        if keep != .checkInTime { showCheckInTimePicker = false }
+        if keep != .onTimeDate { showOnTimeDatePicker = false }
+        if keep != .onTimeTime { showOnTimeTimePicker = false }
+        if keep != .lateDate { showLateDatePicker = false }
+        if keep != .lateTime { showLateTimePicker = false }
+    }
+
+    /// 현재 활성 picker 슬롯 식별자
+    private enum PickerSlot {
+        case checkInDate, checkInTime, onTimeDate, onTimeTime, lateDate, lateTime
+    }
+}
+
+// MARK: - Attendance Policy Section
+
+/// 출석 정책 입력 섹션 (운영진 전용, 비-하루종일 일정 한정).
+///
+/// `canCreateAttendanceRequiredSchedule` 권한과 `isAllDay == false` 가 모두 충족될 때만
+/// 노출되며, 토글 ON 시 3개 시각 행과 인라인 검증 에러를 표시합니다.
+fileprivate struct AttendancePolicySection: View {
+
+    @Bindable var viewModel: ScheduleRegistrationViewModel
+
+    var body: some View {
+        if shouldShowSection {
+            Section {
+                Toggle(isOn: toggleBinding) {
+                    Text("출석 필수")
+                        .appFont(.body, color: .black)
+                }
+                .tint(.indigo500)
+
+                if viewModel.isAttendanceRequired {
+                    AttendancePolicyTimeSection(
+                        checkInStartAt: $viewModel.attendanceCheckInStartAt,
+                        onTimeEndAt: $viewModel.attendanceOnTimeEndAt,
+                        lateEndAt: $viewModel.attendanceLateEndAt,
+                        showCheckInDatePicker: $viewModel.showCheckInStartDatePicker,
+                        showCheckInTimePicker: $viewModel.showCheckInStartTimePicker,
+                        showOnTimeDatePicker: $viewModel.showOnTimeEndDatePicker,
+                        showOnTimeTimePicker: $viewModel.showOnTimeEndTimePicker,
+                        showLateDatePicker: $viewModel.showLateEndDatePicker,
+                        showLateTimePicker: $viewModel.showLateEndTimePicker,
+                        onTimesChanged: {
+                            viewModel.attendanceTimesChanged()
+                        }
+                    )
+
+                    if let message = viewModel.attendancePolicyError?.message {
+                        Text(message)
+                            .appFont(.footnote, color: .red500)
+                    }
+                }
+            } header: {
+                Text("출석 체크")
+            }
+        }
+    }
+
+    /// 권한 + 비-하루종일 조건이 모두 충족됐는지 여부.
+    private var shouldShowSection: Bool {
+        guard !viewModel.isAllDay else { return false }
+        guard case .loaded(let caps) = viewModel.capabilitiesState else { return false }
+        return caps.canCreateAttendanceRequiredSchedule
+    }
+
+    /// 토글 변경 시 ViewModel 의 dirty/prefill 처리를 함께 트리거하는 바인딩.
+    private var toggleBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.isAttendanceRequired },
+            set: { newValue in
+                viewModel.attendanceToggleChanged(to: newValue)
+            }
+        )
+    }
 }
 
 // MARK: - Memo Section


### PR DESCRIPTION
## ✨ PR 유형

Feature — 일정 생성/수정 화면에 운영진용 **출석 정책 입력 UI** 를 추가합니다.

#654 (Capabilities + AttendancePolicy 인프라) / #655 (일반 일정 V2) / #656 (스터디 일정 V2) 머지 이후 마지막 남은 운영진 입력 측면을 완성합니다. 기존에 `attendancePolicy: nil` 로 하드코딩되어 있던 송신 측을 폼 상태에서 산출하도록 연결합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

> UI 변경: 운영진 계정 진입 시 일정 생성/수정 화면 하단에 **출석 체크 섹션** 이 노출됩니다. 시뮬레이터 시나리오 검증 영상/스크린샷은 PR 코멘트에 첨부 예정.

## 🛠️ 작업내용

**Domain**
- `AttendancePolicyError` enum 신설 — 단조 증가(`checkInVsOnTime` / `onTimeVsLate`) + `lateExceedsEnd` 인라인 검증 에러 + 한국어 메시지

**Presentation — ViewModel**
- 출석 정책 상태 추가: `capabilitiesState: Loadable<ScheduleCapabilities>`, `isAttendanceRequired`, `attendanceCheckInStartAt` / `attendanceOnTimeEndAt` / `attendanceLateEndAt`, `attendancePolicyError`, `isAttendancePolicyDirty` (private), `initialIsAttendanceRequired` (private), 6개 picker 토글 상태
- 신규 메서드:
  - `loadCapabilities()` — 진입 시 `GET /api/v2/schedules/capabilities` 호출, 권한 없으면 토글 자동 OFF
  - `prefillAttendancePolicyIfNeeded()` — `startsAt - 20분 / startsAt / startsAt + 60분` 자동 프리필 (dirty flag 미설정 시에만)
  - `attendanceToggleChanged(to:)` / `attendanceTimesChanged()` — dirty flag 토글 + 인라인 검증 갱신
  - `validateAttendancePolicy()` — 단조 증가 + `lateEndAt ≤ endsAt` 검증
  - `makeAttendancePolicyDTOForSubmit()` / `makeAttendancePolicyDTOForUpdate()` — 생성/수정용 DTO 산출
  - `attendanceRequiredTransitionFlag` — PATCH 송신용 3-state 전환 플래그 (null=유지, true/false=전환)
- `applyPrefill` 에서 기존 정책 prefill + `initialIsAttendanceRequired` 보존
- `submitSchedule()` / `updateSchedule()` 에서 검증 → DTO 산출 → 송신 (수정 시 `isAttendanceRequired` 전환 플래그 함께 전송)

**Presentation — View**
- `AttendancePolicySection` 신설 — `canCreateAttendanceRequiredSchedule == true` AND `!isAllDay` 일 때만 노출되는 운영진 전용 섹션
- `AttendancePolicyTimeSection` 신설 — 체크인 시작 / 정시 종료 / 지각 종료 3개 행 + 한 번에 하나의 picker 만 열리는 토글 패턴 (기존 `DateTimeSection` 동일 패턴 재사용)
- `KeyboardDismissOnPickerToggle` ViewModifier 분리 — body 의 `.onChange` 체인이 11개로 늘어나며 발생한 Swift 컴파일러 type-check 타임아웃 회피
- `.task` 에서 `loadCapabilities()` 호출 / `startsAt`·`isAllDay` 변경 시 `prefillAttendancePolicyIfNeeded()` 트리거

**DI**
- `HomeUseCaseProvider` 에 `fetchScheduleCapabilitiesUseCase` 노출 + 생성자에 `scheduleCapabilitiesRepository` 인자 추가
- `DIContainer` 의 `HomeUseCaseProvider` 조립부에서 `ScheduleCapabilitiesRepositoryProtocol` 주입 동기화

## 📋 추후 진행 상황

- 9기 운영 데이터 확정 후 자동 프리필 기본값(현재 -20분 / +60분) 재조정
- 하루종일 일정에 출석 정책을 허용해야 한다면 백엔드/기획팀과 후속 컨펌 → 별도 이슈
- `isOnline` 도 동일 3-state 전환 플래그 패턴으로 정리 권장 (별도 이슈)
- 스터디 일정에 운영진 수동 입력 UI 가 필요한지는 별도 이슈로 분리

## 📌 리뷰 포인트

- `Features/Home/Domain/Models/Schedule/AttendancePolicyError.swift` — 검증 에러 enum / 한국어 메시지 톤
- `Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift`
  - `loadCapabilities()` — 권한 로드 실패 시 안전 기본값(섹션 비노출) 처리 적절성
  - `prefillAttendancePolicyIfNeeded()` + `isAttendancePolicyDirty` — Q1=B안(dirty flag) 동작 확인
  - `attendanceRequiredTransitionFlag` + `makeAttendancePolicyDTOForUpdate()` — Q3 PATCH 전환 플래그 4가지 케이스 (ON 유지 / OFF→ON / ON→OFF / OFF 유지) 분기
  - `submitSchedule()` / `updateSchedule()` 에서 검증 실패 시 인라인 에러 + 송신 차단 흐름
- `Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift`
  - `AttendancePolicySection` — `canCreateAttendanceRequiredSchedule` + `!isAllDay` 가드 조건
  - `KeyboardDismissOnPickerToggle` 분리 — body type-check 타임아웃 회피 의도
- `Features/Home/Presentation/Provider/HomeUseCaseProvider.swift` / `Core/DIContainer/DIContainer.swift` — Capabilities Repository 주입 누락 여부

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)