### PR TITLE
🐛[Fix] Response DTO Int 디코딩에 String 폴백 추가 + 컨벤션 문서화

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/CurriculumDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/CurriculumDTO.swift
@@ -14,6 +14,26 @@ struct CurriculumDTO: Codable, Sendable, Equatable {
     let curriculumId: Int
     let title: String
     let weeks: [WeeklyCurriculumDTO]
+
+    private enum CodingKeys: String, CodingKey {
+        case curriculumId
+        case title
+        case weeks
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        curriculumId = try container.decodeIntFlexibleIfPresent(forKey: .curriculumId) ?? 0
+        title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+        weeks = try container.decodeIfPresent([WeeklyCurriculumDTO].self, forKey: .weeks) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(curriculumId, forKey: .curriculumId)
+        try container.encode(title, forKey: .title)
+        try container.encode(weeks, forKey: .weeks)
+    }
 }
 
 struct WeeklyCurriculumDTO: Codable, Sendable, Equatable {
@@ -23,6 +43,35 @@ struct WeeklyCurriculumDTO: Codable, Sendable, Equatable {
     let startsAt: String
     let endsAt: String
     let isExtra: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case weeklyCurriculumId
+        case weekNo
+        case title
+        case startsAt
+        case endsAt
+        case isExtra
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        weeklyCurriculumId = try container.decodeIntFlexibleIfPresent(forKey: .weeklyCurriculumId) ?? 0
+        weekNo = try container.decodeIntFlexibleIfPresent(forKey: .weekNo) ?? 0
+        title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+        startsAt = try container.decodeIfPresent(String.self, forKey: .startsAt) ?? ""
+        endsAt = try container.decodeIfPresent(String.self, forKey: .endsAt) ?? ""
+        isExtra = try container.decodeIfPresent(Bool.self, forKey: .isExtra) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(weeklyCurriculumId, forKey: .weeklyCurriculumId)
+        try container.encode(weekNo, forKey: .weekNo)
+        try container.encode(title, forKey: .title)
+        try container.encode(startsAt, forKey: .startsAt)
+        try container.encode(endsAt, forKey: .endsAt)
+        try container.encode(isExtra, forKey: .isExtra)
+    }
 }
 
 // MARK: - toDomain
@@ -119,4 +168,33 @@ private extension ISO8601DateFormatter {
         formatter.formatOptions = [.withInternetDateTime]
         return formatter
     }()
+}
+
+private extension KeyedDecodingContainer {
+    func decodeIntFlexible(forKey key: Key) throws -> Int {
+        if let value = try? decode(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(String.self, forKey: key),
+           let intValue = Int(value) {
+            return intValue
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return Int(value)
+        }
+        throw DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected Int/String-number/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        return try? decodeIntFlexible(forKey: key)
+    }
 }

--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/ScheduleAttendanceInfoDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/ScheduleAttendanceInfoDTO.swift
@@ -66,14 +66,14 @@ struct ScheduleAttendanceInfoDTO: Codable, Sendable, Equatable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        scheduleId = try container.decodeIfPresent(Int.self, forKey: .scheduleId) ?? 0
+        scheduleId = try container.decodeIntFlexibleIfPresent(forKey: .scheduleId) ?? 0
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
         startsAt = try container.decodeIfPresent(String.self, forKey: .startsAt) ?? ""
         endsAt = try container.decodeIfPresent(String.self, forKey: .endsAt) ?? ""
         isOnline = try container.decodeIfPresent(Bool.self, forKey: .isOnline) ?? false
         location = try container.decodeIfPresent(V2LocationDTO.self, forKey: .location)
-        authorMemberId = try container.decodeIfPresent(Int.self, forKey: .authorMemberId) ?? 0
+        authorMemberId = try container.decodeIntFlexibleIfPresent(forKey: .authorMemberId) ?? 0
         attendancePolicy = try container.decodeIfPresent(V2AttendancePolicyDTO.self, forKey: .attendancePolicy)
         tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
         participants = try container.decodeIfPresent([V2AttendanceParticipantDTO].self, forKey: .participants) ?? []
@@ -116,5 +116,34 @@ extension ScheduleAttendanceInfoDTO {
             tags: tags,
             participants: participants.map { $0.toDomain() }
         )
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeIntFlexible(forKey key: Key) throws -> Int {
+        if let value = try? decode(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(String.self, forKey: key),
+           let intValue = Int(value) {
+            return intValue
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return Int(value)
+        }
+        throw DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected Int/String-number/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        return try? decodeIntFlexible(forKey: key)
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/V2AttendanceParticipantDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/V2AttendanceParticipantDTO.swift
@@ -59,11 +59,11 @@ struct V2AttendanceParticipantDTO: Codable, Sendable, Equatable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        memberId = try container.decodeIfPresent(Int.self, forKey: .memberId) ?? 0
+        memberId = try container.decodeIntFlexibleIfPresent(forKey: .memberId) ?? 0
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
         profileImageUrl = try container.decodeIfPresent(String.self, forKey: .profileImageUrl)
-        schoolId = try container.decodeIfPresent(Int.self, forKey: .schoolId) ?? 0
+        schoolId = try container.decodeIntFlexibleIfPresent(forKey: .schoolId) ?? 0
         schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
         attendanceStatus = try container.decodeIfPresent(String.self, forKey: .attendanceStatus)
         isLocationVerified = try container.decodeIfPresent(Bool.self, forKey: .isLocationVerified) ?? false
@@ -114,5 +114,34 @@ extension V2AttendanceParticipantDTO {
             isLocationVerified: isLocationVerified,
             excuseReason: normalizedReason
         )
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeIntFlexible(forKey key: Key) throws -> Int {
+        if let value = try? decode(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(String.self, forKey: key),
+           let intValue = Int(value) {
+            return intValue
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return Int(value)
+        }
+        throw DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected Int/String-number/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        return try? decodeIntFlexible(forKey: key)
     }
 }

--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/WorkbookSubmissionDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/WorkbookSubmissionDetailDTO.swift
@@ -13,4 +13,50 @@ import Foundation
 struct WorkbookSubmissionDetailDTO: Codable, Sendable, Equatable {
     let challengerWorkbookId: Int
     let submission: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerWorkbookId
+        case submission
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        challengerWorkbookId = try container.decodeIntFlexibleIfPresent(forKey: .challengerWorkbookId) ?? 0
+        submission = try container.decodeIfPresent(String.self, forKey: .submission)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(challengerWorkbookId, forKey: .challengerWorkbookId)
+        try container.encodeIfPresent(submission, forKey: .submission)
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeIntFlexible(forKey key: Key) throws -> Int {
+        if let value = try? decode(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(String.self, forKey: key),
+           let intValue = Int(value) {
+            return intValue
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return Int(value)
+        }
+        throw DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected Int/String-number/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        return try? decodeIntFlexible(forKey: key)
+    }
 }

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleCapabilitiesDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleCapabilitiesDTO.swift
@@ -22,6 +22,26 @@ struct ScheduleCapabilitiesDTO: Codable {
 
     /// 직책별 최대 초대 가능 인원
     let maxParticipantCount: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case canCreateSchedule
+        case canCreateAttendanceRequiredSchedule
+        case maxParticipantCount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        canCreateSchedule = try container.decodeIfPresent(Bool.self, forKey: .canCreateSchedule) ?? false
+        canCreateAttendanceRequiredSchedule = try container.decodeIfPresent(Bool.self, forKey: .canCreateAttendanceRequiredSchedule) ?? false
+        maxParticipantCount = try container.decodeIntFlexibleIfPresent(forKey: .maxParticipantCount) ?? 0
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(canCreateSchedule, forKey: .canCreateSchedule)
+        try container.encode(canCreateAttendanceRequiredSchedule, forKey: .canCreateAttendanceRequiredSchedule)
+        try container.encode(maxParticipantCount, forKey: .maxParticipantCount)
+    }
 }
 
 // MARK: - Domain Mapping
@@ -35,5 +55,34 @@ extension ScheduleCapabilitiesDTO {
             canCreateAttendanceRequiredSchedule: canCreateAttendanceRequiredSchedule,
             maxParticipantCount: maxParticipantCount
         )
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeIntFlexible(forKey key: Key) throws -> Int {
+        if let value = try? decode(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(String.self, forKey: key),
+           let intValue = Int(value) {
+            return intValue
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return Int(value)
+        }
+        throw DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected Int/String-number/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        return try? decodeIntFlexible(forKey: key)
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleParticipantDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ScheduleParticipantDTO.swift
@@ -31,6 +31,35 @@ struct ScheduleParticipantDTO: Codable, Sendable, Equatable {
 
     /// 학교명
     let schoolName: String
+
+    private enum CodingKeys: String, CodingKey {
+        case memberId
+        case name
+        case nickname
+        case profileImageUrl
+        case schoolId
+        case schoolName
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        memberId = try container.decodeIntFlexibleIfPresent(forKey: .memberId) ?? 0
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
+        profileImageUrl = try container.decodeIfPresent(String.self, forKey: .profileImageUrl)
+        schoolId = try container.decodeIntFlexibleIfPresent(forKey: .schoolId) ?? 0
+        schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(memberId, forKey: .memberId)
+        try container.encode(name, forKey: .name)
+        try container.encode(nickname, forKey: .nickname)
+        try container.encodeIfPresent(profileImageUrl, forKey: .profileImageUrl)
+        try container.encode(schoolId, forKey: .schoolId)
+        try container.encode(schoolName, forKey: .schoolName)
+    }
 }
 
 // MARK: - Domain Mapping
@@ -47,5 +76,34 @@ extension ScheduleParticipantDTO {
             schoolId: schoolId,
             schoolName: schoolName
         )
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeIntFlexible(forKey key: Key) throws -> Int {
+        if let value = try? decode(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(String.self, forKey: key),
+           let intValue = Int(value) {
+            return intValue
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return Int(value)
+        }
+        throw DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected Int/String-number/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        return try? decodeIntFlexible(forKey: key)
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,6 +454,100 @@ case .addLink(_, let body):
 - **신규 라우터/엔드포인트**: 처음부터 DTO 분리.
 - **기존 라우터**: 별도 마이그레이션 작업으로 진행 (기능 작업과 분리해 PR을 따로 연다).
 
+## Response DTO Decoding
+
+서버는 **응답으로 내려주는 모든 정수 값을 String 으로 직렬화**합니다.
+JSON Number 가 아닌 String 으로 오므로, Response DTO 가 `Int` 로
+선언된 필드를 그대로 디코딩하면 런타임 `DecodingError.typeMismatch`
+가 발생합니다.
+
+### 원칙
+
+1. **Response DTO 의 모든 `Int` 필드는 String 폴백을 보장한다**
+2. **synthesized `Codable` 금지** — `Int` 필드가 있으면 반드시 custom
+   `init(from:)` + `encode(to:)` 를 작성
+3. **`decode(Int.self)` / `decodeIfPresent(Int.self)` 직접 호출 금지** —
+   `decodeIntFlexibleIfPresent` 헬퍼 사용
+4. **폴백 순서**: `Int` → `String("123")` → `Double(123.0)` → throw
+5. **Request DTO (Encodable, 우리가 보내는 쪽) 는 제외** — `Int` 그대로 OK
+
+### ❌ 안티패턴
+
+```swift
+struct UserDTO: Codable {
+    let userId: Int           // synthesized Codable — "123" String 응답에서 typeMismatch
+    let name: String
+}
+
+// 또는 custom init 안에서 직접 Int decode
+init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    userId = try container.decodeIfPresent(Int.self, forKey: .userId) ?? 0
+}
+```
+
+### ✅ 권장 패턴
+
+```swift
+struct UserDTO: Codable {
+    let userId: Int
+    let name: String
+
+    private enum CodingKeys: String, CodingKey {
+        case userId, name
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        userId = try container.decodeIntFlexibleIfPresent(forKey: .userId) ?? 0
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(userId, forKey: .userId)
+        try container.encode(name, forKey: .name)
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeIntFlexible(forKey key: Key) throws -> Int {
+        if let value = try? decode(Int.self, forKey: key) { return value }
+        if let value = try? decode(String.self, forKey: key),
+           let intValue = Int(value) { return intValue }
+        if let value = try? decode(Double.self, forKey: key) { return Int(value) }
+        throw DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected Int/String-number/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if (try? decodeNil(forKey: key)) == true { return nil }
+        return try? decodeIntFlexible(forKey: key)
+    }
+}
+```
+
+### 리뷰 체크리스트
+
+Response DTO 변경이 포함된 PR 리뷰 시 검증:
+
+- [ ] `Int` / `Int?` / `[Int]` / `Int64` 등 정수 타입 필드가 있는가
+- [ ] 정수 필드가 있다면 custom `init(from:)` 이 정의되어 있는가 (synthesized Codable 금지)
+- [ ] `init(from:)` 안에서 `decodeIntFlexibleIfPresent` (또는 동급) 사용 — `decode(Int.self)` 직접 호출 없음
+- [ ] 헬퍼가 파일 내 `private extension KeyedDecodingContainer` 로 정의되어 있는가
+- [ ] **Request/Encodable DTO 는 적용 제외 확인** — 보내는 쪽이라 무관
+
+### 적용 범위
+
+- **신규 Response DTO**: 처음부터 위 패턴 적용
+- **기존 Response DTO**: 별도 마이그레이션 PR 로 진행
+- **공용 헬퍼 통합**: 현재 파일별 중복 정의 — 추후 `Core/Common/Decoding/` 위치로 단일화 예정
+
 ## 디자인 시스템
 
 토큰 정의: `DefaultConstant.swift`, `DefaultSpacing.swift`


### PR DESCRIPTION
## ✨ PR 유형

Fix + Docs — 서버가 Int 값을 String 으로 직렬화해 내려주는 케이스에서 발생하던 `DecodingError.typeMismatch` 런타임 크래시 방어

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음 (네트워크 디코딩 레이어 변경)

## 🛠️ 작업내용

### Int 디코딩 폴백 적용 (6개 DTO)
기존 다른 DTO 들에서 이미 사용 중인 `decodeIntFlexibleIfPresent` 패턴(Int → String → Double 순서로 폴백) 을 동일하게 적용.

- `V2AttendanceParticipantDTO` — memberId, schoolId
- `ScheduleAttendanceInfoDTO` — scheduleId, authorMemberId
- `CurriculumDTO` / `WeeklyCurriculumDTO` — curriculumId, weeklyCurriculumId, weekNo
- `WorkbookSubmissionDetailDTO` — challengerWorkbookId
- `ScheduleParticipantDTO` — memberId, schoolId
- `ScheduleCapabilitiesDTO` — maxParticipantCount

### 컨벤션 문서화
- `CLAUDE.md` 에 `## Response DTO Decoding` 섹션 추가
  - 원칙(synthesized Codable 금지, `decodeIntFlexibleIfPresent` 사용)
  - 안티패턴 / 권장 패턴 코드 예시
  - 리뷰 체크리스트
  - 적용 범위(신규 / 기존 마이그레이션 / Core 공용 헬퍼 통합 계획)

## 📋 추후 진행 상황

- 헬퍼가 현재 각 파일 `private extension KeyedDecodingContainer` 로 중복 정의되어 있음 — 추후 `Core/Common/Decoding/` 위치로 단일화 (별도 PR)
- 나머지 Response DTO 들에 대해서도 일괄 마이그레이션 PR 진행 예정

## 📌 리뷰 포인트

- 각 DTO 의 `init(from:)` 이 `decodeIntFlexibleIfPresent` 를 사용하는지 (직접 `decode(Int.self)` 호출 없음)
- `encode(to:)` 가 함께 구현되어 있는지 (synthesized Codable 금지)
- Request/Encodable DTO 는 적용 대상이 아님을 확인 (보내는 쪽)
- `CLAUDE.md` 컨벤션이 팀 합의 가능한 수준인지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)