### PR TITLE
♻️ [Refactor] Session 모델 + Attendance 잔여 모델 ActivityDomain 이관

### DIFF
--- a/UMCApp/Core/DesignSystem/Project.swift
+++ b/UMCApp/Core/DesignSystem/Project.swift
@@ -4,9 +4,7 @@ import ProjectDescriptionHelpers
 let project = coreProject(
     name: "CoreDesignSystem",
     bundleIdSuffix: "designsystem",
-    dependencies: [
-        .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-    ],
+    dependencies: [],
     resources: [
         "Resources/Fonts/**",
         "Resources/Colors.xcassets",

--- a/UMCApp/Core/DesignSystem/Project.swift
+++ b/UMCApp/Core/DesignSystem/Project.swift
@@ -4,6 +4,9 @@ import ProjectDescriptionHelpers
 let project = coreProject(
     name: "CoreDesignSystem",
     bundleIdSuffix: "designsystem",
+    dependencies: [
+        .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+    ],
     resources: [
         "Resources/Fonts/**",
         "Resources/Colors.xcassets",

--- a/UMCApp/Core/DesignSystem/Sources/Extensions/ScheduleIconCategory+Visual.swift
+++ b/UMCApp/Core/DesignSystem/Sources/Extensions/ScheduleIconCategory+Visual.swift
@@ -1,0 +1,56 @@
+//
+//  ScheduleIconCategory+Visual.swift
+//  CoreDesignSystem
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import SwiftUI
+import UMCFoundation
+
+/// `ScheduleIconCategory` 에 대한 시각 표현(SF Symbol, 테마 색상) 매핑.
+///
+/// raw 값 매핑은 `UMCFoundation` 의 enum 정의에 위치하고,
+/// SwiftUI 의존이 필요한 시각 토큰만 본 모듈에 분리합니다.
+public extension ScheduleIconCategory {
+
+    /// 카테고리별 시스템 심볼 이미지 이름
+    var symbol: String {
+        switch self {
+        case .leadership:   return "person.3.sequence.fill"
+        case .study:        return "book.closed.fill"
+        case .fee:          return "wonsign.circle.fill"
+        case .meeting:      return "person.2.fill"
+        case .networking:   return "bubble.left.and.bubble.right.fill"
+        case .hackathon:    return "laptopcomputer"
+        case .project:      return "hammer.fill"
+        case .presentation: return "mic.fill"
+        case .workshop:     return "tent.fill"
+        case .review:       return "lightbulb.fill"
+        case .celebration:  return "sparkles"
+        case .orientation:  return "megaphone.fill"
+        case .testing:      return "chevron.left.forwardslash.chevron.right"
+        case .general:      return "calendar.badge"
+        }
+    }
+
+    /// 카테고리별 테마 색상
+    var color: Color {
+        switch self {
+        case .leadership:   return .indigo
+        case .study:        return .blue
+        case .fee:          return .green
+        case .meeting:      return .cyan
+        case .networking:   return .teal
+        case .hackathon:    return .purple
+        case .project:      return .orange
+        case .presentation: return .red
+        case .workshop:     return .mint
+        case .review:       return .yellow
+        case .celebration:  return .accentColor
+        case .orientation:  return .orange
+        case .testing:      return .gray
+        case .general:      return .indigo500
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Project.swift
+++ b/UMCApp/Core/Foundation/Project.swift
@@ -5,6 +5,7 @@ let project = coreProject(
     name: "UMCFoundation",
     bundleIdSuffix: "foundation",
     destinations: [.iPhone, .appleWatch],
-    deploymentTargets: .multiplatform(iOS: "26.3", watchOS: "26.3")
+    deploymentTargets: .multiplatform(iOS: "26.3", watchOS: "26.3"),
+    includesTests: true
 )
 

--- a/UMCApp/Core/Foundation/Sources/Enums/ScheduleIconCategory.swift
+++ b/UMCApp/Core/Foundation/Sources/Enums/ScheduleIconCategory.swift
@@ -1,0 +1,73 @@
+//
+//  ScheduleIconCategory.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+
+/// 일정 카테고리 분류
+///
+/// 일정의 종류(스터디, 회의, 해커톤 등)를 정의합니다.
+/// 시각 매핑(SF Symbol, Color)은 `CoreDesignSystem`의 extension에서 제공합니다.
+public enum ScheduleIconCategory: String, Codable, CaseIterable, Sendable {
+    /// 리더십 관련 활동
+    case leadership = "LEADERSHIP"
+    /// 스터디 활동
+    case study = "STUDY"
+    /// 회비 관련
+    case fee = "DUES"
+    /// 회의 (운영진 회의 등)
+    case meeting = "MEETING"
+    /// 네트워킹 행사
+    case networking = "NETWORKING"
+    /// 해커톤 행사
+    case hackathon = "HACKATHON"
+    /// 프로젝트 활동
+    case project = "PROJECT"
+    /// 발표 관련 (데모데이 등)
+    case presentation = "PRESENTATION"
+    /// 워크샵 행사
+    case workshop = "WORKSHOP"
+    /// 회고 활동
+    case review = "RETROSPECTIVE"
+    /// 뒷풀이/축하 행사
+    case celebration = "AFTER_PARTY"
+    /// 오리엔테이션 (OT)
+    case orientation = "ORIENTATION"
+    /// 테스트/검증 일정
+    case testing = "TESTING"
+    /// 일반 일정
+    case general = "GENERAL"
+
+    /// 일정 등록 화면에서 노출할 카테고리 목록
+    public static var selectableCases: [ScheduleIconCategory] {
+        allCases.filter { $0 != .testing }
+    }
+
+    /// 더 이상 신규 입력에 사용하지 않는 레거시 카테고리 여부
+    public var isDeprecated: Bool {
+        self == .testing
+    }
+
+    /// 카테고리별 한글 명칭
+    public var korean: String {
+        switch self {
+        case .leadership:   return "리더십"
+        case .study:        return "스터디"
+        case .fee:          return "회비"
+        case .meeting:      return "회의"
+        case .networking:   return "네트워킹"
+        case .hackathon:    return "해커톤"
+        case .project:      return "프로젝트"
+        case .presentation: return "발표"
+        case .workshop:     return "워크샵"
+        case .review:       return "회고"
+        case .celebration:  return "뒷풀이"
+        case .orientation:  return "오리엔테이션"
+        case .testing:      return "테스트"
+        case .general:      return "일반"
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Extensions/ServerDateTimeConverter.swift
+++ b/UMCApp/Core/Foundation/Sources/Extensions/ServerDateTimeConverter.swift
@@ -1,0 +1,158 @@
+//
+//  ServerDateTimeConverter.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+
+/// 서버 응답의 UTC 기반 날짜/시간 문자열을 `Date`로 변환하거나 KST 표시 문자열로 포매팅하는 유틸리티.
+///
+/// - Note: 모든 정적 함수는 `nonisolated`이므로 액터 컨텍스트와 무관하게 호출 가능.
+public enum ServerDateTimeConverter {
+
+    // MARK: - TimeZone
+
+    public nonisolated static let utcTimeZone: TimeZone = .init(secondsFromGMT: 0) ?? .current
+    public nonisolated static let kstTimeZone: TimeZone = .init(identifier: "Asia/Seoul") ?? .current
+
+    // MARK: - Function
+
+    public nonisolated static func parseUTCDateTime(_ value: String) -> Date? {
+        guard !value.isEmpty else { return nil }
+
+        let formatterWithFraction = ISO8601DateFormatter()
+        formatterWithFraction.formatOptions = [
+            .withInternetDateTime,
+            .withFractionalSeconds
+        ]
+        if let date = formatterWithFraction.date(from: value) {
+            return date
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        if let date = formatter.date(from: value) {
+            return date
+        }
+
+        for format in [
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ",
+            "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+            "yyyy-MM-dd'T'HH:mm:ssZ",
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS",
+            "yyyy-MM-dd'T'HH:mm:ss.SSS",
+            "yyyy-MM-dd'T'HH:mm:ss"
+        ] {
+            let fallback = DateFormatter()
+            fallback.locale = Locale(identifier: "en_US_POSIX")
+            fallback.timeZone = utcTimeZone
+            fallback.dateFormat = format
+            if let date = fallback.date(from: value) {
+                return date
+            }
+        }
+
+        return nil
+    }
+
+    public nonisolated static func toUTCDateTimeString(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = utcTimeZone
+        formatter.formatOptions = [
+            .withInternetDateTime,
+            .withFractionalSeconds
+        ]
+        return formatter.string(from: date)
+    }
+
+    public nonisolated static func parseUTCDateTimeOrTime(
+        _ value: String,
+        utcDate: String? = nil
+    ) -> Date? {
+        if let date = parseUTCDateTime(value) {
+            return date
+        }
+        return parseUTCTime(value, utcDate: utcDate)
+    }
+
+    public nonisolated static func parseUTCTime(
+        _ value: String,
+        utcDate: String? = nil
+    ) -> Date? {
+        guard !value.isEmpty else { return nil }
+
+        let calendar = makeUTCCalendar()
+        let baseDate = parseUTCDate(utcDate ?? "") ?? Date()
+
+        for format in ["HH:mm:ss", "HH:mm"] {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = utcTimeZone
+            formatter.dateFormat = format
+
+            guard let time = formatter.date(from: value) else {
+                continue
+            }
+
+            var components = calendar.dateComponents(
+                [.year, .month, .day],
+                from: baseDate
+            )
+            let timeComponents = calendar.dateComponents(
+                [.hour, .minute, .second],
+                from: time
+            )
+            components.hour = timeComponents.hour
+            components.minute = timeComponents.minute
+            components.second = timeComponents.second
+
+            if let date = calendar.date(from: components) {
+                return date
+            }
+        }
+
+        return nil
+    }
+
+    public nonisolated static func parseUTCDate(_ value: String) -> Date? {
+        guard !value.isEmpty else { return nil }
+
+        for format in ["yyyy-MM-dd", "yyyy.MM.dd"] {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = utcTimeZone
+            formatter.dateFormat = format
+            if let date = formatter.date(from: value) {
+                return date
+            }
+        }
+
+        return nil
+    }
+
+    public nonisolated static func toKSTDateString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR_POSIX")
+        formatter.timeZone = kstTimeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    public nonisolated static func toKSTTimeString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR_POSIX")
+        formatter.timeZone = kstTimeZone
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
+    }
+
+    // MARK: - Private
+
+    nonisolated private static func makeUTCCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = utcTimeZone
+        return calendar
+    }
+}

--- a/UMCApp/Core/Foundation/Tests/ScheduleIconCategoryTests.swift
+++ b/UMCApp/Core/Foundation/Tests/ScheduleIconCategoryTests.swift
@@ -1,0 +1,115 @@
+//
+//  ScheduleIconCategoryTests.swift
+//  UMCFoundationTests
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+import Testing
+@testable import UMCFoundation
+
+@Suite("ScheduleIconCategory — 서버 rawValue 매핑 (도메인 규칙)")
+struct ScheduleIconCategoryTests {
+
+    // MARK: - Raw Value Mapping
+
+    @Test(
+        "rawValue ↔ enum 매핑이 정확하다",
+        arguments: [
+            ("LEADERSHIP",   ScheduleIconCategory.leadership),
+            ("STUDY",        .study),
+            ("DUES",         .fee),
+            ("MEETING",      .meeting),
+            ("NETWORKING",   .networking),
+            ("HACKATHON",    .hackathon),
+            ("PROJECT",      .project),
+            ("PRESENTATION", .presentation),
+            ("WORKSHOP",     .workshop),
+            ("RETROSPECTIVE", .review),
+            ("AFTER_PARTY",  .celebration),
+            ("ORIENTATION",  .orientation),
+            ("TESTING",      .testing),
+            ("GENERAL",      .general)
+        ]
+    )
+    func rawValueMapping(rawValue: String, expected: ScheduleIconCategory) {
+        let decoded = ScheduleIconCategory(rawValue: rawValue)
+
+        #expect(decoded == expected)
+        #expect(expected.rawValue == rawValue)
+    }
+
+    @Test("alllCases 는 14개를 포함한다")
+    func allCasesCount() {
+        #expect(ScheduleIconCategory.allCases.count == 14)
+    }
+
+    // MARK: - selectableCases
+
+    @Test("selectableCases 는 testing 을 제외한다")
+    func selectableExcludesTesting() {
+        let selectable = ScheduleIconCategory.selectableCases
+
+        #expect(selectable.contains(.testing) == false)
+        #expect(selectable.count == ScheduleIconCategory.allCases.count - 1)
+    }
+
+    // MARK: - isDeprecated
+
+    @Test("testing 카테고리는 isDeprecated=true")
+    func testingIsDeprecated() {
+        #expect(ScheduleIconCategory.testing.isDeprecated == true)
+    }
+
+    @Test("그 외 카테고리는 isDeprecated=false")
+    func othersAreNotDeprecated() {
+        for category in ScheduleIconCategory.allCases where category != .testing {
+            #expect(category.isDeprecated == false, "Expected \(category) to not be deprecated")
+        }
+    }
+
+    // MARK: - Korean
+
+    @Test(
+        "한글 명칭 매핑이 정확하다",
+        arguments: [
+            (ScheduleIconCategory.leadership, "리더십"),
+            (.study, "스터디"),
+            (.fee, "회비"),
+            (.meeting, "회의"),
+            (.networking, "네트워킹"),
+            (.hackathon, "해커톤"),
+            (.project, "프로젝트"),
+            (.presentation, "발표"),
+            (.workshop, "워크샵"),
+            (.review, "회고"),
+            (.celebration, "뒷풀이"),
+            (.orientation, "오리엔테이션"),
+            (.testing, "테스트"),
+            (.general, "일반")
+        ]
+    )
+    func koreanText(category: ScheduleIconCategory, expected: String) {
+        #expect(category.korean == expected)
+    }
+
+    // MARK: - Codable
+
+    @Test("Codable round-trip 시 동일한 케이스가 보존된다")
+    func codableRoundTrip() throws {
+        for original in ScheduleIconCategory.allCases {
+            let data = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(ScheduleIconCategory.self, from: data)
+
+            #expect(decoded == original, "Round-trip failed for \(original)")
+        }
+    }
+
+    @Test("알 수 없는 rawValue 디코딩 시 nil 반환")
+    func unknownRawValueReturnsNil() {
+        let decoded = ScheduleIconCategory(rawValue: "UNKNOWN_VALUE")
+
+        #expect(decoded == nil)
+    }
+}

--- a/UMCApp/Core/UIComponents/Project.swift
+++ b/UMCApp/Core/UIComponents/Project.swift
@@ -5,6 +5,7 @@ let project = coreProject(
     name: "CoreUIComponents",
     bundleIdSuffix: "uicomponents",
     dependencies: [
+        .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
         .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
         .external(name: "Kingfisher"),
     ]

--- a/UMCApp/Core/UIComponents/Sources/Extensions/ScheduleIconCategory+Visual.swift
+++ b/UMCApp/Core/UIComponents/Sources/Extensions/ScheduleIconCategory+Visual.swift
@@ -1,17 +1,22 @@
 //
 //  ScheduleIconCategory+Visual.swift
-//  CoreDesignSystem
+//  CoreUIComponents
 //
 //  Created by jaewon Lee on 5/7/26.
 //
 
 import SwiftUI
+import CoreDesignSystem
 import UMCFoundation
 
 /// `ScheduleIconCategory` 에 대한 시각 표현(SF Symbol, 테마 색상) 매핑.
 ///
 /// raw 값 매핑은 `UMCFoundation` 의 enum 정의에 위치하고,
 /// SwiftUI 의존이 필요한 시각 토큰만 본 모듈에 분리합니다.
+///
+/// - Note: 도메인 enum → 시각 표현 매핑은 `CoreUIComponents/Extensions/` 에 둡니다.
+///   `CoreDesignSystem` 은 디자인 토큰(색상/타입/간격) 전용 레이어이므로
+///   도메인(UMCFoundation) 의존을 갖지 않습니다.
 public extension ScheduleIconCategory {
 
     /// 카테고리별 시스템 심볼 이미지 이름

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceStatus.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceStatus.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum AttendanceStatus: String, CaseIterable {
+public enum AttendanceStatus: String, CaseIterable, Sendable {
     case beforeAttendance = "pending"
     case pendingApproval
     case present

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceTimeWindow.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/AttendanceTimeWindow.swift
@@ -10,7 +10,7 @@ import Foundation
 /// 출석 시간대 상태 (시간 체크 전용)
 ///
 /// `isWithinAttendanceTime(session:)`에서 현재 시간이 어느 시간대에 속하는지 반환합니다.
-public enum AttendanceTimeWindow {
+public enum AttendanceTimeWindow: Sendable {
     /// 출석 시간 전 (아직 출석 체크 불가)
     case tooEarly
 

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/MyAttendanceItemStatus.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/MyAttendanceItemStatus.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum MyAttendanceItemStatus: Equatable {
+public enum MyAttendanceItemStatus: Equatable, Sendable {
     case pendingApproval
     case present
     case late

--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Session/SessionStatus.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Session/SessionStatus.swift
@@ -1,0 +1,36 @@
+//
+//  SessionStatus.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+
+/// 운영진 세션 진행 상태
+public enum OperatorSessionStatus: String, CaseIterable, Sendable {
+    case beforeStart = "진행전"
+    case inProgress = "진행중"
+    case ended = "종료됨"
+
+    // MARK: - Property
+
+    public var displayText: String { rawValue }
+
+    // MARK: - Factory Method
+
+    /// 시작/종료 시간으로부터 현재 상태 계산
+    public static func from(
+        startTime: Date,
+        endTime: Date,
+        now: Date = Date()
+    ) -> OperatorSessionStatus {
+        if now < startTime {
+            return .beforeStart
+        } else if now >= startTime && now <= endTime {
+            return .inProgress
+        } else {
+            return .ended
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceType.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceType.swift
@@ -10,7 +10,7 @@ import Foundation
 /// 출석 방식
 ///
 /// GPS 위치 인증 출석과 사유 기반 출석 두 가지를 구분합니다.
-public enum AttendanceType: String {
+public enum AttendanceType: String, Sendable {
     /// GPS 위치 인증을 통한 출석
     case gps
 

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/MyAttendanceItemModel.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/MyAttendanceItemModel.swift
@@ -1,0 +1,145 @@
+//
+//  MyAttendanceItemModel.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - MyAttendanceItemModel
+
+/// 내 출석 이력 화면에서 사용하는 표시용 모델
+///
+/// `Session` 또는 `AttendanceHistoryItem` 으로부터 변환되며,
+/// 화면에 노출할 주차/시간/카테고리/상태 정보를 정규화합니다.
+public struct MyAttendanceItemModel: Equatable, Identifiable, Sendable {
+    public let id: UUID
+    public let week: Int
+    public let title: String
+    public let startTime: Date
+    public let endTime: Date
+    public let status: MyAttendanceItemStatus
+    public let category: ScheduleIconCategory
+
+    public init(
+        id: UUID = .init(),
+        week: Int,
+        title: String,
+        startTime: Date,
+        endTime: Date,
+        status: MyAttendanceItemStatus,
+        category: ScheduleIconCategory = .general
+    ) {
+        self.id = id
+        self.week = week
+        self.title = title
+        self.startTime = startTime
+        self.endTime = endTime
+        self.status = status
+        self.category = category
+    }
+
+    // MARK: - Computed
+
+    /// 주차 표시 텍스트 (예: "1주차")
+    public var weekText: String {
+        "\(week)주차"
+    }
+
+    /// 시간 범위 텍스트 (예: "14:00 - 18:00")
+    public var timeRange: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return "\(formatter.string(from: startTime)) - \(formatter.string(from: endTime))"
+    }
+}
+
+// MARK: - Session Conversion
+
+public extension MyAttendanceItemModel {
+    /// Session에서 변환
+    /// - Parameters:
+    ///   - session: 변환할 세션
+    ///   - category: ML 분류 결과 (기본값: .general)
+    /// - Note: pending 상태는 nil 반환
+    @MainActor
+    init?(from session: Session, category: ScheduleIconCategory = .general) {
+        guard let itemStatus = MyAttendanceItemStatus(from: session.attendanceStatus) else {
+            return nil
+        }
+
+        self.id = session.info.id
+        self.week = session.info.week
+        self.title = session.info.title
+        self.startTime = session.info.startTime
+        self.endTime = session.info.endTime
+        self.status = itemStatus
+        self.category = category
+    }
+}
+
+// MARK: - AttendanceHistoryItem Conversion
+
+public extension MyAttendanceItemModel {
+    /// AttendanceHistoryItem에서 변환
+    /// - Note: beforeAttendance 상태는 nil 반환
+    init?(from item: AttendanceHistoryItem) {
+        guard let itemStatus = MyAttendanceItemStatus(from: item.status) else {
+            return nil
+        }
+
+        self.id = item.id
+        self.week = 0
+        self.title = item.scheduleName
+        self.startTime = Self.parseTimeString(item.startTime)
+        var parsedEnd = Self.parseTimeString(item.endTime)
+        // FIXME: 자정 넘김 휴리스틱 — 서버가 ISO 8601 datetime 반환 시 제거 (#304)
+        if parsedEnd < self.startTime {
+            parsedEnd = Calendar.current.date(
+                byAdding: .day, value: 1, to: parsedEnd
+            ) ?? parsedEnd
+        }
+        self.endTime = parsedEnd
+        self.status = itemStatus
+        self.category = .general
+    }
+}
+
+// MARK: - Internal Helper
+
+extension MyAttendanceItemModel {
+    /// "HH:mm:ss" 또는 "HH:mm" → 오늘 Date 변환
+    ///
+    /// - Note: 외부 모듈 노출이 불필요한 헬퍼이므로 별도 extension 으로 분리해
+    ///   default `internal` 접근으로 둡니다. 테스트는 `@testable import` 로 접근.
+    static func parseTimeString(_ timeString: String) -> Date {
+        if let isoDate = ServerDateTimeConverter.parseUTCDateTime(timeString) {
+            return isoDate
+        }
+
+        let calendar = Calendar.current
+        let now = Date()
+        for format in ["HH:mm:ss", "HH:mm"] {
+            let formatter = DateFormatter()
+            formatter.dateFormat = format
+            formatter.locale = Locale(identifier: "ko_KR")
+            if let time = formatter.date(from: timeString) {
+                var components = calendar.dateComponents(
+                    [.year, .month, .day], from: now
+                )
+                let timeComponents = calendar.dateComponents(
+                    [.hour, .minute, .second], from: time
+                )
+                components.hour = timeComponents.hour
+                components.minute = timeComponents.minute
+                components.second = timeComponents.second
+                if let date = calendar.date(from: components) {
+                    return date
+                }
+            }
+        }
+        return now
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Identifier/Identifier.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Identifier/Identifier.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// 세션(스터디/세미나) 식별자
 /// - 출석 요청, 세션 조회 등 서버 API 호출 시 사용
-public struct SessionID: Hashable, Codable {
+public struct SessionID: Hashable, Codable, Sendable {
     public let value: String
 
     public init(value: String) {
@@ -24,7 +24,7 @@ public struct SessionID: Hashable, Codable {
 
 /// 사용자 식별자
 /// - 출석 요청, 사용자 정보 조회 등 서버 API 호출 시 사용
-public struct UserID: Hashable, Codable {
+public struct UserID: Hashable, Codable, Sendable {
     public let value: String
 
     public init(value: String) {
@@ -34,7 +34,7 @@ public struct UserID: Hashable, Codable {
 
 /// 출석 기록 식별자
 /// - 출석 상태 변경, 출석 기록 조회 등 서버 API 호출 시 사용
-public struct AttendanceID: Hashable, Codable {
+public struct AttendanceID: Hashable, Codable, Sendable {
     public let value: String
 
     public init(value: String) {

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorSessionAttendance.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorSessionAttendance.swift
@@ -1,0 +1,96 @@
+//
+//  OperatorSessionAttendance.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+
+/// 운영진 관점의 세션 출석 정보
+///
+/// 세션별 출석 현황과 승인 대기 멤버 목록을 관리합니다.
+///
+/// - Note: `session` 프로퍼티의 일부 멤버는 `@MainActor`로 격리되어 있으므로,
+///   해당 값에 접근하려면 호출 측이 메인 액터에서 실행되어야 합니다.
+public struct OperatorSessionAttendance: Identifiable, Equatable {
+
+    // MARK: - Property
+
+    public let id: UUID
+    public let serverID: String?
+    public let session: Session
+    public let attendanceRate: Double
+    public let attendedCount: Int
+    public let totalCount: Int
+    public let pendingCount: Int
+    public let pendingMembers: [OperatorPendingMember]
+
+    // MARK: - Init
+
+    public init(
+        id: UUID = UUID(),
+        serverID: String? = nil,
+        session: Session,
+        attendanceRate: Double,
+        attendedCount: Int,
+        totalCount: Int,
+        pendingCount: Int,
+        pendingMembers: [OperatorPendingMember] = []
+    ) {
+        self.id = id
+        self.serverID = serverID
+        self.session = session
+        self.attendanceRate = attendanceRate
+        self.attendedCount = attendedCount
+        self.totalCount = totalCount
+        self.pendingCount = pendingCount
+        self.pendingMembers = pendingMembers
+    }
+
+    // MARK: - Computed
+
+    /// 모든 출석이 승인 완료되었는지 여부
+    public var isAllApproved: Bool {
+        pendingCount == 0
+    }
+}
+
+// MARK: - copyWith
+
+public extension OperatorSessionAttendance {
+    /// 특정 프로퍼티만 변경한 새 인스턴스 생성
+    ///
+    /// - Parameters:
+    ///   - attendedCount: 출석 완료 인원 (nil이면 기존 값 유지)
+    ///   - pendingCount: 승인 대기 인원 (nil이면 pendingMembers.count 우선, 그 외 기존 값 유지)
+    ///   - pendingMembers: 승인 대기 멤버 목록 (nil이면 기존 값 유지)
+    /// - Returns: 변경된 프로퍼티가 적용된 새 인스턴스
+    ///
+    /// - Note: `attendedCount` 변경 시 `attendanceRate`가 자동 재계산됩니다.
+    func copyWith(
+        attendedCount: Int? = nil,
+        pendingCount: Int? = nil,
+        pendingMembers: [OperatorPendingMember]? = nil
+    ) -> OperatorSessionAttendance {
+        let newAttendedCount = attendedCount ?? self.attendedCount
+        let newAttendanceRate = totalCount > 0
+            ? Double(newAttendedCount) / Double(totalCount)
+            : 0.0
+        let newPendingMembers = pendingMembers ?? self.pendingMembers
+        let newPendingCount = pendingCount
+            ?? pendingMembers?.count
+            ?? self.pendingCount
+
+        return OperatorSessionAttendance(
+            id: self.id,
+            serverID: self.serverID,
+            session: self.session,
+            attendanceRate: newAttendanceRate,
+            attendedCount: newAttendedCount,
+            totalCount: self.totalCount,
+            pendingCount: newPendingCount,
+            pendingMembers: newPendingMembers
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Session/Session.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Session/Session.swift
@@ -1,0 +1,203 @@
+//
+//  Session.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 세션 엔티티
+///
+/// 출석 상태를 포함한 세션 정보를 관리합니다.
+/// `@Observable`로 출석 상태 변경 시 UI가 자동 업데이트됩니다.
+@MainActor
+@Observable
+public final class Session: Identifiable, Equatable {
+
+    // MARK: - Property
+
+    public nonisolated let id: SessionID
+    public nonisolated let info: SessionInfo
+
+    public private(set) var attendanceLoadable: Loadable<Attendance> = .idle
+    public private(set) var hasSubmitted: Bool = false
+
+    // MARK: - Init
+
+    public init(info: SessionInfo, initialAttendance: Attendance? = nil) {
+        self.info = info
+        self.id = info.sessionId
+        if let attendance = initialAttendance {
+            attendanceLoadable = .loaded(attendance)
+        }
+    }
+
+    // MARK: - Equatable
+
+    public nonisolated static func == (lhs: Session, rhs: Session) -> Bool {
+        lhs.id == rhs.id
+        && lhs.info.id == rhs.info.id
+    }
+
+    // MARK: - Computed
+
+    public var attendance: Attendance? {
+        attendanceLoadable.value
+    }
+
+    public var attendanceStatus: AttendanceStatus {
+        // 제출 완료 + 아직 확정되지 않은 경우 → 승인 대기
+        if hasSubmitted, attendanceLoadable.value?.status == .beforeAttendance {
+            return .pendingApproval
+        }
+        return attendanceLoadable.value?.status ?? .beforeAttendance
+    }
+
+    public var isLoading: Bool {
+        attendanceLoadable.isLoading
+    }
+
+    public var isSuccess: Bool {
+        hasSubmitted
+        || (attendanceStatus != .beforeAttendance && attendanceStatus != .pendingApproval)
+    }
+
+    /// 출석 가능 여부 (출석 전 또는 승인 대기 상태)
+    public var isAttendanceAvailable: Bool {
+        attendanceStatus == .beforeAttendance || attendanceStatus == .pendingApproval
+    }
+
+    // MARK: - Function
+
+    /// 출석 요청 가능 여부 (도메인 규칙)
+    ///
+    /// - Parameters:
+    ///   - timeWindow: 현재 시간대 (정시/지각/마감 등)
+    ///   - isInsideGeofence: 지오펜스 내부 여부
+    ///   - isLocationAuthorized: 위치 권한 허용 여부
+    /// - Returns: 출석 요청 버튼 활성화 여부
+    public func canRequestAttendance(
+        timeWindow: AttendanceTimeWindow,
+        isInsideGeofence: Bool,
+        isLocationAuthorized: Bool
+    ) -> Bool {
+        timeWindow == .onTime
+        && isInsideGeofence
+        && isLocationAuthorized
+        && !isLoading
+        && !hasSubmitted
+    }
+
+    /// 사유 제출 가능 여부
+    ///
+    /// 아직 제출하지 않은 세션은 시간대와 무관하게 사유를 제출할 수 있습니다.
+    public func canSubmitReason() -> Bool {
+        !isLoading
+        && !hasSubmitted
+        && attendanceStatus == .beforeAttendance
+    }
+
+    /// 출석 상태 업데이트
+    public func updateState(_ state: Loadable<Attendance>) {
+        self.attendanceLoadable = state
+    }
+
+    /// 출석 제출 완료 처리
+    public func markSubmitted() {
+        hasSubmitted = true
+    }
+
+    /// Polling 응답 기반 출석 상태 동기화
+    ///
+    /// 서버에서 받은 최신 상태가 현재와 다를 때만 업데이트합니다.
+    /// - 기존 Attendance가 있으면 status만 교체한 복사본으로 갱신
+    /// - 기존 Attendance가 없으면 최소 Attendance 생성
+    /// - 서버가 최종 확정(출석/지각/결석)하면 hasSubmitted 초기화
+    public func updateStatusFromPolling(
+        _ serverStatus: AttendanceStatus,
+        userId: UserID
+    ) {
+        // raw status로 비교
+        // (computed attendanceStatus는 hasSubmitted 기반 pendingApproval 매핑이 있어 불필요한 mutation 발생)
+        if let existing = attendance {
+            guard existing.status != serverStatus else { return }
+        } else {
+            guard serverStatus != .beforeAttendance else { return }
+        }
+
+        if let existing = attendance {
+            let updated = Attendance(
+                sessionId: existing.sessionId,
+                userId: existing.userId,
+                type: existing.type,
+                status: serverStatus,
+                locationVerification: existing.locationVerification,
+                reason: existing.reason
+            )
+            attendanceLoadable = .loaded(updated)
+        } else {
+            let minimal = Attendance(
+                sessionId: id,
+                userId: userId,
+                type: .gps,
+                status: serverStatus,
+                locationVerification: nil,
+                reason: nil
+            )
+            attendanceLoadable = .loaded(minimal)
+        }
+
+        // 서버가 최종 상태 확정 시 hasSubmitted 리셋
+        if serverStatus != .beforeAttendance
+            && serverStatus != .pendingApproval {
+            hasSubmitted = false
+        }
+    }
+
+    /// 출석 버튼에 표시할 텍스트
+    ///
+    /// 위치 권한, 지오펜스 상태, 시간대에 따라 적절한 메시지를 반환합니다.
+    public func buttonTitle(
+        isLocationAuthorized: Bool,
+        isInsideGeofence: Bool,
+        timeWindow: AttendanceTimeWindow
+    ) -> String {
+        if isLoading {
+            return "출석 처리 중..."
+        }
+
+        // 승인 대기 상태
+        if attendanceStatus == .pendingApproval {
+            return "승인 대기 중"
+        }
+
+        // 최종 결정됨 (출석 / 지각 / 결석)
+        if attendanceStatus != .beforeAttendance && attendanceStatus != .pendingApproval {
+            return attendanceStatus.displayText
+        }
+
+        // 시간대 체크
+        switch timeWindow {
+        case .tooEarly:
+            return "아직 출석 시간이 아닙니다"
+        case .lateWindow:
+            return "지각 - 사유를 제출하세요"
+        case .expired:
+            return "출석 마감됨"
+        case .onTime:
+            break  // 아래 조건들 계속 체크
+        }
+
+        if !isLocationAuthorized {
+            return "위치 권한 필요"
+        }
+
+        if !isInsideGeofence {
+            return "출석 범위 밖"
+        }
+
+        return "현 위치로 출석체크"
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Session/SessionInfo.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Session/SessionInfo.swift
@@ -1,0 +1,52 @@
+//
+//  SessionInfo.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 스터디/세미나 세션 정보
+///
+/// 출석 체크, 일정 표시 등에 사용되는 세션 데이터 모델입니다.
+/// - Note: `id`는 SwiftUI List/ForEach용, `sessionId`는 서버 API용
+/// - Note: 시각 표현(SF Symbol, 색상)이 필요하면 Presentation 레이어에서
+///   `ScheduleIconCategory` 의 `symbol`/`color` extension을 사용합니다.
+public struct SessionInfo: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let sessionId: SessionID
+    public let category: ScheduleIconCategory
+    public let iconName: String
+    public let title: String
+    public let week: Int
+    public let startTime: Date
+    public let endTime: Date
+    public let location: Coordinate
+    public let isAllDay: Bool
+
+    public init(
+        id: UUID = .init(),
+        sessionId: SessionID,
+        category: ScheduleIconCategory = .general,
+        iconName: String,
+        title: String,
+        week: Int,
+        startTime: Date,
+        endTime: Date,
+        location: Coordinate,
+        isAllDay: Bool = false
+    ) {
+        self.id = id
+        self.sessionId = sessionId
+        self.category = category
+        self.iconName = iconName
+        self.title = title
+        self.week = week
+        self.startTime = startTime
+        self.endTime = endTime
+        self.location = location
+        self.isAllDay = isAllDay
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/AttendanceStatusTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/AttendanceStatusTests.swift
@@ -1,0 +1,81 @@
+//
+//  AttendanceStatusTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/8/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityDomain
+
+@Suite("AttendanceStatus — 서버 응답 매핑 (도메인 규칙)")
+struct AttendanceStatusTests {
+
+    // MARK: - 직접 매핑
+
+    @Test(
+        "확정 상태 문자열 매핑",
+        arguments: [
+            ("PRESENT", AttendanceStatus.present),
+            ("EXCUSED", .present),     // 사유 인정 = 출석 처리
+            ("LATE",    .late),
+            ("ABSENT",  .absent),
+            ("PENDING", .beforeAttendance)
+        ]
+    )
+    func mapsKnownStatuses(serverStatus: String, expected: AttendanceStatus) {
+        let result = AttendanceStatus(serverStatus: serverStatus)
+
+        #expect(result == expected)
+    }
+
+    // MARK: - PENDING 접미사 분기
+
+    @Test(
+        "명시적인 _PENDING 접미사는 .pendingApproval 로 매핑된다",
+        arguments: [
+            "PRESENT_PENDING",
+            "LATE_PENDING",
+            "EXCUSED_PENDING"
+        ]
+    )
+    func mapsExplicitPendingSuffixes(serverStatus: String) {
+        let result = AttendanceStatus(serverStatus: serverStatus)
+
+        #expect(result == .pendingApproval)
+    }
+
+    @Test("알 수 없는 상태라도 _PENDING 으로 끝나면 .pendingApproval 로 매핑된다")
+    func mapsUnknownPendingSuffixToPendingApproval() {
+        // 서버에 새로운 PENDING 변형이 추가돼도 안전하게 흡수
+        let result = AttendanceStatus(serverStatus: "FUTURE_NEW_TYPE_PENDING")
+
+        #expect(result == .pendingApproval)
+    }
+
+    // MARK: - Fallback
+
+    @Test("완전히 알 수 없는 상태는 .beforeAttendance 로 fallback 된다")
+    func unknownStatusFallsBackToBeforeAttendance() {
+        let result = AttendanceStatus(serverStatus: "TOTALLY_UNKNOWN")
+
+        #expect(result == .beforeAttendance)
+    }
+
+    @Test("빈 문자열도 .beforeAttendance 로 fallback 된다")
+    func emptyStringFallsBack() {
+        let result = AttendanceStatus(serverStatus: "")
+
+        #expect(result == .beforeAttendance)
+    }
+
+    // MARK: - 대소문자 민감도 (현재 구현은 대소문자 구분)
+
+    @Test("소문자 'present' 는 매칭되지 않고 fallback 된다 — 서버는 대문자만 보낸다는 계약")
+    func lowercasedDoesNotMatch() {
+        let result = AttendanceStatus(serverStatus: "present")
+
+        #expect(result == .beforeAttendance)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/AttendanceTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/AttendanceTests.swift
@@ -1,0 +1,167 @@
+//
+//  AttendanceTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/8/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityDomain
+
+@Suite("Attendance — 빌더 메서드 (도메인 규칙)")
+struct AttendanceTests {
+
+    // MARK: - Helper
+
+    private func makeBase(
+        status: AttendanceStatus = .beforeAttendance,
+        type: AttendanceType = .gps,
+        reason: String? = nil,
+        verification: LocationVerification? = nil
+    ) -> Attendance {
+        Attendance(
+            sessionId: SessionID(value: "S-1"),
+            userId: UserID(value: "U-1"),
+            type: type,
+            status: status,
+            locationVerification: verification,
+            reason: reason
+        )
+    }
+
+    private func makeVerification() -> LocationVerification {
+        LocationVerification(
+            isVerified: true,
+            coordinate: Coordinate(latitude: 37.5, longitude: 127.0),
+            address: Address(fullAddress: "서울 강남구 테헤란로 1", city: "서울", district: "강남구"),
+            verifiedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    // MARK: - approved(with:)
+
+    @Test("approved(with:) 호출 시 status 가 .present 로 변경되고 verification 이 첨부된다")
+    func approvedSetsPresentWithVerification() {
+        let original = makeBase(status: .beforeAttendance)
+        let verification = makeVerification()
+
+        let result = original.approved(with: verification)
+
+        #expect(result.status == .present)
+        #expect(result.locationVerification == verification)
+        #expect(result.sessionId == original.sessionId)
+        #expect(result.userId == original.userId)
+    }
+
+    @Test("approved(with:) 는 reason 을 변경하지 않는다 (기존 값 보존)")
+    func approvedPreservesReason() {
+        let original = makeBase(status: .late, reason: "지각 사유")
+
+        let result = original.approved(with: makeVerification())
+
+        #expect(result.reason == "지각 사유")
+    }
+
+    // MARK: - beforeAttendance()
+
+    @Test("beforeAttendance() 호출 시 status 가 .beforeAttendance 로 리셋된다")
+    func beforeAttendanceResetsStatus() {
+        let original = makeBase(status: .present)
+
+        let result = original.beforeAttendance()
+
+        #expect(result.status == .beforeAttendance)
+    }
+
+    @Test("beforeAttendance() 는 verification/reason 을 그대로 유지한다")
+    func beforeAttendancePreservesOtherFields() {
+        let verification = makeVerification()
+        let original = makeBase(
+            status: .late,
+            reason: "기존 사유",
+            verification: verification
+        )
+
+        let result = original.beforeAttendance()
+
+        #expect(result.locationVerification == verification)
+        #expect(result.reason == "기존 사유")
+    }
+
+    // MARK: - rejected(status:)
+
+    @Test(
+        "rejected(status:) 는 인자로 받은 status 로 교체한다",
+        arguments: [
+            AttendanceStatus.absent,
+            .late,
+            .pendingApproval
+        ]
+    )
+    func rejectedSetsGivenStatus(_ targetStatus: AttendanceStatus) {
+        let original = makeBase(status: .present)
+
+        let result = original.rejected(status: targetStatus)
+
+        #expect(result.status == targetStatus)
+    }
+
+    // MARK: - late(reason:)
+
+    @Test("late(reason:) 는 status=.late 로 변경하고 reason 을 첨부한다")
+    func lateSetsLateAndReason() {
+        let original = makeBase(status: .beforeAttendance)
+
+        let result = original.late(reason: "버스 지연")
+
+        #expect(result.status == .late)
+        #expect(result.reason == "버스 지연")
+    }
+
+    @Test("late(reason:) 호출은 기존 reason 을 덮어쓴다")
+    func lateOverwritesPreviousReason() {
+        let original = makeBase(status: .beforeAttendance, reason: "이전 사유")
+
+        let result = original.late(reason: "새 사유")
+
+        #expect(result.reason == "새 사유")
+    }
+
+    // MARK: - absent(reason:)
+
+    @Test("absent(reason:) 는 status=.absent 로 변경하고 reason 을 첨부한다")
+    func absentSetsAbsentAndReason() {
+        let original = makeBase(status: .beforeAttendance)
+
+        let result = original.absent(reason: "본인 사정")
+
+        #expect(result.status == .absent)
+        #expect(result.reason == "본인 사정")
+    }
+
+    // MARK: - 빌더 체이닝 (도메인 흐름)
+
+    @Test("출석 전 → 지각 사유 제출 → 운영자 거절(absent) 흐름")
+    func chainBeforeAttendanceLateRejected() {
+        let initial = makeBase(status: .beforeAttendance)
+
+        let lateRequested = initial.late(reason: "교통 정체")
+        let rejected = lateRequested.rejected(status: .absent)
+
+        #expect(rejected.status == .absent)
+        #expect(rejected.reason == "교통 정체")  // reason 은 보존
+    }
+
+    @Test("승인된 출석은 sessionId/userId 를 절대 변경하지 않는다")
+    func approvedKeepsIdentity() {
+        let original = makeBase(status: .beforeAttendance)
+        let originalSessionId = original.sessionId
+        let originalUserId = original.userId
+
+        let result = original.approved(with: makeVerification())
+
+        #expect(result.sessionId == originalSessionId)
+        #expect(result.userId == originalUserId)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/MyAttendanceItemModelTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/MyAttendanceItemModelTests.swift
@@ -1,0 +1,185 @@
+//
+//  MyAttendanceItemModelTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+@Suite("MyAttendanceItemModel — 변환/표시 (도메인 규칙)")
+struct MyAttendanceItemModelTests {
+
+    // MARK: - Helper
+
+    private func makeHistoryItem(
+        status: AttendanceStatus = .present,
+        startTime: String = "09:00",
+        endTime: String = "11:00"
+    ) -> AttendanceHistoryItem {
+        AttendanceHistoryItem(
+            attendanceId: 1,
+            scheduleId: 10,
+            scheduleName: "1주차 OT",
+            tags: ["OT"],
+            scheduledDate: "2026-05-07",
+            startTime: startTime,
+            endTime: endTime,
+            status: status,
+            statusDisplay: "출석"
+        )
+    }
+
+    private func makeSessionInfo() -> SessionInfo {
+        SessionInfo(
+            sessionId: SessionID(value: "S-1"),
+            iconName: "calendar.badge",
+            title: "1주차 OT",
+            week: 1,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 0, longitude: 0)
+        )
+    }
+
+    // MARK: - Computed Property
+
+    @Test("weekText 는 '{week}주차' 형태이다")
+    func weekTextFormat() {
+        let model = MyAttendanceItemModel(
+            week: 3,
+            title: "Test",
+            startTime: Date(),
+            endTime: Date(),
+            status: .present
+        )
+
+        #expect(model.weekText == "3주차")
+    }
+
+    @Test("timeRange 는 'HH:mm - HH:mm' 형태이다")
+    func timeRangeFormat() {
+        // 시스템 타임존을 고려하여 컴포넌트 기반으로 Date 생성
+        var startComponents = DateComponents()
+        startComponents.year = 2026
+        startComponents.month = 5
+        startComponents.day = 7
+        startComponents.hour = 14
+        startComponents.minute = 0
+
+        var endComponents = startComponents
+        endComponents.hour = 16
+
+        guard let start = Calendar.current.date(from: startComponents),
+              let end = Calendar.current.date(from: endComponents) else {
+            Issue.record("Failed to construct test dates")
+            return
+        }
+
+        let model = MyAttendanceItemModel(
+            week: 1,
+            title: "Test",
+            startTime: start,
+            endTime: end,
+            status: .present
+        )
+
+        #expect(model.timeRange == "14:00 - 16:00")
+    }
+
+    // MARK: - Init from AttendanceHistoryItem
+
+    @Test("AttendanceHistoryItem(present) 변환 시 status 는 present")
+    func initFromHistoryItemPresent() {
+        let item = makeHistoryItem(status: .present)
+
+        let model = MyAttendanceItemModel(from: item)
+
+        #expect(model?.status == .present)
+        #expect(model?.title == "1주차 OT")
+        #expect(model?.week == 0)
+    }
+
+    @Test("AttendanceHistoryItem(beforeAttendance) 변환은 nil 반환")
+    func initFromHistoryItemBeforeAttendanceReturnsNil() {
+        let item = makeHistoryItem(status: .beforeAttendance)
+
+        let model = MyAttendanceItemModel(from: item)
+
+        #expect(model == nil)
+    }
+
+    @Test(
+        "변환 시 변환 가능한 상태 enum 매핑 검증",
+        arguments: [
+            (AttendanceStatus.present, MyAttendanceItemStatus.present),
+            (.late, .late),
+            (.absent, .absent),
+            (.pendingApproval, .pendingApproval)
+        ]
+    )
+    func statusMappingFromHistory(
+        legacy: AttendanceStatus,
+        expected: MyAttendanceItemStatus
+    ) {
+        let item = makeHistoryItem(status: legacy)
+
+        let model = MyAttendanceItemModel(from: item)
+
+        #expect(model?.status == expected)
+    }
+
+    // MARK: - Init from Session
+
+    @Test("Session(loaded(present)) 변환 시 status 는 present")
+    @MainActor
+    func initFromSessionPresent() {
+        let attendance = Attendance(
+            sessionId: SessionID(value: "S-1"),
+            userId: UserID(value: "U-1"),
+            type: .gps,
+            status: .present
+        )
+        let session = Session(info: makeSessionInfo(), initialAttendance: attendance)
+
+        let model = MyAttendanceItemModel(from: session, category: .study)
+
+        #expect(model?.status == .present)
+        #expect(model?.category == .study)
+        #expect(model?.title == "1주차 OT")
+    }
+
+    @Test("Session(idle) 변환은 nil 반환 (beforeAttendance 매핑)")
+    @MainActor
+    func initFromSessionIdleReturnsNil() {
+        let session = Session(info: makeSessionInfo())
+
+        let model = MyAttendanceItemModel(from: session)
+
+        #expect(model == nil)
+    }
+
+    // MARK: - parseTimeString
+
+    @Test("HH:mm 포맷 문자열은 오늘 날짜의 해당 시각으로 파싱된다")
+    func parseTimeStringHHmm() {
+        let date = MyAttendanceItemModel.parseTimeString("14:30")
+
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        #expect(components.hour == 14)
+        #expect(components.minute == 30)
+    }
+
+    @Test("ISO 8601 datetime 문자열은 해당 절대 시각으로 파싱된다")
+    func parseTimeStringISO8601() {
+        let iso = "2026-05-07T05:30:00Z"
+
+        let date = MyAttendanceItemModel.parseTimeString(iso)
+
+        let expected = ServerDateTimeConverter.parseUTCDateTime(iso)
+        #expect(date == expected)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/OperatorPendingMemberTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/OperatorPendingMemberTests.swift
@@ -1,0 +1,153 @@
+//
+//  OperatorPendingMemberTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/8/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityDomain
+
+@Suite("OperatorPendingMember — computed property + 매퍼 (도메인 규칙)")
+struct OperatorPendingMemberTests {
+
+    // MARK: - hasReason
+
+    @Test("reason 이 nil 이면 hasReason=false")
+    func hasReasonNilReturnsFalse() {
+        let member = OperatorPendingMember(
+            name: "홍길동",
+            university: "한성대",
+            requestTime: Date(timeIntervalSince1970: 0),
+            reason: nil
+        )
+
+        #expect(member.hasReason == false)
+    }
+
+    @Test("reason 이 빈 문자열이면 hasReason=false (공백 포함 안된 케이스)")
+    func hasReasonEmptyStringReturnsFalse() {
+        let member = OperatorPendingMember(
+            name: "홍길동",
+            university: "한성대",
+            requestTime: Date(timeIntervalSince1970: 0),
+            reason: ""
+        )
+
+        #expect(member.hasReason == false)
+    }
+
+    @Test("reason 에 내용이 있으면 hasReason=true")
+    func hasReasonWithContentReturnsTrue() {
+        let member = OperatorPendingMember(
+            name: "홍길동",
+            university: "한성대",
+            requestTime: Date(timeIntervalSince1970: 0),
+            reason: "교통 지연"
+        )
+
+        #expect(member.hasReason == true)
+    }
+
+    // MARK: - displayName
+
+    @Test("nickname 이 있으면 'nickname/name' 형태로 표시된다")
+    func displayNameWithNickname() {
+        let member = OperatorPendingMember(
+            name: "홍길동",
+            nickname: "길동이",
+            university: "한성대",
+            requestTime: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(member.displayName == "길동이/홍길동")
+    }
+
+    @Test("nickname 이 nil 이면 name 만 표시된다")
+    func displayNameWithoutNickname() {
+        let member = OperatorPendingMember(
+            name: "홍길동",
+            nickname: nil,
+            university: "한성대",
+            requestTime: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(member.displayName == "홍길동")
+    }
+
+    // MARK: - init(from: PendingAttendanceRecord)
+
+    @Test("PendingAttendanceRecord → OperatorPendingMember 변환 — 핵심 필드 매핑")
+    func mapsRecordToMemberCoreFields() {
+        let record = PendingAttendanceRecord(
+            attendanceId: 42,
+            memberId: "M-1",
+            memberName: "김철수",
+            nickname: "철수",
+            profileImageLink: URL(string: "https://example.com/profile.png"),
+            schoolName: "한성대",
+            status: .pendingApproval,
+            reason: "회의 지연",
+            requestedAt: Date(timeIntervalSince1970: 1000)
+        )
+
+        let member = OperatorPendingMember(from: record)
+
+        #expect(member.serverID == "42")  // Int → String 변환
+        #expect(member.name == "김철수")
+        #expect(member.nickname == "철수")
+        #expect(member.university == "한성대")
+        #expect(member.reason == "회의 지연")
+        #expect(member.requestTime == Date(timeIntervalSince1970: 1000))
+        #expect(member.profileImageURL == "https://example.com/profile.png")
+    }
+
+    @Test("profileImageLink 가 nil 이면 profileImageURL 도 nil 로 매핑된다")
+    func mapsRecordWithNilProfileImage() {
+        let record = PendingAttendanceRecord(
+            attendanceId: 1,
+            memberId: "M-1",
+            memberName: "김철수",
+            nickname: "철수",
+            profileImageLink: nil,
+            schoolName: "한성대",
+            status: .pendingApproval,
+            reason: nil,
+            requestedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        let member = OperatorPendingMember(from: record)
+
+        #expect(member.profileImageURL == nil)
+    }
+
+    @Test("매퍼 결과에 hasReason 도메인 규칙이 그대로 적용된다")
+    func mappedMemberRespectsHasReasonRule() {
+        let withReason = PendingAttendanceRecord(
+            attendanceId: 1,
+            memberId: "M-1",
+            memberName: "A",
+            nickname: "a",
+            profileImageLink: nil,
+            schoolName: "한성대",
+            status: .pendingApproval,
+            reason: "사유",
+            requestedAt: Date(timeIntervalSince1970: 0)
+        )
+        let withoutReason = PendingAttendanceRecord(
+            attendanceId: 2,
+            memberId: "M-2",
+            memberName: "B",
+            nickname: "b",
+            profileImageLink: nil,
+            schoolName: "한성대",
+            status: .pendingApproval,
+            reason: nil,
+            requestedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(OperatorPendingMember(from: withReason).hasReason == true)
+        #expect(OperatorPendingMember(from: withoutReason).hasReason == false)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/OperatorSessionAttendanceTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/OperatorSessionAttendanceTests.swift
@@ -1,0 +1,152 @@
+//
+//  OperatorSessionAttendanceTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+@MainActor
+@Suite("OperatorSessionAttendance — copyWith 집계 규칙 (도메인 규칙)")
+struct OperatorSessionAttendanceTests {
+
+    // MARK: - Helper
+
+    private func makeSession() -> Session {
+        let info = SessionInfo(
+            sessionId: SessionID(value: "S-1"),
+            iconName: "calendar.badge",
+            title: "1주차 OT",
+            week: 1,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 0, longitude: 0)
+        )
+        return Session(info: info)
+    }
+
+    private func makeMember(name: String = "홍길동") -> OperatorPendingMember {
+        OperatorPendingMember(
+            name: name,
+            university: "한성대",
+            requestTime: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    private func makeAttendance(
+        attendedCount: Int = 5,
+        totalCount: Int = 10,
+        pendingCount: Int = 2,
+        pendingMembers: [OperatorPendingMember] = []
+    ) -> OperatorSessionAttendance {
+        OperatorSessionAttendance(
+            session: makeSession(),
+            attendanceRate: totalCount > 0
+                ? Double(attendedCount) / Double(totalCount)
+                : 0.0,
+            attendedCount: attendedCount,
+            totalCount: totalCount,
+            pendingCount: pendingCount,
+            pendingMembers: pendingMembers
+        )
+    }
+
+    // MARK: - isAllApproved
+
+    @Test("pendingCount==0 이면 isAllApproved=true")
+    func allApprovedWhenPendingZero() {
+        let attendance = makeAttendance(pendingCount: 0)
+
+        #expect(attendance.isAllApproved == true)
+    }
+
+    @Test("pendingCount>0 이면 isAllApproved=false")
+    func notApprovedWhenPendingExists() {
+        let attendance = makeAttendance(pendingCount: 3)
+
+        #expect(attendance.isAllApproved == false)
+    }
+
+    // MARK: - copyWith
+
+    @Test("copyWith(attendedCount:) 변경 시 attendanceRate 가 자동 재계산된다")
+    func copyWithAttendedCountRecalculatesRate() {
+        let original = makeAttendance(attendedCount: 5, totalCount: 10)
+
+        let updated = original.copyWith(attendedCount: 8)
+
+        #expect(updated.attendedCount == 8)
+        #expect(updated.attendanceRate == 0.8)
+    }
+
+    @Test("totalCount 가 0이면 attendanceRate 는 0.0")
+    func copyWithZeroTotalGivesZeroRate() {
+        let original = makeAttendance(attendedCount: 0, totalCount: 0)
+
+        let updated = original.copyWith(attendedCount: 0)
+
+        #expect(updated.attendanceRate == 0.0)
+    }
+
+    @Test("copyWith(pendingMembers:) 명시 시 해당 멤버 목록으로 갱신된다")
+    func copyWithPendingMembersUpdatesList() {
+        let original = makeAttendance(pendingMembers: [])
+        let m1 = makeMember(name: "A")
+        let m2 = makeMember(name: "B")
+
+        let updated = original.copyWith(pendingMembers: [m1, m2])
+
+        #expect(updated.pendingMembers.count == 2)
+    }
+
+    @Test("pendingCount 미지정 시 pendingMembers.count 가 자동 적용된다")
+    func copyWithPendingCountFromMembers() {
+        let original = makeAttendance(pendingCount: 0, pendingMembers: [])
+        let members = [makeMember(name: "A"), makeMember(name: "B")]
+
+        let updated = original.copyWith(pendingMembers: members)
+
+        #expect(updated.pendingCount == 2)
+    }
+
+    @Test("pendingCount 명시 시 그 값이 우선한다 (members.count 보다 우선)")
+    func copyWithExplicitPendingCountWins() {
+        let original = makeAttendance()
+        let members = [makeMember(name: "A"), makeMember(name: "B")]
+
+        let updated = original.copyWith(pendingCount: 99, pendingMembers: members)
+
+        #expect(updated.pendingCount == 99)
+        #expect(updated.pendingMembers.count == 2)
+    }
+
+    @Test("아무것도 지정하지 않으면 기존 값이 유지된다")
+    func copyWithNoChangesKeepsOriginal() {
+        let original = makeAttendance(
+            attendedCount: 5,
+            totalCount: 10,
+            pendingCount: 3
+        )
+
+        let updated = original.copyWith()
+
+        #expect(updated.attendedCount == 5)
+        #expect(updated.pendingCount == 3)
+        #expect(updated.attendanceRate == original.attendanceRate)
+    }
+
+    // MARK: - Identity
+
+    @Test("copyWith 결과는 동일한 id 를 유지한다")
+    func copyWithKeepsIdentity() {
+        let original = makeAttendance()
+
+        let updated = original.copyWith(attendedCount: 100)
+
+        #expect(updated.id == original.id)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/OperatorSessionStatusTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/OperatorSessionStatusTests.swift
@@ -1,0 +1,91 @@
+//
+//  OperatorSessionStatusTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/8/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityDomain
+
+@Suite("OperatorSessionStatus — 시간 기반 상태 결정 (도메인 규칙)")
+struct OperatorSessionStatusTests {
+
+    // MARK: - Helper
+
+    private func date(_ epoch: TimeInterval) -> Date {
+        Date(timeIntervalSince1970: epoch)
+    }
+
+    // MARK: - 분기 검증
+
+    @Test("now < startTime 이면 .beforeStart")
+    func returnsBeforeStartWhenBeforeStart() {
+        let start = date(1000)
+        let end = date(2000)
+        let now = date(500)
+
+        let status = OperatorSessionStatus.from(startTime: start, endTime: end, now: now)
+
+        #expect(status == .beforeStart)
+    }
+
+    @Test("startTime <= now <= endTime 이면 .inProgress")
+    func returnsInProgressWhenWithinRange() {
+        let start = date(1000)
+        let end = date(2000)
+        let now = date(1500)
+
+        let status = OperatorSessionStatus.from(startTime: start, endTime: end, now: now)
+
+        #expect(status == .inProgress)
+    }
+
+    @Test("now == startTime (경계) 일 때도 .inProgress")
+    func boundaryStartIsInProgress() {
+        let start = date(1000)
+        let end = date(2000)
+
+        let status = OperatorSessionStatus.from(startTime: start, endTime: end, now: start)
+
+        #expect(status == .inProgress)
+    }
+
+    @Test("now == endTime (경계) 일 때도 .inProgress")
+    func boundaryEndIsInProgress() {
+        let start = date(1000)
+        let end = date(2000)
+
+        let status = OperatorSessionStatus.from(startTime: start, endTime: end, now: end)
+
+        #expect(status == .inProgress)
+    }
+
+    @Test("now > endTime 이면 .ended")
+    func returnsEndedWhenAfterEnd() {
+        let start = date(1000)
+        let end = date(2000)
+        let now = date(2500)
+
+        let status = OperatorSessionStatus.from(startTime: start, endTime: end, now: now)
+
+        #expect(status == .ended)
+    }
+
+    // MARK: - 엣지 케이스
+
+    @Test("startTime == endTime 인 즉시 종료 세션은 그 시점에 .inProgress, 직후 .ended")
+    func zeroDurationSession() {
+        let instant = date(1000)
+
+        #expect(
+            OperatorSessionStatus.from(startTime: instant, endTime: instant, now: instant)
+            == .inProgress
+        )
+        #expect(
+            OperatorSessionStatus.from(startTime: instant, endTime: instant, now: date(1001))
+            == .ended
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/SessionInfoTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/SessionInfoTests.swift
@@ -1,0 +1,137 @@
+//
+//  SessionInfoTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+@Suite("SessionInfo — 값 동등성 + 기본값 (도메인 규칙)")
+struct SessionInfoTests {
+
+    // MARK: - Helper
+
+    private func makeInfo(
+        sessionId: String = "S-1",
+        category: ScheduleIconCategory = .general,
+        title: String = "1주차 OT",
+        week: Int = 1,
+        isAllDay: Bool = false
+    ) -> SessionInfo {
+        SessionInfo(
+            sessionId: SessionID(value: sessionId),
+            category: category,
+            iconName: "calendar.badge",
+            title: title,
+            week: week,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 37.5, longitude: 127.0),
+            isAllDay: isAllDay
+        )
+    }
+
+    // MARK: - Default Values
+
+    @Test("category 기본값은 .general 이다")
+    func defaultCategoryIsGeneral() {
+        let info = SessionInfo(
+            sessionId: SessionID(value: "S-1"),
+            iconName: "calendar.badge",
+            title: "기본",
+            week: 1,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 0, longitude: 0)
+        )
+
+        #expect(info.category == .general)
+    }
+
+    @Test("isAllDay 기본값은 false 이다")
+    func defaultIsAllDayIsFalse() {
+        let info = SessionInfo(
+            sessionId: SessionID(value: "S-1"),
+            iconName: "calendar.badge",
+            title: "기본",
+            week: 1,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 0, longitude: 0)
+        )
+
+        #expect(info.isAllDay == false)
+    }
+
+    // MARK: - Equatable
+
+    @Test("동일한 모든 프로퍼티(같은 id 포함)면 Equatable 비교가 같다")
+    func equalWhenAllPropertiesMatch() {
+        let sharedID = UUID()
+        let lhs = SessionInfo(
+            id: sharedID,
+            sessionId: SessionID(value: "S-1"),
+            iconName: "calendar.badge",
+            title: "OT",
+            week: 1,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 1, longitude: 2)
+        )
+        let rhs = SessionInfo(
+            id: sharedID,
+            sessionId: SessionID(value: "S-1"),
+            iconName: "calendar.badge",
+            title: "OT",
+            week: 1,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 1, longitude: 2)
+        )
+
+        #expect(lhs == rhs)
+    }
+
+    @Test("UUID(id)가 다르면 Equatable 비교가 다르다")
+    func notEqualWhenIDDiffers() {
+        let lhs = makeInfo()
+        let rhs = makeInfo()  // 새 UUID 생성
+
+        #expect(lhs != rhs)
+    }
+
+    // MARK: - Category
+
+    @Test("카테고리가 다르면 Equatable 비교가 다르다")
+    func notEqualWhenCategoryDiffers() {
+        let sharedID = UUID()
+        let general = SessionInfo(
+            id: sharedID,
+            sessionId: SessionID(value: "S-1"),
+            category: .general,
+            iconName: "calendar.badge",
+            title: "OT",
+            week: 1,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 0, longitude: 0)
+        )
+        let study = SessionInfo(
+            id: sharedID,
+            sessionId: SessionID(value: "S-1"),
+            category: .study,
+            iconName: "calendar.badge",
+            title: "OT",
+            week: 1,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 0, longitude: 0)
+        )
+
+        #expect(general != study)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/SessionTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/SessionTests.swift
@@ -1,0 +1,416 @@
+//
+//  SessionTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+@MainActor
+@Suite("Session — 출석 상태 전이 (도메인 규칙)")
+struct SessionTests {
+
+    // MARK: - Helper
+
+    private func makeInfo(
+        sessionId: String = "S-1",
+        week: Int = 1
+    ) -> SessionInfo {
+        SessionInfo(
+            sessionId: SessionID(value: sessionId),
+            iconName: "calendar.badge",
+            title: "1주차 OT",
+            week: week,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            location: Coordinate(latitude: 37.5, longitude: 127.0)
+        )
+    }
+
+    private func makeSession(
+        sessionId: String = "S-1",
+        initialAttendance: Attendance? = nil
+    ) -> Session {
+        Session(info: makeInfo(sessionId: sessionId), initialAttendance: initialAttendance)
+    }
+
+    private func makeAttendance(
+        sessionId: String = "S-1",
+        status: AttendanceStatus = .beforeAttendance
+    ) -> Attendance {
+        Attendance(
+            sessionId: SessionID(value: sessionId),
+            userId: UserID(value: "U-1"),
+            type: .gps,
+            status: status
+        )
+    }
+
+    // MARK: - Init
+
+    @Test("init 시 id 는 info.sessionId 와 동일하다")
+    func initSetsIDFromInfo() {
+        let session = makeSession(sessionId: "S-42")
+
+        #expect(session.id == SessionID(value: "S-42"))
+    }
+
+    @Test("initialAttendance 가 주어지면 loadable 이 .loaded 로 시작한다")
+    func initialAttendanceSetsLoaded() {
+        let attendance = makeAttendance(status: .present)
+        let session = makeSession(initialAttendance: attendance)
+
+        #expect(session.attendance == attendance)
+        #expect(session.attendanceStatus == .present)
+    }
+
+    @Test("initialAttendance 가 없으면 loadable 은 .idle 이다")
+    func defaultLoadableIsIdle() {
+        let session = makeSession()
+
+        #expect(session.attendance == nil)
+        #expect(session.attendanceStatus == .beforeAttendance)
+    }
+
+    // MARK: - attendanceStatus
+
+    @Test("hasSubmitted=true && loaded(beforeAttendance) → pendingApproval")
+    func hasSubmittedMapsToPendingApproval() {
+        let session = makeSession(initialAttendance: makeAttendance(status: .beforeAttendance))
+        session.markSubmitted()
+
+        #expect(session.attendanceStatus == .pendingApproval)
+    }
+
+    @Test("loaded(present) 는 그대로 present 를 반환한다")
+    func loadedPresentReturnsPresent() {
+        let session = makeSession(initialAttendance: makeAttendance(status: .present))
+
+        #expect(session.attendanceStatus == .present)
+    }
+
+    // MARK: - canRequestAttendance
+
+    @Test("정시 + 지오펜스 내부 + 권한 허용 + 미제출 + 비로딩 → true")
+    func canRequestWhenAllConditionsMet() {
+        let session = makeSession()
+
+        let result = session.canRequestAttendance(
+            timeWindow: .onTime,
+            isInsideGeofence: true,
+            isLocationAuthorized: true
+        )
+
+        #expect(result == true)
+    }
+
+    @Test(
+        "tooEarly/lateWindow/expired 는 모두 false",
+        arguments: [AttendanceTimeWindow.tooEarly, .lateWindow, .expired]
+    )
+    func cannotRequestWhenNotOnTime(timeWindow: AttendanceTimeWindow) {
+        let session = makeSession()
+
+        let result = session.canRequestAttendance(
+            timeWindow: timeWindow,
+            isInsideGeofence: true,
+            isLocationAuthorized: true
+        )
+
+        #expect(result == false)
+    }
+
+    @Test("지오펜스 밖이면 false")
+    func cannotRequestWhenOutsideGeofence() {
+        let session = makeSession()
+
+        let result = session.canRequestAttendance(
+            timeWindow: .onTime,
+            isInsideGeofence: false,
+            isLocationAuthorized: true
+        )
+
+        #expect(result == false)
+    }
+
+    @Test("위치 권한 미허용이면 false")
+    func cannotRequestWhenLocationNotAuthorized() {
+        let session = makeSession()
+
+        let result = session.canRequestAttendance(
+            timeWindow: .onTime,
+            isInsideGeofence: true,
+            isLocationAuthorized: false
+        )
+
+        #expect(result == false)
+    }
+
+    @Test("이미 제출했으면 false")
+    func cannotRequestWhenAlreadySubmitted() {
+        let session = makeSession()
+        session.markSubmitted()
+
+        let result = session.canRequestAttendance(
+            timeWindow: .onTime,
+            isInsideGeofence: true,
+            isLocationAuthorized: true
+        )
+
+        #expect(result == false)
+    }
+
+    @Test("로딩 중이면 false")
+    func cannotRequestWhenLoading() {
+        let session = makeSession()
+        session.updateState(.loading)
+
+        let result = session.canRequestAttendance(
+            timeWindow: .onTime,
+            isInsideGeofence: true,
+            isLocationAuthorized: true
+        )
+
+        #expect(result == false)
+    }
+
+    // MARK: - canSubmitReason
+
+    @Test("미제출 + 비로딩 + beforeAttendance → 사유 제출 가능")
+    func canSubmitReasonWhenIdle() {
+        let session = makeSession()
+
+        #expect(session.canSubmitReason() == true)
+    }
+
+    @Test("이미 제출했으면 사유 제출 불가")
+    func cannotSubmitReasonWhenSubmitted() {
+        let session = makeSession()
+        session.markSubmitted()
+
+        #expect(session.canSubmitReason() == false)
+    }
+
+    @Test("loaded(present) 상태면 사유 제출 불가")
+    func cannotSubmitReasonWhenAlreadyPresent() {
+        let session = makeSession(initialAttendance: makeAttendance(status: .present))
+
+        #expect(session.canSubmitReason() == false)
+    }
+
+    // MARK: - isSuccess / isAttendanceAvailable
+
+    @Test("hasSubmitted=true 이면 isSuccess=true")
+    func isSuccessWhenSubmitted() {
+        let session = makeSession()
+        session.markSubmitted()
+
+        #expect(session.isSuccess == true)
+    }
+
+    @Test("loaded(present) 면 isSuccess=true")
+    func isSuccessWhenPresent() {
+        let session = makeSession(initialAttendance: makeAttendance(status: .present))
+
+        #expect(session.isSuccess == true)
+    }
+
+    @Test("idle 상태면 isAttendanceAvailable=true (beforeAttendance)")
+    func isAvailableWhenIdle() {
+        let session = makeSession()
+
+        #expect(session.isAttendanceAvailable == true)
+    }
+
+    @Test("loaded(present) 상태면 isAttendanceAvailable=false")
+    func isNotAvailableWhenPresent() {
+        let session = makeSession(initialAttendance: makeAttendance(status: .present))
+
+        #expect(session.isAttendanceAvailable == false)
+    }
+
+    // MARK: - updateStatusFromPolling
+
+    @Test("idle 상태에서 서버가 present 통보 → loaded(present) 로 갱신")
+    func pollingFromIdleToPresent() {
+        let session = makeSession()
+
+        session.updateStatusFromPolling(.present, userId: UserID(value: "U-1"))
+
+        #expect(session.attendance?.status == .present)
+        #expect(session.attendanceStatus == .present)
+    }
+
+    @Test("loaded(present) 상태에서 동일한 present 통보 → mutation 발생 안함")
+    func pollingSameStatusKeepsAttendanceUnchanged() {
+        let initial = makeAttendance(status: .present)
+        let session = makeSession(initialAttendance: initial)
+
+        session.updateStatusFromPolling(.present, userId: UserID(value: "U-1"))
+
+        // 같은 상태면 attendance 객체가 그대로 유지됨
+        #expect(session.attendance?.id == initial.id)
+    }
+
+    @Test("최종 확정 상태(present/late/absent) 통보 시 hasSubmitted 가 리셋된다")
+    func pollingFinalStatusResetsHasSubmitted() {
+        let session = makeSession()
+        session.markSubmitted()
+
+        session.updateStatusFromPolling(.present, userId: UserID(value: "U-1"))
+
+        #expect(session.hasSubmitted == false)
+    }
+
+    @Test("pendingApproval 통보 시 hasSubmitted 는 유지된다")
+    func pollingPendingApprovalKeepsHasSubmitted() {
+        let session = makeSession()
+        session.markSubmitted()
+
+        session.updateStatusFromPolling(.pendingApproval, userId: UserID(value: "U-1"))
+
+        #expect(session.hasSubmitted == true)
+    }
+
+    // MARK: - buttonTitle
+
+    @Test("로딩 중이면 '출석 처리 중...'")
+    func buttonTitleWhenLoading() {
+        let session = makeSession()
+        session.updateState(.loading)
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: true,
+            isInsideGeofence: true,
+            timeWindow: .onTime
+        )
+
+        #expect(title == "출석 처리 중...")
+    }
+
+    @Test("정시 + 권한 + 지오펜스 내부 → '현 위치로 출석체크'")
+    func buttonTitleAllReady() {
+        let session = makeSession()
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: true,
+            isInsideGeofence: true,
+            timeWindow: .onTime
+        )
+
+        #expect(title == "현 위치로 출석체크")
+    }
+
+    @Test("정시 + 권한 + 지오펜스 밖 → '출석 범위 밖'")
+    func buttonTitleOutsideGeofence() {
+        let session = makeSession()
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: true,
+            isInsideGeofence: false,
+            timeWindow: .onTime
+        )
+
+        #expect(title == "출석 범위 밖")
+    }
+
+    @Test("정시 + 권한 미허용 → '위치 권한 필요'")
+    func buttonTitleLocationNotAuthorized() {
+        let session = makeSession()
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: false,
+            isInsideGeofence: true,
+            timeWindow: .onTime
+        )
+
+        #expect(title == "위치 권한 필요")
+    }
+
+    @Test("출석 시간 전이면 '아직 출석 시간이 아닙니다' (다른 조건과 무관)")
+    func buttonTitleTooEarly() {
+        let session = makeSession()
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: true,
+            isInsideGeofence: true,
+            timeWindow: .tooEarly
+        )
+
+        #expect(title == "아직 출석 시간이 아닙니다")
+    }
+
+    @Test("지각 시간대면 '지각 - 사유를 제출하세요'")
+    func buttonTitleLateWindow() {
+        let session = makeSession()
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: true,
+            isInsideGeofence: true,
+            timeWindow: .lateWindow
+        )
+
+        #expect(title == "지각 - 사유를 제출하세요")
+    }
+
+    @Test("출석 마감되면 '출석 마감됨'")
+    func buttonTitleExpired() {
+        let session = makeSession()
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: true,
+            isInsideGeofence: true,
+            timeWindow: .expired
+        )
+
+        #expect(title == "출석 마감됨")
+    }
+
+    @Test("승인 대기 상태면 다른 입력과 무관하게 '승인 대기 중'")
+    func buttonTitlePendingApproval() {
+        // pendingApproval 매핑 조건: loaded(beforeAttendance) + hasSubmitted=true
+        let initial = makeAttendance(status: .beforeAttendance)
+        let session = makeSession(initialAttendance: initial)
+        session.markSubmitted()
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: false,
+            isInsideGeofence: false,
+            timeWindow: .expired
+        )
+
+        #expect(title == "승인 대기 중")
+    }
+
+    @Test("최종 확정(present) 상태면 status displayText 가 그대로 노출된다")
+    func buttonTitleFinalPresent() {
+        let attendance = makeAttendance(status: .present)
+        let session = makeSession(initialAttendance: attendance)
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: true,
+            isInsideGeofence: true,
+            timeWindow: .onTime
+        )
+
+        #expect(title == AttendanceStatus.present.displayText)
+    }
+
+    @Test("최종 확정(absent) 상태면 status displayText 가 그대로 노출된다")
+    func buttonTitleFinalAbsent() {
+        let attendance = makeAttendance(status: .absent)
+        let session = makeSession(initialAttendance: attendance)
+
+        let title = session.buttonTitle(
+            isLocationAuthorized: false,
+            isInsideGeofence: false,
+            timeWindow: .expired
+        )
+
+        #expect(title == AttendanceStatus.absent.displayText)
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Extensions/AttendanceStatus+Color.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Extensions/AttendanceStatus+Color.swift
@@ -1,0 +1,32 @@
+//
+//  AttendanceStatus+Color.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import SwiftUI
+import ActivityDomain
+
+/// `AttendanceStatus` 의 시각 표현 매핑.
+///
+/// 도메인 enum 자체는 SwiftUI 의존을 갖지 않도록 분리되어 있으며,
+/// 본 extension 은 Presentation 레이어 전용 색상 매핑을 제공합니다.
+public extension AttendanceStatus {
+
+    /// 배지/버튼 배경 색상
+    var backgroundColor: Color {
+        switch self {
+        case .beforeAttendance: return .gray.opacity(0.7)
+        case .pendingApproval:  return .yellow.opacity(0.7)
+        case .present:          return .green.opacity(0.7)
+        case .late:             return .yellow.opacity(0.7)
+        case .absent:           return .red.opacity(0.7)
+        }
+    }
+
+    /// 배지/버튼 폰트 색상
+    var fontColor: Color {
+        .white
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Extensions/MyAttendanceItemStatus+Color.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Extensions/MyAttendanceItemStatus+Color.swift
@@ -1,0 +1,31 @@
+//
+//  MyAttendanceItemStatus+Color.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 5/7/26.
+//
+
+import SwiftUI
+import ActivityDomain
+
+/// `MyAttendanceItemStatus` 의 시각 표현 매핑.
+///
+/// 도메인 enum 자체는 SwiftUI 의존을 갖지 않도록 분리되어 있으며,
+/// 본 extension 은 Presentation 레이어 전용 색상 매핑을 제공합니다.
+public extension MyAttendanceItemStatus {
+
+    /// 배지/버튼 배경 색상
+    var backgroundColor: Color {
+        switch self {
+        case .pendingApproval: return .yellow.opacity(0.7)
+        case .present:         return .green.opacity(0.7)
+        case .late:            return .yellow.opacity(0.7)
+        case .absent:          return .red.opacity(0.7)
+        }
+    }
+
+    /// 배지/버튼 폰트 색상
+    var fontColor: Color {
+        .white
+    }
+}

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -7,5 +7,6 @@ let project = featureProject(
     domainDeploymentTargets: .multiplatform(iOS: "26.3", watchOS: "26.3"),
     presentationExtraDependencies: [
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
-    ]
+    ],
+    includesDomainTests: true
 )

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
@@ -9,6 +9,9 @@ private let bundleIdBase = "dev.umc.feature"
 /// - Data: {Name}Domain + CoreNetwork + UMCFoundation 의존
 /// - Presentation: {Name}Domain + CoreDesignSystem + CoreUIComponents + UMCFoundation 의존
 ///
+/// 테스트 타겟은 레이어별로 옵션 활성화 시 생성됩니다 (`{Name}DomainTests`, `{Name}DataTests`, `{Name}PresentationTests`).
+/// 메인 타겟은 자동으로 의존성에 포함됩니다.
+///
 /// - Parameters:
 ///   - name: Feature 이름 (예: "Auth", "Home"). 타겟명 및 bundleId 생성에 사용됩니다.
 ///   - domainDestinations: Domain 타겟의 지원 플랫폼 (기본값: `.iOS`). watchOS 공유가 필요한 경우 `[.iPhone, .appleWatch]`로 지정.
@@ -16,58 +19,114 @@ private let bundleIdBase = "dev.umc.feature"
 ///   - domainExtraDependencies: Domain 타겟에 추가할 의존성
 ///   - dataExtraDependencies: Data 타겟에 추가할 의존성
 ///   - presentationExtraDependencies: Presentation 타겟에 추가할 의존성
+///   - includesDomainTests: `true`이면 `Domain/Tests/**` 소스를 사용하는 unitTests 타겟 생성
+///   - domainTestDependencies: Domain 테스트 타겟에 추가로 주입할 의존성 (메인 Domain은 자동 포함)
+///   - includesDataTests: `true`이면 `Data/Tests/**` 소스를 사용하는 unitTests 타겟 생성
+///   - dataTestDependencies: Data 테스트 타겟에 추가로 주입할 의존성 (메인 Data는 자동 포함)
+///   - includesPresentationTests: `true`이면 `Presentation/Tests/**` 소스를 사용하는 unitTests 타겟 생성
+///   - presentationTestDependencies: Presentation 테스트 타겟에 추가로 주입할 의존성 (메인 Presentation은 자동 포함)
 public func featureProject(
     name: String,
     domainDestinations: Destinations = .iOS,
     domainDeploymentTargets: DeploymentTargets = .iOS("26.3"),
     domainExtraDependencies: [TargetDependency] = [],
     dataExtraDependencies: [TargetDependency] = [],
-    presentationExtraDependencies: [TargetDependency] = []
+    presentationExtraDependencies: [TargetDependency] = [],
+    includesDomainTests: Bool = false,
+    domainTestDependencies: [TargetDependency] = [],
+    includesDataTests: Bool = false,
+    dataTestDependencies: [TargetDependency] = [],
+    includesPresentationTests: Bool = false,
+    presentationTestDependencies: [TargetDependency] = []
 ) -> Project {
     let nameLowered = name.lowercased()
+
+    var targets: [Target] = [
+        .target(
+            name: "\(name)Domain",
+            destinations: domainDestinations,
+            product: .staticFramework,
+            bundleId: "\(bundleIdBase).\(nameLowered).domain",
+            deploymentTargets: domainDeploymentTargets,
+            sources: ["Domain/Sources/**"],
+            dependencies: [
+                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+            ] + domainExtraDependencies
+        ),
+        .target(
+            name: "\(name)Data",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: "\(bundleIdBase).\(nameLowered).data",
+            deploymentTargets: .iOS("26.3"),
+            sources: ["Data/Sources/**"],
+            dependencies: [
+                .target(name: "\(name)Domain"),
+                .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
+                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+            ] + dataExtraDependencies
+        ),
+        .target(
+            name: "\(name)Presentation",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: "\(bundleIdBase).\(nameLowered).presentation",
+            deploymentTargets: .iOS("26.3"),
+            sources: ["Presentation/Sources/**"],
+            dependencies: [
+                .target(name: "\(name)Domain"),
+                .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
+                .project(target: "CoreUIComponents", path: .relativeToRoot("Core/UIComponents")),
+                .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+            ] + presentationExtraDependencies
+        ),
+    ]
+
+    if includesDomainTests {
+        targets.append(
+            .target(
+                name: "\(name)DomainTests",
+                destinations: domainDestinations,
+                product: .unitTests,
+                bundleId: "\(bundleIdBase).\(nameLowered).domain.tests",
+                deploymentTargets: domainDeploymentTargets,
+                sources: ["Domain/Tests/**"],
+                dependencies: [.target(name: "\(name)Domain")] + domainTestDependencies
+            )
+        )
+    }
+
+    if includesDataTests {
+        targets.append(
+            .target(
+                name: "\(name)DataTests",
+                destinations: .iOS,
+                product: .unitTests,
+                bundleId: "\(bundleIdBase).\(nameLowered).data.tests",
+                deploymentTargets: .iOS("26.3"),
+                sources: ["Data/Tests/**"],
+                dependencies: [.target(name: "\(name)Data")] + dataTestDependencies
+            )
+        )
+    }
+
+    if includesPresentationTests {
+        targets.append(
+            .target(
+                name: "\(name)PresentationTests",
+                destinations: .iOS,
+                product: .unitTests,
+                bundleId: "\(bundleIdBase).\(nameLowered).presentation.tests",
+                deploymentTargets: .iOS("26.3"),
+                sources: ["Presentation/Tests/**"],
+                dependencies: [.target(name: "\(name)Presentation")] + presentationTestDependencies
+            )
+        )
+    }
 
     return Project(
         name: name,
         settings: recommendedProjectSettings,
-        targets: [
-            .target(
-                name: "\(name)Domain",
-                destinations: domainDestinations,
-                product: .staticFramework,
-                bundleId: "\(bundleIdBase).\(nameLowered).domain",
-                deploymentTargets: domainDeploymentTargets,
-                sources: ["Domain/Sources/**"],
-                dependencies: [
-                    .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-                ] + domainExtraDependencies
-            ),
-            .target(
-                name: "\(name)Data",
-                destinations: .iOS,
-                product: .staticFramework,
-                bundleId: "\(bundleIdBase).\(nameLowered).data",
-                deploymentTargets: .iOS("26.3"),
-                sources: ["Data/Sources/**"],
-                dependencies: [
-                    .target(name: "\(name)Domain"),
-                    .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
-                    .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-                ] + dataExtraDependencies
-            ),
-            .target(
-                name: "\(name)Presentation",
-                destinations: .iOS,
-                product: .staticFramework,
-                bundleId: "\(bundleIdBase).\(nameLowered).presentation",
-                deploymentTargets: .iOS("26.3"),
-                sources: ["Presentation/Sources/**"],
-                dependencies: [
-                    .target(name: "\(name)Domain"),
-                    .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
-                    .project(target: "CoreUIComponents", path: .relativeToRoot("Core/UIComponents")),
-                    .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-                ] + presentationExtraDependencies
-            ),
-        ]
+        targets: targets
     )
 }


### PR DESCRIPTION
resolves #604

## ✨ PR 유형

♻️ Refactor — Issue [#604](https://github.com/UMC-PRODUCT/umc-product-iOS/issues/604) 작업

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (Domain/Data 레이어 이관 + 테스트 작성)

## 🛠️ 작업내용

### #604 완료 조건 5/5

- [x] **Session 모델 ActivityDomain 이관** — `Session.swift`, `SessionInfo.swift`, `SessionStatus.swift`
- [x] **MyAttendanceItemModel, OperatorSessionAttendance 이관**
- [x] **ScheduleIconCategory 크로스 모듈 의존 해결** — Foundation 에 raw enum, DesignSystem 에 시각 extension 으로 분할
- [x] **Color 매핑을 Presentation extension 으로 복원** — Domain 의 SwiftUI 의존 완전 제거
- [x] **ActivityDomain 타겟 단독 빌드 성공**

### 추가 산출물

- **Swift Testing 기반 단위 테스트 작성** (파트 리드 가이드 — `import Testing`, XCTest 미사용)
  - 테스트 파일 9개 (Activity 5 + Foundation 1 + 도메인 규칙 보강 4) / 총 **85 cases / 8 suites**
  - **ActivityDomain 커버리지 68.22% → 92.26%** (목표 80% 초과)
- **`featureProject` Tuist 헬퍼 확장** — `includesDomainTests/DataTests/PresentationTests` 옵션 추가 (기본값 `false` 라 다른 Feature 영향 없음). 5차 이후 다른 Feature 테스트 작성 시 그대로 재사용
- **Sendable conformance 보강** — Activity Domain 의 enum/식별자 단순 타입에 Sendable 표기 추가 (Swift 6 strict concurrency 경고 0건)

### 핵심 설계 결정 3건

| 결정 | 근거 |
|------|------|
| `ScheduleIconCategory` 를 Foundation+DesignSystem 으로 **분할 이관** | Home 담당자 미정 상태이므로 공용 위치가 안전. 추후 Home 이관 시 재작업 0 |
| `Session` 의 `id`/`info`/`==` 를 **`nonisolated`** 로 선언 | `@MainActor @Observable` 클래스의 `Equatable`/`Identifiable` 프로토콜 합성 충돌 해소 (Swift 6 정석 패턴) |
| `OperatorSessionAttendance` 에서 `@MainActor` **제거** | struct 자체는 격리 불필요. Session 참조만 메인 액터에서 접근하면 충분 + Equatable 합성 가능 |

## 📋 추후 진행 상황

- 5차 스프린트: Activity UseCase 이식 (이번 PR 의 도메인 모델 위에서 작업)
- Activity Data 레이어: Endpoint(TargetType), DTO, Repository 구현체 (5~6차)
- 레거시 AppProduct 측 동일 모델 정리는 별도 이슈로 분리 (현 PR 에서는 레거시 유지 — 회귀 위험 0)

## 📌 리뷰 포인트

### 인프라 변경의 PR 포함 사유 (테스트 인프라가 본 PR 검증의 전제조건)

`Tuist/ProjectDescriptionHelpers/Project+Feature.swift`, `Features/Activity/Project.swift`, `Core/Foundation/Project.swift`, `Core/DesignSystem/Project.swift` 변경은 **테스트 작성을 위한 인프라**입니다.

- `featureProject` 에 테스트 타겟 생성 옵션이 없어 Swift Testing 으로 작성한 ActivityDomainTests 를 빌드/실행할 수 없는 상태였음
- `coreProject` 와 동일한 패턴으로 옵션 추가 (기본값 `false`)
- `CoreDesignSystem` 에 `UMCFoundation` 의존성 추가는 `ScheduleIconCategory+Visual` extension 작성에 **필수** (raw enum 위치)

분리 PR 도 검토했지만, 본 PR 의 테스트 코드가 그 변경 위에서만 빌드/통과하므로 함께 머지해야 검증 가능합니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)