### PR TITLE
🎨[Design] Schedule V2 화면 UI 개선 (#659)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/UIComponents/Badge/AttendanceStatusBadge.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/Badge/AttendanceStatusBadge.swift
@@ -44,7 +44,7 @@ struct AttendanceStatusBadge: View, Equatable {
                 Image(systemName: "questionmark.circle")
                     .font(.system(size: Constants.unknownIconSize, weight: .semibold))
             }
-            Text(status.displayText)
+            Text(status.badgeText)
                 .lineLimit(1)
         }
         .appFont(.caption1, color: foregroundColor)
@@ -54,6 +54,8 @@ struct AttendanceStatusBadge: View, Equatable {
             .clear.tint(tintColor.opacity(Constants.backgroundOpacity)),
             in: Capsule()
         )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(status.displayText)
     }
 
     // MARK: - Style

--- a/AppProduct/AppProduct/Features/Activity/Domain/Enum/Attendance/AttendanceStatusV2.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Enum/Attendance/AttendanceStatusV2.swift
@@ -64,6 +64,9 @@ enum AttendanceStatusV2: String, Codable, Sendable, CaseIterable, Equatable, Has
     // MARK: - Display
 
     /// 배지/필터 칩에 표시할 한국어 텍스트
+    ///
+    /// `.unknown` 은 "상태 미지정" — 접근성 라벨 및 필터 옵션에 사용합니다.
+    /// 폭 제약이 있는 뱃지 UI 에는 ``badgeText`` 를 사용하세요.
     var displayText: String {
         switch self {
         case .presentPending:   return "출석 승인 대기"
@@ -76,6 +79,14 @@ enum AttendanceStatusV2: String, Codable, Sendable, CaseIterable, Equatable, Has
         case .pending:          return "출석 전"
         case .unknown:          return "상태 미지정"
         }
+    }
+
+    /// 뱃지 컴포넌트에 렌더링할 짧은 텍스트
+    ///
+    /// `.unknown` 은 폭 제약 때문에 `"알 수 없음"` 으로 단축합니다.
+    /// VoiceOver 에는 ``displayText`` 가 읽히므로 접근성이 유지됩니다.
+    var badgeText: String {
+        self == .unknown ? "알 수 없음" : displayText
     }
 
     /// 서버 쿼리 파라미터로 보낼 raw 값

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Enum/AttendancePeriodPreset.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Enum/AttendancePeriodPreset.swift
@@ -1,0 +1,61 @@
+//
+//  AttendancePeriodPreset.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+// MARK: - AttendancePeriodPreset
+
+/// 출석 현황 기간 필터 프리셋
+///
+/// - SeeAlso: ``AttendanceListViewModel``
+enum AttendancePeriodPreset: String, CaseIterable, Identifiable {
+    case oneWeek     = "oneWeek"
+    case oneMonth    = "oneMonth"
+    case threeMonths = "threeMonths"
+    case custom      = "custom"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .oneWeek:     return "최근 1주"
+        case .oneMonth:    return "최근 1개월"
+        case .threeMonths: return "최근 3개월"
+        case .custom:      return "직접 입력"
+        }
+    }
+
+    // MARK: - Date Range
+
+    /// 프리셋에 해당하는 `(fromDate, toDate)` 쌍을 반환합니다.
+    ///
+    /// - `.custom` 은 날짜를 직접 지정하므로 `nil` 반환.
+    /// - `toDate` 는 조회 시점 기준 +24시간으로 고정하여 진행 중인 일정도 포함합니다.
+    var dateRange: (fromDate: Date, toDate: Date)? {
+        guard self != .custom else { return nil }
+        let now = Date()
+        let toDate = now.addingTimeInterval(24 * 60 * 60)
+        let fromDate: Date
+        switch self {
+        case .oneWeek:
+            fromDate = Calendar.kstGregorian.date(
+                byAdding: .day, value: -7, to: now
+            ) ?? now.addingTimeInterval(-7 * 24 * 60 * 60)
+        case .oneMonth:
+            fromDate = Calendar.kstGregorian.date(
+                byAdding: .month, value: -1, to: now
+            ) ?? now.addingTimeInterval(-30 * 24 * 60 * 60)
+        case .threeMonths:
+            fromDate = Calendar.kstGregorian.date(
+                byAdding: .month, value: -3, to: now
+            ) ?? now.addingTimeInterval(-90 * 24 * 60 * 60)
+        case .custom:
+            return nil
+        }
+        return (fromDate, toDate)
+    }
+}

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/AttendanceListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/AttendanceListViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// 운영진 출석 현황 목록 화면 ViewModel (Schedule V2)
 ///
-/// `GET /api/v2/schedules/attendance` 호출 결과를 상태별로 필터링해 표시합니다.
+/// `GET /api/v2/schedules/attendance` 호출 결과를 상태별/기간별로 필터링해 표시합니다.
 /// 직책별 조회 범위는 서버에서 자동 분기되므로 클라이언트는 권한 분기 없이 호출만 합니다.
 ///
 /// ## 권한 분기 (AC-E1)
@@ -29,11 +29,28 @@ final class AttendanceListViewModel {
     /// 출석 현황 로드 상태
     private(set) var listState: Loadable<[ScheduleAttendanceInfo]> = .idle
 
-    /// 현재 선택된 필터 (`nil` = 전체)
+    /// 현재 선택된 상태 필터 (`nil` = 전체)
     private(set) var selectedFilter: AttendanceStatusV2?
 
-    /// 필터 칩에 표시할 후보 (필터 가능 케이스 = `unknown` 제외)
+    /// 필터 칩에 표시할 후보 (`.unknown` 제외 — AC#7)
     let filterableStatuses: [AttendanceStatusV2] = AttendanceStatusV2.filterableCases
+
+    // MARK: - Period Filter (AC#7)
+
+    /// 기간 필터 펼침/접힘 상태
+    var isFilterExpanded: Bool = false
+
+    /// 선택된 기간 프리셋 (기본값: 최근 1개월)
+    private(set) var periodPreset: AttendancePeriodPreset = .oneMonth
+
+    /// 조회 시작 일시
+    var fromDate: Date = {
+        Calendar.kstGregorian.date(byAdding: .month, value: -1, to: Date())
+            ?? Date().addingTimeInterval(-30 * 24 * 60 * 60)
+    }()
+
+    /// 조회 종료 일시 (기본값: 현재 +24시간, 진행 중 일정 포함)
+    var toDate: Date = Date().addingTimeInterval(24 * 60 * 60)
 
     // MARK: - Init
 
@@ -51,14 +68,14 @@ final class AttendanceListViewModel {
 
     /// 출석 현황 목록 조회
     ///
-    /// `from`/`to` 미지정 → 서버 기본값(요청 시점 -1개월 ~ +24시간) 적용.
+    /// `fromDate`/`toDate` 를 파라미터로 전달합니다.
     @MainActor
     func fetch() async {
         listState = .loading
         do {
             let list = try await useCase.fetchAttendanceList(
-                from: nil,
-                to: nil,
+                from: fromDate,
+                to: toDate,
                 attendanceStatus: selectedFilter
             )
             listState = .loaded(list)
@@ -76,7 +93,7 @@ final class AttendanceListViewModel {
         }
     }
 
-    /// 필터 칩 탭
+    /// 상태 필터 칩 탭
     ///
     /// 같은 필터를 다시 누르면 해제 (전체 보기). 변경 즉시 재조회.
     @MainActor
@@ -85,6 +102,20 @@ final class AttendanceListViewModel {
             selectedFilter = nil
         } else {
             selectedFilter = status
+        }
+        await fetch()
+    }
+
+    /// 기간 프리셋 선택
+    ///
+    /// `.custom` 선택 시에는 `fromDate`/`toDate` 를 현재 값으로 유지하며
+    /// 사용자가 DatePicker 로 직접 조정합니다.
+    @MainActor
+    func presetSelected(_ preset: AttendancePeriodPreset) async {
+        periodPreset = preset
+        if let range = preset.dateRange {
+            fromDate = range.fromDate
+            toDate = range.toDate
         }
         await fetch()
     }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// 운영진 출석 현황 목록 화면 (Schedule V2 #658)
 ///
 /// `GET /api/v2/schedules/attendance` 의 응답을 카드 리스트로 표시하고,
-/// 상태 필터 칩을 통해 클라이언트가 서버 측 필터링을 트리거합니다.
+/// 상태 필터 칩 + 기간 필터(AC#7)를 통해 서버 측 필터링을 트리거합니다.
 ///
 /// 행 탭 시 `Activity.attendanceDetail(scheduleId:)` 로 stack push.
 struct AttendanceListView: View {
@@ -41,6 +41,11 @@ struct AttendanceListView: View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
             filterChipRow
 
+            if viewModel.isFilterExpanded {
+                periodFilterExpandedRow
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+
             switch viewModel.listState {
             case .idle, .loading:
                 loadingView
@@ -54,6 +59,7 @@ struct AttendanceListView: View {
                 errorView(error: error)
             }
         }
+        .animation(.easeInOut(duration: 0.2), value: viewModel.isFilterExpanded)
         .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
         .padding(.top, DefaultConstant.defaultSafeTop)
         .navigationTitle("출석 현황")
@@ -86,9 +92,80 @@ struct AttendanceListView: View {
                         Task { await viewModel.filterButtonTapped(status) }
                     }
                     .buttonSize(.small)
+                    .accessibilityAddTraits(viewModel.selectedFilter == status ? .isSelected : [])
                 }
+
+                periodFilterToggleButton
             }
         }
+    }
+
+    private var periodFilterToggleButton: some View {
+        ChipButton(
+            viewModel.periodPreset.label,
+            isSelected: viewModel.isFilterExpanded,
+            trailingIcon: true,
+            action: { viewModel.isFilterExpanded.toggle() }
+        )
+        .buttonSize(.small)
+        .accessibilityLabel("기간 필터")
+        .accessibilityHint(viewModel.isFilterExpanded ? "필터 접기" : "필터 펼치기")
+    }
+
+    private var periodFilterExpandedRow: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    ForEach(AttendancePeriodPreset.allCases) { preset in
+                        ChipButton(
+                            preset.label,
+                            isSelected: viewModel.periodPreset == preset
+                        ) {
+                            Task { await viewModel.presetSelected(preset) }
+                        }
+                        .buttonSize(.small)
+                        .accessibilityAddTraits(viewModel.periodPreset == preset ? .isSelected : [])
+                    }
+                }
+            }
+
+            if viewModel.periodPreset == .custom {
+                customDatePickerRow
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .animation(.easeInOut(duration: 0.2), value: viewModel.periodPreset == .custom)
+            }
+        }
+    }
+
+    private var customDatePickerRow: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            DatePicker(
+                "시작",
+                selection: $viewModel.fromDate,
+                displayedComponents: .date
+            )
+            .datePickerStyle(.compact)
+            .font(.app(.footnote))
+            .onChange(of: viewModel.fromDate) {
+                if viewModel.toDate < viewModel.fromDate {
+                    viewModel.toDate = viewModel.fromDate.addingTimeInterval(24 * 60 * 60)
+                }
+                Task { await viewModel.fetch() }
+            }
+
+            DatePicker(
+                "종료",
+                selection: $viewModel.toDate,
+                in: viewModel.fromDate...,
+                displayedComponents: .date
+            )
+            .datePickerStyle(.compact)
+            .font(.app(.footnote))
+            .onChange(of: viewModel.toDate) {
+                Task { await viewModel.fetch() }
+            }
+        }
+        .padding(.horizontal, DefaultSpacing.spacing4)
     }
 
     private var loadingView: some View {
@@ -230,18 +307,27 @@ private struct AttendanceListRow: View, Equatable {
     }
 
     private var dateRangeText: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "M월 d일 (E) HH:mm"
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-        let start = formatter.string(from: info.startsAt)
-
-        let endFormatter = DateFormatter()
-        endFormatter.dateFormat = "HH:mm"
-        endFormatter.locale = Locale(identifier: "ko_KR")
-        endFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-        let end = endFormatter.string(from: info.endsAt)
-
+        guard info.startsAt <= info.endsAt else {
+            return AttendanceListRow.kstDetailFormatter.string(from: info.startsAt)
+        }
+        let start = AttendanceListRow.kstDetailFormatter.string(from: info.startsAt)
+        let end = AttendanceListRow.kstHourMinuteFormatter.string(from: info.endsAt)
         return "\(start) ~ \(end)"
     }
+
+    private static let kstDetailFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "M월 d일 (E) HH:mm"
+        f.locale = Locale(identifier: "ko_KR")
+        f.timeZone = .kst
+        return f
+    }()
+
+    private static let kstHourMinuteFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        f.locale = Locale(identifier: "ko_KR")
+        f.timeZone = .kst
+        return f
+    }()
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
@@ -15,6 +15,7 @@ struct OperatorAttendanceSectionView: View {
 
     // MARK: - Property
 
+    @Environment(NavigationRouter.self) private var router
     @State private var viewModel: OperatorAttendanceViewModel
     @State private var selectedPendingSessionId: UUID?
     @Environment(\.scenePhase) private var scenePhase
@@ -169,6 +170,8 @@ struct OperatorAttendanceSectionView: View {
     private func sessionListView(
         sessions: [OperatorSessionAttendance]) -> some View {
         LazyVStack(spacing: DefaultSpacing.spacing16) {
+            attendanceListEntryButton
+
             ForEach(sessions) { sessionAttendance in
                 OperatorSessionCard(
                     sessionAttendance: sessionAttendance,
@@ -178,6 +181,49 @@ struct OperatorAttendanceSectionView: View {
             }
         }
         .padding(.top, DefaultSpacing.spacing16)
+    }
+
+    // MARK: - Attendance List Entry Button
+
+    private var attendanceListEntryButton: some View {
+        Button {
+            router.push(to: .activity(.attendanceList))
+        } label: {
+            HStack(spacing: DefaultSpacing.spacing12) {
+                Image(systemName: "checklist")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.indigo500)
+
+                VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                    Text("출석 현황 목록")
+                        .appFont(.calloutEmphasis)
+                    Text("일정별 출석률과 참여자 상태를 확인합니다")
+                        .appFont(.footnote, color: .grey500)
+                }
+
+                Spacer()
+
+                InfoBadge(
+                    "운영진 전용",
+                    textColor: .indigo500,
+                    tintColor: .indigo,
+                    glassVariant: .clear
+                )
+            }
+            .padding(DefaultSpacing.spacing16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .glassEffect(
+                .regular.interactive(),
+                in: ConcentricRectangle(
+                    corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                    isUniform: true
+                )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("출석 현황 목록")
+        .accessibilityHint("일정별 출석률과 참여자 상태를 확인합니다")
+        .accessibilityAddTraits(.isButton)
     }
 
     // MARK: - Action Factories

--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift
@@ -1,0 +1,175 @@
+//
+//  AttendancePolicyDisplaySection.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import SwiftUI
+
+// MARK: - AttendancePolicyDisplaySection
+
+/// 일정 상세 화면에서 출석 정책 시각을 read-only 로 표시하는 섹션 컴포넌트
+///
+/// - 체크인 시작(`checkInStartAt`), 정시 종료(`onTimeEndAt`), 결석 시작(`lateEndAt`) 3개 행을
+///   `Divider()` 로 구분하여 세로 카드로 배치합니다.
+/// - 비대면 / 출석 비필수 일정은 `AttendancePolicy` 자체가 `nil` 이므로 호출 측에서 노출을 제어합니다.
+/// - Container-Presenter 패턴(`Equatable`)으로 불필요한 리렌더링을 방지합니다.
+struct AttendancePolicyDisplaySection: View, Equatable {
+
+    // MARK: - Property
+
+    let policy: AttendancePolicy
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.policy == rhs.policy
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text("출석 정책")
+                .appFont(.title2Emphasis, color: .black)
+
+            policyCard
+        }
+    }
+
+    // MARK: - Card
+
+    private var policyCard: some View {
+        VStack(spacing: .zero) {
+            policyRow(
+                iconName: "door.right.hand.open",
+                label: "체크인 시작",
+                tintColor: .green,
+                date: policy.checkInStartAt
+            )
+            .accessibilityLabel(accessibilityLabel(for: "체크인 시작", date: policy.checkInStartAt))
+
+            Divider()
+
+            policyRow(
+                iconName: "clock.badge.checkmark",
+                label: "정시 종료",
+                tintColor: .orange,
+                date: policy.onTimeEndAt
+            )
+            .accessibilityLabel(accessibilityLabel(for: "정시 종료", date: policy.onTimeEndAt))
+
+            Divider()
+
+            policyRow(
+                iconName: "xmark.circle",
+                label: "결석 시작",
+                tintColor: .red,
+                date: policy.lateEndAt
+            )
+            .accessibilityLabel(accessibilityLabel(for: "결석 시작", date: policy.lateEndAt))
+        }
+        .background {
+            ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+            .fill(Color.white)
+            .glass()
+        }
+    }
+
+    // MARK: - Row
+
+    private func policyRow(
+        iconName: String,
+        label: String,
+        tintColor: Color,
+        date: Date
+    ) -> some View {
+        HStack(spacing: DefaultSpacing.spacing16) {
+            policyIcon(systemName: iconName, tintColor: tintColor)
+
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                Text(AttendancePolicyDisplaySection.kstTimeText(for: date, anchor: policy.checkInStartAt))
+                    .appFont(.calloutEmphasis)
+                    .foregroundStyle(.black)
+
+                Text(label)
+                    .appFont(.footnote)
+                    .foregroundStyle(.grey500)
+            }
+
+            Spacer()
+        }
+        .padding(DefaultSpacing.spacing16)
+    }
+
+    private func policyIcon(systemName: String, tintColor: Color) -> some View {
+        Image(systemName: systemName)
+            .foregroundStyle(tintColor)
+            .font(.system(size: 16))
+            .padding()
+            .background(tintColor.opacity(0.4), in: .circle)
+            .glassEffect(.clear, in: .circle)
+    }
+
+    // MARK: - Helper
+
+    /// 정책 시각을 KST 기준으로 표시합니다.
+    ///
+    /// 같은 날이면 `"HH:mm"`, 다른 날(자정을 넘는 정책 등)이면 `"M/d HH:mm"`.
+    private static func kstTimeText(for date: Date, anchor: Date) -> String {
+        if Calendar.kstGregorian.isDate(date, inSameDayAs: anchor) {
+            return Self.kstHourMinuteFormatter.string(from: date)
+        }
+        return Self.kstDateTimeFormatter.string(from: date)
+    }
+
+    private func accessibilityLabel(for role: String, date: Date) -> String {
+        let timeStr = AttendancePolicyDisplaySection.kstAccessibilityFormatter.string(from: date)
+        return "\(role): \(timeStr)"
+    }
+
+    // MARK: - Formatters
+
+    private static let kstHourMinuteFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.timeZone = .kst
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+
+    private static let kstDateTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.timeZone = .kst
+        f.dateFormat = "M/d HH:mm"
+        return f
+    }()
+
+    private static let kstAccessibilityFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.timeZone = .kst
+        f.dateFormat = "HH시 mm분"
+        return f
+    }()
+}
+
+// MARK: - Preview
+
+#Preview {
+    let now = Date()
+    let policy = AttendancePolicy(
+        checkInStartAt: now.addingTimeInterval(-3600),
+        onTimeEndAt: now.addingTimeInterval(0),
+        lateEndAt: now.addingTimeInterval(1800)
+    )
+    return ScrollView {
+        AttendancePolicyDisplaySection(policy: policy)
+            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+}

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
@@ -36,6 +36,12 @@ class ScheduleDetailViewModel {
     /// 일정 삭제 진행 중 여부
     var isDeleting: Bool = false
 
+    /// 일정이 이미 시작되었는지 여부 (상세 화면 수정 버튼 사전 차단용)
+    var isScheduleStarted: Bool {
+        guard case .loaded(let data) = self.data else { return false }
+        return Date() >= data.startsAt
+    }
+
     // MARK: - Init
     init(scheduleId: Int) {
         self.scheduleId = scheduleId

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -75,6 +75,9 @@ class ScheduleRegistrationViewModel {
     /// 인라인 에러 메시지 (예: 시작된 일정 수정 차단 SCHEDULE-0028)
     private(set) var inlineErrorMessage: String?
 
+    /// 파괴적 작업 확인 다이얼로그 상태
+    var alertPrompt: AlertPrompt?
+
     // MARK: - Attendance Policy
 
     /// 일정 생성/수정 권한 조회 상태
@@ -369,12 +372,36 @@ class ScheduleRegistrationViewModel {
         isAttendancePolicyDirty = true
     }
 
-    /// 출석 필수 토글 변경 시 dirty 플래그를 리셋하고 즉시 prefill 합니다.
+    /// 출석 필수 토글 변경 진입점.
+    ///
+    /// 수정 모드에서 기존에 출석이 필수였던 일정을 OFF 로 전환할 때만
+    /// destructive AlertPrompt 를 띄워 사용자의 의도를 재확인합니다.
+    /// 그 외 경우(생성 모드, 단순 ON, 기존 OFF → ON 등)는 즉시 반영합니다.
+    @MainActor
+    func attendanceToggleChanged(to newValue: Bool) {
+        if !newValue, initialIsAttendanceRequired {
+            alertPrompt = AlertPrompt(
+                title: "출석 데이터 삭제",
+                message: "출석 필수를 해제하면 기존 출석 데이터가 삭제됩니다. 계속하시겠습니까?",
+                positiveBtnTitle: "해제",
+                positiveBtnAction: { [weak self] in
+                    self?.applyAttendanceToggle(to: false)
+                },
+                negativeBtnTitle: "취소",
+                isPositiveBtnDestructive: true
+            )
+            return
+        }
+        applyAttendanceToggle(to: newValue)
+    }
+
+    /// 출석 필수 토글을 실제 적용합니다.
     ///
     /// OFF -> ON 전환은 사용자가 새로 정책을 부여하려는 명확한 의도이므로
     /// 이전 dirty 상태를 무효화하고 일정 시각 기준 기본값으로 채웁니다.
     @MainActor
-    func attendanceToggleChanged(to newValue: Bool) {
+    func applyAttendanceToggle(to newValue: Bool) {
+        isAttendanceRequired = newValue
         if newValue {
             isAttendancePolicyDirty = false
             prefillAttendancePolicyIfNeeded()
@@ -554,6 +581,21 @@ class ScheduleRegistrationViewModel {
             memberIds.append(myMemberId)
         }
         return memberIds
+    }
+
+    /// 대면/비대면 토글 변경 시 호출합니다.
+    ///
+    /// - Parameter isInPerson: `true` 이면 대면(`isOnline = false`), `false` 이면 비대면(`isOnline = true`).
+    ///   비대면으로 전환할 때는 `place` 를 빈 값으로 초기화합니다.
+    func inPersonModeToggleChanged(to isInPerson: Bool) {
+        isOnline = !isInPerson
+        if !isInPerson {
+            place = PlaceSearchInfo(
+                name: "",
+                address: "",
+                coordinate: Coordinate(latitude: 0.0, longitude: 0.0)
+            )
+        }
     }
 
     /// 송신용 location DTO — 비대면이면 `nil`, 그 외엔 현재 장소 좌표

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
@@ -118,6 +118,13 @@ struct ScheduleDetailView: View {
                     }) {
                         Image(systemName: "pencil")
                     }
+                    .disabled(viewModel.isScheduleStarted)
+                    .accessibilityLabel(
+                        viewModel.isScheduleStarted ? "일정 수정 불가" : "일정 수정"
+                    )
+                    .accessibilityHint(
+                        viewModel.isScheduleStarted ? "이미 시작된 일정은 수정할 수 없습니다" : ""
+                    )
                 }
 
                 if viewModel.canDeleteSchedule {
@@ -222,6 +229,10 @@ struct ScheduleDetailView: View {
         ScrollView(content: {
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing24, content: {
                 topContent(data)
+                if let policy = data.attendancePolicy {
+                    AttendancePolicyDisplaySection(policy: policy)
+                        .equatable()
+                }
                 detailDescription(data)
             })
         })
@@ -246,6 +257,14 @@ struct ScheduleDetailView: View {
                 }
             )
             .equatable()
+
+            if viewModel.isScheduleStarted {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Image(systemName: "lock.fill")
+                    Text("이미 시작된 일정은 수정할 수 없습니다")
+                }
+                .appFont(.caption1, color: .grey500)
+            }
         })
     }
 
@@ -365,22 +384,16 @@ private struct SchedulePlaceDateInfo: View, Equatable {
     }
 
     private var dateText: String {
-        if Calendar.current.isDate(data.startsAt, inSameDayAs: data.endsAt) {
+        guard data.startsAt <= data.endsAt else {
             return data.startsAt.toYearMonthDayWithWeekday()
         }
-
-        return "\(data.startsAt.toYearMonthDayWithWeekday()) - \(data.endsAt.toYearMonthDayWithWeekday())"
+        return (data.startsAt...data.endsAt).scheduleDateRangeText
     }
 
     private var timeText: String {
-        if data.isAllDay {
-            return "종일"
+        guard data.startsAt <= data.endsAt else {
+            return data.startsAt.toHourMinutes()
         }
-
-        if Calendar.current.isDate(data.startsAt, inSameDayAs: data.endsAt) {
-            return data.startsAt.timeRange(to: data.endsAt)
-        }
-
-        return "\(data.startsAt.toMonthDayWeekDayWithTime()) - \(data.endsAt.toMonthDayWeekDayWithTime())"
+        return (data.startsAt...data.endsAt).scheduleTimeRangeText
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -97,12 +97,33 @@ struct ScheduleRegistrationView: View {
     private var formContent: some View {
         Form {
             inlineErrorSection
-            section(.title, .place)
+            section(.title)
+            placeSection
             section(.allDay, .date)
             AttendancePolicySection(viewModel: viewModel)
             section(.participation)
             section(.tag)
             section(.memo)
+        }
+        .alertPrompt(item: $viewModel.alertPrompt)
+    }
+
+    /// 대면/비대면 토글과 장소 선택을 묶은 섹션입니다.
+    private var placeSection: some View {
+        Section {
+            InPersonToggle(
+                isInPerson: Binding(
+                    get: { !viewModel.isOnline },
+                    set: { viewModel.inPersonModeToggleChanged(to: $0) }
+                )
+            )
+
+            if !viewModel.isOnline {
+                PlaceSelectView(place: $viewModel.place)
+            } else {
+                Text("비대면 일정은 장소가 자동으로 비워집니다")
+                    .appFont(.footnote, color: .grey500)
+            }
         }
     }
 
@@ -312,7 +333,13 @@ struct ScheduleRegistrationView: View {
             Memo(memo: $viewModel.memo)
                 .equatable()
         case .participation:
-            ParticipantSection(challenger: $viewModel.participatn)
+            ParticipantSection(
+                challenger: $viewModel.participatn,
+                maxParticipantCount: {
+                    guard case .loaded(let caps) = viewModel.capabilitiesState else { return nil }
+                    return caps.maxParticipantCount
+                }()
+            )
         case .tag:
             TagSection(
                 tag: Binding(
@@ -351,6 +378,28 @@ fileprivate struct TitleView: View, Equatable {
         Text(ScheduleGenerationType.title.placeholder ?? "")
             .font(ScheduleGenerationType.title.placeholderFont)
             .foregroundStyle(ScheduleGenerationType.title.placeholderColor)
+    }
+}
+
+// MARK: - In-Person Toggle
+
+/// "대면 일정" 설정 토글 뷰
+///
+/// `isInPerson == true` 이면 대면(장소 입력 필수), `false` 이면 비대면.
+/// ViewModel의 `isOnline` 과 의미가 반전되어 있으므로 inverse binding 으로 연결합니다.
+fileprivate struct InPersonToggle: View, Equatable {
+    @Binding var isInPerson: Bool
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.isInPerson == rhs.isInPerson
+    }
+
+    var body: some View {
+        Toggle(isOn: $isInPerson) {
+            Text("대면 일정")
+                .appFont(.body, color: .black)
+        }
+        .tint(.indigo500)
     }
 }
 
@@ -574,48 +623,66 @@ fileprivate struct TagSection: View {
 
 /// 참여자(챌린저) 선택 및 관리 섹션
 fileprivate struct ParticipantSection: View {
-    
+
     /// 선택된 참여자 리스트 바인딩
     @Binding var challenger: [ChallengerInfo]
-    
+
+    /// 최대 초대 가능 인원 (`nil` = 제한 없음)
+    let maxParticipantCount: Int?
+
     /// 참여자 선택 시트 표시 여부
     @State private var showParticipantSheet: Bool = false
-    
+
     private enum Constants {
         static let challengerText: String = "초대받은 챌린저"
         static let chevronImage: String = "chevron.right"
     }
-    
+
+    private var isAtCapacity: Bool {
+        guard let max = maxParticipantCount else { return false }
+        return challenger.count >= max
+    }
+
     var body: some View {
-        Button {
-            showParticipantSheet.toggle()
-        } label: {
-            HStack {
-                Text(Constants.challengerText)
-                    .foregroundStyle(.black)
-                Spacer()
-                participant
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+            Button {
+                showParticipantSheet.toggle()
+            } label: {
+                HStack {
+                    Text(Constants.challengerText)
+                        .foregroundStyle(.black)
+                    Spacer()
+                    participant
+                }
+            }
+            .disabled(isAtCapacity)
+            .sheet(isPresented: $showParticipantSheet) {
+                SelectedChallengerView(challenger: $challenger)
+                    .interactiveDismissDisabled()
+            }
+
+            if let max = maxParticipantCount, isAtCapacity {
+                Text("최대 \(max)명까지 추가할 수 있습니다")
+                    .appFont(.caption1, color: .grey500)
             }
         }
-        .sheet(isPresented: $showParticipantSheet) {
-            SelectedChallengerView(challenger: $challenger)
-                .interactiveDismissDisabled()
-        }
     }
-    
-    /// 선택된 참여자 수 표시
+
+    /// 선택된 참여자 수 (및 상한 도달 시 카운터) 표시
     private var participant: some View {
-        HStack(spacing: DefaultSpacing.spacing8, content: {
-            if !challenger.isEmpty {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            if let max = maxParticipantCount {
+                Text("\(challenger.count) / \(max)")
+                    .appFont(.footnote, color: isAtCapacity ? .red : .grey600)
+            } else if !challenger.isEmpty {
                 Text("\(challenger.count)명")
                     .appFont(.callout, color: .grey500)
             }
-            
+
             Image(systemName: Constants.chevronImage)
-                .foregroundStyle(.grey500)
-        })
+                .foregroundStyle(isAtCapacity ? Color.grey400 : Color.grey500)
+        }
     }
-    
 }
 
 // MARK: - Keyboard Dismiss On Picker Toggle

--- a/AppProduct/AppProduct/Utilities/Extensions/Date+ScheduleDisplay.swift
+++ b/AppProduct/AppProduct/Utilities/Extensions/Date+ScheduleDisplay.swift
@@ -1,0 +1,70 @@
+//
+//  Date+ScheduleDisplay.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/7/26.
+//
+
+import Foundation
+
+// MARK: - ClosedRange<Date> (일정 표시 헬퍼)
+
+extension ClosedRange where Bound == Date {
+
+    /// 일정 시간 범위 표시용 텍스트 (KST)
+    ///
+    /// - 하루종일(`isAllDayInKST`)이면 `"하루종일"` 반환
+    /// - 그 외에는 `"HH:mm ~ HH:mm"` (KST 24시간제)
+    ///
+    /// 기존 `Date.timeRange(to:)` 가 시스템 시간대를 사용하는 것과 달리,
+    /// 이 헬퍼는 `Asia/Seoul` (KST) 를 고정으로 적용합니다.
+    var scheduleTimeRangeText: String {
+        if isAllDayInKST {
+            return "하루종일"
+        }
+        let formatter = ClosedRange.kstHourMinuteFormatter
+        return "\(formatter.string(from: lowerBound)) ~ \(formatter.string(from: upperBound))"
+    }
+
+    /// 일정 날짜 범위 표시용 텍스트 (KST)
+    ///
+    /// - 시작·끝이 KST 기준 **같은 날**이면 `"yyyy.MM.dd (E)"` (예: `"2025.12.08 (일)"`)
+    /// - 다른 날이면 `"M/d ~ M/d"` (예: `"12/8 ~ 12/9"`)
+    var scheduleDateRangeText: String {
+        let calendar = Calendar.kstGregorian
+        if calendar.isDate(lowerBound, inSameDayAs: upperBound) {
+            return ClosedRange.kstYearMonthDayWeekdayFormatter.string(from: lowerBound)
+        }
+        let shortFormatter = ClosedRange.kstMonthDayFormatter
+        return "\(shortFormatter.string(from: lowerBound)) ~ \(shortFormatter.string(from: upperBound))"
+    }
+}
+
+// MARK: - Formatters (private)
+
+private extension ClosedRange where Bound == Date {
+
+    static let kstHourMinuteFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.timeZone = .kst
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+
+    static let kstYearMonthDayWeekdayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.timeZone = .kst
+        f.dateFormat = "yyyy.MM.dd (E)"
+        return f
+    }()
+
+    static let kstMonthDayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.timeZone = .kst
+        f.dateFormat = "M/d"
+        return f
+    }()
+}


### PR DESCRIPTION
## ✨ PR 유형

`💄 [Design]` — Schedule V2 마이그레이션(#654/#655/#656/#657/#658) 후속 디자인/UX 개선. 8개 AC 를 단일 PR 에 Phase A → B → C 순으로 처리.

`Closes #659`

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 출석 정책 표시 / 대면 토글 / destructive Alert / 시작된 일정 disabled / 기간 필터 펼침 / 운영진 진입 버튼 GIF 첨부 예정 -->

## 🛠️ 작업내용

### Phase A — 디스플레이 통일 (회귀 위험 낮음)
- `AttendanceStatusBadge.unknown` 뱃지 텍스트 `"알 수 없음"` 분리 + 접근성 라벨 명시
- `Date+ScheduleDisplay` 헬퍼 신설 — `ClosedRange<Date>.scheduleTimeRangeText` / `scheduleDateRangeText` 로 KST 하루종일 / 시간 표시 통일
- 일정 상세에 `AttendancePolicyDisplaySection` 추가 (체크인 시작 / 정시 종료 / 결석 시작 3행, 초록·주황·빨강 아이콘)

### Phase B — 등록/수정 토글 + 가드 (입력 흐름 변경)
- "대면 일정" 명시 Toggle 추가 (`isOnline` inverse binding) — OFF 시 장소 자동 클리어
- 출석 필수 ON→OFF 전환 시 destructive `AlertPrompt` 인터셉트 ("기존 출석 데이터가 삭제됩니다")
- 시작된 일정 → 수정 버튼 사전 `.disabled` + `lock.fill` 인라인 hint + 접근성 라벨

### Phase C — 운영진 분기 (Capabilities 의존)
- 출석 현황 기간 필터 (펼치기 토글 + 프리셋 4종: 1주 / 1개월 / 3개월 / 직접 입력)
- 상태 chip 필터에서 `.unknown` 제외 (badge / data 에서는 사용 유지)
- `OperatorAttendanceSectionView` 세션 목록 상단에 "출석 현황 목록" 진입 버튼 + `"운영진 전용"` `InfoBadge`
- `maxParticipantCount` 카운트 노출 (`현재 / 최대`) + 상한 도달 시 참여자 추가 버튼 `.disabled` + 인라인 hint

## 📋 추후 진행 상황

- 일정 카드(`ScheduleListCard`) `AttendanceStatusBadge` 노출 → `ScheduleDetailData.attendanceStatus` 가 V1 enum 사용 중이라 별도 마이그레이션 이슈로 분리
- UMCApp(Tuist) 마이그레이션 — Schedule V2 전체를 한 번에 옮기는 별도 이슈
- `AttendanceStatusV2` enum 신규 케이스 — 백엔드 컨펌 후 별도
- 사유결석 입력 UI — 별도 이슈

## 📌 리뷰 포인트

- `Features/Home/Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift` — read-only 정책 섹션 (Container-Presenter + Equatable, `.glassEffect(.regular)`)
- `Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift` — 시작된 일정 수정 버튼 disabled 분기 + lock.fill hint row 위치
- `Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift` — `isOnline` inverse binding 패턴 + 출석 필수 ON→OFF destructive `AlertPrompt`
- `Features/Activity/Presentation/Enum/AttendancePeriodPreset.swift` — 프리셋 4종 + 기본값 (`-30d ~ +24h`) 정의
- `Features/Activity/Presentation/Views/Operation/AttendanceListView.swift` — 펼치기 토글 애니메이션 + `.compact` DatePicker 노출 조건
- `Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift` — 진입 버튼 위치 (`sessionListView` LazyVStack 최상단) + `InfoBadge`
- `Utilities/Extensions/Date+ScheduleDisplay.swift` — KST 하루종일 / 시간 분기 헬퍼 (사용처 통일)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)