### PR TITLE
♻️ [Refactor] NoticeRepository Protocol 이식 — DTO 불필요 인터페이스 우선

### DIFF
--- a/UMCApp/Features/Notice/Domain/Sources/Interfaces/NoticeEditorTargetRepositoryProtocol.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Interfaces/NoticeEditorTargetRepositoryProtocol.swift
@@ -12,16 +12,16 @@ public protocol NoticeEditorTargetRepositoryProtocol {
     /// 전체 지부 목록을 조회합니다.
     func fetchAllBranches() async throws -> [NoticeTargetOption]
     /// 특정 기수에 속한 지부 목록을 조회합니다.
-    func fetchBranches(gisuId: Int) async throws -> [NoticeTargetOption]
+    func fetchBranches(gisuId: String) async throws -> [NoticeTargetOption]
     /// 지부 ID로 지부명을 조회합니다.
-    func fetchBranchName(chapterId: Int) async throws -> String
+    func fetchBranchName(chapterId: String) async throws -> String
     /// 전체 학교 목록을 조회합니다.
     func fetchAllSchools() async throws -> [NoticeTargetOption]
     /// 특정 기수에 속한 학교 목록을 조회합니다.
-    func fetchSchools(gisuId: Int) async throws -> [NoticeTargetOption]
+    func fetchSchools(gisuId: String) async throws -> [NoticeTargetOption]
     /// 특정 지부(챕터)에 속한 학교 목록을 조회합니다.
     /// - Parameters:
     ///   - chapterId: 지부 ID
     ///   - gisuId: 기수 ID
-    func fetchSchools(inChapterId chapterId: Int, gisuId: Int) async throws -> [NoticeTargetOption]
+    func fetchSchools(inChapterId chapterId: String, gisuId: String) async throws -> [NoticeTargetOption]
 }

--- a/UMCApp/Features/Notice/Domain/Sources/Interfaces/NoticeEditorTargetRepositoryProtocol.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Interfaces/NoticeEditorTargetRepositoryProtocol.swift
@@ -1,0 +1,27 @@
+//
+//  NoticeEditorTargetRepositoryProtocol.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/9/26.
+//
+
+import Foundation
+
+/// 공지 에디터 타겟(지부/학교) 조회 Repository 인터페이스
+public protocol NoticeEditorTargetRepositoryProtocol {
+    /// 전체 지부 목록을 조회합니다.
+    func fetchAllBranches() async throws -> [NoticeTargetOption]
+    /// 특정 기수에 속한 지부 목록을 조회합니다.
+    func fetchBranches(gisuId: Int) async throws -> [NoticeTargetOption]
+    /// 지부 ID로 지부명을 조회합니다.
+    func fetchBranchName(chapterId: Int) async throws -> String
+    /// 전체 학교 목록을 조회합니다.
+    func fetchAllSchools() async throws -> [NoticeTargetOption]
+    /// 특정 기수에 속한 학교 목록을 조회합니다.
+    func fetchSchools(gisuId: Int) async throws -> [NoticeTargetOption]
+    /// 특정 지부(챕터)에 속한 학교 목록을 조회합니다.
+    /// - Parameters:
+    ///   - chapterId: 지부 ID
+    ///   - gisuId: 기수 ID
+    func fetchSchools(inChapterId chapterId: Int, gisuId: Int) async throws -> [NoticeTargetOption]
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Interfaces/NoticeReadRepositoryProtocol.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Interfaces/NoticeReadRepositoryProtocol.swift
@@ -14,8 +14,8 @@ import Foundation
 public protocol NoticeReadRepositoryProtocol {
 
     /// 특정 멤버가 읽은 공지 ID 집합을 조회합니다.
-    func fetchReadNoticeIDs(memberId: Int) throws -> Set<String>
+    func fetchReadNoticeIDs(memberId: String) throws -> Set<String>
 
     /// 특정 멤버의 공지를 읽음 상태로 저장합니다.
-    func markAsRead(noticeId: String, memberId: Int) throws
+    func markAsRead(noticeId: String, memberId: String) throws
 }

--- a/UMCApp/Features/Notice/Domain/Sources/Interfaces/NoticeReadRepositoryProtocol.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Interfaces/NoticeReadRepositoryProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  NoticeReadRepositoryProtocol.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/9/26.
+//
+
+import Foundation
+
+/// 공지 읽음 상태의 로컬 저장소 인터페이스입니다.
+///
+/// 서버 목록 응답에 `isRead`가 없는 동안, 현재 계정 기준으로 읽은 공지 ID를
+/// SwiftData에 저장하고 목록 표시에 재사용합니다.
+public protocol NoticeReadRepositoryProtocol {
+
+    /// 특정 멤버가 읽은 공지 ID 집합을 조회합니다.
+    func fetchReadNoticeIDs(memberId: Int) throws -> Set<String>
+
+    /// 특정 멤버의 공지를 읽음 상태로 저장합니다.
+    func markAsRead(noticeId: String, memberId: Int) throws
+}


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor — DTO 의존 없이 이식 가능한 Repository Protocol 2개 이식

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음

## 🛠️ 작업내용

- `Domain/Interfaces/NoticeReadRepositoryProtocol`: 공지 읽음 상태 로컬 저장소 인터페이스
  - `fetchReadNoticeIDs`, `markAsRead` — 원시 타입만 의존, DTO 불필요
- `Domain/Interfaces/NoticeEditorTargetRepositoryProtocol`: 에디터 타겟(지부/학교) 조회 인터페이스
  - `NoticeTargetOption` 반환 — 이미 이식된 Domain 타입만 의존, DTO 불필요

## 📋 추후 진행 상황

- Notice DTOs 이식
- NoticeEndpoint 이식
- NoticeRepositoryProtocol 이식 (DTO 의존)
- NoticeRepository 구현체 이식 (read 우선)

## 📌 리뷰 포인트

- `NoticeDomain` — `import Foundation`만 사용, SwiftUI/DTO 의존 없는지 확인
- `NoticeEditorTargetRepositoryProtocol` — `NoticeTargetOption`이 Domain에 정의된 타입인지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)