### PR TITLE
✨ [Feat] 운영진 출석 현황 V2 API 마이그레이션 + 목록/상세 화면 추가 (#658)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/UIComponents/Badge/AttendanceStatusBadge.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/Badge/AttendanceStatusBadge.swift
@@ -1,0 +1,105 @@
+//
+//  AttendanceStatusBadge.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import SwiftUI
+
+// MARK: - AttendanceStatusBadge
+
+/// V2 출석 현황 화면에서 참여자별 상태를 표시하는 뱃지 컴포넌트
+///
+/// ``AttendanceStatusV2`` 의 9개 케이스(`unknown` 포함)를 색상으로 구분합니다.
+/// 운영진 출석 현황 목록/상세 양쪽에서 동일하게 사용됩니다.
+///
+/// ## 색상 매핑
+/// | 상태 | 색상 |
+/// |------|------|
+/// | 출석/사유결석 | 초록 |
+/// | 지각 | 주황 |
+/// | 결석 | 빨강 |
+/// | *_PENDING | 노랑 |
+/// | 출석 전 | 회색 |
+/// | unknown | 회색 + "?" 아이콘 |
+struct AttendanceStatusBadge: View, Equatable {
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let backgroundOpacity: Double = 0.18
+        static let unknownIconSize: CGFloat = 11
+    }
+
+    // MARK: - Property
+
+    let status: AttendanceStatusV2
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing4) {
+            if status == .unknown {
+                Image(systemName: "questionmark.circle")
+                    .font(.system(size: Constants.unknownIconSize, weight: .semibold))
+            }
+            Text(status.displayText)
+                .lineLimit(1)
+        }
+        .appFont(.caption1, color: foregroundColor)
+        .padding(.horizontal, DefaultSpacing.spacing8)
+        .padding(.vertical, DefaultSpacing.spacing4)
+        .glassEffect(
+            .clear.tint(tintColor.opacity(Constants.backgroundOpacity)),
+            in: Capsule()
+        )
+    }
+
+    // MARK: - Style
+
+    private var tintColor: Color {
+        switch status {
+        case .present, .excused:
+            return .green
+        case .late:
+            return .orange
+        case .absent:
+            return .red
+        case .presentPending, .latePending, .excusedPending:
+            return .yellow
+        case .pending, .unknown:
+            return .gray
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch status {
+        case .present, .excused:
+            return .green
+        case .late:
+            return .orange
+        case .absent:
+            return .red
+        case .presentPending, .latePending, .excusedPending:
+            return .orange
+        case .pending, .unknown:
+            return .grey600
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+        ForEach(AttendanceStatusV2.allCases, id: \.self) { status in
+            HStack {
+                AttendanceStatusBadge(status: status)
+                Text(status.rawValue)
+                    .appFont(.footnote, color: .grey500)
+            }
+        }
+    }
+    .padding()
+}

--- a/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
@@ -95,6 +95,15 @@ enum NavigationDestination: Hashable {
     enum Activity: Hashable {
         /// 스터디 일정 등록 (studyName: 스터디명, studyGroupId: 스터디 그룹 ID)
         case studyScheduleRegistration(studyName: String, studyGroupId: Int)
+        /// 운영진 출석 현황 목록 (Schedule V2)
+        ///
+        /// 필터: 상태(`AttendanceStatusV2`) + 기간 (`from`/`to`).
+        /// `canCreateAttendanceRequiredSchedule = true` 인 사용자만 진입 가능 (AC-E1).
+        case attendanceList
+        /// 운영진 단일 일정 출석 현황 (Schedule V2)
+        ///
+        /// 진입 경로: 출석 현황 목록 → 행 탭, 또는 일정 상세 → "출석 현황" 버튼.
+        case attendanceDetail(scheduleId: Int)
     }
 
     case auth(Auth)

--- a/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
@@ -140,6 +140,17 @@ private extension NavigationRoutingView {
                 studyName: studyName,
                 studyGroupId: studyGroupId
             )
+        case .attendanceList:
+            AttendanceListView(
+                container: di,
+                errorHandler: errorHandler
+            )
+        case .attendanceDetail(let scheduleId):
+            AttendanceDetailView(
+                container: di,
+                errorHandler: errorHandler,
+                scheduleId: scheduleId
+            )
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/ScheduleAttendanceInfoDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/ScheduleAttendanceInfoDTO.swift
@@ -1,0 +1,120 @@
+//
+//  ScheduleAttendanceInfoDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import Foundation
+
+/// V2 운영진 출석 현황 응답 DTO (목록/단일 공용)
+///
+/// - 목록 응답: `[ScheduleAttendanceInfoDTO]`
+/// - 단일 응답: `ScheduleAttendanceInfoDTO`
+///
+/// 두 엔드포인트가 동일한 객체 스키마를 사용하므로 DTO 도 단일로 정의합니다.
+///
+/// - SeeAlso: ``ScheduleAttendanceInfo``
+struct ScheduleAttendanceInfoDTO: Codable, Sendable, Equatable {
+
+    /// 일정 식별자
+    let scheduleId: Int
+
+    /// 일정 제목
+    let name: String
+
+    /// 일정 설명
+    let description: String
+
+    /// 시작 일시 (UTC ISO8601)
+    let startsAt: String
+
+    /// 종료 일시 (UTC ISO8601)
+    let endsAt: String
+
+    /// 비대면 일정 여부
+    let isOnline: Bool
+
+    /// 장소 (`nil` = 비대면)
+    let location: V2LocationDTO?
+
+    /// 작성자 멤버 ID
+    let authorMemberId: Int
+
+    /// 출석 정책 (`nil` 가능)
+    let attendancePolicy: V2AttendancePolicyDTO?
+
+    /// 카테고리 태그
+    let tags: [String]
+
+    /// 참여자별 출석 정보
+    let participants: [V2AttendanceParticipantDTO]
+
+    private enum CodingKeys: String, CodingKey {
+        case scheduleId
+        case name
+        case description
+        case startsAt
+        case endsAt
+        case isOnline
+        case location
+        case authorMemberId
+        case attendancePolicy
+        case tags
+        case participants
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        scheduleId = try container.decodeIfPresent(Int.self, forKey: .scheduleId) ?? 0
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+        startsAt = try container.decodeIfPresent(String.self, forKey: .startsAt) ?? ""
+        endsAt = try container.decodeIfPresent(String.self, forKey: .endsAt) ?? ""
+        isOnline = try container.decodeIfPresent(Bool.self, forKey: .isOnline) ?? false
+        location = try container.decodeIfPresent(V2LocationDTO.self, forKey: .location)
+        authorMemberId = try container.decodeIfPresent(Int.self, forKey: .authorMemberId) ?? 0
+        attendancePolicy = try container.decodeIfPresent(V2AttendancePolicyDTO.self, forKey: .attendancePolicy)
+        tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
+        participants = try container.decodeIfPresent([V2AttendanceParticipantDTO].self, forKey: .participants) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(scheduleId, forKey: .scheduleId)
+        try container.encode(name, forKey: .name)
+        try container.encode(description, forKey: .description)
+        try container.encode(startsAt, forKey: .startsAt)
+        try container.encode(endsAt, forKey: .endsAt)
+        try container.encode(isOnline, forKey: .isOnline)
+        try container.encodeIfPresent(location, forKey: .location)
+        try container.encode(authorMemberId, forKey: .authorMemberId)
+        try container.encodeIfPresent(attendancePolicy, forKey: .attendancePolicy)
+        try container.encode(tags, forKey: .tags)
+        try container.encode(participants, forKey: .participants)
+    }
+}
+
+// MARK: - Domain Mapping
+
+extension ScheduleAttendanceInfoDTO {
+
+    /// DTO → 도메인 변환
+    ///
+    /// 일자 파싱 실패 시 ISO8601 빈 값(`.now`) 으로 폴백.
+    func toDomain() -> ScheduleAttendanceInfo {
+        ScheduleAttendanceInfo(
+            scheduleId: scheduleId,
+            name: name,
+            description: description,
+            startsAt: ServerDateTimeConverter.parseUTCDateTime(startsAt) ?? .now,
+            endsAt: ServerDateTimeConverter.parseUTCDateTime(endsAt) ?? .now,
+            location: location?.toDomain(),
+            isOnline: isOnline,
+            authorMemberId: authorMemberId,
+            attendancePolicy: attendancePolicy?.toDomain(),
+            tags: tags,
+            participants: participants.map { $0.toDomain() }
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/V2AttendanceParticipantDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/V2AttendanceParticipantDTO.swift
@@ -1,0 +1,118 @@
+//
+//  V2AttendanceParticipantDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import Foundation
+
+/// V2 출석 현황 응답의 `participants[]` 항목 DTO
+///
+/// `GET /api/v2/schedules/attendance`, `GET /api/v2/schedules/{id}/attendance`
+/// 양쪽 응답에서 동일한 형태로 사용됩니다.
+///
+/// - SeeAlso: ``ParticipantAttendance``, ``AttendanceStatusV2``
+struct V2AttendanceParticipantDTO: Codable, Sendable, Equatable {
+
+    /// 멤버 식별자
+    let memberId: Int
+
+    /// 본명
+    let name: String
+
+    /// 닉네임
+    let nickname: String
+
+    /// 프로필 이미지 URL
+    let profileImageUrl: String?
+
+    /// 학교 식별자
+    let schoolId: Int
+
+    /// 학교명
+    let schoolName: String
+
+    /// 출석 상태 raw 문자열
+    ///
+    /// `unknown` 폴백 디코딩을 위해 enum 이 아닌 String 으로 받고
+    /// 도메인 변환 시 ``AttendanceStatusV2`` 로 매핑합니다.
+    let attendanceStatus: String?
+
+    /// GPS 위치 인증 여부
+    let isLocationVerified: Bool
+
+    /// 사유 결석 사유 (없으면 `nil` 또는 빈 문자열)
+    let excuseReason: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case memberId
+        case name
+        case nickname
+        case profileImageUrl
+        case schoolId
+        case schoolName
+        case attendanceStatus
+        case isLocationVerified
+        case excuseReason
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        memberId = try container.decodeIfPresent(Int.self, forKey: .memberId) ?? 0
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
+        profileImageUrl = try container.decodeIfPresent(String.self, forKey: .profileImageUrl)
+        schoolId = try container.decodeIfPresent(Int.self, forKey: .schoolId) ?? 0
+        schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
+        attendanceStatus = try container.decodeIfPresent(String.self, forKey: .attendanceStatus)
+        isLocationVerified = try container.decodeIfPresent(Bool.self, forKey: .isLocationVerified) ?? false
+        excuseReason = try container.decodeIfPresent(String.self, forKey: .excuseReason)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(memberId, forKey: .memberId)
+        try container.encode(name, forKey: .name)
+        try container.encode(nickname, forKey: .nickname)
+        try container.encodeIfPresent(profileImageUrl, forKey: .profileImageUrl)
+        try container.encode(schoolId, forKey: .schoolId)
+        try container.encode(schoolName, forKey: .schoolName)
+        try container.encodeIfPresent(attendanceStatus, forKey: .attendanceStatus)
+        try container.encode(isLocationVerified, forKey: .isLocationVerified)
+        try container.encodeIfPresent(excuseReason, forKey: .excuseReason)
+    }
+}
+
+// MARK: - Domain Mapping
+
+extension V2AttendanceParticipantDTO {
+
+    /// DTO → 도메인 변환
+    ///
+    /// `attendanceStatus` 가 nil 이거나 알 수 없는 값이면 ``AttendanceStatusV2/unknown`` 으로 매핑.
+    /// `excuseReason` 이 빈 문자열이면 `nil` 로 정규화합니다.
+    func toDomain() -> ParticipantAttendance {
+        let status: AttendanceStatusV2 = {
+            guard let raw = attendanceStatus else { return .unknown }
+            return AttendanceStatusV2(rawValue: raw) ?? .unknown
+        }()
+
+        let normalizedReason: String? = {
+            guard let reason = excuseReason, !reason.isEmpty else { return nil }
+            return reason
+        }()
+
+        return ParticipantAttendance(
+            memberId: memberId,
+            name: name,
+            nickname: nickname,
+            profileImageUrl: profileImageUrl ?? "",
+            schoolId: schoolId,
+            schoolName: schoolName,
+            attendanceStatus: status,
+            isLocationVerified: isLocationVerified,
+            excuseReason: normalizedReason
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/AttendanceRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/AttendanceRepository.swift
@@ -127,6 +127,42 @@ final class AttendanceRepository: ChallengerAttendanceRepositoryProtocol,
         return try apiResponse.unwrap().map { $0.toDomain() }
     }
 
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> [ScheduleAttendanceInfo] {
+        let response = try await adapter.request(
+            ScheduleV2Router.getAttendanceList(
+                from: from,
+                to: to,
+                attendanceStatus: attendanceStatus?.serverQueryValue
+            )
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<[ScheduleAttendanceInfoDTO]>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap().map { $0.toDomain() }
+    }
+
+    func fetchAttendanceDetail(
+        scheduleId: Int,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> ScheduleAttendanceInfo {
+        let response = try await adapter.request(
+            ScheduleV2Router.getAttendanceDetail(
+                scheduleId: scheduleId,
+                attendanceStatus: attendanceStatus?.serverQueryValue
+            )
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<ScheduleAttendanceInfoDTO>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap().toDomain()
+    }
+
     // MARK: - 액션
 
     func approveAttendance(recordId: Int) async throws {

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockAttendanceRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockAttendanceRepository.swift
@@ -104,6 +104,83 @@ final class MockAttendanceRepository: ChallengerAttendanceRepositoryProtocol,
         ]
     }
 
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> [ScheduleAttendanceInfo] {
+        _ = from
+        _ = to
+        _ = attendanceStatus
+        return [
+            ScheduleAttendanceInfo(
+                scheduleId: 1,
+                name: "9기 OT",
+                description: "오리엔테이션",
+                startsAt: .now,
+                endsAt: .now.addingTimeInterval(60 * 90),
+                location: ScheduleLocation(
+                    latitude: 37.50543,
+                    longitude: 126.9569,
+                    locationName: "중앙대학교 R&D센터"
+                ),
+                isOnline: false,
+                authorMemberId: 1,
+                attendancePolicy: nil,
+                tags: ["LEADERSHIP"],
+                participants: [
+                    ParticipantAttendance(
+                        memberId: 1,
+                        name: "홍길동",
+                        nickname: "길동이",
+                        profileImageUrl: "",
+                        schoolId: 1,
+                        schoolName: "중앙대학교",
+                        attendanceStatus: .presentPending,
+                        isLocationVerified: true,
+                        excuseReason: nil
+                    )
+                ]
+            )
+        ]
+    }
+
+    func fetchAttendanceDetail(
+        scheduleId: Int,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> ScheduleAttendanceInfo {
+        _ = attendanceStatus
+        return ScheduleAttendanceInfo(
+            scheduleId: scheduleId,
+            name: "9기 OT",
+            description: "오리엔테이션",
+            startsAt: .now,
+            endsAt: .now.addingTimeInterval(60 * 90),
+            location: ScheduleLocation(
+                latitude: 37.50543,
+                longitude: 126.9569,
+                locationName: "중앙대학교 R&D센터"
+            ),
+            isOnline: false,
+            authorMemberId: 1,
+            attendancePolicy: nil,
+            tags: ["LEADERSHIP"],
+            participants: [
+                ParticipantAttendance(
+                    memberId: 1,
+                    name: "홍길동",
+                    nickname: "길동이",
+                    profileImageUrl: "",
+                    schoolId: 1,
+                    schoolName: "중앙대학교",
+                    attendanceStatus: .present,
+                    isLocationVerified: true,
+                    excuseReason: nil
+                )
+            ]
+        )
+    }
+
     func getAvailableSchedules(
     ) async throws -> [AvailableAttendanceSchedule] {
         [

--- a/AppProduct/AppProduct/Features/Activity/Domain/Enum/Attendance/AttendanceStatusV2.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Enum/Attendance/AttendanceStatusV2.swift
@@ -1,0 +1,101 @@
+//
+//  AttendanceStatusV2.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import Foundation
+
+/// 운영진 출석 현황 V2 응답의 참여자별 출석 상태
+///
+/// `GET /api/v2/schedules/attendance` 와 `GET /api/v2/schedules/{id}/attendance` 의
+/// `participants[].attendanceStatus` 필드 전용 enum 입니다.
+///
+/// Swagger 에는 `PRESENT_PENDING` 만 명시되어 있어 전체 케이스가 미확정이므로,
+/// **`unknown` 폴백 패턴** 으로 디코딩합니다. 백엔드가 새 케이스를 추가해도
+/// 디코딩 실패가 발생하지 않으며, UI 는 `.unknown` 을 "상태 미지정" 으로 표시합니다.
+///
+/// 기존 ``AttendanceStatus`` 와 분리한 이유:
+/// - V1 enum 은 5개 케이스(`beforeAttendance/pendingApproval/present/late/absent`)
+///   로 합쳐져 `EXCUSED` 등 V2 신규 케이스를 별도 표시할 수 없음
+/// - V1 enum 은 화면 색상까지 들고 있어 책임이 섞여 있음
+/// - V2 응답은 참여자별 상태이며, 운영진 출석 현황 화면 전용
+///
+/// - SeeAlso: ``AttendanceStatus``, ``ScheduleAttendanceInfo``
+enum AttendanceStatusV2: String, Codable, Sendable, CaseIterable, Equatable, Hashable {
+
+    /// 출석 승인 대기 (체크인 완료, 운영진 승인 전)
+    case presentPending = "PRESENT_PENDING"
+    /// 지각 승인 대기
+    case latePending = "LATE_PENDING"
+    /// 사유 결석 승인 대기
+    case excusedPending = "EXCUSED_PENDING"
+    /// 출석 (정시)
+    case present = "PRESENT"
+    /// 지각
+    case late = "LATE"
+    /// 결석
+    case absent = "ABSENT"
+    /// 사유 결석 (출석으로 인정)
+    case excused = "EXCUSED"
+    /// 출석 전 (정책 시작 전)
+    case pending = "PENDING"
+    /// 알 수 없는 상태 (서버가 새 케이스를 추가했을 때 폴백)
+    case unknown
+
+    // MARK: - Decoding
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = AttendanceStatusV2(rawValue: raw) ?? .unknown
+    }
+
+    // MARK: - Filterable
+
+    /// 필터 UI 에 노출할 케이스 (`.unknown` 제외)
+    ///
+    /// PRD 결정: `.unknown` 은 사용자 의도와 무관한 시스템 케이스이므로
+    /// 필터 칩에서 제외합니다.
+    static var filterableCases: [AttendanceStatusV2] {
+        allCases.filter { $0 != .unknown }
+    }
+
+    // MARK: - Display
+
+    /// 배지/필터 칩에 표시할 한국어 텍스트
+    var displayText: String {
+        switch self {
+        case .presentPending:   return "출석 승인 대기"
+        case .latePending:      return "지각 승인 대기"
+        case .excusedPending:   return "사유 승인 대기"
+        case .present:          return "출석"
+        case .late:             return "지각"
+        case .absent:           return "결석"
+        case .excused:          return "사유 결석"
+        case .pending:          return "출석 전"
+        case .unknown:          return "상태 미지정"
+        }
+    }
+
+    /// 서버 쿼리 파라미터로 보낼 raw 값
+    ///
+    /// `.unknown` 은 서버에 보낼 수 없으므로 `nil` 을 반환합니다.
+    var serverQueryValue: String? {
+        self == .unknown ? nil : rawValue
+    }
+
+    // MARK: - Categorization
+
+    /// 승인 대기 상태 여부
+    ///
+    /// 운영진 화면에서 "처리 필요" 표시 등에 활용합니다.
+    var isPending: Bool {
+        switch self {
+        case .presentPending, .latePending, .excusedPending:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/OperatorAttendanceRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/OperatorAttendanceRepositoryProtocol.swift
@@ -29,7 +29,36 @@ protocol OperatorAttendanceRepositoryProtocol {
     ) async throws -> [AttendanceHistoryItem]
 
     /// 일정별 출석 통계 조회 (관리자)
+    ///
+    /// - Important: V1 엔드포인트(`GET /api/v1/schedules`) 호출. V2 마이그레이션 완료 후 제거 예정.
+    /// - SeeAlso: ``fetchAttendanceList(from:to:attendanceStatus:)`` (V2)
     func getScheduleStats() async throws -> [ScheduleAttendanceStats]
+
+    /// 일정 출석 현황 목록 조회 (V2, 관리자)
+    ///
+    /// `GET /api/v2/schedules/attendance` 호출. 직책별 조회 범위는 서버에서 자동 분기.
+    ///
+    /// - Parameters:
+    ///   - from: 조회 시작 시각 (`nil` 이면 서버 기본값 = 요청 시점 -1개월)
+    ///   - to: 조회 종료 시각 (`nil` 이면 서버 기본값 = 요청 시점 +24시간)
+    ///   - attendanceStatus: 필터링할 출석 상태 (`nil` 이면 모든 상태)
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> [ScheduleAttendanceInfo]
+
+    /// 단일 일정 출석 현황 조회 (V2, 관리자)
+    ///
+    /// `GET /api/v2/schedules/{scheduleId}/attendance` 호출.
+    ///
+    /// - Parameters:
+    ///   - scheduleId: 일정 식별자
+    ///   - attendanceStatus: 필터링할 출석 상태 (`nil` 이면 모든 상태)
+    func fetchAttendanceDetail(
+        scheduleId: Int,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> ScheduleAttendanceInfo
 
     // MARK: - 액션
 

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/ParticipantAttendance.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/ParticipantAttendance.swift
@@ -1,0 +1,49 @@
+//
+//  ParticipantAttendance.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import Foundation
+
+/// 운영진 출석 현황 화면의 참여자별 출석 정보 도메인 모델
+///
+/// `GET /api/v2/schedules/attendance` 또는 `GET /api/v2/schedules/{id}/attendance`
+/// 응답의 `participants[]` 항목을 도메인으로 변환한 값입니다.
+///
+/// V1 의 `ScheduleParticipant` 와 달리 출석 상태(`attendanceStatus`),
+/// GPS 인증 여부(`isLocationVerified`), 사유 결석 사유(`excuseReason`) 를 포함합니다.
+///
+/// - SeeAlso: ``ScheduleAttendanceInfo``, ``AttendanceStatusV2``
+struct ParticipantAttendance: Equatable, Sendable, Identifiable {
+
+    /// 멤버 식별자
+    let memberId: Int
+
+    /// 본명
+    let name: String
+
+    /// 닉네임
+    let nickname: String
+
+    /// 프로필 이미지 URL (없으면 빈 문자열)
+    let profileImageUrl: String
+
+    /// 학교 식별자
+    let schoolId: Int
+
+    /// 학교명
+    let schoolName: String
+
+    /// 출석 상태 (V2)
+    let attendanceStatus: AttendanceStatusV2
+
+    /// GPS 위치 인증 완료 여부
+    let isLocationVerified: Bool
+
+    /// 사유 결석 사유 (없으면 `nil`)
+    let excuseReason: String?
+
+    var id: Int { memberId }
+}

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/ScheduleAttendanceInfo.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/ScheduleAttendanceInfo.swift
@@ -1,0 +1,91 @@
+//
+//  ScheduleAttendanceInfo.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import Foundation
+
+/// 운영진 출석 현황 도메인 모델 (목록/단일 공용)
+///
+/// V2 신규 엔드포인트 응답을 도메인으로 변환한 값입니다.
+/// - 목록: `GET /api/v2/schedules/attendance` (배열)
+/// - 단일: `GET /api/v2/schedules/{id}/attendance` (객체)
+///
+/// 두 엔드포인트의 응답 스키마는 동일하므로 단일 도메인 모델로 표현합니다.
+/// 클라이언트는 이 모델을 받아 필터링/카운팅을 수행합니다.
+///
+/// 서버에서 직책 역할별로 조회 범위가 자동 분기되므로
+/// (중앙 총괄단/운영진/회장단/파트장/기타), 클라이언트는 권한 분기 없이 호출합니다.
+///
+/// - SeeAlso: ``ParticipantAttendance``, ``ScheduleAttendanceFilter``
+struct ScheduleAttendanceInfo: Equatable, Sendable, Identifiable {
+
+    /// 일정 식별자
+    let scheduleId: Int
+
+    /// 일정 제목
+    let name: String
+
+    /// 일정 설명 (메모)
+    let description: String
+
+    /// 시작 일시
+    let startsAt: Date
+
+    /// 종료 일시
+    let endsAt: Date
+
+    /// 장소 (`nil` = 비대면)
+    let location: ScheduleLocation?
+
+    /// 비대면 일정 여부
+    ///
+    /// 서버 `isOnline` 필드 직접 노출 (`location` 이 `nil` 인 경우와 일치하는 것이 정상).
+    let isOnline: Bool
+
+    /// 작성자 멤버 ID
+    let authorMemberId: Int
+
+    /// 출석 정책 (`nil` = 정책 미부착, SCHEDULE-0021 발생 가능)
+    let attendancePolicy: AttendancePolicy?
+
+    /// 카테고리 태그 (e.g., `"LEADERSHIP"`)
+    let tags: [String]
+
+    /// 참여자별 출석 정보
+    let participants: [ParticipantAttendance]
+
+    var id: Int { scheduleId }
+
+    // MARK: - Helpers
+
+    /// 출석 인원 카운트 (`PRESENT` + `EXCUSED` + `LATE`)
+    ///
+    /// V1 출석 통계의 `presentCount` 를 V2 응답에서 직접 계산할 때 사용합니다.
+    var presentCount: Int {
+        participants.filter {
+            switch $0.attendanceStatus {
+            case .present, .excused, .late:
+                return true
+            default:
+                return false
+            }
+        }.count
+    }
+
+    /// 승인 대기 인원 카운트
+    var pendingCount: Int {
+        participants.filter(\.attendanceStatus.isPending).count
+    }
+
+    /// 전체 참여자 수
+    var totalCount: Int { participants.count }
+
+    /// 출석률 (0.0 - 1.0)
+    var attendanceRate: Double {
+        guard totalCount > 0 else { return 0.0 }
+        return Double(presentCount) / Double(totalCount)
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/OperatorAttendanceUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/OperatorAttendanceUseCase.swift
@@ -59,4 +59,26 @@ final class OperatorAttendanceUseCase: OperatorAttendanceUseCaseProtocol {
     {
         try await repository.getScheduleStats()
     }
+
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> [ScheduleAttendanceInfo] {
+        try await repository.fetchAttendanceList(
+            from: from,
+            to: to,
+            attendanceStatus: attendanceStatus
+        )
+    }
+
+    func fetchAttendanceDetail(
+        scheduleId: Int,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> ScheduleAttendanceInfo {
+        try await repository.fetchAttendanceDetail(
+            scheduleId: scheduleId,
+            attendanceStatus: attendanceStatus
+        )
+    }
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/OperatorAttendanceUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/OperatorAttendanceUseCaseProtocol.swift
@@ -29,5 +29,23 @@ protocol OperatorAttendanceUseCaseProtocol {
     ) async throws
 
     /// 일정별 출석 통계 조회
+    ///
+    /// - Important: V1 엔드포인트 호출. V2 마이그레이션 완료 후 제거 예정.
+    /// - SeeAlso: ``fetchAttendanceList(from:to:attendanceStatus:)``
     func fetchScheduleStats() async throws -> [ScheduleAttendanceStats]
+
+    /// 운영진용 일정 출석 현황 목록 조회 (V2)
+    ///
+    /// 직책별 조회 범위는 서버에서 자동 분기됩니다.
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> [ScheduleAttendanceInfo]
+
+    /// 단일 일정 출석 현황 조회 (V2)
+    func fetchAttendanceDetail(
+        scheduleId: Int,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> ScheduleAttendanceInfo
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/AttendanceDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/AttendanceDetailViewModel.swift
@@ -1,0 +1,105 @@
+//
+//  AttendanceDetailViewModel.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import Foundation
+
+/// 단일 일정 출석 현황 상세 화면 ViewModel (Schedule V2)
+///
+/// `GET /api/v2/schedules/{id}/attendance` 호출 결과를 표시하고,
+/// 상태 필터 칩으로 참여자 목록을 클라이언트 측에서 필터링합니다.
+///
+/// ## Edge Case (AC-E2)
+/// 진입 후 일정이 삭제된 경우 (SCHEDULE-0009) `Loadable.failed` 에 명시적인 메시지를
+/// 담아 "삭제된 일정" 표시 + Stack pop 버튼을 노출합니다.
+///
+/// - SeeAlso: ``AttendanceDetailView``
+@Observable
+final class AttendanceDetailViewModel {
+
+    // MARK: - Property
+
+    private var container: DIContainer
+    private var errorHandler: ErrorHandler
+    private var useCase: OperatorAttendanceUseCaseProtocol
+
+    let scheduleId: Int
+
+    /// 출석 현황 로드 상태
+    private(set) var detailState: Loadable<ScheduleAttendanceInfo> = .idle
+
+    /// 현재 선택된 필터 (`nil` = 전체)
+    private(set) var selectedFilter: AttendanceStatusV2?
+
+    let filterableStatuses: [AttendanceStatusV2] = AttendanceStatusV2.filterableCases
+
+    /// 일정이 삭제됐는지 여부 (AC-E2 감지)
+    private(set) var isScheduleDeleted: Bool = false
+
+    // MARK: - Init
+
+    init(
+        container: DIContainer,
+        errorHandler: ErrorHandler,
+        useCase: OperatorAttendanceUseCaseProtocol,
+        scheduleId: Int
+    ) {
+        self.container = container
+        self.errorHandler = errorHandler
+        self.useCase = useCase
+        self.scheduleId = scheduleId
+    }
+
+    // MARK: - Action
+
+    /// 단일 일정 출석 현황 조회
+    @MainActor
+    func fetch() async {
+        detailState = .loading
+        isScheduleDeleted = false
+        do {
+            let info = try await useCase.fetchAttendanceDetail(
+                scheduleId: scheduleId,
+                attendanceStatus: nil
+            )
+            detailState = .loaded(info)
+        } catch let error as DomainError {
+            detailState = .failed(.domain(error))
+        } catch let error as RepositoryError {
+            if case .serverError(let code, _) = error,
+               code == "SCHEDULE-0009"
+            {
+                isScheduleDeleted = true
+            }
+            detailState = .failed(.unknown(message: error.localizedDescription))
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "fetchAttendanceDetail",
+                retryAction: { [weak self] in
+                    await self?.fetch()
+                }
+            ))
+            detailState = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    /// 필터 칩 탭 (클라이언트 측 필터링)
+    func filterButtonTapped(_ status: AttendanceStatusV2) {
+        if selectedFilter == status {
+            selectedFilter = nil
+        } else {
+            selectedFilter = status
+        }
+    }
+
+    /// 현재 필터를 적용한 참여자 목록
+    var filteredParticipants: [ParticipantAttendance] {
+        guard case .loaded(let info) = detailState else { return [] }
+        guard let filter = selectedFilter else { return info.participants }
+        return info.participants.filter { $0.attendanceStatus == filter }
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/AttendanceListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/AttendanceListViewModel.swift
@@ -1,0 +1,91 @@
+//
+//  AttendanceListViewModel.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import Foundation
+
+/// 운영진 출석 현황 목록 화면 ViewModel (Schedule V2)
+///
+/// `GET /api/v2/schedules/attendance` 호출 결과를 상태별로 필터링해 표시합니다.
+/// 직책별 조회 범위는 서버에서 자동 분기되므로 클라이언트는 권한 분기 없이 호출만 합니다.
+///
+/// ## 권한 분기 (AC-E1)
+/// `canCreateAttendanceRequiredSchedule = false` 인 사용자가 진입한 경우
+/// 빈 폴백 화면을 표시하고, 호출 측 (ActivityView root) 에서 카드 자체를 숨깁니다.
+///
+/// - SeeAlso: ``AttendanceListView``, ``OperatorAttendanceUseCaseProtocol/fetchAttendanceList(from:to:attendanceStatus:)``
+@Observable
+final class AttendanceListViewModel {
+
+    // MARK: - Property
+
+    private var container: DIContainer
+    private var errorHandler: ErrorHandler
+    private var useCase: OperatorAttendanceUseCaseProtocol
+
+    /// 출석 현황 로드 상태
+    private(set) var listState: Loadable<[ScheduleAttendanceInfo]> = .idle
+
+    /// 현재 선택된 필터 (`nil` = 전체)
+    private(set) var selectedFilter: AttendanceStatusV2?
+
+    /// 필터 칩에 표시할 후보 (필터 가능 케이스 = `unknown` 제외)
+    let filterableStatuses: [AttendanceStatusV2] = AttendanceStatusV2.filterableCases
+
+    // MARK: - Init
+
+    init(
+        container: DIContainer,
+        errorHandler: ErrorHandler,
+        useCase: OperatorAttendanceUseCaseProtocol
+    ) {
+        self.container = container
+        self.errorHandler = errorHandler
+        self.useCase = useCase
+    }
+
+    // MARK: - Action
+
+    /// 출석 현황 목록 조회
+    ///
+    /// `from`/`to` 미지정 → 서버 기본값(요청 시점 -1개월 ~ +24시간) 적용.
+    @MainActor
+    func fetch() async {
+        listState = .loading
+        do {
+            let list = try await useCase.fetchAttendanceList(
+                from: nil,
+                to: nil,
+                attendanceStatus: selectedFilter
+            )
+            listState = .loaded(list)
+        } catch let error as DomainError {
+            listState = .failed(.domain(error))
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "fetchAttendanceList",
+                retryAction: { [weak self] in
+                    await self?.fetch()
+                }
+            ))
+            listState = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    /// 필터 칩 탭
+    ///
+    /// 같은 필터를 다시 누르면 해제 (전체 보기). 변경 즉시 재조회.
+    @MainActor
+    func filterButtonTapped(_ status: AttendanceStatusV2) async {
+        if selectedFilter == status {
+            selectedFilter = nil
+        } else {
+            selectedFilter = status
+        }
+        await fetch()
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
@@ -1,0 +1,333 @@
+//
+//  AttendanceDetailView.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import SwiftUI
+
+/// 단일 일정 출석 현황 상세 화면 (Schedule V2 #658)
+///
+/// `GET /api/v2/schedules/{id}/attendance` 응답을 헤더 + 참여자 리스트로 표시합니다.
+/// 진입 경로:
+/// - 출석 현황 목록 (`AttendanceListView`) → 행 탭
+/// - 일정 상세 화면 → "출석 현황" 버튼 (cross-tab 라우팅 정책 후속, AC-Q1)
+struct AttendanceDetailView: View {
+
+    // MARK: - Property
+
+    @Environment(NavigationRouter.self) private var router
+    @State private var viewModel: AttendanceDetailViewModel
+
+    // MARK: - Init
+
+    init(
+        container: DIContainer,
+        errorHandler: ErrorHandler,
+        scheduleId: Int
+    ) {
+        let useCase = container.resolve(ActivityUseCaseProviding.self)
+            .operatorAttendanceUseCase
+        _viewModel = State(initialValue: AttendanceDetailViewModel(
+            container: container,
+            errorHandler: errorHandler,
+            useCase: useCase,
+            scheduleId: scheduleId
+        ))
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            switch viewModel.detailState {
+            case .idle, .loading:
+                loadingView
+            case .loaded(let info):
+                content(info: info)
+            case .failed(let error):
+                errorView(error: error)
+            }
+        }
+        .navigationTitle("출석 현황")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            if case .idle = viewModel.detailState {
+                await viewModel.fetch()
+            }
+        }
+    }
+
+    // MARK: - View Components
+
+    private var loadingView: some View {
+        VStack {
+            Spacer()
+            ProgressView()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func errorView(error: AppError) -> some View {
+        VStack(spacing: DefaultSpacing.spacing16) {
+            Spacer()
+            Image(systemName: viewModel.isScheduleDeleted ? "trash.slash" : "exclamationmark.triangle")
+                .font(.system(size: 40))
+                .foregroundStyle(.orange)
+            Text(viewModel.isScheduleDeleted ? "삭제된 일정입니다" : error.userMessage)
+                .appFont(.subheadline, color: .grey600)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+
+            if viewModel.isScheduleDeleted {
+                Button("이전으로") {
+                    router.pop()
+                }
+                .buttonStyle(.borderedProminent)
+            } else {
+                Button("다시 시도") {
+                    Task { await viewModel.fetch() }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func content(info: ScheduleAttendanceInfo) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+                headerCard(info: info)
+                statsRow(info: info)
+                filterChipRow
+                participantList
+            }
+            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+            .padding(.top, DefaultConstant.defaultSafeTop)
+            .padding(.bottom, DefaultConstant.defaultSafeBottom)
+        }
+    }
+
+    private func headerCard(info: ScheduleAttendanceInfo) -> some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            Text(info.name)
+                .appFont(.title3Emphasis, color: .grey700)
+                .lineLimit(2)
+
+            if !info.description.isEmpty {
+                Text(info.description)
+                    .appFont(.subheadline, color: .grey600)
+            }
+
+            HStack(spacing: DefaultSpacing.spacing8) {
+                Image(systemName: "calendar")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.grey500)
+                Text(dateRangeText(info: info))
+                    .appFont(.footnote, color: .grey500)
+            }
+
+            if let location = info.location {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Image(systemName: "mappin.and.ellipse")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.grey500)
+                    Text(location.locationName)
+                        .appFont(.footnote, color: .grey500)
+                }
+            } else if info.isOnline {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Image(systemName: "video")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.grey500)
+                    Text("비대면")
+                        .appFont(.footnote, color: .grey500)
+                }
+            }
+        }
+        .padding(DefaultSpacing.spacing16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassEffect(
+            .regular,
+            in: ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
+    }
+
+    private func statsRow(info: ScheduleAttendanceInfo) -> some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            statBlock(label: "출석", value: "\(info.presentCount) / \(info.totalCount)")
+            statBlock(label: "대기", value: "\(info.pendingCount)")
+            statBlock(label: "출석률", value: rateText(info: info))
+        }
+    }
+
+    private func statBlock(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+            Text(label)
+                .appFont(.caption1, color: .grey500)
+            Text(value)
+                .appFont(.calloutEmphasis, color: .grey700)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(DefaultSpacing.spacing12)
+        .glassEffect(
+            .regular,
+            in: ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
+    }
+
+    private var filterChipRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: DefaultSpacing.spacing8) {
+                ChipButton(
+                    "전체",
+                    isSelected: viewModel.selectedFilter == nil
+                ) {
+                    if let current = viewModel.selectedFilter {
+                        viewModel.filterButtonTapped(current)
+                    }
+                }
+                .buttonSize(.small)
+
+                ForEach(viewModel.filterableStatuses, id: \.self) { status in
+                    ChipButton(
+                        status.displayText,
+                        isSelected: viewModel.selectedFilter == status
+                    ) {
+                        viewModel.filterButtonTapped(status)
+                    }
+                    .buttonSize(.small)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var participantList: some View {
+        let participants = viewModel.filteredParticipants
+        if participants.isEmpty {
+            VStack(spacing: DefaultSpacing.spacing12) {
+                Image(systemName: "person.2.slash")
+                    .font(.system(size: 28))
+                    .foregroundStyle(.grey400)
+                Text("표시할 참여자가 없습니다")
+                    .appFont(.subheadline, color: .grey500)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, DefaultSpacing.spacing24)
+        } else {
+            LazyVStack(spacing: DefaultSpacing.spacing8) {
+                ForEach(participants) { participant in
+                    ParticipantAttendanceRow(participant: participant)
+                }
+            }
+        }
+    }
+
+    // MARK: - Helper
+
+    private func dateRangeText(info: ScheduleAttendanceInfo) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.M.d (E) HH:mm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        let start = formatter.string(from: info.startsAt)
+
+        let endFormatter = DateFormatter()
+        endFormatter.dateFormat = "HH:mm"
+        endFormatter.locale = Locale(identifier: "ko_KR")
+        endFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        let end = endFormatter.string(from: info.endsAt)
+        return "\(start) ~ \(end)"
+    }
+
+    private func rateText(info: ScheduleAttendanceInfo) -> String {
+        guard info.totalCount > 0 else { return "—" }
+        let percent = Int((info.attendanceRate * 100).rounded())
+        return "\(percent)%"
+    }
+}
+
+// MARK: - Row
+
+private struct ParticipantAttendanceRow: View, Equatable {
+
+    let participant: ParticipantAttendance
+
+    static func == (lhs: ParticipantAttendanceRow, rhs: ParticipantAttendanceRow) -> Bool {
+        lhs.participant.memberId == rhs.participant.memberId
+            && lhs.participant.attendanceStatus == rhs.participant.attendanceStatus
+            && lhs.participant.isLocationVerified == rhs.participant.isLocationVerified
+            && lhs.participant.excuseReason == rhs.participant.excuseReason
+    }
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            avatar
+
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Text(participant.name)
+                        .appFont(.calloutEmphasis, color: .grey700)
+                        .lineLimit(1)
+                    Text(participant.nickname)
+                        .appFont(.footnote, color: .grey500)
+                        .lineLimit(1)
+                }
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Text(participant.schoolName)
+                        .appFont(.caption1, color: .grey500)
+                        .lineLimit(1)
+
+                    if participant.isLocationVerified {
+                        HStack(spacing: 2) {
+                            Image(systemName: "location.fill")
+                                .font(.system(size: 10))
+                            Text("GPS 인증")
+                                .appFont(.caption2, color: .green)
+                        }
+                        .foregroundStyle(.green)
+                    }
+                }
+
+                if let reason = participant.excuseReason {
+                    Text("사유: \(reason)")
+                        .appFont(.caption1, color: .grey600)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer()
+
+            AttendanceStatusBadge(status: participant.attendanceStatus)
+        }
+        .padding(DefaultSpacing.spacing12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassEffect(
+            .regular,
+            in: ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
+    }
+
+    private var avatar: some View {
+        RemoteImage(
+            urlString: participant.profileImageUrl,
+            size: CGSize(width: 40, height: 40),
+            cornerRadius: 20
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
@@ -1,0 +1,247 @@
+//
+//  AttendanceListView.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/6/26.
+//
+
+import SwiftUI
+
+/// 운영진 출석 현황 목록 화면 (Schedule V2 #658)
+///
+/// `GET /api/v2/schedules/attendance` 의 응답을 카드 리스트로 표시하고,
+/// 상태 필터 칩을 통해 클라이언트가 서버 측 필터링을 트리거합니다.
+///
+/// 행 탭 시 `Activity.attendanceDetail(scheduleId:)` 로 stack push.
+struct AttendanceListView: View {
+
+    // MARK: - Property
+
+    @Environment(NavigationRouter.self) private var router
+    @State private var viewModel: AttendanceListViewModel
+
+    // MARK: - Init
+
+    init(
+        container: DIContainer,
+        errorHandler: ErrorHandler
+    ) {
+        let useCase = container.resolve(ActivityUseCaseProviding.self)
+            .operatorAttendanceUseCase
+        _viewModel = State(initialValue: AttendanceListViewModel(
+            container: container,
+            errorHandler: errorHandler,
+            useCase: useCase
+        ))
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+            filterChipRow
+
+            switch viewModel.listState {
+            case .idle, .loading:
+                loadingView
+            case .loaded(let infos):
+                if infos.isEmpty {
+                    emptyView
+                } else {
+                    listContent(infos: infos)
+                }
+            case .failed(let error):
+                errorView(error: error)
+            }
+        }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .padding(.top, DefaultConstant.defaultSafeTop)
+        .navigationTitle("출석 현황")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            if case .idle = viewModel.listState {
+                await viewModel.fetch()
+            }
+        }
+    }
+
+    // MARK: - View Components
+
+    private var filterChipRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: DefaultSpacing.spacing8) {
+                ChipButton(
+                    "전체",
+                    isSelected: viewModel.selectedFilter == nil
+                ) {
+                    Task { await viewModel.filterButtonTapped(viewModel.selectedFilter ?? .present) }
+                }
+                .buttonSize(.small)
+
+                ForEach(viewModel.filterableStatuses, id: \.self) { status in
+                    ChipButton(
+                        status.displayText,
+                        isSelected: viewModel.selectedFilter == status
+                    ) {
+                        Task { await viewModel.filterButtonTapped(status) }
+                    }
+                    .buttonSize(.small)
+                }
+            }
+        }
+    }
+
+    private var loadingView: some View {
+        VStack {
+            Spacer()
+            ProgressView()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            Spacer()
+            Image(systemName: "calendar.badge.exclamationmark")
+                .font(.system(size: 36))
+                .foregroundStyle(.grey400)
+            Text("표시할 일정이 없습니다")
+                .appFont(.subheadline, color: .grey500)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func errorView(error: AppError) -> some View {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 36))
+                .foregroundStyle(.orange)
+            Text(error.userMessage)
+                .appFont(.subheadline, color: .grey600)
+                .multilineTextAlignment(.center)
+            Button("다시 시도") {
+                Task { await viewModel.fetch() }
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private func listContent(infos: [ScheduleAttendanceInfo]) -> some View {
+        ScrollView {
+            LazyVStack(spacing: DefaultSpacing.spacing12) {
+                ForEach(infos) { info in
+                    Button {
+                        router.push(to: .activity(.attendanceDetail(scheduleId: info.scheduleId)))
+                    } label: {
+                        AttendanceListRow(info: info)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct AttendanceListRow: View, Equatable {
+
+    let info: ScheduleAttendanceInfo
+
+    static func == (lhs: AttendanceListRow, rhs: AttendanceListRow) -> Bool {
+        lhs.info.scheduleId == rhs.info.scheduleId
+            && lhs.info.totalCount == rhs.info.totalCount
+            && lhs.info.presentCount == rhs.info.presentCount
+            && lhs.info.pendingCount == rhs.info.pendingCount
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(info.name)
+                    .appFont(.calloutEmphasis, color: .grey700)
+                    .lineLimit(1)
+                Spacer()
+                Text(rateText)
+                    .appFont(.footnote, color: .grey500)
+            }
+
+            HStack(spacing: DefaultSpacing.spacing8) {
+                Image(systemName: "calendar")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.grey500)
+                Text(dateRangeText)
+                    .appFont(.footnote, color: .grey500)
+            }
+
+            if let location = info.location {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Image(systemName: "mappin.and.ellipse")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.grey500)
+                    Text(location.locationName)
+                        .appFont(.footnote, color: .grey500)
+                        .lineLimit(1)
+                }
+            } else if info.isOnline {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Image(systemName: "video")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.grey500)
+                    Text("비대면")
+                        .appFont(.footnote, color: .grey500)
+                }
+            }
+
+            HStack(spacing: DefaultSpacing.spacing8) {
+                Text("출석 \(info.presentCount) / \(info.totalCount)")
+                    .appFont(.footnote, color: .grey600)
+                if info.pendingCount > 0 {
+                    InfoBadge(
+                        "대기 \(info.pendingCount)",
+                        textColor: .orange,
+                        tintColor: .yellow,
+                        glassVariant: .clear
+                    )
+                }
+            }
+        }
+        .padding(DefaultSpacing.spacing16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassEffect(
+            .regular.interactive(),
+            in: ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
+    }
+
+    private var rateText: String {
+        guard info.totalCount > 0 else { return "—" }
+        let percent = Int((info.attendanceRate * 100).rounded())
+        return "\(percent)%"
+    }
+
+    private var dateRangeText: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "M월 d일 (E) HH:mm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        let start = formatter.string(from: info.startsAt)
+
+        let endFormatter = DateFormatter()
+        endFormatter.dateFormat = "HH:mm"
+        endFormatter.locale = Locale(identifier: "ko_KR")
+        endFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        let end = endFormatter.string(from: info.endsAt)
+
+        return "\(start) ~ \(end)"
+    }
+}

--- a/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleV2Router.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleV2Router.swift
@@ -28,6 +28,14 @@ enum ScheduleV2Router {
     case patchSchedule(scheduleId: Int, request: UpdateScheduleRequestDTO)
     /// 일정 삭제 (스터디 그룹 일정 2단계 실패 시 베스트 에포트 롤백 등)
     case deleteSchedule(scheduleId: Int)
+    /// 운영진용 일정 출석 현황 목록 조회 (SCHEDULE-Q004)
+    ///
+    /// - `from` / `to` 미지정 시 서버 기본값(요청 시점 -1개월 ~ +24시간) 적용
+    /// - `attendanceStatus` 미지정 시 모든 상태 반환
+    /// - 직책별 조회 범위는 서버에서 자동 분기
+    case getAttendanceList(from: Date?, to: Date?, attendanceStatus: String?)
+    /// 운영진용 단일 일정 출석 현황 조회 (SCHEDULE-Q005)
+    case getAttendanceDetail(scheduleId: Int, attendanceStatus: String?)
 }
 
 extension ScheduleV2Router: BaseTargetType {
@@ -48,6 +56,10 @@ extension ScheduleV2Router: BaseTargetType {
             return "/api/v2/schedules/\(scheduleId)"
         case .deleteSchedule(let scheduleId):
             return "/api/v2/schedules/\(scheduleId)"
+        case .getAttendanceList:
+            return "/api/v2/schedules/attendance"
+        case .getAttendanceDetail(let scheduleId, _):
+            return "/api/v2/schedules/\(scheduleId)/attendance"
         }
     }
 
@@ -55,7 +67,8 @@ extension ScheduleV2Router: BaseTargetType {
 
     var method: Moya.Method {
         switch self {
-        case .getCapabilities, .getMySchedules, .getScheduleDetail:
+        case .getCapabilities, .getMySchedules, .getScheduleDetail,
+             .getAttendanceList, .getAttendanceDetail:
             return .get
         case .postSchedule:
             return .post
@@ -85,6 +98,29 @@ extension ScheduleV2Router: BaseTargetType {
             return .requestJSONEncodable(request)
         case .patchSchedule(_, let request):
             return .requestJSONEncodable(request)
+        case .getAttendanceList(let from, let to, let attendanceStatus):
+            var parameters: [String: Any] = [:]
+            if let from {
+                parameters["from"] = ServerDateTimeConverter.toUTCDateTimeString(from)
+            }
+            if let to {
+                parameters["to"] = ServerDateTimeConverter.toUTCDateTimeString(to)
+            }
+            if let attendanceStatus {
+                parameters["attendanceStatus"] = attendanceStatus
+            }
+            return .requestParameters(
+                parameters: parameters,
+                encoding: URLEncoding.queryString
+            )
+        case .getAttendanceDetail(_, let attendanceStatus):
+            guard let attendanceStatus else {
+                return .requestPlain
+            }
+            return .requestParameters(
+                parameters: ["attendanceStatus": attendanceStatus],
+                encoding: URLEncoding.queryString
+            )
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Feature — 운영진 출석 현황 조회 V2 API 마이그레이션 + 신규 목록/상세 화면 2개 추가

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 신규 화면 2종(AttendanceListView, AttendanceDetailView) 시뮬레이터 영상 첨부 예정 -->

## 🛠️ 작업내용

### Domain
- `AttendanceStatusV2` enum 추가 — 9개 케이스 (`presentPending`, `latePending`, `excusedPending`, `present`, `late`, `absent`, `excused`, `pending`, `unknown`) + 디코딩 시 `.unknown` 폴백 패턴 적용
- `filterableCases` static — 필터 칩 후보(`.unknown` 제외)
- `ScheduleAttendanceInfo` / `ParticipantAttendance` 도메인 모델 신설 (`attendancePolicy`, `isLocationVerified`, `excuseReason` 포함)
- `OperatorAttendanceRepositoryProtocol` / `OperatorAttendanceUseCaseProtocol` 에 V2 메서드 2개 추가

### Data
- `ScheduleV2Router` 에 `.getAttendanceList(from:to:attendanceStatus:)` / `.getAttendanceDetail(scheduleId:attendanceStatus:)` 라우트 추가 (`URLEncoding.queryString`, 옵셔널 파라미터 조건부 포함)
- `ScheduleAttendanceInfoDTO` / `V2AttendanceParticipantDTO` 신설 — `toDomain()` 에서 `ServerDateTimeConverter.parseUTCDateTime` 사용 + `attendanceStatus` String → `AttendanceStatusV2` 변환 시 `.unknown` 폴백
- `AttendanceRepository` V2 메서드 구현 (Moya `decoder.decode(APIResponse<...>.self)` 패턴)
- `MockAttendanceRepository` Mock 구현 추가

### Navigation
- `NavigationDestination.Activity` 에 `.attendanceList`, `.attendanceDetail(scheduleId:)` 케이스 추가
- `NavigationRoutingView` 라우팅 분기 추가

### Presentation (신규 화면 2개)
- `AttendanceListView` + `AttendanceListViewModel` — 출석 현황 목록, 상태 필터 칩(서버 측 필터링), 행 탭 시 상세로 push
- `AttendanceDetailView` + `AttendanceDetailViewModel` — 단일 일정 헤더/통계/필터/참여자 리스트, **AC-E2**: `SCHEDULE-0009` (삭제된 일정) 감지 시 "삭제된 일정입니다" + "이전으로" pop 폴백
- `AttendanceStatusBadge` 공용 컴포넌트 — 9개 상태 색상 매핑 (출석/사유결석=초록, 지각=주황, 결석=빨강, *_PENDING=노랑, 출석 전=회색, unknown=회색+? 아이콘)

## 📋 추후 진행 상황

- [ ] **(별도 이슈 분리)** 기존 `OperatorAttendanceViewModel.fetchSessions()` V1 → V2 마이그레이션 — pending 멤버 lazy 로딩, 공유 `Session` 객체, 승인/반려/위치 변경 흐름과 강결합되어 별도 작업 필요
- [ ] 신규 화면 진입 경로 연결 (홈 대시보드 / 일정 상세 → 출석 현황 버튼)

## 📌 리뷰 포인트

- `Features/Activity/Domain/Enum/Attendance/AttendanceStatusV2.swift` — `.unknown` 폴백 디코딩 패턴 + `filterableCases` 분리 전략 (서버에 새 상태가 추가돼도 클라이언트가 깨지지 않음)
- `Features/Activity/Data/DTOs/ScheduleAttendanceInfoDTO.swift` / `V2AttendanceParticipantDTO.swift` — `toDomain()` 매핑 (UTC 파싱 + 빈 `excuseReason` → nil 정규화)
- `Features/Home/Data/Router/ScheduleV2Router.swift` — V2 라우트 2개 (옵셔널 쿼리 파라미터 처리)
- `Features/Activity/Presentation/ViewModels/Operation/AttendanceDetailViewModel.swift` — **AC-E2** `RepositoryError.serverError(code: "SCHEDULE-0009")` 캐치 후 `isScheduleDeleted` 플래그 노출
- `Features/Activity/Presentation/ViewModels/Operation/AttendanceListViewModel.swift` — 필터 변경 시 즉시 재조회 (서버 측 필터링)
- `Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift` — 헤더 카드 / 통계 / 필터 칩 / 참여자 리스트 4-section 레이아웃, `ParticipantAttendanceRow` Equatable 비교 키 (`memberId` + `attendanceStatus` + `isLocationVerified` + `excuseReason`)
- `Core/Common/UIComponents/Badge/AttendanceStatusBadge.swift` — 색상 매핑 + Liquid Glass `.clear.tint()` 적용

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)