### PR TITLE
♻️[Refactor] 라우터 인라인 파라미터 딕셔너리 → DTO 이관 + queryItems → toParameters 네이밍 통일 (#681)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/AttendanceRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/AttendanceRepository.swift
@@ -134,9 +134,11 @@ final class AttendanceRepository: ChallengerAttendanceRepositoryProtocol,
     ) async throws -> [ScheduleAttendanceInfo] {
         let response = try await adapter.request(
             ScheduleV2Router.getAttendanceList(
-                from: from,
-                to: to,
-                attendanceStatus: attendanceStatus?.serverQueryValue
+                query: AttendanceListQuery(
+                    from: from,
+                    to: to,
+                    attendanceStatus: attendanceStatus?.serverQueryValue
+                )
             )
         )
         let apiResponse = try decoder.decode(
@@ -153,7 +155,9 @@ final class AttendanceRepository: ChallengerAttendanceRepositoryProtocol,
         let response = try await adapter.request(
             ScheduleV2Router.getAttendanceDetail(
                 scheduleId: scheduleId,
-                attendanceStatus: attendanceStatus?.serverQueryValue
+                query: AttendanceDetailQuery(
+                    attendanceStatus: attendanceStatus?.serverQueryValue
+                )
             )
         )
         let apiResponse = try decoder.decode(

--- a/AppProduct/AppProduct/Features/Activity/Data/Router/AttendanceRouter.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Router/AttendanceRouter.swift
@@ -104,14 +104,7 @@ extension AttendanceRouter: BaseTargetType {
         case .check(let body):
             return .requestJSONEncodable(body)
         case .patchScheduleLocation(_, let body):
-            return .requestParameters(
-                parameters: [
-                    "locationName": body.locationName,
-                    "latitude": body.latitude,
-                    "longitude": body.longitude
-                ],
-                encoding: JSONEncoding.default
-            )
+            return .requestJSONEncodable(body)
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/CheckLoginIdAvailabilityQuery.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/CheckLoginIdAvailabilityQuery.swift
@@ -1,0 +1,21 @@
+//
+//  CheckLoginIdAvailabilityQuery.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 로그인 ID 중복 검사 Query DTO
+///
+/// `GET /api/v1/auth/login-id/availability`
+struct CheckLoginIdAvailabilityQuery: Encodable {
+    /// 검사 대상 로그인 ID
+    let loginId: String
+
+    /// Query Parameter Dictionary 변환
+    var toParameters: [String: Any] {
+        ["loginId": loginId]
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginAppleRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginAppleRequestDTO.swift
@@ -1,0 +1,46 @@
+//
+//  LoginAppleRequestDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// Apple 소셜 로그인 요청 DTO
+///
+/// `POST /api/v1/auth/login/apple`
+///
+/// `email` / `fullName`은 최초 로그인 시에만 Apple이 내려주므로
+/// 빈 문자열 또는 nil인 경우 페이로드에서 키를 제거합니다.
+struct LoginAppleRequestDTO: Encodable {
+    /// Apple Sign In 인증 코드
+    let authorizationCode: String
+    /// Apple 계정 이메일 (최초 로그인 시)
+    let email: String?
+    /// Apple 계정 이름 (최초 로그인 시)
+    let fullName: String?
+
+    init(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    ) {
+        self.authorizationCode = authorizationCode
+        self.email = (email?.isEmpty == false) ? email : nil
+        self.fullName = (fullName?.isEmpty == false) ? fullName : nil
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case authorizationCode
+        case email
+        case fullName
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(authorizationCode, forKey: .authorizationCode)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(fullName, forKey: .fullName)
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginKakaoRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginKakaoRequestDTO.swift
@@ -1,0 +1,18 @@
+//
+//  LoginKakaoRequestDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 카카오 소셜 로그인 요청 DTO
+///
+/// `POST /api/v1/auth/login/kakao`
+struct LoginKakaoRequestDTO: Encodable {
+    /// 카카오 SDK 액세스 토큰
+    let accessToken: String
+    /// 카카오 계정 이메일
+    let email: String
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/RenewTokenRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/RenewTokenRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  RenewTokenRequestDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 액세스 토큰 재발급 요청 DTO
+///
+/// `POST /api/v1/auth/token/renew`
+struct RenewTokenRequestDTO: Encodable {
+    /// 리프레시 토큰
+    let refreshToken: String
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/SendEmailVerificationRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/SendEmailVerificationRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  SendEmailVerificationRequestDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 이메일 인증 코드 발송 요청 DTO
+///
+/// `POST /api/v1/auth/email-verification`
+struct SendEmailVerificationRequestDTO: Encodable {
+    /// 인증할 이메일 주소
+    let email: String
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/VerifyEmailCodeRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/VerifyEmailCodeRequestDTO.swift
@@ -1,0 +1,18 @@
+//
+//  VerifyEmailCodeRequestDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 이메일 인증 코드 검증 요청 DTO
+///
+/// `POST /api/v1/auth/email-verification/code`
+struct VerifyEmailCodeRequestDTO: Encodable {
+    /// 이메일 인증 ID
+    let emailVerificationId: String
+    /// 사용자가 입력한 인증 코드
+    let verificationCode: String
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -42,7 +42,12 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         email: String
     ) async throws -> OAuthLoginResult {
         let response = try await adapter.requestWithoutAuth(
-            AuthRouter.loginKakao(accessToken: accessToken, email: email)
+            AuthRouter.loginKakao(
+                body: LoginKakaoRequestDTO(
+                    accessToken: accessToken,
+                    email: email
+                )
+            )
         )
         #if DEBUG
         if let json = String(data: response.data, encoding: .utf8) {
@@ -70,9 +75,11 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
     ) async throws -> OAuthLoginResult {
         let response = try await adapter.requestWithoutAuth(
             AuthRouter.loginApple(
-                authorizationCode: authorizationCode,
-                email: email,
-                fullName: fullName
+                body: LoginAppleRequestDTO(
+                    authorizationCode: authorizationCode,
+                    email: email,
+                    fullName: fullName
+                )
             )
         )
         #if DEBUG
@@ -148,7 +155,9 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
     ) async throws -> Bool {
         do {
             let response = try await adapter.requestWithoutAuth(
-                AuthRouter.checkLoginIdAvailability(loginId: loginId)
+                AuthRouter.checkLoginIdAvailability(
+                    query: CheckLoginIdAvailabilityQuery(loginId: loginId)
+                )
             )
             let apiResponse = try decoder.decode(
                 APIResponse<CheckLoginIdAvailabilityResponseDTO>.self,
@@ -165,7 +174,9 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         refreshToken: String
     ) async throws -> TokenPair {
         let response = try await adapter.requestWithoutAuth(
-            AuthRouter.renewToken(refreshToken: refreshToken)
+            AuthRouter.renewToken(
+                body: RenewTokenRequestDTO(refreshToken: refreshToken)
+            )
         )
         let apiResponse = try decoder.decode(
             APIResponse<TokenRenewResponseDTO>.self,
@@ -236,7 +247,9 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         email: String
     ) async throws -> String {
         let response = try await adapter.requestWithoutAuth(
-            AuthRouter.sendEmailVerification(email: email)
+            AuthRouter.sendEmailVerification(
+                body: SendEmailVerificationRequestDTO(email: email)
+            )
         )
         let apiResponse = try decoder.decode(
             APIResponse<EmailVerificationResponseDTO>.self,
@@ -257,8 +270,10 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
     ) async throws -> String {
         let response = try await adapter.requestWithoutAuth(
             AuthRouter.verifyEmailCode(
-                emailVerificationId: emailVerificationId,
-                verificationCode: verificationCode
+                body: VerifyEmailCodeRequestDTO(
+                    emailVerificationId: emailVerificationId,
+                    verificationCode: verificationCode
+                )
             )
         )
         let apiResponse = try decoder.decode(

--- a/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
@@ -15,21 +15,17 @@ enum AuthRouter: BaseTargetType {
     // MARK: - Cases
 
     /// 카카오 소셜 로그인
-    case loginKakao(accessToken: String, email: String)
+    case loginKakao(body: LoginKakaoRequestDTO)
     /// Apple 소셜 로그인
-    case loginApple(
-        authorizationCode: String,
-        email: String?,
-        fullName: String?
-    )
+    case loginApple(body: LoginAppleRequestDTO)
     /// ID/PW 로그인 (App Store 리뷰어용)
     case loginByIdPw(body: LoginByIdPwRequestDTO)
     /// ID/PW 회원가입 (App Store 리뷰어용)
     case registerByIdPw(body: RegisterByIdPwRequestDTO)
     /// 로그인 ID 중복 검사
-    case checkLoginIdAvailability(loginId: String)
+    case checkLoginIdAvailability(query: CheckLoginIdAvailabilityQuery)
     /// 액세스 토큰 재발급
-    case renewToken(refreshToken: String)
+    case renewToken(body: RenewTokenRequestDTO)
     /// 내 OAuth 연동 정보 조회
     case getMyOAuth
     /// 로그인 OAuth 수단 추가 연동
@@ -41,12 +37,9 @@ enum AuthRouter: BaseTargetType {
         kakaoAccessToken: String?
     )
     /// 이메일 인증 발송
-    case sendEmailVerification(email: String)
+    case sendEmailVerification(body: SendEmailVerificationRequestDTO)
     /// 이메일 인증코드 검증
-    case verifyEmailCode(
-        emailVerificationId: String,
-        verificationCode: String
-    )
+    case verifyEmailCode(body: VerifyEmailCodeRequestDTO)
     /// 회원가입
     case register(body: RegisterRequestDTO)
     /// 기존 챌린저 코드 인증
@@ -115,44 +108,21 @@ enum AuthRouter: BaseTargetType {
 
     var task: Moya.Task {
         switch self {
-        case .loginKakao(let accessToken, let email):
-            return .requestParameters(
-                parameters: [
-                    "accessToken": accessToken,
-                    "email": email
-                ],
-                encoding: JSONEncoding.default
-            )
-        case .loginApple(let authorizationCode, let email, let fullName):
-            var parameters: [String: String] = [
-                "authorizationCode": authorizationCode
-            ]
-            if let email, !email.isEmpty {
-                parameters["email"] = email
-            }
-            if let fullName, !fullName.isEmpty {
-                parameters["fullName"] = fullName
-            }
-            return .requestParameters(
-                parameters: parameters,
-                encoding: JSONEncoding.default
-            )
+        case .loginKakao(let body):
+            return .requestJSONEncodable(body)
+        case .loginApple(let body):
+            return .requestJSONEncodable(body)
         case .loginByIdPw(let body):
             return .requestJSONEncodable(body)
         case .registerByIdPw(let body):
             return .requestJSONEncodable(body)
-        case .checkLoginIdAvailability(let loginId):
+        case .checkLoginIdAvailability(let query):
             return .requestParameters(
-                parameters: ["loginId": loginId],
+                parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
-        case .renewToken(let refreshToken):
-            return .requestParameters(
-                parameters: [
-                    "refreshToken": refreshToken
-                ],
-                encoding: JSONEncoding.default
-            )
+        case .renewToken(let body):
+            return .requestJSONEncodable(body)
         case .getMyOAuth:
             return .requestPlain
         case .addMemberOAuth(let oAuthVerificationToken):
@@ -172,19 +142,10 @@ enum AuthRouter: BaseTargetType {
                     kakaoAccessToken: kakaoAccessToken
                 )
             )
-        case .sendEmailVerification(let email):
-            return .requestParameters(
-                parameters: ["email": email],
-                encoding: JSONEncoding.default
-            )
-        case .verifyEmailCode(let id, let code):
-            return .requestParameters(
-                parameters: [
-                    "emailVerificationId": id,
-                    "verificationCode": code
-                ],
-                encoding: JSONEncoding.default
-            )
+        case .sendEmailVerification(let body):
+            return .requestJSONEncodable(body)
+        case .verifyEmailCode(let body):
+            return .requestJSONEncodable(body)
         case .register(let body):
             return .requestJSONEncodable(body)
         case .registerExistingChallenger(let code):

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/AttendanceDetailQuery.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/AttendanceDetailQuery.swift
@@ -1,0 +1,24 @@
+//
+//  AttendanceDetailQuery.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 운영진용 단일 일정 출석 현황 조회 Query DTO (SCHEDULE-Q005)
+///
+/// `GET /api/v2/schedules/{scheduleId}/attendance`
+///
+/// - `attendanceStatus` 미지정 시 모든 상태 반환 (`requestPlain` 으로 전송)
+struct AttendanceDetailQuery: Encodable {
+    /// 출석 상태 필터 (옵션)
+    let attendanceStatus: String?
+
+    /// Query Parameter Dictionary 변환 (nil 항목은 키 제거)
+    var toParameters: [String: Any] {
+        guard let attendanceStatus else { return [:] }
+        return ["attendanceStatus": attendanceStatus]
+    }
+}

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/AttendanceListQuery.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/AttendanceListQuery.swift
@@ -1,0 +1,38 @@
+//
+//  AttendanceListQuery.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 운영진용 일정 출석 현황 목록 조회 Query DTO (SCHEDULE-Q004)
+///
+/// `GET /api/v2/schedules/attendance`
+///
+/// - `from` / `to` 미지정 시 서버 기본값(요청 시점 -1개월 ~ +24시간) 적용
+/// - `attendanceStatus` 미지정 시 모든 상태 반환
+struct AttendanceListQuery: Encodable {
+    /// 조회 시작 시각 (옵션)
+    let from: Date?
+    /// 조회 종료 시각 (옵션)
+    let to: Date?
+    /// 출석 상태 필터 (옵션)
+    let attendanceStatus: String?
+
+    /// Query Parameter Dictionary 변환 (nil 항목은 키 제거)
+    var toParameters: [String: Any] {
+        var params: [String: Any] = [:]
+        if let from {
+            params["from"] = ServerDateTimeConverter.toUTCDateTimeString(from)
+        }
+        if let to {
+            params["to"] = ServerDateTimeConverter.toUTCDateTimeString(to)
+        }
+        if let attendanceStatus {
+            params["attendanceStatus"] = attendanceStatus
+        }
+        return params
+    }
+}

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerSearchDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerSearchDTO.swift
@@ -31,7 +31,7 @@ struct ChallengerSearchRequestDTO {
     }
 
     /// Query Parameter Dictionary 변환
-    var queryItems: [String: Any] {
+    var toParameters: [String: Any] {
         var params: [String: Any] = [
             "size": size
         ]

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/MySchedulesQuery.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/MySchedulesQuery.swift
@@ -1,0 +1,29 @@
+//
+//  MySchedulesQuery.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 내 일정 목록 조회 Query DTO
+///
+/// `GET /api/v2/schedules/me`
+struct MySchedulesQuery: Encodable {
+    /// 조회 시작 시각
+    let from: Date
+    /// 조회 종료 시각
+    let to: Date
+    /// 출석 필수 일정만 조회 여부
+    let isAttendanceRequired: Bool
+
+    /// Query Parameter Dictionary 변환
+    var toParameters: [String: Any] {
+        [
+            "from": ServerDateTimeConverter.toUTCDateTimeString(from),
+            "to": ServerDateTimeConverter.toUTCDateTimeString(to),
+            "isAttendanceRequired": isAttendanceRequired
+        ]
+    }
+}

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
@@ -43,7 +43,7 @@ struct NoticeListRequestDTO {
     }
 
     /// Query Parameter Dictionary 변환
-    var queryItems: [String: Any] {
+    var toParameters: [String: Any] {
         var params: [String: Any] = [
             "gisuId": gisuId,
             "page": page,

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/HomeRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/HomeRepository.swift
@@ -48,9 +48,11 @@ final class HomeRepository: HomeRepositoryProtocol, @unchecked Sendable {
     ) async throws -> [Date: [ScheduleDetailData]] {
         let response = try await adapter.request(
             ScheduleV2Router.getMySchedules(
-                from: from,
-                to: to,
-                isAttendanceRequired: isAttendanceRequired
+                query: MySchedulesQuery(
+                    from: from,
+                    to: to,
+                    isAttendanceRequired: isAttendanceRequired
+                )
             )
         )
         let apiResponse = try decoder.decode(

--- a/AppProduct/AppProduct/Features/Home/Data/Router/ChallengerSearchRouter.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Router/ChallengerSearchRouter.swift
@@ -45,7 +45,7 @@ extension ChallengerSearchRouter: BaseTargetType {
         switch self {
         case .searchCursor(let query):
             return .requestParameters(
-                parameters: query.queryItems,
+                parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
         }

--- a/AppProduct/AppProduct/Features/Home/Data/Router/HomeRouter.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Router/HomeRouter.swift
@@ -60,7 +60,7 @@ extension HomeRouter: BaseTargetType {
             return .requestPlain
         case .getNoticeRecent(let query):
             return .requestParameters(
-                parameters: query.queryItems,
+                parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
         case .getGisuDetail:

--- a/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleV2Router.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleV2Router.swift
@@ -19,7 +19,7 @@ enum ScheduleV2Router {
     /// 일정 생성/수정 권한 사전 조회 (SCHEDULE-Q001)
     case getCapabilities
     /// 내 일정 목록 조회 (기간 + 출석 필수 필터)
-    case getMySchedules(from: Date, to: Date, isAttendanceRequired: Bool)
+    case getMySchedules(query: MySchedulesQuery)
     /// 일정 상세 조회
     case getScheduleDetail(scheduleId: Int)
     /// 일정 생성
@@ -33,9 +33,9 @@ enum ScheduleV2Router {
     /// - `from` / `to` 미지정 시 서버 기본값(요청 시점 -1개월 ~ +24시간) 적용
     /// - `attendanceStatus` 미지정 시 모든 상태 반환
     /// - 직책별 조회 범위는 서버에서 자동 분기
-    case getAttendanceList(from: Date?, to: Date?, attendanceStatus: String?)
+    case getAttendanceList(query: AttendanceListQuery)
     /// 운영진용 단일 일정 출석 현황 조회 (SCHEDULE-Q005)
-    case getAttendanceDetail(scheduleId: Int, attendanceStatus: String?)
+    case getAttendanceDetail(scheduleId: Int, query: AttendanceDetailQuery)
 }
 
 extension ScheduleV2Router: BaseTargetType {
@@ -85,40 +85,27 @@ extension ScheduleV2Router: BaseTargetType {
         switch self {
         case .getCapabilities, .getScheduleDetail, .deleteSchedule:
             return .requestPlain
-        case .getMySchedules(let from, let to, let isAttendanceRequired):
+        case .getMySchedules(let query):
             return .requestParameters(
-                parameters: [
-                    "from": ServerDateTimeConverter.toUTCDateTimeString(from),
-                    "to": ServerDateTimeConverter.toUTCDateTimeString(to),
-                    "isAttendanceRequired": isAttendanceRequired
-                ],
+                parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
         case .postSchedule(let request):
             return .requestJSONEncodable(request)
         case .patchSchedule(_, let request):
             return .requestJSONEncodable(request)
-        case .getAttendanceList(let from, let to, let attendanceStatus):
-            var parameters: [String: Any] = [:]
-            if let from {
-                parameters["from"] = ServerDateTimeConverter.toUTCDateTimeString(from)
-            }
-            if let to {
-                parameters["to"] = ServerDateTimeConverter.toUTCDateTimeString(to)
-            }
-            if let attendanceStatus {
-                parameters["attendanceStatus"] = attendanceStatus
-            }
+        case .getAttendanceList(let query):
             return .requestParameters(
-                parameters: parameters,
+                parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
-        case .getAttendanceDetail(_, let attendanceStatus):
-            guard let attendanceStatus else {
+        case .getAttendanceDetail(_, let query):
+            let params = query.toParameters
+            guard !params.isEmpty else {
                 return .requestPlain
             }
             return .requestParameters(
-                parameters: ["attendanceStatus": attendanceStatus],
+                parameters: params,
                 encoding: URLEncoding.queryString
             )
         }

--- a/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPagePostDTO.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPagePostDTO.swift
@@ -22,7 +22,7 @@ struct MyPagePostListQuery {
         self.sort = sort
     }
 
-    var queryItems: [String: Any] {
+    var toParameters: [String: Any] {
         var params: [String: Any] = [
             "page": page,
             "size": size

--- a/AppProduct/AppProduct/Features/MyPage/Data/Router/MyPageRouter.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/Router/MyPageRouter.swift
@@ -109,7 +109,7 @@ extension MyPageRouter: BaseTargetType {
              .getCommentedPosts(let query),
              .getScrappedPosts(let query):
             return .requestParameters(
-                parameters: query.queryItems,
+                parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
         case .getTerms:

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeImagesRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeImagesRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  NoticeImagesRequestDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 공지 이미지 추가/수정 요청 DTO
+///
+/// - `POST /api/v1/notices/{noticeId}/images`
+/// - `PATCH /api/v1/notices/{noticeId}/images`
+struct NoticeImagesRequestDTO: Encodable {
+    /// 첨부 이미지 ID 목록
+    let imageIds: [String]
+}

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeLinksRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeLinksRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  NoticeLinksRequestDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 공지 링크 추가/수정 요청 DTO
+///
+/// - `POST /api/v1/notices/{noticeId}/links`
+/// - `PATCH /api/v1/notices/{noticeId}/links`
+struct NoticeLinksRequestDTO: Encodable {
+    /// 첨부 링크 URL 목록
+    let links: [String]
+}

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeReadStatusListQuery.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeReadStatusListQuery.swift
@@ -1,0 +1,32 @@
+//
+//  NoticeReadStatusListQuery.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 공지 열람 현황 상세 조회 Query DTO
+///
+/// `GET /api/v1/notices/{noticeId}/read-status`
+struct NoticeReadStatusListQuery: Encodable {
+    /// 이전 페이지의 마지막 항목 ID (커서 기반)
+    let cursorId: Int
+    /// 필터 타입 (운영진 / 챌린저 등)
+    let filterType: String
+    /// 조직(지부/학교) ID 목록
+    let organizationIds: [Int]
+    /// 열람 상태 필터 (READ / UNREAD)
+    let status: String
+
+    /// Query Parameter Dictionary 변환
+    var toParameters: [String: Any] {
+        [
+            "cursorId": cursorId,
+            "filterType": filterType,
+            "organizationIds": organizationIds,
+            "status": status
+        ]
+    }
+}

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeReminderRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeReminderRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  NoticeReminderRequestDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 공지 리마인더 발송 요청 DTO
+///
+/// `POST /api/v1/notices/{noticeId}/reminders`
+struct NoticeReminderRequestDTO: Encodable {
+    /// 알림을 다시 보낼 대상 멤버 ID 목록
+    let targetIds: [Int]
+}

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeVoteResponseRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticeVoteResponseRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  NoticeVoteResponseRequestDTO.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+/// 공지 투표 응답(제출/수정) 요청 DTO
+///
+/// - `POST /api/v1/notices/{noticeId}/votes/responses`
+/// - `PUT /api/v1/notices/{noticeId}/votes/responses`
+struct NoticeVoteResponseRequestDTO: Encodable {
+    /// 사용자가 선택한 옵션 ID 목록
+    let optionIds: [Int]
+}

--- a/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Repositories/NoticeRepository.swift
@@ -43,13 +43,19 @@ struct NoticeRepository: NoticeRepositoryProtocol {
         
         if !links.isEmpty {
             _ = try await adapter.request(
-                NoticeRouter.addLink(noticeId: noticeId, links: links)
+                NoticeRouter.addLink(
+                    noticeId: noticeId,
+                    body: NoticeLinksRequestDTO(links: links)
+                )
             )
         }
-        
+
         if !imageIds.isEmpty {
             let imageResponse = try await adapter.request(
-                NoticeRouter.addImage(noticeId: noticeId, imageIds: imageIds)
+                NoticeRouter.addImage(
+                    noticeId: noticeId,
+                    body: NoticeImagesRequestDTO(imageIds: imageIds)
+                )
             )
             let imageApiResponse = try JSONDecoder().decode(
                 APIResponse<NoticeAddImagesResponseDTO>.self,
@@ -138,7 +144,10 @@ struct NoticeRepository: NoticeRepositoryProtocol {
     /// 공지사항 링크 추가 → NoticeItemModel 반환
     func addLink(noticeId: Int, links: [String]) async throws -> NoticeItemModel {
         let response = try await adapter.request(
-            NoticeRouter.addLink(noticeId: noticeId, links: links)
+            NoticeRouter.addLink(
+                noticeId: noticeId,
+                body: NoticeLinksRequestDTO(links: links)
+            )
         )
         
         let apiResponse = try JSONDecoder().decode(
@@ -153,7 +162,10 @@ struct NoticeRepository: NoticeRepositoryProtocol {
     /// 공지사항 이미지 추가 → NoticeItemModel 반환
     func addImage(noticeId: Int, imageIds: [String]) async throws -> NoticeItemModel {
         let response = try await adapter.request(
-            NoticeRouter.addImage(noticeId: noticeId, imageIds: imageIds)
+            NoticeRouter.addImage(
+                noticeId: noticeId,
+                body: NoticeImagesRequestDTO(imageIds: imageIds)
+            )
         )
         
         let apiResponse = try JSONDecoder().decode(
@@ -168,7 +180,10 @@ struct NoticeRepository: NoticeRepositoryProtocol {
     /// 공지사항 리마인더 발송
     func sendReminder(noticeId: Int, targetIds: [Int]) async throws {
         let response = try await adapter.request(
-            NoticeRouter.sendReminder(noticeId: noticeId, targetIds: targetIds)
+            NoticeRouter.sendReminder(
+                noticeId: noticeId,
+                body: NoticeReminderRequestDTO(targetIds: targetIds)
+            )
         )
         
         let apiResponse = try JSONDecoder().decode(
@@ -194,7 +209,10 @@ struct NoticeRepository: NoticeRepositoryProtocol {
     /// 투표 응답(사용자 선택 전송)
     func submitVoteResponse(noticeId: Int, optionIds: [Int]) async throws {
         let response = try await adapter.request(
-            NoticeRouter.submitVoteResponse(noticeId: noticeId, optionIds: optionIds)
+            NoticeRouter.submitVoteResponse(
+                noticeId: noticeId,
+                body: NoticeVoteResponseRequestDTO(optionIds: optionIds)
+            )
         )
 
         let apiResponse = try JSONDecoder().decode(
@@ -207,7 +225,10 @@ struct NoticeRepository: NoticeRepositoryProtocol {
     /// 투표 응답 수정
     func updateVoteResponse(noticeId: Int, optionIds: [Int]) async throws {
         let response = try await adapter.request(
-            NoticeRouter.updateVoteResponse(noticeId: noticeId, optionIds: optionIds)
+            NoticeRouter.updateVoteResponse(
+                noticeId: noticeId,
+                body: NoticeVoteResponseRequestDTO(optionIds: optionIds)
+            )
         )
 
         let apiResponse = try JSONDecoder().decode(
@@ -238,7 +259,10 @@ struct NoticeRepository: NoticeRepositoryProtocol {
     /// 공지사항 링크 수정 → NoticeDetail 반환
     func updateLinks(noticeId: Int, links: [String]) async throws -> NoticeDetail {
         let response = try await adapter.request(
-            NoticeRouter.updateLink(noticeId: noticeId, links: links)
+            NoticeRouter.updateLink(
+                noticeId: noticeId,
+                body: NoticeLinksRequestDTO(links: links)
+            )
         )
         
         let apiResponse = try JSONDecoder().decode(
@@ -254,7 +278,10 @@ struct NoticeRepository: NoticeRepositoryProtocol {
     /// 공지사항 이미지 수정 → NoticeDetail 반환
     func updateImages(noticeId: Int, imageIds: [String]) async throws -> NoticeDetail {
         let response = try await adapter.request(
-            NoticeRouter.updateImage(noticeId: noticeId, imageIds: imageIds)
+            NoticeRouter.updateImage(
+                noticeId: noticeId,
+                body: NoticeImagesRequestDTO(imageIds: imageIds)
+            )
         )
         
         let apiResponse = try JSONDecoder().decode(
@@ -287,7 +314,7 @@ struct NoticeRepository: NoticeRepositoryProtocol {
             #if DEBUG
             print(
                 "[NoticeRepository] getAllNotices success " +
-                "query=\(request.queryItems) " +
+                "query=\(request.toParameters) " +
                 "contentCount=\(pageDTO.content.count) " +
                 "totalElements=\(pageDTO.totalElements)"
             )
@@ -352,10 +379,12 @@ struct NoticeRepository: NoticeRepositoryProtocol {
         let response = try await adapter.request(
             NoticeRouter.getNoticeReadStatusList(
                 noticeId: noticeId,
-                cursorId: cursorId,
-                filterType: filterType,
-                organizationIds: organizationIds,
-                status: status
+                query: NoticeReadStatusListQuery(
+                    cursorId: cursorId,
+                    filterType: filterType,
+                    organizationIds: organizationIds,
+                    status: status
+                )
             )
         )
         

--- a/AppProduct/AppProduct/Features/Notice/Data/Router/NoticeRouter.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/Router/NoticeRouter.swift
@@ -25,10 +25,7 @@ enum NoticeRouter: BaseTargetType {
     /// 공지 열람 현황 상세 조회 (사용자 리스트)
     case getNoticeReadStatusList(
         noticeId: Int,
-        cursorId: Int,
-        filterType: String,
-        organizationIds: [Int],
-        status: String
+        query: NoticeReadStatusListQuery
     )
     /// 공지사항 검색
     case searchNotice(
@@ -47,29 +44,29 @@ enum NoticeRouter: BaseTargetType {
     /// 공지사항 링크 추가
     case addLink(
         noticeId: Int,
-        links: [String]
+        body: NoticeLinksRequestDTO
     )
     /// 공지사항 이미지 추가
     case addImage(
         noticeId: Int,
-        imageIds: [String]
+        body: NoticeImagesRequestDTO
     )
     /// 공지사항 리마인더 발송
     case sendReminder(
         noticeId: Int,
-        targetIds: [Int]
+        body: NoticeReminderRequestDTO
     )
     /// 공지사항 읽음 처리
     case readNotice(noticeId: Int)
     /// 투표 응답(사용자 선택 전송)
     case submitVoteResponse(
         noticeId: Int,
-        optionIds: [Int]
+        body: NoticeVoteResponseRequestDTO
     )
     /// 투표 응답 수정
     case updateVoteResponse(
         noticeId: Int,
-        optionIds: [Int]
+        body: NoticeVoteResponseRequestDTO
     )
     
     // PATCH Method
@@ -81,12 +78,12 @@ enum NoticeRouter: BaseTargetType {
     /// 공지사항 링크 수정
     case updateLink(
         noticeId: Int,
-        links: [String]
+        body: NoticeLinksRequestDTO
     )
     /// 공지사항 이미지 수정
     case updateImage(
         noticeId: Int,
-        imageIds: [String]
+        body: NoticeImagesRequestDTO
     )
     
     // DELETE Method
@@ -106,7 +103,7 @@ enum NoticeRouter: BaseTargetType {
             return "/api/v1/notices/\(noticeId)"
         case .getNoticeReadStatusCount(let noticeId):
             return "/api/v1/notices/\(noticeId)/read-statics"
-        case .getNoticeReadStatusList(let noticeId, _, _, _, _):
+        case .getNoticeReadStatusList(let noticeId, _):
             return "/api/v1/notices/\(noticeId)/read-status"
         case .searchNotice:
             return "/api/v1/notices/search"
@@ -164,31 +161,20 @@ enum NoticeRouter: BaseTargetType {
         switch self {
         case .getAllNotices(let request):
             return .requestParameters(
-                parameters: request.queryItems,
+                parameters: request.toParameters,
                 encoding: URLEncoding.queryString
             )
         case .getDetailNotice:
             return .requestPlain
         case .getNoticeReadStatusCount:
             return .requestPlain
-        case .getNoticeReadStatusList(
-            _,
-            let cursorId,
-            let filterType,
-            let organizationIds,
-            let status
-        ):
+        case .getNoticeReadStatusList(_, let query):
             return .requestParameters(
-                parameters: [
-                    "cursorId": cursorId,
-                    "filterType": filterType,
-                    "organizationIds": organizationIds,
-                    "status": status
-                ],
+                parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
         case .searchNotice(let keyword, let request):
-            var params = request.queryItems
+            var params = request.toParameters
             params["keyword"] = keyword
             return .requestParameters(
                 parameters: params,
@@ -198,45 +184,24 @@ enum NoticeRouter: BaseTargetType {
             return .requestJSONEncodable(body)
         case .addVote(_, let body):
             return .requestJSONEncodable(body)
-        case .addLink(_, let links):
-            return .requestParameters(
-                parameters: ["links": links],
-                encoding: JSONEncoding.default
-            )
-        case .addImage(_, let imageIds):
-            return .requestParameters(
-                parameters: ["imageIds": imageIds],
-                encoding: JSONEncoding.default
-            )
-        case .sendReminder(_, let targetIds):
-            return .requestParameters(
-                parameters: ["targetIds": targetIds],
-                encoding: JSONEncoding.default
-            )
+        case .addLink(_, let body):
+            return .requestJSONEncodable(body)
+        case .addImage(_, let body):
+            return .requestJSONEncodable(body)
+        case .sendReminder(_, let body):
+            return .requestJSONEncodable(body)
         case .readNotice:
             return .requestPlain
-        case .submitVoteResponse(_, let optionIds):
-            return .requestParameters(
-                parameters: ["optionIds": optionIds],
-                encoding: JSONEncoding.default
-            )
-        case .updateVoteResponse(_, let optionIds):
-            return .requestParameters(
-                parameters: ["optionIds": optionIds],
-                encoding: JSONEncoding.default
-            )
+        case .submitVoteResponse(_, let body):
+            return .requestJSONEncodable(body)
+        case .updateVoteResponse(_, let body):
+            return .requestJSONEncodable(body)
         case .updateNotice(_, let body):
             return .requestJSONEncodable(body)
-        case .updateLink(_, let links):
-            return .requestParameters(
-                parameters: ["links": links],
-                encoding: JSONEncoding.default
-            )
-        case .updateImage(_, let imageIds):
-            return .requestParameters(
-                parameters: ["imageIds": imageIds],
-                encoding: JSONEncoding.default
-            )
+        case .updateLink(_, let body):
+            return .requestJSONEncodable(body)
+        case .updateImage(_, let body):
+            return .requestJSONEncodable(body)
         case .deleteNotice, .deleteVote:
             return .requestPlain
         }


### PR DESCRIPTION
## Summary

PR #680 에서 정립한 Network Router 컨벤션(인라인 딕셔너리 금지 / Body·Query DTO 분리 / `toParameters` 네이밍 통일)을 기존 라우터 4곳에 일괄 적용하는 마이그레이션 PR 입니다.

Closes #681
관련 컨벤션: #680

## Changes

### 1. AuthRouter — 6개 case
`loginKakao`, `loginApple`, `renewToken`, `sendEmailVerification`, `verifyEmailCode`, `checkLoginIdAvailability` 가 모두 인라인 딕셔너리를 사용하고 있었습니다.

- Body 5종 + Query 1종 DTO 신규 작성 (`Features/Auth/Data/DTOs/`)
- Router는 DTO 만 받아 `.requestJSONEncodable` / `.requestParameters(query.toParameters, …)` 로 위임
- `LoginAppleRequestDTO` 는 Apple 로그인 특성상 `email` / `fullName` 이 nil 또는 빈 문자열일 수 있어 커스텀 `encode(to:)` 로 nil 키를 페이로드에서 제거 (서버 호환성 유지)

### 2. NoticeRouter — 8개 case
- `getNoticeReadStatusList` → `NoticeReadStatusListQuery` (Query)
- `addLink` / `updateLink` → `NoticeLinksRequestDTO` (공유)
- `addImage` / `updateImage` → `NoticeImagesRequestDTO` (공유)
- `reminderNotice` → `NoticeReminderRequestDTO`
- `submitVoteResponse` / `updateVoteResponse` → `NoticeVoteResponseRequestDTO` (공유)

동일 페이로드 구조를 갖는 case 들은 단일 DTO 로 공유해 중복을 제거했습니다 (의미는 호출부 컨텍스트로 구분).

### 3. ScheduleV2Router — 3개 case
- `getMySchedules` → `MySchedulesQuery` (UTC 변환 포함)
- `getAttendanceList` → `AttendanceListQuery` (옵셔널 필드 조건부 포함)
- `getAttendanceDetail` → `AttendanceDetailQuery` (`attendanceStatus` 미지정 시 `requestPlain` 으로 폴백 — 기존 동작 보존)

### 4. AttendanceRouter — 1개 case
`patchScheduleLocation` 은 이미 `ScheduleLocationUpdateRequestDTO (Codable)` 가 있었으므로 `.requestJSONEncodable(body)` 로 단순화만 진행했습니다.

### 5. `queryItems` → `toParameters` 네이밍 통일
표준 `[URLQueryItem]` 과 혼동 방지를 위해 컨벤션과 일치하도록 변경:

- `ChallengerSearchDTO.queryItems` → `toParameters`
- `NoticeListDTO.queryItems` → `toParameters`
- `MyPagePostDTO.queryItems` → `toParameters`
- 호출부 갱신: `ChallengerSearchRouter`, `HomeRouter`, `MyPageRouter`, `NoticeRouter`(2곳), `NoticeRepository` 디버그 로그 1곳

## 영향 범위 / 비영향

- **레이어 경계 유지**: Repository public 메서드 시그니처(원시 타입 파라미터)는 그대로 두고 DTO 생성은 Repository 호출부에 인라인으로 캡슐화 → Domain/UseCase/Presentation 코드는 미변경
- **HTTP 페이로드 동등성**: 키 이름·인코딩 방식·옵셔널 누락 규칙 모두 기존과 동일 (특히 `LoginAppleRequestDTO` 의 빈 값 제거 동작 보존)

## Test plan

- [x] `xcodebuild -project AppProduct/AppProduct.xcodeproj -scheme AppProduct build` 성공 확인 (** BUILD SUCCEEDED **)
- [ ] 카카오/애플 로그인 정상 동작 (이메일 미동의 케이스 포함)
- [ ] 토큰 재발급 / 이메일 인증 코드 발송·검증 / 로그인 아이디 중복 체크
- [ ] 공지사항 수신 확인 목록 조회 (필터/커서 모두 적용)
- [ ] 공지 링크/이미지 추가·수정, 리마인더 발송, 투표 제출·수정
- [ ] 홈 내 일정 조회, 운영진 출석 현황 목록·상세 조회
- [ ] 일정 위치 변경 (관리자)