### PR TITLE
♻️ [Refactor] NoticeDomain 이식 — 모델/열거형 레이어 분리 및 UMCPartType 공유 타입 추가

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeItemModel.swift
@@ -13,7 +13,7 @@ import SwiftUI
 struct NoticeItemModel: Equatable, Identifiable {
     let id = UUID()
     let noticeId: String
-    let generation: Int
+    let generation: String
     // 공지 출처 (중앙/지부/교내)
     let scope: NoticeScope
     // 공지 카테고리 (일반/파트별)
@@ -29,7 +29,7 @@ struct NoticeItemModel: Equatable, Identifiable {
     let links: [String]
     let images: [String]
     let vote: NoticeVote?
-    let viewCount: Int
+    let viewCount: String
     let scopeDisplayName: String?
     let targetsAllGenerations: Bool
     let parts: [UMCPartType]
@@ -37,7 +37,7 @@ struct NoticeItemModel: Equatable, Identifiable {
 
     init(
         noticeId: String = UUID().uuidString,
-        generation: Int,
+        generation: String,
         scope: NoticeScope,
         category: NoticeCategory,
         mustRead: Bool,
@@ -51,7 +51,7 @@ struct NoticeItemModel: Equatable, Identifiable {
         links: [String],
         images: [String],
         vote: NoticeVote?,
-        viewCount: Int,
+        viewCount: String,
         scopeDisplayName: String? = nil,
         targetsAllGenerations: Bool = false,
         parts: [UMCPartType] = [],

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeModel.swift
@@ -11,8 +11,8 @@ import SwiftUI
 // MARK: - Generation
 /// 기수 모델
 struct Generation: Identifiable, Equatable, Hashable {
-    let value: Int
-    var id: Int { value }
+    let value: String
+    var id: String { value }
     var title: String { "\(value)기" }
 }
 

--- a/UMCApp/Core/Foundation/Sources/Types/UMCPartType.swift
+++ b/UMCApp/Core/Foundation/Sources/Types/UMCPartType.swift
@@ -1,0 +1,202 @@
+//
+//  UMCPartType.swift
+//  UMCFoundation
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import Foundation
+
+/// UMC 동아리의 파트(직무) 유형을 정의하는 열거형입니다.
+///
+/// UMC는 PM, 디자인, 서버(Spring/Node), 프론트(Web/Android/iOS) 파트로 구성되며,
+/// 이 열거형은 각 파트와 세부 기술 스택을 타입 안전하게 표현합니다.
+///
+/// - Note: Associated Value를 사용하여 서버/프론트 파트의 세부 기술 스택을 구분합니다.
+///
+/// - Usage:
+/// ```swift
+/// let userPart: UMCPartType = .front(type: .ios)
+/// print(userPart.name)  // "iOS"
+///
+/// let serverPart: UMCPartType = .server(type: .spring)
+/// print(serverPart.name)  // "Spring"
+/// ```
+public enum UMCPartType: Codable, Equatable, Hashable {
+    // MARK: - Cases
+
+    /// 운영진 파트
+    case admin
+
+    /// 기획 파트 (Project Manager)
+    case pm
+
+    /// 디자인 파트 (UI/UX Designer)
+    case design
+
+    /// 서버 파트 (Backend Developer)
+    ///
+    /// - Parameter type: 서버 기술 스택 (Spring, Node.js)
+    case server(type: ServerType)
+
+    /// 프론트 파트 (Frontend Developer)
+    ///
+    /// - Parameter type: 프론트 기술 스택 (Web, Android, iOS)
+    case front(type: FrontType)
+
+    // MARK: - Property
+
+    /// 파트의 표시 이름을 반환합니다.
+    ///
+    /// - Returns:
+    ///   - PM: "PM"
+    ///   - Design: "Design"
+    ///   - Server: "Spring" 또는 "NodeJS"
+    ///   - Front: "Web", "Android", "iOS"
+    public var name: String {
+        switch self {
+        case .admin:
+            return "Admin"
+        case .pm:
+            return "PM"
+        case .design:
+            return "Design"
+        case .server(let type):
+            return type.rawValue
+        case .front(let type):
+            return type.rawValue
+        }
+    }
+    
+    /// 파트의 정렬 순서를 반환합니다.
+    ///
+    /// 정렬 순서: PM(0) > Design(1) > Web(2) > iOS(3) > Android(4) > Spring(5) > NodeJS(6)
+    public var sortOrder: Int {
+        switch self {
+        case .admin:
+            return -1
+        case .pm:
+            return 0
+        case .design:
+            return 1
+        case .front(let type):
+            switch type {
+            case .web:
+                return 2
+            case .ios:
+                return 3
+            case .android:
+                return 4
+            }
+        case .server(let type):
+            switch type {
+            case .spring:
+                return 5
+            case .node:
+                return 6
+            }
+        }
+    }
+   
+    /// 파트별 아이콘
+    public var icon: String {
+        switch self {
+        case .admin: return "person.badge.key.fill"
+        case .pm: return "doc.text.fill"
+        case .design: return "paintpalette.fill"
+        case .server(type: .spring): return "leaf.fill"
+        case .server(type: .node): return "hexagon.fill"
+        case .front(type: .web): return "globe"
+        case .front(type: .android): return "inset.filled.applewatch.case"
+        case .front(type: .ios): return "apple.logo"
+        }
+    }
+
+    /// 모든 파트 조합 (Associated Value로 CaseIterable 불가하여 직접 정의)
+    public static let allCases: [UMCPartType] = [
+        .pm, .design,
+        .server(type: .spring), .server(type: .node),
+        .front(type: .web), .front(type: .android),
+        .front(type: .ios)
+    ]
+
+    // MARK: - Nested Types
+
+    /// 서버 파트의 기술 스택을 정의하는 열거형입니다.
+    public enum ServerType: String, Codable, Equatable, Hashable {
+        /// Spring Framework 기반 백엔드 개발
+        case spring = "Spring"
+
+        /// Node.js 기반 백엔드 개발
+        case node = "NodeJS"
+    }
+
+    /// 프론트 파트의 기술 스택을 정의하는 열거형입니다.
+    public enum FrontType: String, Codable, Equatable, Hashable {
+        /// 웹 프론트엔드 개발 (React, Vue 등)
+        case web = "Web"
+
+        /// Android 네이티브 앱 개발 (Kotlin/Java)
+        case android = "Android"
+
+        /// iOS 네이티브 앱 개발 (Swift)
+        case ios = "iOS"
+    }
+
+    // MARK: - API 변환
+
+    /// 서버 API 쿼리 파라미터용 문자열
+    public var apiValue: String {
+        switch self {
+        case .admin:                    return "ADMIN"
+        case .pm:                       return "PLAN"
+        case .design:                   return "DESIGN"
+        case .server(let type):
+            switch type {
+            case .spring:               return "SPRINGBOOT"
+            case .node:                 return "NODEJS"
+            }
+        case .front(let type):
+            switch type {
+            case .web:                  return "WEB"
+            case .android:              return "ANDROID"
+            case .ios:                  return "IOS"
+            }
+        }
+    }
+
+    /// 서버 API 문자열로부터 생성
+    public init?(apiValue: String) {
+        switch apiValue {
+        case "ADMIN":       self = .admin
+        case "PLAN":        self = .pm
+        case "DESIGN":      self = .design
+        case "SPRINGBOOT":  self = .server(type: .spring)
+        case "NODEJS":      self = .server(type: .node)
+        case "WEB":         self = .front(type: .web)
+        case "ANDROID":     self = .front(type: .android)
+        case "IOS":         self = .front(type: .ios)
+        default:            return nil
+        }
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+
+        guard let part = UMCPartType(apiValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid UMCPartType api value: \(rawValue)"
+            )
+        }
+        self = part
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(apiValue)
+    }
+}

--- a/UMCApp/Core/UIComponents/Project.swift
+++ b/UMCApp/Core/UIComponents/Project.swift
@@ -6,6 +6,7 @@ let project = coreProject(
     bundleIdSuffix: "uicomponents",
     dependencies: [
         .project(target: "CoreDesignSystem", path: .relativeToRoot("Core/DesignSystem")),
+        .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
         .external(name: "Kingfisher"),
     ]
 )

--- a/UMCApp/Core/UIComponents/Sources/Extensions/UMCPartType+Color.swift
+++ b/UMCApp/Core/UIComponents/Sources/Extensions/UMCPartType+Color.swift
@@ -1,6 +1,6 @@
 //
 //  UMCPartType+Color.swift
-//  CoreDesignSystem
+//  CoreUIComponents
 //
 //  Created by 이예지 on 5/8/26.
 //

--- a/UMCApp/Core/UIComponents/Sources/Extensions/UMCPartType+Color.swift
+++ b/UMCApp/Core/UIComponents/Sources/Extensions/UMCPartType+Color.swift
@@ -1,0 +1,34 @@
+//
+//  UMCPartType+Color.swift
+//  CoreDesignSystem
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import SwiftUI
+import UMCFoundation
+
+extension UMCPartType {
+    /// 파트별 고유 색상
+    public var color: Color {
+        switch self {
+        case .admin:
+            return .indigo
+        case .pm:
+            return .purple
+        case .design:
+            return .pink
+        case .server(let type):
+            switch type {
+            case .spring: return .green
+            case .node:   return .yellow
+            }
+        case .front(let type):
+            switch type {
+            case .web:     return .brown
+            case .android: return .teal
+            case .ios:     return .orange
+            }
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Enums/NoticePart.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Enums/NoticePart.swift
@@ -1,0 +1,112 @@
+//
+//  NoticePart.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - NoticePart
+/// 공지 탭(UI 필터) 전용 파트 타입
+public enum NoticePart: String, CaseIterable, Identifiable, Equatable, Hashable {
+    case web
+    case ios
+    case android
+    case design
+    case plan
+    case nodejs
+    case springboot
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .web:
+            return "Web"
+        case .ios:
+            return "iOS"
+        case .android:
+            return "Android"
+        case .design:
+            return "Design"
+        case .plan:
+            return "Plan"
+        case .nodejs:
+            return "Node.js"
+        case .springboot:
+            return "SpringBoot"
+        }
+    }
+
+    public var iconName: String {
+        switch self {
+        case .web:
+            return "globe"
+        case .ios:
+            return "apple.logo"
+        case .android:
+            return "inset.filled.applewatch.case"
+        case .design:
+            return "paintpalette.fill"
+        case .plan:
+            return "doc.text.fill"
+        case .nodejs:
+            return "hexagon.fill"
+        case .springboot:
+            return "leaf.fill"
+        }
+    }
+
+    public var umcPartType: UMCPartType {
+        switch self {
+        case .web:
+            return .front(type: .web)
+        case .ios:
+            return .front(type: .ios)
+        case .android:
+            return .front(type: .android)
+        case .design:
+            return .design
+        case .plan:
+            return .pm
+        case .nodejs:
+            return .server(type: .node)
+        case .springboot:
+            return .server(type: .spring)
+        }
+    }
+
+    public init?(apiValue: String) {
+        guard let part = UMCPartType(apiValue: apiValue) else { return nil }
+        self.init(umcPartType: part)
+    }
+
+    public init?(umcPartType: UMCPartType) {
+        switch umcPartType {
+        case .admin:
+            return nil
+        case .front(let type):
+            switch type {
+            case .web:
+                self = .web
+            case .ios:
+                self = .ios
+            case .android:
+                self = .android
+            }
+        case .design:
+            self = .design
+        case .pm:
+            self = .plan
+        case .server(let type):
+            switch type {
+            case .node:
+                self = .nodejs
+            case .spring:
+                self = .springboot
+            }
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Enums/NoticeType.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Enums/NoticeType.swift
@@ -1,0 +1,18 @@
+//
+//  NoticeType.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import Foundation
+
+// MARK: - NoticeType
+/// NoticeChip에 쓰이는 enum
+public enum NoticeType: String, Equatable {
+    case essential = "필독"
+    case core = "중앙"
+    case branch = "지부"
+    case campus = "교내"
+    case part = "파트"
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
@@ -15,7 +15,7 @@ public struct NoticeDetail: Equatable, Identifiable, Hashable {
     /// 공지 고유 ID
     public let id: String
     /// 기수
-    public let generation: Int
+    public let generation: String
     /// 공지 범위 (중앙/지부/교내)
     public let scope: NoticeScope
     /// 공지 카테고리
@@ -80,25 +80,19 @@ public struct NoticeDetail: Equatable, Identifiable, Hashable {
     }
 
     private var generationOrdinalText: String {
-        guard generation > 0 else { return "" }
+        guard let gen = Int(generation), gen > 0 else { return "" }
         return "-\(generation)\(generationOrdinalSuffix)"
     }
 
     private var generationOrdinalSuffix: String {
-        let suffixBase = generation % 100
-        if (11...13).contains(suffixBase) {
-            return "th"
-        }
-
-        switch generation % 10 {
-        case 1:
-            return "st"
-        case 2:
-            return "nd"
-        case 3:
-            return "rd"
-        default:
-            return "th"
+        guard let gen = Int(generation) else { return "th" }
+        let suffixBase = gen % 100
+        if (11...13).contains(suffixBase) { return "th" }
+        switch gen % 10 {
+        case 1: return "st"
+        case 2: return "nd"
+        case 3: return "rd"
+        default: return "th"
         }
     }
 
@@ -122,7 +116,7 @@ public struct NoticeDetail: Equatable, Identifiable, Hashable {
     
     public init(
         id: String,
-        generation: Int,
+        generation: String,
         scope: NoticeScope,
         category: NoticeCategory,
         isMustRead: Bool,
@@ -169,26 +163,31 @@ public struct NoticeDetail: Equatable, Identifiable, Hashable {
 public struct NoticeAttachmentImage: Equatable, Hashable, Identifiable {
     public let id: String
     public let url: String
+    
+    public init(id: String, url: String) {
+        self.id = id
+        self.url = url
+    }
 }
 
 
 // MARK: - TargetAudienc
 /// 공지 수신 대상
 public struct TargetAudience: Equatable, Hashable {
-    public let generation: Int
+    public let generation: String
     public let scope: NoticeScope
     public let parts: [UMCPartType]
-    public let chapterId: Int?
-    public let schoolId: Int?
+    public let chapterId: String?
+    public let schoolId: String?
     public let branches: [String]
     public let schools: [String]
 
     public init(
-        generation: Int,
+        generation: String,
         scope: NoticeScope,
         parts: [UMCPartType],
-        chapterId: Int? = nil,
-        schoolId: Int? = nil,
+        chapterId: String? = nil,
+        schoolId: String? = nil,
         branches: [String],
         schools: [String]
     ) {
@@ -204,7 +203,7 @@ public struct TargetAudience: Equatable, Hashable {
 
 extension TargetAudience {
     /// 전체 대상 (기본값)
-    public static func all(generation: Int, scope: NoticeScope) -> TargetAudience {
+    public static func all(generation: String, scope: NoticeScope) -> TargetAudience {
         TargetAudience(
             generation: generation,
             scope: scope,
@@ -222,7 +221,7 @@ extension TargetAudience {
 /// fullScreenCover에서 Identifiable 사용을 위한 래퍼
 public struct ImageViewerItem: Identifiable {
     public let id = UUID()
-    public let index: Int
+    public let index: String
 }
 
 
@@ -244,7 +243,7 @@ public struct NoticeVote: Equatable, Identifiable, Hashable {
     /// 투표 상태 (서버 제공)
     public let status: VoteStatus
     /// 전체 참여자 수 (서버 제공) — 복수 선택 시 voteCount 합과 다를 수 있음
-    public let totalParticipants: Int
+    public let totalParticipants: String
 
     public init(
         id: String,
@@ -256,7 +255,7 @@ public struct NoticeVote: Equatable, Identifiable, Hashable {
         isAnonymous: Bool,
         userVotedOptionIds: [String],
         status: VoteStatus? = nil,
-        totalParticipants: Int? = nil
+        totalParticipants: String? = nil
     ) {
         self.id = id
         self.question = question
@@ -269,13 +268,13 @@ public struct NoticeVote: Equatable, Identifiable, Hashable {
         self.status = status
             ?? VoteStatus.fallback(now: .now, startsAt: startDate, endsAt: endDate)
         self.totalParticipants = totalParticipants
-            ?? options.reduce(0) { $0 + $1.voteCount }
+              ?? String(options.reduce(0) { $0 + (Int($1.voteCount) ?? 0) })
     }
 
     /// 옵션별 voteCount 합계 (복수 선택 시 totalParticipants와 다름)
     public var totalVotes: Int {
-        options.reduce(0) { $0 + $1.voteCount }
-    }
+          options.reduce(0) { $0 + (Int($1.voteCount) ?? 0) }
+      }
 
     /// 투표 종료 여부
     public var isEnded: Bool {
@@ -292,30 +291,30 @@ public struct NoticeVote: Equatable, Identifiable, Hashable {
 public struct VoteOption: Equatable, Identifiable, Hashable {
     public let id: String
     public let title: String
-    public let voteCount: Int
+    public let voteCount: String
     public let selectedMemberIds: [String]
     /// 옵션 득표율 (서버 계산값, 0.0 ~ 100.0)
-    public let voteRate: Double
+    public let voteRate: String?
 
     public init(
         id: String,
         title: String,
-        voteCount: Int,
+        voteCount: String,
         selectedMemberIds: [String] = [],
-        voteRate: Double? = nil
+        voteRate: String? = nil
     ) {
         self.id = id
         self.title = title
         self.voteCount = voteCount
         self.selectedMemberIds = selectedMemberIds
-        self.voteRate = voteRate ?? 0
+        self.voteRate = voteRate
     }
 
     /// 투표율 — 서버 voteRate 우선, 없으면 클라이언트 계산
     public func percentage(totalVotes: Int) -> Double {
-        if voteRate > 0 { return voteRate }
+        if let rate = voteRate, let r = Double(rate), r > 0 { return r }
         guard totalVotes > 0 else { return 0 }
-        return Double(voteCount) / Double(totalVotes) * 100
+        return Double(Int(voteCount) ?? 0) / Double(totalVotes) * 100
     }
 }
 
@@ -351,17 +350,17 @@ public struct NoticeReadStatus: Equatable {
     public let unconfirmedUsers: [ReadStatusUser]
     
     /// 확인한 사람 수
-    public var confirmedCount: Int {
-        confirmedUsers.count
+    public var confirmedCount: String {
+        String(confirmedUsers.count)
     }
     
     /// 미확인한 사람 수
-    public var unconfirmedCount: Int {
-        unconfirmedUsers.count
+    public var unconfirmedCount: String {
+        String(unconfirmedUsers.count)
     }
     
     /// 전체 대상자 수
-    public var totalCount: Int {
+    public var totalCount: String {
         confirmedCount + unconfirmedCount
     }
     

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
@@ -1,0 +1,423 @@
+//
+//  NoticeDetailModel.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - NoticeDetail
+
+/// 공지사항 상세정보 엔티티
+public struct NoticeDetail: Equatable, Identifiable, Hashable {
+    /// 공지 고유 ID
+    public let id: String
+    /// 기수
+    public let generation: Int
+    /// 공지 범위 (중앙/지부/교내)
+    public let scope: NoticeScope
+    /// 공지 카테고리
+    public let category: NoticeCategory
+
+    /// 필독 여부
+    public let isMustRead: Bool
+
+    /// 공지 제목
+    public let title: String
+    /// 공지 본문
+    public let content: String
+
+    /// 작성자 ID
+    public let authorID: String
+    /// 작성자 멤버 ID (authorMemberId)
+    public let authorMemberId: String?
+    /// 작성자 닉네임
+    public let authorNickname: String?
+    /// 작성자 이름
+    public let authorName: String
+    /// 작성자 프로필 이미지 URL
+    public let authorImageURL: String?
+
+    /// 생성일
+    public let createdAt: Date
+    /// 수정일
+    public let updatedAt: Date?
+
+    /// 수신 대상
+    public let targetAudience: TargetAudience
+
+    /// 수정/삭제 권한 보유 여부
+    public let hasPermission: Bool
+
+    /// 첨부 이미지 URL 목록
+    public let images: [String]
+    /// 첨부 이미지 원본 메타데이터 (수정 화면의 교체 API 구성에 사용)
+    public var imageItems: [NoticeAttachmentImage] = []
+    /// 첨부 링크 목록
+    public let links: [String]
+    /// 첨부 투표
+    public let vote: NoticeVote?
+
+    /// 작성자 표기 기본값 (닉네임/이름-xxth)
+    public var defaultAuthorDisplayName: String {
+        let trimmedNickname = authorNickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let trimmedName = authorName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let generationText = generationOrdinalText
+
+        if trimmedName.isEmpty || trimmedName == "알 수 없음" {
+            return "알 수 없음"
+        }
+
+        if !trimmedNickname.isEmpty && !trimmedName.isEmpty {
+            return "\(trimmedNickname)/\(trimmedName)\(generationText)"
+        }
+        if !trimmedNickname.isEmpty {
+            return "\(trimmedNickname)\(generationText)"
+        }
+        return "\(trimmedName)\(generationText)"
+    }
+
+    private var generationOrdinalText: String {
+        guard generation > 0 else { return "" }
+        return "-\(generation)\(generationOrdinalSuffix)"
+    }
+
+    private var generationOrdinalSuffix: String {
+        let suffixBase = generation % 100
+        if (11...13).contains(suffixBase) {
+            return "th"
+        }
+
+        switch generation % 10 {
+        case 1:
+            return "st"
+        case 2:
+            return "nd"
+        case 3:
+            return "rd"
+        default:
+            return "th"
+        }
+    }
+
+    /// NoticeChip에 표시할 공지 타입
+    public var noticeType: NoticeType {
+        // 파트 공지인 경우
+        if case .part = category {
+            return .part
+        }
+        
+        // scope에 따라 구분
+        switch scope {
+        case .central:
+            return .core
+        case .branch:
+            return .branch
+        case .campus:
+            return .campus
+        }
+    }
+    
+    public init(
+        id: String,
+        generation: Int,
+        scope: NoticeScope,
+        category: NoticeCategory,
+        isMustRead: Bool,
+        title: String,
+        content: String,
+        authorID: String,
+        authorMemberId: String? = nil,
+        authorNickname: String? = nil,
+        authorName: String,
+        authorImageURL: String?,
+        createdAt: Date,
+        updatedAt: Date?,
+        targetAudience: TargetAudience,
+        hasPermission: Bool,
+        images: [String],
+        imageItems: [NoticeAttachmentImage] = [],
+        links: [String],
+        vote: NoticeVote?
+    ) {
+        self.id = id
+        self.generation = generation
+        self.scope = scope
+        self.category = category
+        self.isMustRead = isMustRead
+        self.title = title
+        self.content = content
+        self.authorID = authorID
+        self.authorMemberId = authorMemberId
+        self.authorNickname = authorNickname
+        self.authorName = authorName
+        self.authorImageURL = authorImageURL
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.targetAudience = targetAudience
+        self.hasPermission = hasPermission
+        self.images = images
+        self.imageItems = imageItems
+        self.links = links
+        self.vote = vote
+    }
+}
+
+/// 공지 첨부 이미지 메타데이터
+public struct NoticeAttachmentImage: Equatable, Hashable, Identifiable {
+    public let id: String
+    public let url: String
+}
+
+
+// MARK: - TargetAudienc
+/// 공지 수신 대상
+public struct TargetAudience: Equatable, Hashable {
+    public let generation: Int
+    public let scope: NoticeScope
+    public let parts: [UMCPartType]
+    public let chapterId: Int?
+    public let schoolId: Int?
+    public let branches: [String]
+    public let schools: [String]
+
+    public init(
+        generation: Int,
+        scope: NoticeScope,
+        parts: [UMCPartType],
+        chapterId: Int? = nil,
+        schoolId: Int? = nil,
+        branches: [String],
+        schools: [String]
+    ) {
+        self.generation = generation
+        self.scope = scope
+        self.parts = parts
+        self.chapterId = chapterId
+        self.schoolId = schoolId
+        self.branches = branches
+        self.schools = schools
+    }
+}
+
+extension TargetAudience {
+    /// 전체 대상 (기본값)
+    public static func all(generation: Int, scope: NoticeScope) -> TargetAudience {
+        TargetAudience(
+            generation: generation,
+            scope: scope,
+            parts: [],
+            chapterId: nil,
+            schoolId: nil,
+            branches: [],
+            schools: []
+        )
+    }
+}
+
+
+// MARK: - ImageViewerItem
+/// fullScreenCover에서 Identifiable 사용을 위한 래퍼
+public struct ImageViewerItem: Identifiable {
+    public let id = UUID()
+    public let index: Int
+}
+
+
+// MARK: - NoticeVote
+
+/// 공지사항 투표
+public struct NoticeVote: Equatable, Identifiable, Hashable {
+    public let id: String
+    public let question: String
+    public let options: [VoteOption]
+    public let startDate: Date
+    public let endDate: Date
+    /// 복수 선택 허용 여부
+    public let allowMultipleChoices: Bool
+    /// 익명 투표 여부
+    public let isAnonymous: Bool
+    /// 현재 사용자가 투표한 옵션 ID 목록
+    public let userVotedOptionIds: [String]
+    /// 투표 상태 (서버 제공)
+    public let status: VoteStatus
+    /// 전체 참여자 수 (서버 제공) — 복수 선택 시 voteCount 합과 다를 수 있음
+    public let totalParticipants: Int
+
+    public init(
+        id: String,
+        question: String,
+        options: [VoteOption],
+        startDate: Date,
+        endDate: Date,
+        allowMultipleChoices: Bool,
+        isAnonymous: Bool,
+        userVotedOptionIds: [String],
+        status: VoteStatus? = nil,
+        totalParticipants: Int? = nil
+    ) {
+        self.id = id
+        self.question = question
+        self.options = options
+        self.startDate = startDate
+        self.endDate = endDate
+        self.allowMultipleChoices = allowMultipleChoices
+        self.isAnonymous = isAnonymous
+        self.userVotedOptionIds = userVotedOptionIds
+        self.status = status
+            ?? VoteStatus.fallback(now: .now, startsAt: startDate, endsAt: endDate)
+        self.totalParticipants = totalParticipants
+            ?? options.reduce(0) { $0 + $1.voteCount }
+    }
+
+    /// 옵션별 voteCount 합계 (복수 선택 시 totalParticipants와 다름)
+    public var totalVotes: Int {
+        options.reduce(0) { $0 + $1.voteCount }
+    }
+
+    /// 투표 종료 여부
+    public var isEnded: Bool {
+        status == .ended
+    }
+
+    /// 사용자 투표 여부
+    public var hasUserVoted: Bool {
+        !userVotedOptionIds.isEmpty
+    }
+}
+
+/// 투표 옵션
+public struct VoteOption: Equatable, Identifiable, Hashable {
+    public let id: String
+    public let title: String
+    public let voteCount: Int
+    public let selectedMemberIds: [String]
+    /// 옵션 득표율 (서버 계산값, 0.0 ~ 100.0)
+    public let voteRate: Double
+
+    public init(
+        id: String,
+        title: String,
+        voteCount: Int,
+        selectedMemberIds: [String] = [],
+        voteRate: Double? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.voteCount = voteCount
+        self.selectedMemberIds = selectedMemberIds
+        self.voteRate = voteRate ?? 0
+    }
+
+    /// 투표율 — 서버 voteRate 우선, 없으면 클라이언트 계산
+    public func percentage(totalVotes: Int) -> Double {
+        if voteRate > 0 { return voteRate }
+        guard totalVotes > 0 else { return 0 }
+        return Double(voteCount) / Double(totalVotes) * 100
+    }
+}
+
+/// 투표 상태 (서버 enum 매핑)
+public enum VoteStatus: String {
+    case notStarted = "NOT_STARTED"
+    case active = "OPEN"
+    case ended = "CLOSED"
+
+    /// 미정의 raw value 또는 서버 미제공 시 fallback (시작/종료 시각 기반)
+    public static func fallback(now: Date, startsAt: Date, endsAt: Date) -> VoteStatus {
+        if now < startsAt { return .notStarted }
+        if now >= endsAt { return .ended }
+        return .active
+    }
+}
+
+
+// MARK: - ReadStatusTab
+
+/// 공지 열람 현황 탭 (확인/미확인)
+public enum ReadStatusTab: String, CaseIterable {
+    case confirmed = "확인"
+    case unconfirmed = "미확인"
+}
+
+// MARK: - NoticeReadStatus
+
+/// 공지 열람 현황 전체 데이터
+public struct NoticeReadStatus: Equatable {
+    public let noticeId: String
+    public let confirmedUsers: [ReadStatusUser]
+    public let unconfirmedUsers: [ReadStatusUser]
+    
+    /// 확인한 사람 수
+    public var confirmedCount: Int {
+        confirmedUsers.count
+    }
+    
+    /// 미확인한 사람 수
+    public var unconfirmedCount: Int {
+        unconfirmedUsers.count
+    }
+    
+    /// 전체 대상자 수
+    public var totalCount: Int {
+        confirmedCount + unconfirmedCount
+    }
+    
+    /// 하단 메시지 (예: "이미 3명이 공지를 확인했습니다.")
+    public var bottomMessage: String {
+        "이미 \(confirmedCount)명이 공지를 확인했습니다."
+    }
+}
+
+
+// MARK: - ReadStatusUser
+
+/// 공지 열람 현황 - 사용자 정보
+public struct ReadStatusUser: Equatable, Identifiable {
+    public let id: String
+    public let name: String
+    public let nickName: String
+    public let part: String
+    public let branch: String
+    public let campus: String
+    public let profileImageURL: String?
+    public let isRead: Bool
+    
+    /// NoticeReadStatusItemModel로 변환
+    public func toItemModel() -> NoticeReadStatusItemModel {
+        NoticeReadStatusItemModel(
+            profileImageURL: profileImageURL,
+            userName: name,
+            nickName: nickName,
+            part: part,
+            location: branch,
+            campus: campus,
+            isRead: isRead
+        )
+    }
+}
+
+// MARK: - ReadStatusFilterType
+
+/// 공지 열람 현황 필터 타입
+public enum ReadStatusFilterType: String, CaseIterable, Identifiable {
+    case all = "전체 보기"
+    case branch = "지부별 보기"
+    case school = "학교별 보기"
+    
+    public var id: String { rawValue }
+
+    /// 열람 현황 필터 메뉴 아이콘
+    public var iconName: String {
+        switch self {
+        case .all:
+            return "line.3.horizontal.decrease"
+        case .branch:
+            return "mappin.and.ellipse"
+        case .school:
+            return "graduationcap"
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
@@ -171,7 +171,7 @@ public struct NoticeAttachmentImage: Equatable, Hashable, Identifiable {
 }
 
 
-// MARK: - TargetAudienc
+// MARK: - TargetAudience
 /// 공지 수신 대상
 public struct TargetAudience: Equatable, Hashable {
     public let generation: String
@@ -273,8 +273,8 @@ public struct NoticeVote: Equatable, Identifiable, Hashable {
 
     /// 옵션별 voteCount 합계 (복수 선택 시 totalParticipants와 다름)
     public var totalVotes: Int {
-          options.reduce(0) { $0 + (Int($1.voteCount) ?? 0) }
-      }
+        options.reduce(0) { $0 + (Int($1.voteCount) ?? 0) }
+    }
 
     /// 투표 종료 여부
     public var isEnded: Bool {
@@ -361,7 +361,7 @@ public struct NoticeReadStatus: Equatable {
     
     /// 전체 대상자 수
     public var totalCount: String {
-        confirmedCount + unconfirmedCount
+        String(confirmedUsers.count + unconfirmedUsers.count)
     }
     
     /// 하단 메시지 (예: "이미 3명이 공지를 확인했습니다.")
@@ -407,16 +407,4 @@ public enum ReadStatusFilterType: String, CaseIterable, Identifiable {
     case school = "학교별 보기"
     
     public var id: String { rawValue }
-
-    /// 열람 현황 필터 메뉴 아이콘
-    public var iconName: String {
-        switch self {
-        case .all:
-            return "line.3.horizontal.decrease"
-        case .branch:
-            return "mappin.and.ellipse"
-        case .school:
-            return "graduationcap"
-        }
-    }
 }

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeEditorModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeEditorModel.swift
@@ -11,10 +11,10 @@ import UMCFoundation
 // MARK: - NoticeTargetOption
 /// 공지 타겟 선택(지부/학교)용 옵션 모델
 public struct NoticeTargetOption: Identifiable, Equatable, Hashable {
-    public let id: Int
+    public let id: String
     public let name: String
     
-    public init(id: Int, name: String) {
+    public init(id: String, name: String) {
         self.id = id
         self.name = name
     }

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeEditorModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeEditorModel.swift
@@ -1,0 +1,24 @@
+//
+//  NoticeEditorModel.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - NoticeTargetOption
+/// 공지 타겟 선택(지부/학교)용 옵션 모델
+public struct NoticeTargetOption: Identifiable, Equatable, Hashable {
+    public let id: Int
+    public let name: String
+    
+    public init(id: Int, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+
+

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeItemModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeItemModel.swift
@@ -1,0 +1,132 @@
+//
+//  NoticeItemModel.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 공지사항 목록 아이템 모델
+///
+/// 공지 리스트 셀에 표시할 정보를 담으며, scope/category 조합으로 태그를 생성합니다.
+public struct NoticeItemModel: Equatable, Identifiable {
+    public let id = UUID()
+    public let noticeId: String
+    public let generation: Int
+    // 공지 출처 (중앙/지부/교내)
+    public let scope: NoticeScope
+    // 공지 카테고리 (일반/파트별)
+    public let category: NoticeCategory
+    public let mustRead: Bool
+    public let isAlert: Bool
+    public let date: Date
+    public let title: String
+    public let content: String
+    public let writer: String
+    public let authorNickname: String?
+    public let authorName: String?
+    public let links: [String]
+    public let images: [String]
+    public let vote: NoticeVote?
+    public let viewCount: Int
+    public let scopeDisplayName: String?
+    public let targetsAllGenerations: Bool
+    public let parts: [UMCPartType]
+    public let isRead: Bool
+
+    public init(
+        noticeId: String = UUID().uuidString,
+        generation: Int,
+        scope: NoticeScope,
+        category: NoticeCategory,
+        mustRead: Bool,
+        isAlert: Bool,
+        date: Date,
+        title: String,
+        content: String,
+        writer: String,
+        authorNickname: String? = nil,
+        authorName: String? = nil,
+        links: [String],
+        images: [String],
+        vote: NoticeVote?,
+        viewCount: Int,
+        scopeDisplayName: String? = nil,
+        targetsAllGenerations: Bool = false,
+        parts: [UMCPartType] = [],
+        isRead: Bool = false
+    ) {
+        self.noticeId = noticeId
+        self.generation = generation
+        self.scope = scope
+        self.category = category
+        self.mustRead = mustRead
+        self.isAlert = isAlert
+        self.date = date
+        self.title = title
+        self.content = content
+        self.writer = writer
+        self.authorNickname = authorNickname
+        self.authorName = authorName
+        self.links = links
+        self.images = images
+        self.vote = vote
+        self.viewCount = viewCount
+        self.scopeDisplayName = scopeDisplayName
+        self.targetsAllGenerations = targetsAllGenerations
+        self.parts = parts
+        self.isRead = isRead
+    }
+    
+    public var hasLink: Bool { !links.isEmpty }
+    public var hasVote: Bool { vote != nil }
+    public var displayWriter: String {
+        let trimmedName = (authorName ?? writer).trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNickname = authorNickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if !trimmedName.isEmpty && !trimmedNickname.isEmpty {
+            return "\(trimmedName)/\(trimmedNickname)"
+        }
+        if !trimmedName.isEmpty {
+            return trimmedName
+        }
+        if !trimmedNickname.isEmpty {
+            return trimmedNickname
+        }
+        return writer
+    }
+}
+
+extension NoticeItemModel {
+    /// 목록 아이템을 상세 화면용 NoticeDetail로 변환합니다.
+    public func toNoticeDetail() -> NoticeDetail {
+        NoticeDetail(
+            id: noticeId,
+            generation: generation,
+            scope: scope,
+            category: category,
+            isMustRead: mustRead,
+            title: title,
+            content: content,
+            authorID: "temp-\(id)",
+            authorNickname: authorNickname,
+            authorName: authorName ?? writer,
+            authorImageURL: nil,
+            createdAt: date,
+            updatedAt: nil,
+            targetAudience: TargetAudience(
+                generation: generation,
+                scope: scope,
+                parts: parts,
+                branches: [],
+                schools: []
+            ),
+            hasPermission: false,
+            images: images,
+            links: links,
+            vote: vote
+        )
+    }
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeItemModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeItemModel.swift
@@ -14,7 +14,7 @@ import UMCFoundation
 public struct NoticeItemModel: Equatable, Identifiable {
     public let id = UUID()
     public let noticeId: String
-    public let generation: Int
+    public let generation: String
     // 공지 출처 (중앙/지부/교내)
     public let scope: NoticeScope
     // 공지 카테고리 (일반/파트별)
@@ -30,7 +30,7 @@ public struct NoticeItemModel: Equatable, Identifiable {
     public let links: [String]
     public let images: [String]
     public let vote: NoticeVote?
-    public let viewCount: Int
+    public let viewCount: String
     public let scopeDisplayName: String?
     public let targetsAllGenerations: Bool
     public let parts: [UMCPartType]
@@ -38,7 +38,7 @@ public struct NoticeItemModel: Equatable, Identifiable {
 
     public init(
         noticeId: String = UUID().uuidString,
-        generation: Int,
+        generation: String,
         scope: NoticeScope,
         category: NoticeCategory,
         mustRead: Bool,
@@ -52,7 +52,7 @@ public struct NoticeItemModel: Equatable, Identifiable {
         links: [String],
         images: [String],
         vote: NoticeVote?,
-        viewCount: Int,
+        viewCount: String,
         scopeDisplayName: String? = nil,
         targetsAllGenerations: Bool = false,
         parts: [UMCPartType] = [],

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeModel.swift
@@ -11,11 +11,11 @@ import UMCFoundation
 // MARK: - Generation
 /// 기수 모델
 public struct Generation: Identifiable, Equatable, Hashable {
-    public let value: Int
-    public var id: Int { value }
+    public let value: String
+    public var id: String { value }
     public var title: String { "\(value)기" }
     
-    public init(value: Int) {
+    public init(value: String) {
         self.value = value
     }
 }

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeModel.swift
@@ -1,0 +1,42 @@
+//
+//  NoticeModel.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - Generation
+/// 기수 모델
+public struct Generation: Identifiable, Equatable, Hashable {
+    public let value: Int
+    public var id: Int { value }
+    public var title: String { "\(value)기" }
+    
+    public init(value: Int) {
+        self.value = value
+    }
+}
+
+// MARK: - NoticeScope
+/// 공지 출처 (어디서 온 공지인지)
+public enum NoticeScope: Equatable, Hashable {
+    // 중앙
+    case central
+    // 지부
+    case branch
+    // 교내
+    case campus
+}
+
+// MARK: - NoticeCategory
+/// 공지 카테고리 (일반/파트별)
+public enum NoticeCategory: Equatable, Hashable {
+    // 일반 공지
+    case general
+    // 파트별 공지
+    case part(UMCPartType)
+}
+

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeReadStatusItemModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeReadStatusItemModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// 공지 확인 상태 모델
 public struct NoticeReadStatusItemModel: Equatable, Identifiable {
     public let id = UUID()
     public let profileImageURL: String?

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeReadStatusItemModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeReadStatusItemModel.swift
@@ -1,0 +1,29 @@
+//
+//  NoticeReadStatusItemModel.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import Foundation
+
+public struct NoticeReadStatusItemModel: Equatable, Identifiable {
+    public let id = UUID()
+    public let profileImageURL: String?
+    public let userName: String
+    public let nickName: String
+    public let part: String
+    public let location: String
+    public let campus: String
+    public let isRead: Bool
+
+    public var identityText: String {
+        let trimmedNickname = nickName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedName = userName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !trimmedNickname.isEmpty, !trimmedName.isEmpty, trimmedNickname != trimmedName {
+            return "\(trimmedNickname)/\(trimmedName)"
+        }
+        return !trimmedNickname.isEmpty ? trimmedNickname : trimmedName
+    }
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeReadStatusItemModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeReadStatusItemModel.swift
@@ -27,4 +27,22 @@ public struct NoticeReadStatusItemModel: Equatable, Identifiable {
         }
         return !trimmedNickname.isEmpty ? trimmedNickname : trimmedName
     }
+    
+    public init(
+        profileImageURL: String?,
+        userName: String,
+        nickName: String,
+        part: String,
+        location: String,
+        campus: String,
+        isRead: Bool
+    ) {
+        self.profileImageURL = profileImageURL
+        self.userName = userName
+        self.nickName = nickName
+        self.part = part
+        self.location = location
+        self.campus = campus
+        self.isRead = isRead
+    }
 }

--- a/UMCApp/Features/Notice/Presentation/Sources/Editor/EditorMockData.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Editor/EditorMockData.swift
@@ -1,0 +1,59 @@
+//
+//  EditorMockData.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 5/9/26.
+//
+
+import Foundation
+import NoticeDomain
+
+// MARK: - EditorMockData
+/// 공지 에디터 프리뷰/디버그용 목 데이터
+public enum EditorMockData {
+    public static let branches: [NoticeTargetOption] = [
+        .init(id: 1, name: "Nova"),
+        .init(id: 2, name: "Leo"),
+        .init(id: 3, name: "Cetus"),
+        .init(id: 4, name: "Aquarius"),
+        .init(id: 5, name: "Cassiopeia"),
+        .init(id: 6, name: "Scorpio"),
+        .init(id: 7, name: "Pegasus")
+    ]
+    public static let chapterSchools: [Int: [NoticeTargetOption]] = [
+        1: [
+            .init(id: 101, name: "가천대"), .init(id: 102, name: "강릉원주대"), .init(id: 103, name: "건국대"),
+            .init(id: 104, name: "경기대"), .init(id: 105, name: "경북대"), .init(id: 106, name: "경희대"),
+            .init(id: 107, name: "고려대")
+        ],
+        2: [
+            .init(id: 201, name: "광운대"), .init(id: 202, name: "국민대"), .init(id: 203, name: "단국대"),
+            .init(id: 204, name: "동국대"), .init(id: 205, name: "명지대"), .init(id: 206, name: "부산대"),
+            .init(id: 207, name: "서울과기대")
+        ],
+        3: [
+            .init(id: 301, name: "서울대"), .init(id: 302, name: "서울시립대"), .init(id: 303, name: "서강대"),
+            .init(id: 304, name: "성균관대"), .init(id: 305, name: "세종대"), .init(id: 306, name: "숙명여대")
+        ],
+        4: [
+            .init(id: 401, name: "숭실대"), .init(id: 402, name: "아주대"), .init(id: 403, name: "연세대"),
+            .init(id: 404, name: "이화여대"), .init(id: 405, name: "인하대"), .init(id: 406, name: "전남대"),
+            .init(id: 407, name: "전북대")
+        ],
+        5: [
+            .init(id: 501, name: "중앙대"), .init(id: 502, name: "충남대"), .init(id: 503, name: "한양대")
+        ]
+    ]
+    public static let schools: [NoticeTargetOption] = [
+        .init(id: 101, name: "가천대"), .init(id: 102, name: "강릉원주대"), .init(id: 103, name: "건국대"),
+        .init(id: 104, name: "경기대"), .init(id: 105, name: "경북대"), .init(id: 106, name: "경희대"),
+        .init(id: 107, name: "고려대"), .init(id: 201, name: "광운대"), .init(id: 202, name: "국민대"),
+        .init(id: 203, name: "단국대"), .init(id: 204, name: "동국대"), .init(id: 205, name: "명지대"),
+        .init(id: 206, name: "부산대"), .init(id: 207, name: "서울과기대"), .init(id: 301, name: "서울대"),
+        .init(id: 302, name: "서울시립대"), .init(id: 303, name: "서강대"), .init(id: 304, name: "성균관대"),
+        .init(id: 305, name: "세종대"), .init(id: 306, name: "숙명여대"), .init(id: 401, name: "숭실대"),
+        .init(id: 402, name: "아주대"), .init(id: 403, name: "연세대"), .init(id: 404, name: "이화여대"),
+        .init(id: 405, name: "인하대"), .init(id: 406, name: "전남대"), .init(id: 407, name: "전북대"),
+        .init(id: 501, name: "중앙대"), .init(id: 502, name: "충남대"), .init(id: 503, name: "한양대")
+    ]
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Editor/EditorMockData.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Editor/EditorMockData.swift
@@ -8,52 +8,54 @@
 import Foundation
 import NoticeDomain
 
+#if DEBUG
 // MARK: - EditorMockData
 /// 공지 에디터 프리뷰/디버그용 목 데이터
 public enum EditorMockData {
     public static let branches: [NoticeTargetOption] = [
-        .init(id: 1, name: "Nova"),
-        .init(id: 2, name: "Leo"),
-        .init(id: 3, name: "Cetus"),
-        .init(id: 4, name: "Aquarius"),
-        .init(id: 5, name: "Cassiopeia"),
-        .init(id: 6, name: "Scorpio"),
-        .init(id: 7, name: "Pegasus")
+        .init(id: "1", name: "Nova"),
+        .init(id: "2", name: "Leo"),
+        .init(id: "3", name: "Cetus"),
+        .init(id: "4", name: "Aquarius"),
+        .init(id: "5", name: "Cassiopeia"),
+        .init(id: "6", name: "Scorpio"),
+        .init(id: "7", name: "Pegasus")
     ]
     public static let chapterSchools: [Int: [NoticeTargetOption]] = [
         1: [
-            .init(id: 101, name: "가천대"), .init(id: 102, name: "강릉원주대"), .init(id: 103, name: "건국대"),
-            .init(id: 104, name: "경기대"), .init(id: 105, name: "경북대"), .init(id: 106, name: "경희대"),
-            .init(id: 107, name: "고려대")
+            .init(id: "101", name: "가천대"), .init(id: "102", name: "강릉원주대"), .init(id: "103", name: "건국대"),
+            .init(id: "104", name: "경기대"), .init(id: "105", name: "경북대"), .init(id: "106", name: "경희대"),
+            .init(id: "107", name: "고려대")
         ],
         2: [
-            .init(id: 201, name: "광운대"), .init(id: 202, name: "국민대"), .init(id: 203, name: "단국대"),
-            .init(id: 204, name: "동국대"), .init(id: 205, name: "명지대"), .init(id: 206, name: "부산대"),
-            .init(id: 207, name: "서울과기대")
+            .init(id: "201", name: "광운대"), .init(id: "202", name: "국민대"), .init(id: "203", name: "단국대"),
+            .init(id: "204", name: "동국대"), .init(id: "205", name: "명지대"), .init(id: "206", name: "부산대"),
+            .init(id: "207", name: "서울과기대")
         ],
         3: [
-            .init(id: 301, name: "서울대"), .init(id: 302, name: "서울시립대"), .init(id: 303, name: "서강대"),
-            .init(id: 304, name: "성균관대"), .init(id: 305, name: "세종대"), .init(id: 306, name: "숙명여대")
+            .init(id: "301", name: "서울대"), .init(id: "302", name: "서울시립대"), .init(id: "303", name: "서강대"),
+            .init(id: "304", name: "성균관대"), .init(id: "305", name: "세종대"), .init(id: "306", name: "숙명여대")
         ],
         4: [
-            .init(id: 401, name: "숭실대"), .init(id: 402, name: "아주대"), .init(id: 403, name: "연세대"),
-            .init(id: 404, name: "이화여대"), .init(id: 405, name: "인하대"), .init(id: 406, name: "전남대"),
-            .init(id: 407, name: "전북대")
+            .init(id: "401", name: "숭실대"), .init(id: "402", name: "아주대"), .init(id: "403", name: "연세대"),
+            .init(id: "404", name: "이화여대"), .init(id: "405", name: "인하대"), .init(id: "406", name: "전남대"),
+            .init(id: "407", name: "전북대")
         ],
         5: [
-            .init(id: 501, name: "중앙대"), .init(id: 502, name: "충남대"), .init(id: 503, name: "한양대")
+            .init(id: "501", name: "중앙대"), .init(id: "502", name: "충남대"), .init(id: "503", name: "한양대")
         ]
     ]
     public static let schools: [NoticeTargetOption] = [
-        .init(id: 101, name: "가천대"), .init(id: 102, name: "강릉원주대"), .init(id: 103, name: "건국대"),
-        .init(id: 104, name: "경기대"), .init(id: 105, name: "경북대"), .init(id: 106, name: "경희대"),
-        .init(id: 107, name: "고려대"), .init(id: 201, name: "광운대"), .init(id: 202, name: "국민대"),
-        .init(id: 203, name: "단국대"), .init(id: 204, name: "동국대"), .init(id: 205, name: "명지대"),
-        .init(id: 206, name: "부산대"), .init(id: 207, name: "서울과기대"), .init(id: 301, name: "서울대"),
-        .init(id: 302, name: "서울시립대"), .init(id: 303, name: "서강대"), .init(id: 304, name: "성균관대"),
-        .init(id: 305, name: "세종대"), .init(id: 306, name: "숙명여대"), .init(id: 401, name: "숭실대"),
-        .init(id: 402, name: "아주대"), .init(id: 403, name: "연세대"), .init(id: 404, name: "이화여대"),
-        .init(id: 405, name: "인하대"), .init(id: 406, name: "전남대"), .init(id: 407, name: "전북대"),
-        .init(id: 501, name: "중앙대"), .init(id: 502, name: "충남대"), .init(id: 503, name: "한양대")
+        .init(id: "101", name: "가천대"), .init(id: "102", name: "강릉원주대"), .init(id: "103", name: "건국대"),
+        .init(id: "104", name: "경기대"), .init(id: "105", name: "경북대"), .init(id: "106", name: "경희대"),
+        .init(id: "107", name: "고려대"), .init(id: "201", name: "광운대"), .init(id: "202", name: "국민대"),
+        .init(id: "203", name: "단국대"), .init(id: "204", name: "동국대"), .init(id: "205", name: "명지대"),
+        .init(id: "206", name: "부산대"), .init(id: "207", name: "서울과기대"), .init(id: "301", name: "서울대"),
+        .init(id: "302", name: "서울시립대"), .init(id: "303", name: "서강대"), .init(id: "304", name: "성균관대"),
+        .init(id: "305", name: "세종대"), .init(id: "306", name: "숙명여대"), .init(id: "401", name: "숭실대"),
+        .init(id: "402", name: "아주대"), .init(id: "403", name: "연세대"), .init(id: "404", name: "이화여대"),
+        .init(id: "405", name: "인하대"), .init(id: "406", name: "전남대"), .init(id: "407", name: "전북대"),
+        .init(id: "501", name: "중앙대"), .init(id: "502", name: "충남대"), .init(id: "503", name: "한양대")
     ]
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Editor/NoticeEditorCategories.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Editor/NoticeEditorCategories.swift
@@ -1,0 +1,183 @@
+//
+//  NoticeEditorCategories.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 5/9/26.
+//
+
+import Foundation
+import UMCFoundation
+import NoticeDomain
+
+// MARK: - EditorMainCategory
+/// 공지 에디터 메인 카테고리
+public enum EditorMainCategory: Identifiable, Equatable, Hashable {
+    case all
+    case central
+    case branch
+    case school
+    case part(UMCPartType)
+
+    /// 고유 식별자
+    public var id: String {
+        switch self {
+        case .all: return "all"
+        case .central: return "central"
+        case .branch: return "branch"
+        case .school: return "school"
+        case .part(let part): return "part_\(part.apiValue)"
+        }
+    }
+
+    /// 카테고리 표시 텍스트
+    public var labelText: String {
+        switch self {
+        case .all: return "전체 기수"
+        case .central: return "특정 기수"
+        case .branch: return "지부"
+        case .school: return "학교"
+        case .part(let part): return NoticePart(umcPartType: part)?.displayName ?? part.name
+        }
+    }
+
+    /// 카테고리 아이콘 SF Symbol 이름
+    public var labelIcon: String {
+        switch self {
+        case .all: return "line.3.horizontal.decrease"
+        case .central: return "number.square"
+        case .branch: return "mappin.and.ellipse"
+        case .school: return "graduationcap"
+        case .part: return "person.3.fill"
+        }
+    }
+
+    /// 서브카테고리 목록
+    public var subCategories: [EditorSubCategory] {
+        switch self {
+        case .all:
+            return [.school]
+        case .central:
+            return [.branch, .school, .part]
+        case .branch:
+            return [.all, .part]
+        case .school:
+            return [.school, .part]
+        case .part:
+            return []
+        }
+    }
+
+    /// 서브카테고리가 있는지 여부
+    public var hasSubCategories: Bool {
+        !subCategories.isEmpty
+    }
+}
+
+// MARK: - EditorSubCategory
+/// 공지 에디터 서브 카테고리
+public enum EditorSubCategory: Identifiable, Equatable, Hashable {
+    case all
+    //case staff
+    case branch
+    case school
+    case part
+
+    /// 고유 식별자
+    public var id: String {
+        switch self {
+        case .all: return "all"
+        //case .staff: return "staff"
+        case .branch: return "branch"
+        case .school: return "school"
+        case .part: return "part"
+        }
+    }
+
+    /// 서브카테고리 표시 텍스트
+    public var labelText: String {
+        switch self {
+        case .all: return "전체"
+        //case .staff: return "운영진 공지"
+        case .branch: return "지부"
+        case .school: return "학교"
+        case .part: return "파트"
+        }
+    }
+
+    /// 추가 필터가 필요한지 여부
+    public var hasFilter: Bool {
+        switch self {
+        case .branch, .school, .part:
+            return true
+        case .all:
+            return false
+        }
+    }
+}
+
+// MARK: - EditorSubCategorySelection
+/// 서브카테고리 선택 상태
+public struct EditorSubCategorySelection: Equatable {
+    /// 선택된 서브카테고리 목록
+    public var selectedSubCategories: Set<EditorSubCategory> = []
+    /// 선택된 파트 목록
+    public var selectedParts: Set<UMCPartType> = []
+    /// 선택된 지부
+    public var selectedBranch: NoticeTargetOption?
+    /// 선택된 학교
+    public var selectedSchool: NoticeTargetOption?
+
+    /// 선택 요약 텍스트
+    public var summaryText: String {
+        var items: [String] = []
+
+        if selectedSubCategories.isEmpty {
+            return "선택 안 함"
+        }
+
+        for subCategory in selectedSubCategories.sorted(by: { $0.id < $1.id }) {
+            switch subCategory {
+            case .all:
+                items.append("전체")
+//            case .staff:
+//                items.append("운영진")
+            case .branch:
+                if let selectedBranch {
+                    items.append(selectedBranch.name)
+                } else {
+                    items.append("지부")
+                }
+            case .school:
+                if let selectedSchool {
+                    items.append(selectedSchool.name)
+                } else {
+                    items.append("학교")
+                }
+            case .part:
+                if selectedParts.isEmpty {
+                    items.append("파트")
+                } else {
+                    items.append(
+                        contentsOf: selectedParts.map {
+                            NoticePart(umcPartType: $0)?.displayName ?? $0.name
+                        }
+                    )
+                }
+            }
+        }
+        return items.isEmpty ? "선택" : items.joined(separator: ", ")
+    }
+    
+    public init(
+        selectedSubCategories: Set<EditorSubCategory>,
+        selectedParts: Set<UMCPartType>,
+        selectedBranch: NoticeTargetOption? = nil,
+        selectedSchool: NoticeTargetOption? = nil
+    ) {
+        self.selectedSubCategories = selectedSubCategories
+        self.selectedParts = selectedParts
+        self.selectedBranch = selectedBranch
+        self.selectedSchool = selectedSchool
+    }
+}
+

--- a/UMCApp/Features/Notice/Presentation/Sources/Editor/NoticeEditorForm.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Editor/NoticeEditorForm.swift
@@ -1,0 +1,178 @@
+//
+//  NoticeEditorForm.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 5/9/26.
+//
+
+import Foundation
+import NoticeDomain
+
+// MARK: - TargetSheetType
+/// 게시판 분류별 타겟 설정 sheet(지부, 학교, 파트)
+public enum TargetSheetType: Identifiable {
+    case branch
+    case school
+    case part
+    
+    public var id: String { String(describing: self) }
+    
+    /// Sheet 헤더 표시 텍스트
+    public var title: String {
+        switch self {
+        case .branch: return "지부 선택"
+        case .school: return "학교 선택"
+        case .part: return "파트 선택"
+        }
+    }
+}
+
+// MARK: - LinkItem
+/// 링크 첨부 카드
+public struct NoticeLinkItem: Identifiable, Equatable {
+    public let id = UUID()
+    public var link: String = ""
+    
+    public init(link: String) {
+        self.link = link
+    }
+}
+
+// MARK: - ImageItem
+/// 이미지 첨부 카드
+public struct NoticeImageItem: Identifiable, Equatable {
+    public let id = UUID()
+    /// 로컬에서 선택한 이미지 바이너리
+    public var imageData: Data?
+    /// 서버에 업로드된 이미지 URL (수정 모드에서 기존 이미지)
+    public var imageURL: String? = nil
+    /// 업로드 시 사용할 원본 기반 파일명 (예: IMG_1234.jpg)
+    public var uploadFileName: String? = nil
+    /// Presigned URL 업로드 진행 중 여부
+    public var isLoading: Bool = false
+    /// 서버에 저장된 파일 ID (업로드 완료 후 할당)
+    public var fileId: String? = nil
+    
+    public static func == (lhs: NoticeImageItem, rhs: NoticeImageItem) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.isLoading == rhs.isLoading
+    }
+    
+    public init(
+        imageData: Data? = nil,
+        imageURL: String? = nil,
+        uploadFileName: String? = nil,
+        isLoading: Bool,
+        fileId: String? = nil
+    ) {
+        self.imageData = imageData
+        self.imageURL = imageURL
+        self.uploadFileName = uploadFileName
+        self.isLoading = isLoading
+        self.fileId = fileId
+    }
+}
+
+// MARK: - VoteOptionItem
+/// 투표 옵션 항목
+public struct VoteOptionItem: Identifiable, Equatable {
+    public let id = UUID()
+    public var text: String = ""
+    
+    public init(text: String = "") {
+        self.text = text
+    }
+}
+
+// MARK: - VoteFormData
+/// 투표 폼 데이터
+public struct VoteFormData: Equatable {
+    /// 투표 제목
+    public var title: String = ""
+    /// 투표 선택지 (기본 2개)
+    public var options: [VoteOptionItem] = [
+        VoteOptionItem(),
+        VoteOptionItem()
+    ]
+    /// 익명 투표 여부
+    public var isAnonymous: Bool = false
+    /// 복수 선택 허용 여부
+    public var allowMultipleSelection: Bool = false
+    
+    // 시작일: 00:00:00부터
+    public var startDate: Date = Calendar.current.startOfDay(for: Date())
+    
+    // 마감일: 23:59:59까지
+    public var endDate: Date = {
+        let calendar = Calendar.current
+        let sevenDaysLater = calendar.date(byAdding: .day, value: 7, to: Date()) ?? Date()
+        let startOfDay = calendar.startOfDay(for: sevenDaysLater)
+        return calendar.date(bySettingHour: 23, minute: 59, second: 59, of: startOfDay) ?? sevenDaysLater
+    }()
+    
+    public static let minOptionCount = 2
+    public static let maxOptionCount = 5
+
+    /// 옵션 추가 가능 여부
+    public var canAddOption: Bool {
+        options.count < Self.maxOptionCount
+    }
+    
+    /// 옵션 삭제 가능 여부
+    public var canRemoveOption: Bool {
+        options.count > Self.minOptionCount
+    }
+    
+    /// 투표 만들기 완료조건: 위에서부터 연속으로 채워진 항목 개수
+    public var validOptionsCount: Int {
+        var count = 0
+        for option in options {
+            if option.text.trimmingCharacters(in: .whitespaces).isEmpty {
+                break
+            }
+            count += 1
+        }
+        return count
+    }
+    
+    /// 날짜 범위 유효성 검증
+    public var isDateRangeValid: Bool {
+          let calendar = Calendar.current
+          let startDay = calendar.startOfDay(for: startDate)
+          let endDay = calendar.startOfDay(for: endDate)
+          return endDay > startDay
+      }
+    
+    /// 투표 확정 가능 여부 (제목 + 2개 이상 항목 + 날짜 유효성)
+    public var canConfirm: Bool {
+        !title.trimmingCharacters(in: .whitespaces).isEmpty &&
+        validOptionsCount >= 2 &&
+        isDateRangeValid
+    }
+    
+    public init(
+        title: String,
+        options: [VoteOptionItem],
+        isAnonymous: Bool,
+        allowMultipleSelection: Bool,
+        startDate: Date,
+        endDate: Date
+    ) {
+        self.title = title
+        self.options = options
+        self.isAnonymous = isAnonymous
+        self.allowMultipleSelection = allowMultipleSelection
+        self.startDate = startDate
+        self.endDate = endDate
+    }
+}
+
+// MARK: - NoticeEditorMode
+
+/// 공지 에디터 모드
+public enum NoticeEditorMode: Equatable, Hashable {
+    /// 새 공지 작성
+    case create
+    /// 기존 공지 수정
+    case edit(noticeId: Int, notice: NoticeDetail)
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Editor/NoticeEditorForm.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Editor/NoticeEditorForm.swift
@@ -137,11 +137,11 @@ public struct VoteFormData: Equatable {
     
     /// 날짜 범위 유효성 검증
     public var isDateRangeValid: Bool {
-          let calendar = Calendar.current
-          let startDay = calendar.startOfDay(for: startDate)
-          let endDay = calendar.startOfDay(for: endDate)
-          return endDay > startDay
-      }
+        let calendar = Calendar.current
+        let startDay = calendar.startOfDay(for: startDate)
+        let endDay = calendar.startOfDay(for: endDate)
+        return endDay > startDay
+    }
     
     /// 투표 확정 가능 여부 (제목 + 2개 이상 항목 + 날짜 유효성)
     public var canConfirm: Bool {

--- a/UMCApp/Features/Notice/Presentation/Sources/Editor/NoticeEditorForm.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Editor/NoticeEditorForm.swift
@@ -174,5 +174,5 @@ public enum NoticeEditorMode: Equatable, Hashable {
     /// 새 공지 작성
     case create
     /// 기존 공지 수정
-    case edit(noticeId: Int, notice: NoticeDetail)
+    case edit(noticeId: String, notice: NoticeDetail)
 }

--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeDetail+UI.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeDetail+UI.swift
@@ -1,0 +1,76 @@
+//
+//  NoticeDetail+UI.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import SwiftUI
+import NoticeDomain
+import CoreDesignSystem
+
+/// 목록/상세에서 공통으로 사용할 태그 목록
+extension NoticeDetail {
+    public var tags: [NoticeItemTag] {
+        NoticeItemModel(
+            noticeId: id,
+            generation: generation,
+            scope: scope,
+            category: category,
+            mustRead: isMustRead,
+            isAlert: false,
+            date: createdAt,
+            title: title,
+            content: content,
+            writer: authorName,
+            links: links,
+            images: images,
+            vote: vote,
+            viewCount: 0,
+            scopeDisplayName: targetAudience.branches.first,
+            targetsAllGenerations: targetAudience.generation <= 0,
+            parts: targetAudience.parts,
+            isRead: false
+        ).tags
+    }
+}
+
+extension TargetAudience {
+    /// 수신 대상 표시 텍스트
+    ///
+    /// 레거시 호환용 속성입니다. 신규 UI는 `NoticeDetail.tags`를 사용합니다.
+    public var displayText: String {
+        NoticeDetail(
+            id: "",
+            generation: generation,
+            scope: scope,
+            category: parts.first.map { .part($0) } ?? .general,
+            isMustRead: false,
+            title: "",
+            content: "",
+            authorID: "",
+            authorNickname: nil,
+            authorName: "",
+            authorImageURL: nil,
+            createdAt: .now,
+            updatedAt: nil,
+            targetAudience: self,
+            hasPermission: false,
+            images: [],
+            links: [],
+            vote: nil
+        )
+        .tags
+        .map(\.text)
+        .joined(separator: " / ")
+    }
+}
+
+// TODO: dateRange 모듈 추가
+
+//extension NoticeVote {
+//    /// 날짜 포맷 (MM.dd - MM.dd)
+//    public var formattedPeriod: String {
+//        startDate.dateRange(to: endDate)
+//    }
+//}

--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeDetail+UI.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeDetail+UI.swift
@@ -26,9 +26,9 @@ extension NoticeDetail {
             links: links,
             images: images,
             vote: vote,
-            viewCount: 0,
+            viewCount: "0",
             scopeDisplayName: targetAudience.branches.first,
-            targetsAllGenerations: targetAudience.generation <= 0,
+            targetsAllGenerations: (Int(targetAudience.generation) ?? 0) <= 0,
             parts: targetAudience.parts,
             isRead: false
         ).tags

--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeDetail+UI.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeDetail+UI.swift
@@ -66,6 +66,20 @@ extension TargetAudience {
     }
 }
 
+extension ReadStatusFilterType {
+    /// 열람 현황 필터 메뉴 아이콘 (SF Symbol) — UI 표현이므로 Presentation에 위치
+    public var iconName: String {
+        switch self {
+        case .all:
+            return "line.3.horizontal.decrease"
+        case .branch:
+            return "mappin.and.ellipse"
+        case .school:
+            return "graduationcap"
+        }
+    }
+}
+
 // TODO: dateRange 모듈 추가
 
 //extension NoticeVote {

--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeItemModel+Tags.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeItemModel+Tags.swift
@@ -1,0 +1,78 @@
+//
+//  NoticeDetail+Tags.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import SwiftUI
+import UMCFoundation
+import NoticeDomain
+import CoreDesignSystem
+import CoreUIComponents
+
+extension NoticeItemModel {
+    public var tags: [NoticeItemTag] {
+        var items: [NoticeItemTag] = [
+            NoticeItemTag(
+                text: targetsAllGenerations ? "모든 기수" : "\(generation)기",
+                backColor: .blue
+            )
+        ]
+        
+        if let scopeTag {
+            items.append(scopeTag)
+        }
+        
+        items.append(contentsOf: partTags)
+        
+        return items
+    }
+    
+    var scopeTag: NoticeItemTag? {
+        switch scope {
+        case .central:
+            return nil
+        case .branch:
+            let displayName = scopeDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return NoticeItemTag(
+                text: displayName.isEmpty ? "지부" : displayName,
+                backColor: .orange500
+            )
+        case .campus:
+            return NoticeItemTag(text: "교내", backColor: .green500)
+        }
+    }
+    
+    var resolvedParts: [UMCPartType] {
+        if !parts.isEmpty {
+            return parts
+        }
+        
+        if case .part(let part) = category {
+            return [part]
+        }
+        
+        return []
+    }
+    
+    var partTags: [NoticeItemTag] {
+        guard !resolvedParts.isEmpty else { return [] }
+        
+        if resolvedParts.count >= 4 {
+            return [
+                NoticeItemTag(
+                    text: "여러 파트",
+                    backColor: .grey500
+                )
+            ]
+        }
+        
+        return resolvedParts.prefix(3).map { part in
+            NoticeItemTag(
+                text: NoticePart(umcPartType: part)?.displayName ?? "파트",
+                backColor: part.color
+            )
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeItemModel+Tags.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeItemModel+Tags.swift
@@ -1,5 +1,5 @@
 //
-//  NoticeDetail+Tags.swift
+//  NoticeItemModel+Tags.swift
 //  NoticePresentation
 //
 //  Created by 이예지 on 5/8/26.
@@ -33,7 +33,8 @@ extension NoticeItemModel {
     }
     
     /// 중앙 공지는 출처 태그 없음 — scope 태그는 지부/교내만 표시
-    var scopeTag: NoticeItemTag? {
+    /// `tags` 구성 전용 내부 헬퍼
+    private var scopeTag: NoticeItemTag? {
         switch scope {
         case .central:
             return nil
@@ -51,7 +52,7 @@ extension NoticeItemModel {
     /// parts 배열 우선, 비어 있으면 category에서 파트 추출
     ///
     /// 파트별 공지(category: .part)는 parts 없이 category만 내려오는 경우가 있음
-    var resolvedParts: [UMCPartType] {
+    private var resolvedParts: [UMCPartType] {
         if !parts.isEmpty {
             return parts
         }
@@ -64,7 +65,7 @@ extension NoticeItemModel {
     }
     
     /// 파트가 4개 이상이면 "여러 파트" 단일 태그로 축약, 3개 이하는 개별 표시
-    var partTags: [NoticeItemTag] {
+    private var partTags: [NoticeItemTag] {
         guard !resolvedParts.isEmpty else { return [] }
         
         if resolvedParts.count >= 4 {

--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeItemModel+Tags.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeItemModel+Tags.swift
@@ -12,6 +12,9 @@ import CoreDesignSystem
 import CoreUIComponents
 
 extension NoticeItemModel {
+    /// 공지 목록 셀에 표시할 태그 목록
+    ///
+    /// 순서: 기수 → 출처(scope) → 파트
     public var tags: [NoticeItemTag] {
         var items: [NoticeItemTag] = [
             NoticeItemTag(
@@ -29,6 +32,7 @@ extension NoticeItemModel {
         return items
     }
     
+    /// 중앙 공지는 출처 태그 없음 — scope 태그는 지부/교내만 표시
     var scopeTag: NoticeItemTag? {
         switch scope {
         case .central:
@@ -44,6 +48,9 @@ extension NoticeItemModel {
         }
     }
     
+    /// parts 배열 우선, 비어 있으면 category에서 파트 추출
+    ///
+    /// 파트별 공지(category: .part)는 parts 없이 category만 내려오는 경우가 있음
     var resolvedParts: [UMCPartType] {
         if !parts.isEmpty {
             return parts
@@ -56,6 +63,7 @@ extension NoticeItemModel {
         return []
     }
     
+    /// 파트가 4개 이상이면 "여러 파트" 단일 태그로 축약, 3개 이하는 개별 표시
     var partTags: [NoticeItemTag] {
         guard !resolvedParts.isEmpty else { return [] }
         

--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeType+UI.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeType+UI.swift
@@ -10,6 +10,7 @@ import NoticeDomain
 import CoreDesignSystem
 
 extension NoticeType {
+    /// 필독 유형의 공지 칩
     public var textColor: Color {
         switch self {
         case .essential:

--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeType+UI.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeType+UI.swift
@@ -1,0 +1,30 @@
+//
+//  NoticeDetail+Tags.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import SwiftUI
+import NoticeDomain
+import CoreDesignSystem
+
+extension NoticeType {
+    public var textColor: Color {
+        switch self {
+        case .essential:
+            return .indigo500
+        default:
+            return .white
+        }
+    }
+    
+    public var backgroundColor: Color {
+        switch self {
+        case .essential:
+            return .indigo100
+        default:
+            return .indigo500
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeType+UI.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeType+UI.swift
@@ -1,5 +1,5 @@
 //
-//  NoticeDetail+Tags.swift
+//  NoticeType+UI.swift
 //  NoticePresentation
 //
 //  Created by 이예지 on 5/8/26.

--- a/UMCApp/Features/Notice/Presentation/Sources/Filters/NoticeFilters.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Filters/NoticeFilters.swift
@@ -1,0 +1,189 @@
+//
+//  NoticeFilters.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import Foundation
+import NoticeDomain
+
+// MARK: - NoticeSubFilterType
+/// 서브필터 타입 (전체, 운영진 공지, 파트)
+public enum NoticeSubFilterType: Identifiable, Equatable, Hashable {
+    // 전체
+    case all
+    /// !!!: 추후 운영진 필터 가리기 해제할 것
+    // 운영진 공지
+    // case staff
+    // 파트
+    case part
+
+    public var id: String {
+        switch self {
+        case .all: return "all"
+        //case .staff: return "management"
+        case .part: return "part"
+        }
+    }
+
+    public var labelText: String {
+        switch self {
+        case .all: return "전체"
+        //case .staff: return "운영진 공지"
+        case .part: return "파트"
+        }
+    }
+}
+
+// MARK: - NoticeMainFilterType
+/// 메인필터 타입 (전체, 중앙, 지부, 학교, 파트)
+public enum NoticeMainFilterType: Identifiable, Equatable, Hashable {
+    // 전체
+    case all
+    // 중앙운영사무국
+    case central
+    // 지부
+    case branch(String)
+    // 학교
+    case school(String)
+    // 파트
+    case part(NoticePart)
+
+    public var id: String {
+        switch self {
+        case .all: return "all"
+        case .central: return "central"
+        case .branch(let name): return "\(name)"
+        case .school(let name): return "\(name)"
+        case .part(let part): return part.id
+        }
+    }
+
+    /// 필터 라벨 텍스트
+    public var labelText: String {
+        switch self {
+        case .all: return "전체"
+        case .central: return "UMC 공지"
+        case .branch(let name): return name
+        case .school(let name): return name
+        case .part(let part): return part.displayName
+        }
+    }
+
+    /// 필터 아이콘 (SF Symbol)
+    public var labelIcon: String {
+        switch self {
+        case .all: return "square.grid.2x2"
+        case .central: return "building.columns"
+        case .branch: return "mappin.and.ellipse"
+        case .school: return "graduationcap"
+        case .part: return "person.3.fill"
+        }
+    }
+
+    public static func == (lhs: NoticeMainFilterType, rhs: NoticeMainFilterType) -> Bool {
+        switch (lhs, rhs) {
+        case (.all, .all), (.central, .central):
+            return true
+        case let (.branch(l), .branch(r)):
+            return l == r
+        case let (.school(l), .school(r)):
+            return l == r
+        case let (.part(l), .part(r)):
+            return l == r
+        default:
+            return false
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .all:
+            hasher.combine("all")
+        case .central:
+            hasher.combine("central")
+        case .branch(let name):
+            hasher.combine("branch")
+            hasher.combine(name)
+        case .school(let name):
+            hasher.combine("school")
+            hasher.combine(name)
+        case .part(let part):
+            hasher.combine("part")
+            hasher.combine(part)
+        }
+    }
+}
+
+
+// MARK: - MainFilterKey
+/// 메인필터 키 (Dictionary key용, associated value 없음)
+public enum MainFilterKey: Hashable {
+    case all
+    case central
+    case branch
+    case school
+    case part
+
+    public init(from filter: NoticeMainFilterType) {
+        switch filter {
+        case .all: self = .all
+        case .central: self = .central
+        case .branch: self = .branch
+        case .school: self = .school
+        case .part: self = .part
+        }
+    }
+}
+
+// MARK: - MainFilterState
+/// 메인필터별 서브필터 상태
+public struct MainFilterState: Equatable {
+    public var subFilter: NoticeSubFilterType = .all
+    public var selectedPart: NoticePart?
+}
+
+// MARK: - GenerationFilterState
+/// 기수별 필터 상태
+public struct GenerationFilterState: Equatable {
+    public var mainFilter: NoticeMainFilterType = .all
+    public var mainFilterStates: [MainFilterKey: MainFilterState] = [:]
+
+    /// 특정 메인필터의 서브필터 상태 조회
+    public func state(for key: MainFilterKey) -> MainFilterState {
+        mainFilterStates[key] ?? MainFilterState()
+    }
+
+    /// 특정 메인필터의 서브필터 상태 업데이트
+    public mutating func updateState(for key: MainFilterKey, state: MainFilterState) {
+        mainFilterStates[key] = state
+    }
+}
+
+// MARK: - NoticeListSubFilterChip
+/// 공지 리스트 하단 칩 구성 타입
+public enum NoticeListSubFilterChip: Identifiable, Equatable {
+    case all
+    case branch
+    case school
+    case part
+
+    public var id: String {
+        switch self {
+        case .all: return "all"
+        case .branch: return "branch"
+        case .school: return "school"
+        case .part: return "part"
+        }
+    }
+
+    public var labelText: String {
+        switch self {
+        case .all: return "전체"
+        case .branch: return "지부"
+        case .school: return "학교"
+        case .part: return "파트"
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Tags/NoticeItemTag.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Tags/NoticeItemTag.swift
@@ -1,0 +1,21 @@
+//
+//  NoticeDetail+Tags.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 5/8/26.
+//
+
+import SwiftUI
+
+/// UI 표시용 공지 태그
+public struct NoticeItemTag: Equatable {
+
+    // MARK: - Property
+    public let text: String
+    public let backColor: Color
+    
+    public init(text: String, backColor: Color) {
+        self.text = text
+        self.backColor = backColor
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor — AppProduct 레거시 Notice 도메인을 Tuist 모듈 구조로 이식

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음 (모델/타입 이식 작업)

## 🛠️ 작업내용

**Core 레이어**
- `UMCFoundation/Types/UMCPartType`: 도메인 간 공유 타입 추가
- `CoreUIComponents/Extensions/UMCPartType+Color`: 색상 확장을 CoreDesignSystem → CoreUIComponents로 이관 (CoreDesignSystem은 UMCFoundation을 모르기 때문)
- `CoreUIComponents/Project.swift`: UMCFoundation 의존성 추가

**NoticeDomain 레이어 (Domain/Sources)**
- `Models/NoticeModel`: Generation, NoticeScope, NoticeCategory — 순수 도메인 타입
- `Models/NoticeItemModel`: 공지 목록 아이템 엔티티, SwiftUI 의존성 제거
- `Models/NoticeDetail`: NoticeDetail, TargetAudience, NoticeVote, VoteOption, VoteStatus, NoticeReadStatus, ReadStatusUser, ReadStatusTab, NoticeAttachmentImage, ImageViewerItem
- `Models/NoticeEditorModel`: NoticeTargetOption — Repository Protocol이 참조하는 타입만 유지
- `Models/NoticeReadStatusItemModel`: 열람 현황 아이템 엔티티
- `Enums/NoticePart`: UMCPartType ↔ NoticePart 변환 로직
- `Enums/NoticeType`: 공지 칩 표시용 케이스 정의 (Color 제거)

**NoticePresentation 레이어 (Presentation/Sources)**
- `Tags/NoticeItemTag`: Color를 포함한 태그 타입 (SwiftUI 의존 → Presentation으로 분리)
- `Filters/NoticeFilters`: NoticeSubFilterType, NoticeMainFilterType, MainFilterKey, MainFilterState, GenerationFilterState, NoticeListSubFilterChip, ReadStatusFilterType — UI 상태 타입을 Domain에서 이관
- `Extensions/NoticeItemModel+Tags`: tags, scopeTag, resolvedParts, partTags — Color 반환 연산 프로퍼티
- `Extensions/NoticeType+UI`: textColor, backgroundColor 색상 확장
- `Extensions/NoticeDetail+UI`: NoticeDetail.tags, TargetAudience.displayText
- `Editor/NoticeEditorCategories`: EditorMainCategory, EditorSubCategory, EditorSubCategorySelection
- `Editor/NoticeEditorForm`: TargetSheetType, NoticeLinkItem, NoticeImageItem, VoteOptionItem, VoteFormData, NoticeEditorMode
- `Editor/EditorMockData`: 에디터 프리뷰/디버그용 목 데이터

## 📋 추후 진행 상황

- NoticeRepositoryProtocol, NoticeReadRepositoryProtocol, NoticeEditorTargetRepositoryProtocol 이식
- Notice DTOs, NoticeEndpoint 이식
- NoticeRepository 구현체 (read 우선) 이식

## 📌 리뷰 포인트

- `Core/UIComponents/Project.swift` — UMCFoundation 의존성 추가 여부 확인
- `NoticeDomain` — SwiftUI import 없는지 확인 (Domain 순수성)
- `NoticePresentation` — Color 반환 타입이 모두 Presentation에 있는지 확인
- `UMCPartType+Color` 위치: CoreUIComponents/Extensions (CoreDesignSystem 아님)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)