### PR TITLE
✨[Feat] ID/PW 로그인·회원가입 + memberId Int→String 마이그레이션 (#643)

### DIFF
--- a/AppProduct/AppProduct/App/AppDelegate.swift
+++ b/AppProduct/AppProduct/App/AppDelegate.swift
@@ -163,7 +163,7 @@ private extension AppDelegate {
             logger.notice("[FCM] skip upload trigger=\(trigger, privacy: .public) reason=containerMissing")
             return
         }
-        let memberId = UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+        let memberId = AppStorageKey.legacyMemberIdInt()
         let fcmToken = UserDefaults.standard.string(forKey: AppStorageKey.userFCMToken) ?? ""
         guard memberId != 0, !fcmToken.isEmpty else { return }
 

--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -43,6 +43,8 @@ struct AppProductApp: App {
             fullName: String?,
             postRegisterLoginContext: PostRegisterLoginContext?
         )
+        /// ID/PW 회원가입 화면
+        case signUpByIdPw
         /// 승인 대기 화면
         case pendingApproval
         /// 메인 화면 (탭, 인증 세션)
@@ -106,6 +108,7 @@ extension AppProductApp {
             case .login:
                 LoginView(
                     loginUseCase: authProvider.loginUseCase,
+                    loginByIdPwUseCase: authProvider.loginByIdPwUseCase,
                     fetchMyProfileUseCase: container.resolve(
                         HomeUseCaseProviding.self
                     ).fetchMyProfileUseCase,
@@ -132,6 +135,24 @@ extension AppProductApp {
                     registerUseCase: authProvider.registerUseCase,
                     loginUseCase: authProvider.loginUseCase,
                     fetchSignUpDataUseCase: authProvider.fetchSignUpDataUseCase
+                )
+                .transition(rootTransition)
+
+            case .signUpByIdPw:
+                SignUpByIdPwView(
+                    sendEmailVerificationUseCase: authProvider
+                        .sendEmailVerificationUseCase,
+                    verifyEmailCodeUseCase: authProvider
+                        .verifyEmailCodeUseCase,
+                    registerByIdPwUseCase: authProvider
+                        .registerByIdPwUseCase,
+                    checkLoginIdAvailabilityUseCase: authProvider
+                        .checkLoginIdAvailabilityUseCase,
+                    fetchSignUpDataUseCase: authProvider
+                        .fetchSignUpDataUseCase,
+                    fetchMyProfileUseCase: container.resolve(
+                        HomeUseCaseProviding.self
+                    ).fetchMyProfileUseCase
                 )
                 .transition(rootTransition)
 
@@ -238,6 +259,7 @@ extension AppProductApp {
                     )
                 )
             },
+            showSignUpByIdPw: { transition(to: .signUpByIdPw) },
             showPendingApproval: { transition(to: .pendingApproval) },
             logout: { handleAuthSessionExpired() }
         )

--- a/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
@@ -59,3 +59,34 @@ enum AppStorageKey {
     /// 공지 탭에서 현재 선택한 기수 ID (공지 작성 진입 시 사용)
     static let noticeSelectedGisuId: String = "noticeSelectedGisuId"
 }
+
+// MARK: - Member ID 어댑터
+
+extension AppStorageKey {
+
+    /// 멤버 ID를 `String`으로 조회합니다.
+    ///
+    /// 신규 저장값(`String`)을 우선 사용하고, 레거시 `Int` 저장값을 발견하면
+    /// 문자열로 변환해 반환합니다. 둘 다 없으면 `nil`을 반환합니다.
+    static func memberIdString(in defaults: UserDefaults = .standard) -> String? {
+        if let value = defaults.string(forKey: memberId), !value.isEmpty {
+            return value
+        }
+        let legacyInt = defaults.integer(forKey: memberId)
+        return legacyInt > 0 ? String(legacyInt) : nil
+    }
+
+    /// 멤버 ID를 레거시 `Int` 형태로 조회합니다.
+    ///
+    /// 신규 `String` 저장값을 `Int`로 변환해 우선 반환하고, 변환에 실패하거나
+    /// `String` 값이 없으면 레거시 `Int` 저장값으로 폴백합니다.
+    /// `Int` 식별자를 기대하는 out-of-scope 호출자(Activity / Notice / AppDelegate)가
+    /// 점진적 마이그레이션 동안 사용합니다.
+    static func legacyMemberIdInt(in defaults: UserDefaults = .standard) -> Int {
+        if let stringValue = defaults.string(forKey: memberId),
+           let intValue = Int(stringValue) {
+            return intValue
+        }
+        return defaults.integer(forKey: memberId)
+    }
+}

--- a/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
+++ b/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
@@ -11,10 +11,27 @@ import SwiftUI
 #Preview("로그인") {
     LoginView(
         loginUseCase: PreviewLoginUseCase(),
+        loginByIdPwUseCase: PreviewLoginByIdPwUseCase(),
         fetchMyProfileUseCase: PreviewFetchMyProfileUseCase(),
         tokenStore: KeychainTokenStore(),
         errorHandler: ErrorHandler()
     )
+}
+
+/// Preview 전용 ID/PW 로그인 UseCase
+private struct PreviewLoginByIdPwUseCase: LoginByIdPwUseCaseProtocol {
+    func execute(
+        loginId: String,
+        password: String
+    ) async throws -> LoginByIdPwResult {
+        LoginByIdPwResult(
+            memberId: "preview_member_id",
+            tokenPair: TokenPair(
+                accessToken: "preview",
+                refreshToken: "preview"
+            )
+        )
+    }
 }
 
 /// Preview 전용 LoginUseCase

--- a/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
+++ b/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
@@ -49,7 +49,7 @@ private struct PreviewLoginUseCase: LoginUseCaseProtocol {
 private struct PreviewFetchMyProfileUseCase: FetchMyProfileUseCaseProtocol {
     func execute() async throws -> HomeProfileResult {
         HomeProfileResult(
-            memberId: 1,
+            memberId: "1",
             schoolId: 1,
             schoolName: "중앙대학교",
             latestChallengerId: nil,
@@ -97,8 +97,8 @@ private struct PreviewVerifyCodeUseCase: VerifyEmailCodeUseCaseProtocol {
 }
 
 private struct PreviewRegisterUseCase: RegisterUseCaseProtocol {
-    func execute(request: RegisterRequestDTO) async throws -> Int {
-        1
+    func execute(request: RegisterRequestDTO) async throws -> String {
+        "1"
     }
 }
 

--- a/AppProduct/AppProduct/Core/Mock/MyPageMockData.swift
+++ b/AppProduct/AppProduct/Core/Mock/MyPageMockData.swift
@@ -11,7 +11,7 @@ enum MyPageMockData {
     static let profile = ProfileData(
         challengeId: 269,
         challangerInfo: ChallengerInfo(
-            memberId: 1001,
+            memberId: "1001",
             gen: 8,
             name: "홍길동",
             nickname: "길동",

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/ActivityRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/ActivityRepository.swift
@@ -69,9 +69,7 @@ final class ActivityRepository: ActivityRepositoryProtocol, @unchecked Sendable 
     }
 
     func fetchCurrentUserId() async throws -> UserID {
-        let memberId = UserDefaults.standard.integer(
-            forKey: AppStorageKey.memberId
-        )
+        let memberId = AppStorageKey.legacyMemberIdInt()
         return UserID(value: String(memberId))
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -30,7 +30,7 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
     }
 
     private var currentMemberID: Int {
-        UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+        AppStorageKey.legacyMemberIdInt()
     }
 
     // MARK: - Function

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorStudyManagementViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorStudyManagementViewModel.swift
@@ -299,9 +299,9 @@ final class OperatorStudyManagementViewModel {
             )
             studyGroupDetails[index].members = selectedChallengers.map {
                 StudyGroupMember(
-                    serverID: String($0.memberId),
+                    serverID: $0.memberId,
                     challengerID: resolvedChallengerIDs[$0.selectionKey],
-                    memberID: $0.memberId,
+                    memberID: Int($0.memberId),
                     name: $0.name,
                     nickname: $0.nickname,
                     university: $0.schoolName,
@@ -419,9 +419,7 @@ final class OperatorStudyManagementViewModel {
         memberUpdateTargetGroup = group
         selectedChallengers = group.members.map { member in
             ChallengerInfo(
-                memberId: member.memberID
-                    ?? Int(member.serverID)
-                    ?? 0,
+                memberId: member.memberID.map(String.init) ?? member.serverID,
                 challengerId: member.challengerID
                     ?? member.memberID
                     ?? Int(member.serverID)
@@ -640,9 +638,9 @@ final class OperatorStudyManagementViewModel {
             part: part,
             createdDate: Date(),
             leader: StudyGroupMember(
-                serverID: String(leader.memberId),
+                serverID: leader.memberId,
                 challengerID: leaderId,
-                memberID: leader.memberId,
+                memberID: Int(leader.memberId),
                 name: leader.name,
                 nickname: leader.nickname,
                 university: leader.schoolName,
@@ -651,9 +649,9 @@ final class OperatorStudyManagementViewModel {
             ),
             members: members.compactMap {
                 $0.memberId != leader.memberId ? StudyGroupMember(
-                    serverID: String($0.memberId),
+                    serverID: $0.memberId,
                     challengerID: resolvedChallengerIDs[$0.selectionKey],
-                    memberID: $0.memberId,
+                    memberID: Int($0.memberId),
                     name: $0.name,
                     nickname: $0.nickname,
                     university: $0.schoolName,
@@ -973,15 +971,16 @@ final class OperatorStudyManagementViewModel {
     private func resolveChallengerID(
         for challenger: ChallengerInfo
     ) async -> Int? {
+        let memberIdInt = Int(challenger.memberId) ?? 0
         let hasDistinctChallengerID = challenger.challengerId > 0 &&
-            challenger.challengerId != challenger.memberId
+            challenger.challengerId != memberIdInt
         if hasDistinctChallengerID {
             return challenger.challengerId
         }
 
         do {
             if let resolvedID = try await useCase.resolveChallengerId(
-                memberId: challenger.memberId,
+                memberId: memberIdInt,
                 preferredGeneration: challenger.gen
             ),
                resolvedID > 0 {
@@ -991,7 +990,7 @@ final class OperatorStudyManagementViewModel {
             // 조회 실패 시 아래 fallback 규칙으로 처리
         }
 
-        if challenger.memberId <= 0, challenger.challengerId > 0 {
+        if memberIdInt <= 0, challenger.challengerId > 0 {
             return challenger.challengerId
         }
 

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/CheckLoginIdAvailabilityResponseDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/CheckLoginIdAvailabilityResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  CheckLoginIdAvailabilityResponseDTO.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+/// 로그인 ID 중복 검사 API 응답 DTO
+struct CheckLoginIdAvailabilityResponseDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    /// 검사 대상 로그인 ID (서버가 정규화하여 반환)
+    let loginId: String
+    /// 사용 가능 여부 (true: 사용 가능, false: 이미 사용 중)
+    let available: Bool
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginByIdPwRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginByIdPwRequestDTO.swift
@@ -1,0 +1,19 @@
+//
+//  LoginByIdPwRequestDTO.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+/// ID/PW 로그인 API 요청 DTO
+struct LoginByIdPwRequestDTO: Encodable {
+
+    // MARK: - Property
+
+    /// 로그인 ID (사용자 입력)
+    let loginId: String
+    /// 평문 비밀번호 (TLS 구간 서버 해싱 위임)
+    let password: String
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginByIdPwResponseDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginByIdPwResponseDTO.swift
@@ -1,0 +1,34 @@
+//
+//  LoginByIdPwResponseDTO.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+/// ID/PW 로그인 API 응답 DTO
+struct LoginByIdPwResponseDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    /// 회원 ID (서버 응답 String)
+    let memberId: String
+    /// JWT 액세스 토큰
+    let accessToken: String
+    /// JWT 리프레시 토큰
+    let refreshToken: String
+
+    // MARK: - Mapping
+
+    /// Domain 모델로 변환
+    func toDomain() -> LoginByIdPwResult {
+        LoginByIdPwResult(
+            memberId: memberId,
+            tokenPair: TokenPair(
+                accessToken: accessToken,
+                refreshToken: refreshToken
+            )
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/MemberOAuthDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/MemberOAuthDTO.swift
@@ -14,8 +14,8 @@ struct MemberOAuthDTO: Codable, Sendable, Equatable {
 
     /// OAuth 연동 ID
     let memberOAuthId: Int
-    /// 회원 ID
-    let memberId: Int
+    /// 회원 ID (서버 응답 String 기준)
+    let memberId: String
     /// OAuth 제공자 (KAKAO, APPLE)
     let provider: OAuthProvider
 
@@ -36,7 +36,7 @@ struct MemberOAuthDTO: Codable, Sendable, Equatable {
             from: container,
             forKey: .memberOAuthId
         )
-        memberId = try Self.decodeFlexibleInt(
+        memberId = try Self.decodeFlexibleString(
             from: container,
             forKey: .memberId
         )
@@ -76,6 +76,28 @@ private extension MemberOAuthDTO {
             DecodingError.Context(
                 codingPath: container.codingPath + [key],
                 debugDescription: "\(key.stringValue)는 Int 또는 숫자 문자열이어야 합니다."
+            )
+        )
+    }
+
+    /// 서버가 Int 또는 String 어느 쪽으로도 응답할 수 있는 ID 류 필드를 String 으로 통일 디코딩한다.
+    private static func decodeFlexibleString(
+        from container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) throws -> String {
+        if let stringValue = try? container.decode(String.self, forKey: key) {
+            return stringValue
+        }
+
+        if let intValue = try? container.decode(Int.self, forKey: key) {
+            return String(intValue)
+        }
+
+        throw DecodingError.typeMismatch(
+            String.self,
+            DecodingError.Context(
+                codingPath: container.codingPath + [key],
+                debugDescription: "\(key.stringValue)는 String 또는 Int 이어야 합니다."
             )
         )
     }

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/RegisterByIdPwRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/RegisterByIdPwRequestDTO.swift
@@ -1,0 +1,40 @@
+//
+//  RegisterByIdPwRequestDTO.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+/// ID/PW 회원가입 API 요청 DTO
+struct RegisterByIdPwRequestDTO: Encodable {
+
+    // MARK: - Property
+
+    /// 이메일 인증 토큰 (이메일 인증 완료 시 발급)
+    let emailVerificationToken: String
+    /// 로그인 ID (사용자 입력, 서버 형식 검증)
+    let loginId: String
+    /// 사용자 실명 (1~10자)
+    let name: String
+    /// 닉네임 (`^[가-힣]+$`, 1~5자)
+    let nickname: String
+    /// 평문 비밀번호 (8자 이상)
+    let rawPassword: String
+    /// 학교 ID (서버 응답 String 기준)
+    let schoolId: String
+    /// 약관 동의 목록
+    let termsAgreements: [RegisterByIdPwTermsAgreementDTO]
+}
+
+/// ID/PW 회원가입 약관 동의 항목 DTO
+struct RegisterByIdPwTermsAgreementDTO: Encodable {
+
+    // MARK: - Property
+
+    /// 약관 ID (서버 응답 String 기준)
+    let termsId: String
+    /// 동의 여부
+    let agreed: Bool
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/RegisterByIdPwResponseDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/RegisterByIdPwResponseDTO.swift
@@ -1,0 +1,34 @@
+//
+//  RegisterByIdPwResponseDTO.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+/// ID/PW 회원가입 API 응답 DTO
+struct RegisterByIdPwResponseDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    /// 생성된 회원 ID (서버 응답 String)
+    let memberId: String
+    /// JWT 액세스 토큰
+    let accessToken: String
+    /// JWT 리프레시 토큰
+    let refreshToken: String
+
+    // MARK: - Mapping
+
+    /// Domain 모델로 변환
+    func toDomain() -> RegisterByIdPwResult {
+        RegisterByIdPwResult(
+            memberId: memberId,
+            tokenPair: TokenPair(
+                accessToken: accessToken,
+                refreshToken: refreshToken
+            )
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -87,6 +87,79 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         return try apiResponse.unwrap().toDomain()
     }
 
+    /// ID/PW 로그인을 수행합니다.
+    ///
+    /// - Parameter body: loginId / password
+    /// - Returns: 회원 ID + 토큰 쌍
+    func loginByIdPw(
+        _ body: LoginByIdPwRequestDTO
+    ) async throws -> LoginByIdPwResult {
+        do {
+            let response = try await adapter.requestWithoutAuth(
+                AuthRouter.loginByIdPw(body: body)
+            )
+            #if DEBUG
+            if let json = String(data: response.data, encoding: .utf8) {
+                print("[Auth] ID/PW 로그인 응답: \(json)")
+            }
+            #endif
+            let apiResponse = try decoder.decode(
+                APIResponse<LoginByIdPwResponseDTO>.self,
+                from: response.data
+            )
+            return try apiResponse.unwrap().toDomain()
+        } catch let error as NetworkError {
+            throw Self.parseServerError(from: error) ?? error
+        }
+    }
+
+    /// ID/PW 회원가입을 수행합니다.
+    ///
+    /// - Parameter body: 회원가입 요청 DTO
+    /// - Returns: 생성된 회원 ID + 토큰 쌍 (가입과 동시에 발급)
+    func registerByIdPw(
+        _ body: RegisterByIdPwRequestDTO
+    ) async throws -> RegisterByIdPwResult {
+        do {
+            let response = try await adapter.requestWithoutAuth(
+                AuthRouter.registerByIdPw(body: body)
+            )
+            #if DEBUG
+            if let json = String(data: response.data, encoding: .utf8) {
+                print("[Auth] ID/PW 회원가입 응답: \(json)")
+            }
+            #endif
+            let apiResponse = try decoder.decode(
+                APIResponse<RegisterByIdPwResponseDTO>.self,
+                from: response.data
+            )
+            return try apiResponse.unwrap().toDomain()
+        } catch let error as NetworkError {
+            throw Self.parseServerError(from: error) ?? error
+        }
+    }
+
+    /// 로그인 ID 중복 검사를 수행합니다.
+    ///
+    /// - Parameter loginId: 검사 대상 로그인 ID
+    /// - Returns: 사용 가능 여부 (true = 사용 가능)
+    func checkLoginIdAvailability(
+        loginId: String
+    ) async throws -> Bool {
+        do {
+            let response = try await adapter.requestWithoutAuth(
+                AuthRouter.checkLoginIdAvailability(loginId: loginId)
+            )
+            let apiResponse = try decoder.decode(
+                APIResponse<CheckLoginIdAvailabilityResponseDTO>.self,
+                from: response.data
+            )
+            return try apiResponse.unwrap().available
+        } catch let error as NetworkError {
+            throw Self.parseServerError(from: error) ?? error
+        }
+    }
+
     /// 리프레시 토큰으로 새 토큰 쌍을 발급받습니다.
     func renewToken(
         refreshToken: String

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -198,11 +198,10 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
     /// 회원가입을 수행합니다.
     ///
     /// - Parameter request: 회원가입 요청 DTO
-    /// - Returns: 생성된 회원 ID
-    /// - Throws: `RepositoryError.decodingError` memberId 변환 실패 시
+    /// - Returns: 생성된 회원 ID (서버 응답 String 기준)
     func register(
         request: RegisterRequestDTO
-    ) async throws -> Int {
+    ) async throws -> String {
         do {
             let response = try await adapter.requestWithoutAuth(
                 AuthRouter.register(body: request)
@@ -212,13 +211,7 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
                 from: response.data
             )
             let dto = try apiResponse.unwrap()
-            // 서버에서 memberId를 String으로 넘겨줌에 따른 타입 변환
-            guard let id = Int(dto.memberId) else {
-                throw RepositoryError.decodingError(
-                    detail: "memberId 변환 실패: \(dto.memberId)"
-                )
-            }
-            return id
+            return dto.memberId
         } catch let NetworkError.requestFailed(statusCode, data) {
             #if DEBUG
             if let data,

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
@@ -42,6 +42,50 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         )
     }
 
+    func loginByIdPw(
+        _ body: LoginByIdPwRequestDTO
+    ) async throws -> LoginByIdPwResult {
+        try await Task.sleep(for: .milliseconds(500))
+
+        guard body.loginId == "reviewer" && body.password == "umc12345!" else {
+            throw RepositoryError.serverError(
+                code: "INVALID_CREDENTIALS",
+                message: "아이디 또는 비밀번호가 올바르지 않습니다."
+            )
+        }
+
+        return LoginByIdPwResult(
+            memberId: "999",
+            tokenPair: TokenPair(
+                accessToken: "mock_id_pw_access_token",
+                refreshToken: "mock_id_pw_refresh_token"
+            )
+        )
+    }
+
+    func registerByIdPw(
+        _ body: RegisterByIdPwRequestDTO
+    ) async throws -> RegisterByIdPwResult {
+        try await Task.sleep(for: .milliseconds(500))
+
+        return RegisterByIdPwResult(
+            memberId: "999",
+            tokenPair: TokenPair(
+                accessToken: "mock_id_pw_access_token",
+                refreshToken: "mock_id_pw_refresh_token"
+            )
+        )
+    }
+
+    func checkLoginIdAvailability(
+        loginId: String
+    ) async throws -> Bool {
+        try await Task.sleep(for: .milliseconds(300))
+        // "reviewer" / "admin" / "test" 는 이미 사용 중인 ID 로 간주
+        let reservedIds: Set<String> = ["reviewer", "admin", "test"]
+        return !reservedIds.contains(loginId.lowercased())
+    }
+
     func renewToken(
         refreshToken: String
     ) async throws -> TokenPair {

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
@@ -59,7 +59,7 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         return [
             MemberOAuth(
                 memberOAuthId: 1,
-                memberId: 102,
+                memberId: "102",
                 provider: .kakao
             )
         ]
@@ -73,12 +73,12 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         return [
             MemberOAuth(
                 memberOAuthId: 1,
-                memberId: 102,
+                memberId: "102",
                 provider: .kakao
             ),
             MemberOAuth(
                 memberOAuthId: 2,
-                memberId: 102,
+                memberId: "102",
                 provider: .apple
             )
         ]
@@ -109,9 +109,9 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
 
     func register(
         request: RegisterRequestDTO
-    ) async throws -> Int {
+    ) async throws -> String {
         try await Task.sleep(for: .milliseconds(500))
-        return 1
+        return "1"
     }
 
     func registerExistingChallenger(

--- a/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
@@ -22,6 +22,12 @@ enum AuthRouter: BaseTargetType {
         email: String?,
         fullName: String?
     )
+    /// ID/PW 로그인 (App Store 리뷰어용)
+    case loginByIdPw(body: LoginByIdPwRequestDTO)
+    /// ID/PW 회원가입 (App Store 리뷰어용)
+    case registerByIdPw(body: RegisterByIdPwRequestDTO)
+    /// 로그인 ID 중복 검사
+    case checkLoginIdAvailability(loginId: String)
     /// 액세스 토큰 재발급
     case renewToken(refreshToken: String)
     /// 내 OAuth 연동 정보 조회
@@ -58,6 +64,12 @@ enum AuthRouter: BaseTargetType {
             return "/api/v1/auth/login/kakao"
         case .loginApple:
             return "/api/v1/auth/login/apple"
+        case .loginByIdPw:
+            return "/api/v1/auth/login/id-pw"
+        case .registerByIdPw:
+            return "/api/v1/member/register/id-pw"
+        case .checkLoginIdAvailability:
+            return "/api/v1/auth/login-id/availability"
         case .renewToken:
             return "/api/v1/auth/token/renew"
         case .getMyOAuth:
@@ -85,15 +97,16 @@ enum AuthRouter: BaseTargetType {
 
     var method: Moya.Method {
         switch self {
-        case .loginKakao, .loginApple, .renewToken,
-             .sendEmailVerification, .verifyEmailCode, .register,
-             .registerExistingChallenger:
+        case .loginKakao, .loginApple, .loginByIdPw, .registerByIdPw,
+             .renewToken, .sendEmailVerification, .verifyEmailCode,
+             .register, .registerExistingChallenger:
             return .post
         case .addMemberOAuth:
             return .post
         case .deleteMemberOAuth:
             return .delete
-        case .getMyOAuth, .getSchools, .getTerms:
+        case .getMyOAuth, .getSchools, .getTerms,
+             .checkLoginIdAvailability:
             return .get
         }
     }
@@ -123,6 +136,15 @@ enum AuthRouter: BaseTargetType {
             return .requestParameters(
                 parameters: parameters,
                 encoding: JSONEncoding.default
+            )
+        case .loginByIdPw(let body):
+            return .requestJSONEncodable(body)
+        case .registerByIdPw(let body):
+            return .requestJSONEncodable(body)
+        case .checkLoginIdAvailability(let loginId):
+            return .requestParameters(
+                parameters: ["loginId": loginId],
+                encoding: URLEncoding.queryString
             )
         case .renewToken(let refreshToken):
             return .requestParameters(

--- a/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
@@ -80,10 +80,10 @@ protocol AuthRepositoryProtocol: Sendable {
 
     /// 회원가입
     /// - Parameter request: 회원가입 요청 DTO
-    /// - Returns: 생성된 회원 ID
+    /// - Returns: 생성된 회원 ID (서버 응답 String 기준)
     func register(
         request: RegisterRequestDTO
-    ) async throws -> Int
+    ) async throws -> String
 
     /// 기존 챌린저 코드 인증
     /// - Parameter code: 운영진 발급 6자리 코드

--- a/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
@@ -32,6 +32,27 @@ protocol AuthRepositoryProtocol: Sendable {
         fullName: String?
     ) async throws -> OAuthLoginResult
 
+    /// ID/PW 로그인 (App Store 리뷰어용 비-OAuth 진입)
+    /// - Parameter body: 로그인 요청 DTO (loginId, password)
+    /// - Returns: 회원 ID + 토큰 쌍
+    func loginByIdPw(
+        _ body: LoginByIdPwRequestDTO
+    ) async throws -> LoginByIdPwResult
+
+    /// ID/PW 회원가입 (App Store 리뷰어용 비-OAuth 진입)
+    /// - Parameter body: 회원가입 요청 DTO (이메일 인증 토큰, ID, 비밀번호 등)
+    /// - Returns: 생성된 회원 ID + 토큰 쌍
+    func registerByIdPw(
+        _ body: RegisterByIdPwRequestDTO
+    ) async throws -> RegisterByIdPwResult
+
+    /// 로그인 ID 중복 검사
+    /// - Parameter loginId: 검사 대상 로그인 ID
+    /// - Returns: 사용 가능 여부 (true = 사용 가능)
+    func checkLoginIdAvailability(
+        loginId: String
+    ) async throws -> Bool
+
     /// 토큰 재발급
     /// - Parameter refreshToken: 리프레시 토큰
     /// - Returns: 새 토큰 쌍

--- a/AppProduct/AppProduct/Features/Auth/Domain/Models/LoginByIdPwResult.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Models/LoginByIdPwResult.swift
@@ -1,0 +1,21 @@
+//
+//  LoginByIdPwResult.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+/// ID/PW 로그인 결과
+///
+/// 소셜 로그인과 달리 신규 회원 분기가 없습니다 (회원가입은 별도 플로우).
+struct LoginByIdPwResult: Equatable, Sendable {
+
+    // MARK: - Property
+
+    /// 회원 ID (서버 응답 String)
+    let memberId: String
+    /// 인증 토큰 쌍
+    let tokenPair: TokenPair
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/Models/MemberOAuth.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Models/MemberOAuth.swift
@@ -14,8 +14,8 @@ struct MemberOAuth: Equatable, Sendable {
 
     /// OAuth 연동 ID
     let memberOAuthId: Int
-    /// 회원 ID
-    let memberId: Int
+    /// 회원 ID (서버 응답 String 기준)
+    let memberId: String
     /// OAuth 제공자 (APPLE, KAKAO)
     let provider: OAuthProvider
 }

--- a/AppProduct/AppProduct/Features/Auth/Domain/Models/RegisterByIdPwResult.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Models/RegisterByIdPwResult.swift
@@ -1,0 +1,21 @@
+//
+//  RegisterByIdPwResult.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+/// ID/PW 회원가입 결과
+///
+/// 가입과 동시에 토큰 쌍이 발급되어 별도 로그인 호출 없이 메인 진입이 가능합니다.
+struct RegisterByIdPwResult: Equatable, Sendable {
+
+    // MARK: - Property
+
+    /// 생성된 회원 ID (서버 응답 String)
+    let memberId: String
+    /// 인증 토큰 쌍
+    let tokenPair: TokenPair
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/CheckLoginIdAvailabilityUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/CheckLoginIdAvailabilityUseCaseProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  CheckLoginIdAvailabilityUseCaseProtocol.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+// MARK: - Protocol
+
+/// 로그인 ID 중복 검사 UseCase Protocol
+protocol CheckLoginIdAvailabilityUseCaseProtocol {
+    /// 로그인 ID 중복 여부 확인
+    /// - Parameter loginId: 검사 대상 로그인 ID
+    /// - Returns: 사용 가능 여부 (true = 사용 가능)
+    func execute(loginId: String) async throws -> Bool
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/CheckLoginIdAvailabilityUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/CheckLoginIdAvailabilityUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  CheckLoginIdAvailabilityUseCase.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+// MARK: - CheckLoginIdAvailabilityUseCase
+
+/// 로그인 ID 중복 검사 UseCase 구현체
+final class CheckLoginIdAvailabilityUseCase: CheckLoginIdAvailabilityUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: AuthRepositoryProtocol
+
+    // MARK: - Init
+
+    init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    func execute(loginId: String) async throws -> Bool {
+        try await repository.checkLoginIdAvailability(loginId: loginId)
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/LoginByIdPwUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/LoginByIdPwUseCase.swift
@@ -1,0 +1,50 @@
+//
+//  LoginByIdPwUseCase.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+// MARK: - LoginByIdPwUseCase
+
+/// ID/PW 로그인 UseCase 구현체
+///
+/// 로그인 성공 시 토큰을 즉시 저장합니다 (소셜 로그인 `LoginUseCase`와 동일 패턴).
+final class LoginByIdPwUseCase: LoginByIdPwUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: AuthRepositoryProtocol
+    private let tokenStore: TokenStore
+
+    // MARK: - Init
+
+    init(
+        repository: AuthRepositoryProtocol,
+        tokenStore: TokenStore
+    ) {
+        self.repository = repository
+        self.tokenStore = tokenStore
+    }
+
+    // MARK: - Function
+
+    func execute(
+        loginId: String,
+        password: String
+    ) async throws -> LoginByIdPwResult {
+        let result = try await repository.loginByIdPw(
+            LoginByIdPwRequestDTO(
+                loginId: loginId,
+                password: password
+            )
+        )
+        try await tokenStore.save(
+            accessToken: result.tokenPair.accessToken,
+            refreshToken: result.tokenPair.refreshToken
+        )
+        return result
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/RegisterByIdPwUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/RegisterByIdPwUseCase.swift
@@ -1,0 +1,44 @@
+//
+//  RegisterByIdPwUseCase.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+// MARK: - RegisterByIdPwUseCase
+
+/// ID/PW 회원가입 UseCase 구현체
+///
+/// 가입과 동시에 토큰이 발급되므로 별도 로그인 호출 없이 즉시 저장하여 메인 진입을 지원합니다.
+final class RegisterByIdPwUseCase: RegisterByIdPwUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: AuthRepositoryProtocol
+    private let tokenStore: TokenStore
+
+    // MARK: - Init
+
+    init(
+        repository: AuthRepositoryProtocol,
+        tokenStore: TokenStore
+    ) {
+        self.repository = repository
+        self.tokenStore = tokenStore
+    }
+
+    // MARK: - Function
+
+    func execute(
+        request: RegisterByIdPwRequestDTO
+    ) async throws -> RegisterByIdPwResult {
+        let result = try await repository.registerByIdPw(request)
+        try await tokenStore.save(
+            accessToken: result.tokenPair.accessToken,
+            refreshToken: result.tokenPair.refreshToken
+        )
+        return result
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/RegisterUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/RegisterUseCase.swift
@@ -24,7 +24,7 @@ final class RegisterUseCase: RegisterUseCaseProtocol {
 
     // MARK: - Function
 
-    func execute(request: RegisterRequestDTO) async throws -> Int {
+    func execute(request: RegisterRequestDTO) async throws -> String {
         try await repository.register(request: request)
     }
 }

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/LoginByIdPwUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/LoginByIdPwUseCaseProtocol.swift
@@ -1,0 +1,23 @@
+//
+//  LoginByIdPwUseCaseProtocol.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+// MARK: - Protocol
+
+/// ID/PW 로그인 UseCase Protocol
+protocol LoginByIdPwUseCaseProtocol {
+    /// ID/PW 로그인 실행
+    /// - Parameters:
+    ///   - loginId: 로그인 ID
+    ///   - password: 평문 비밀번호 (TLS 구간 서버 해싱 위임)
+    /// - Returns: 회원 ID + 토큰 쌍
+    func execute(
+        loginId: String,
+        password: String
+    ) async throws -> LoginByIdPwResult
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/RegisterByIdPwUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/RegisterByIdPwUseCaseProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  RegisterByIdPwUseCaseProtocol.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+
+// MARK: - Protocol
+
+/// ID/PW 회원가입 UseCase Protocol
+protocol RegisterByIdPwUseCaseProtocol {
+    /// ID/PW 회원가입 실행
+    /// - Parameter request: 회원가입 요청 DTO
+    /// - Returns: 생성된 회원 ID + 토큰 쌍
+    func execute(
+        request: RegisterByIdPwRequestDTO
+    ) async throws -> RegisterByIdPwResult
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/RegisterUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/RegisterUseCaseProtocol.swift
@@ -13,6 +13,6 @@ import Foundation
 protocol RegisterUseCaseProtocol {
     /// 회원가입 실행
     /// - Parameter request: 회원가입 요청 DTO
-    /// - Returns: 생성된 회원 ID
-    func execute(request: RegisterRequestDTO) async throws -> Int
+    /// - Returns: 생성된 회원 ID (서버 응답 String 기준)
+    func execute(request: RegisterRequestDTO) async throws -> String
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
@@ -11,6 +11,12 @@ import Foundation
 protocol AuthUseCaseProviding {
     /// 소셜 로그인 UseCase
     var loginUseCase: LoginUseCaseProtocol { get }
+    /// ID/PW 로그인 UseCase
+    var loginByIdPwUseCase: LoginByIdPwUseCaseProtocol { get }
+    /// ID/PW 회원가입 UseCase
+    var registerByIdPwUseCase: RegisterByIdPwUseCaseProtocol { get }
+    /// 로그인 ID 중복 검사 UseCase
+    var checkLoginIdAvailabilityUseCase: CheckLoginIdAvailabilityUseCaseProtocol { get }
     /// 내 OAuth 정보 조회 UseCase
     var fetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol { get }
     /// OAuth 수단 추가 연동 UseCase
@@ -37,6 +43,9 @@ final class AuthUseCaseProvider: AuthUseCaseProviding {
     // MARK: - Property
 
     let loginUseCase: LoginUseCaseProtocol
+    let loginByIdPwUseCase: LoginByIdPwUseCaseProtocol
+    let registerByIdPwUseCase: RegisterByIdPwUseCaseProtocol
+    let checkLoginIdAvailabilityUseCase: CheckLoginIdAvailabilityUseCaseProtocol
     let fetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol
     let addMemberOAuthUseCase: AddMemberOAuthUseCaseProtocol
     let deleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol
@@ -57,6 +66,17 @@ final class AuthUseCaseProvider: AuthUseCaseProviding {
         self.loginUseCase = LoginUseCase(
             repository: repository,
             tokenStore: tokenStore
+        )
+        self.loginByIdPwUseCase = LoginByIdPwUseCase(
+            repository: repository,
+            tokenStore: tokenStore
+        )
+        self.registerByIdPwUseCase = RegisterByIdPwUseCase(
+            repository: repository,
+            tokenStore: tokenStore
+        )
+        self.checkLoginIdAvailabilityUseCase = CheckLoginIdAvailabilityUseCase(
+            repository: repository
         )
         self.fetchMyOAuthUseCase = FetchMyOAuthUseCase(
             repository: repository

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
@@ -14,21 +14,32 @@ final class LoginViewModel {
     // MARK: - Property
 
     private let loginUseCase: LoginUseCaseProtocol
+    private let loginByIdPwUseCase: LoginByIdPwUseCaseProtocol
     private let fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol
     private let kakaoLoginManager: KakaoLoginManager
     private let appleLoginManager: AppleLoginManager
     private let tokenStore: TokenStore
     private let errorHandler: ErrorHandler
 
-    /// 로그인 상태
+    /// 로그인 상태 (OAuth)
     private(set) var loginState: Loadable<OAuthLoginResult> = .idle
+    /// 로그인 상태 (ID/PW)
+    private(set) var loginByIdPwState: Loadable<LoginByIdPwResult> = .idle
     /// 로그인 후 이동할 목적지
     private(set) var destination: LoginDestination?
+
+    /// ID/PW 입력 — 로그인 ID
+    var loginIdInput: String = ""
+    /// ID/PW 입력 — 비밀번호
+    var passwordInput: String = ""
+    /// ID/PW 로그인 인라인 에러 메시지 (네트워크 오류 등 Alert는 errorHandler 사용)
+    private(set) var loginByIdPwErrorMessage: String?
 
     // MARK: - Init
 
     init(
         loginUseCase: LoginUseCaseProtocol,
+        loginByIdPwUseCase: LoginByIdPwUseCaseProtocol,
         fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol,
         tokenStore: TokenStore,
         errorHandler: ErrorHandler,
@@ -36,6 +47,7 @@ final class LoginViewModel {
         appleLoginManager: AppleLoginManager = AppleLoginManager()
     ) {
         self.loginUseCase = loginUseCase
+        self.loginByIdPwUseCase = loginByIdPwUseCase
         self.fetchMyProfileUseCase = fetchMyProfileUseCase
         self.tokenStore = tokenStore
         self.errorHandler = errorHandler
@@ -80,6 +92,65 @@ final class LoginViewModel {
                 action: "loginWithKakao",
                 retryAction: { [weak self] in
                     await self?.loginWithKakao()
+                }
+            ))
+        }
+    }
+
+    /// ID/PW 로그인 실행
+    @MainActor
+    func loginWithIdPw() async {
+        let trimmedId = loginIdInput.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        let trimmedPw = passwordInput
+
+        guard !trimmedId.isEmpty, !trimmedPw.isEmpty else {
+            loginByIdPwErrorMessage = "아이디와 비밀번호를 입력해주세요."
+            return
+        }
+
+        loginByIdPwState = .loading
+        loginByIdPwErrorMessage = nil
+        destination = nil
+
+        do {
+            let result = try await loginByIdPwUseCase.execute(
+                loginId: trimmedId,
+                password: trimmedPw
+            )
+            loginByIdPwState = .loaded(result)
+
+            let profile = try await fetchMyProfileUseCase.execute()
+            let isApproved = isApprovedProfile(profile)
+            UserDefaults.standard.set(
+                isApproved,
+                forKey: AppStorageKey.canAutoLogin
+            )
+            destination = isApproved ? .main : .pendingApproval
+        } catch let error as RepositoryError {
+            handleIdPwError(error)
+        } catch let error as AppError {
+            switch error {
+            case .repository(let repositoryError):
+                handleIdPwError(repositoryError)
+            default:
+                loginByIdPwState = .idle
+                errorHandler.handle(error, context: .init(
+                    feature: "Auth",
+                    action: "loginWithIdPw",
+                    retryAction: { [weak self] in
+                        await self?.loginWithIdPw()
+                    }
+                ))
+            }
+        } catch {
+            loginByIdPwState = .idle
+            errorHandler.handle(error, context: .init(
+                feature: "Auth",
+                action: "loginWithIdPw",
+                retryAction: { [weak self] in
+                    await self?.loginWithIdPw()
                 }
             ))
         }
@@ -136,6 +207,19 @@ final class LoginViewModel {
 // MARK: - Private
 
 private extension LoginViewModel {
+    /// ID/PW 로그인 도메인 에러를 인라인 메시지로 변환합니다.
+    @MainActor
+    func handleIdPwError(_ error: RepositoryError) {
+        if case .serverError(_, let message) = error,
+           let message,
+           !message.isEmpty {
+            loginByIdPwErrorMessage = message
+        } else {
+            loginByIdPwErrorMessage = "아이디 또는 비밀번호가 올바르지 않습니다."
+        }
+        loginByIdPwState = .failed(.repository(error))
+    }
+
     /// 로그인 결과를 기반으로 최종 이동 목적지를 계산합니다.
     func resolveDestination(
         from result: OAuthLoginResult,

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpByIdPwViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpByIdPwViewModel.swift
@@ -1,0 +1,375 @@
+//
+//  SignUpByIdPwViewModel.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import Foundation
+import UserNotifications
+import Photos
+
+/// ID/PW 회원가입 화면의 상태와 비즈니스 로직을 관리하는 ViewModel
+///
+/// 이메일 인증, 로그인 ID 중복 확인(debounce), 비밀번호 검증, 약관 동의를 단일 화면에서
+/// 처리합니다. 가입 성공 시 서버가 토큰을 즉시 발급하므로 별도 로그인 단계는 없습니다.
+@Observable
+final class SignUpByIdPwViewModel {
+
+    // MARK: - Property
+
+    private let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
+    private let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
+    private let registerByIdPwUseCase: RegisterByIdPwUseCaseProtocol
+    private let checkLoginIdAvailabilityUseCase: CheckLoginIdAvailabilityUseCaseProtocol
+    private let fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
+
+    // 이메일 인증
+    var emailInput: String = ""
+    var verificationCodeInput: String = ""
+    private(set) var emailVerificationId: String?
+    private(set) var emailVerificationToken: String?
+    var isEmailVerified: Bool = false
+
+    // 로그인 ID
+    var loginIdInput: String = "" {
+        didSet {
+            guard loginIdInput != oldValue else { return }
+            scheduleLoginIdAvailabilityCheck()
+        }
+    }
+    private(set) var loginIdAvailability: Loadable<Bool> = .idle
+    private var loginIdAvailabilityCache: [String: Bool] = [:]
+    private var loginIdAvailabilityTask: Task<Void, Never>?
+
+    // 비밀번호
+    var passwordInput: String = ""
+    var passwordConfirmInput: String = ""
+
+    // 이름 / 닉네임
+    var nameInput: String = ""
+    var nicknameInput: String = ""
+
+    // 학교
+    var selectedSchool: School?
+    private(set) var schoolsState: Loadable<[School]> = .idle
+
+    // 약관
+    private(set) var termsState: Loadable<[Terms]> = .idle
+    var termsAgreements: [String: Bool] = [:]
+
+    // 제출
+    private(set) var registerState: Loadable<RegisterByIdPwResult> = .idle
+    var isLoading: Bool = false
+
+    // MARK: - Init
+
+    init(
+        sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+        verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
+        registerByIdPwUseCase: RegisterByIdPwUseCaseProtocol,
+        checkLoginIdAvailabilityUseCase: CheckLoginIdAvailabilityUseCaseProtocol,
+        fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
+    ) {
+        self.sendEmailVerificationUseCase = sendEmailVerificationUseCase
+        self.verifyEmailCodeUseCase = verifyEmailCodeUseCase
+        self.registerByIdPwUseCase = registerByIdPwUseCase
+        self.checkLoginIdAvailabilityUseCase = checkLoginIdAvailabilityUseCase
+        self.fetchSignUpDataUseCase = fetchSignUpDataUseCase
+    }
+
+    deinit {
+        loginIdAvailabilityTask?.cancel()
+    }
+
+    // MARK: - Validation
+
+    /// 비밀번호 8자 이상 검증
+    var isPasswordValid: Bool {
+        passwordInput.count >= 8
+    }
+
+    /// 비밀번호 확인 일치 검증
+    var isPasswordConfirmed: Bool {
+        !passwordInput.isEmpty && passwordInput == passwordConfirmInput
+    }
+
+    /// 이름 1~10자 검증
+    var isNameValid: Bool {
+        let count = nameInput.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).count
+        return count >= 1 && count <= 10
+    }
+
+    /// 닉네임 한글 1~5자 검증
+    var isNicknameValid: Bool {
+        let trimmed = nicknameInput.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        guard (1...5).contains(trimmed.count) else { return false }
+        let pattern = "^[가-힣]+$"
+        return trimmed.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    /// 로그인 ID 사용 가능 여부 (.loaded(true)만 OK)
+    var isLoginIdAvailable: Bool {
+        if case .loaded(true) = loginIdAvailability {
+            return true
+        }
+        return false
+    }
+
+    /// 필수 약관 모두 동의 여부
+    var isMandatoryTermsAgreed: Bool {
+        guard case .loaded(let terms) = termsState else { return false }
+        return terms
+            .filter { $0.isMandatory }
+            .allSatisfy { termsAgreements[$0.id] == true }
+    }
+
+    /// 전체 약관 동의 여부
+    var isAllTermsAgreed: Bool {
+        !termsAgreements.isEmpty &&
+        termsAgreements.values.allSatisfy { $0 }
+    }
+
+    /// 가입 완료 버튼 활성 조건 (모든 검증 통과)
+    var canSubmit: Bool {
+        isEmailVerified &&
+        isLoginIdAvailable &&
+        isPasswordValid &&
+        isPasswordConfirmed &&
+        isNameValid &&
+        isNicknameValid &&
+        selectedSchool != nil &&
+        isMandatoryTermsAgreed
+    }
+
+    // MARK: - Function
+
+    /// 학교 목록 조회
+    @MainActor
+    func fetchSchools() async {
+        schoolsState = .loading
+        do {
+            let schools = try await fetchSignUpDataUseCase.fetchSchools()
+            schoolsState = .loaded(schools)
+        } catch {
+            schoolsState = .failed(
+                .unknown(message: error.localizedDescription)
+            )
+        }
+    }
+
+    /// 약관 목록 조회 (SERVICE, PRIVACY)
+    @MainActor
+    func fetchTerms() async {
+        termsState = .loading
+        do {
+            var termsList: [Terms] = []
+            termsAgreements.removeAll()
+            for type in [TermsType.service, TermsType.privacy] {
+                let terms = try await fetchSignUpDataUseCase
+                    .fetchTerms(termsType: type.rawValue)
+                termsList.append(terms)
+                termsAgreements[terms.id] = false
+            }
+            termsState = .loaded(termsList)
+        } catch let appError as AppError {
+            termsState = .failed(appError)
+        } catch let repositoryError as RepositoryError {
+            termsState = .failed(.repository(repositoryError))
+        } catch let networkError as NetworkError {
+            termsState = .failed(.network(networkError))
+        } catch {
+            termsState = .failed(
+                .unknown(message: error.localizedDescription)
+            )
+        }
+    }
+
+    /// 이메일 인증번호 요청
+    @MainActor
+    func requestEmailVerification() async throws {
+        let id = try await sendEmailVerificationUseCase
+            .execute(email: emailInput)
+        emailVerificationId = id
+    }
+
+    /// 이메일 인증번호 검증
+    @MainActor
+    func verifyEmailCode(_ code: String) async throws {
+        guard let emailVerificationId else { return }
+        let token = try await verifyEmailCodeUseCase.execute(
+            emailVerificationId: emailVerificationId,
+            verificationCode: code
+        )
+        emailVerificationToken = token
+        verificationCodeInput = code
+        isEmailVerified = true
+    }
+
+    /// 이메일 변경 시 인증 상태 초기화
+    @MainActor
+    func resetEmailVerification() {
+        isEmailVerified = false
+        emailVerificationId = nil
+        emailVerificationToken = nil
+        verificationCodeInput = ""
+    }
+
+    /// 전체 약관 동의/해제 토글
+    func toggleAllTerms(_ agreed: Bool) {
+        for key in termsAgreements.keys {
+            termsAgreements[key] = agreed
+        }
+    }
+
+    /// 회원가입 실행
+    @MainActor
+    func register() async {
+        guard canSubmit,
+              let selectedSchool,
+              let emailVerificationToken else { return }
+
+        isLoading = true
+        registerState = .loading
+
+        let agreements = termsAgreements.map { key, value in
+            RegisterByIdPwTermsAgreementDTO(termsId: key, agreed: value)
+        }
+
+        let request = RegisterByIdPwRequestDTO(
+            emailVerificationToken: emailVerificationToken,
+            loginId: loginIdInput.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ),
+            name: nameInput.trimmingCharacters(in: .whitespacesAndNewlines),
+            nickname: nicknameInput.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ),
+            rawPassword: passwordInput,
+            schoolId: selectedSchool.id,
+            termsAgreements: agreements
+        )
+
+        do {
+            let result = try await registerByIdPwUseCase.execute(
+                request: request
+            )
+            registerState = .loaded(result)
+        } catch let error as AppError {
+            registerState = .failed(error)
+        } catch let error as RepositoryError {
+            registerState = .failed(.repository(error))
+        } catch let error as NetworkError {
+            registerState = .failed(.network(error))
+        } catch let error as AuthError {
+            registerState = .failed(.auth(error))
+        } catch {
+            registerState = .failed(
+                .unknown(message: error.localizedDescription)
+            )
+        }
+
+        isLoading = false
+    }
+}
+
+// MARK: - Login ID Availability (debounce)
+
+private extension SignUpByIdPwViewModel {
+    /// 입력 변경 시 500ms debounce 후 중복 검사 호출
+    func scheduleLoginIdAvailabilityCheck() {
+        loginIdAvailabilityTask?.cancel()
+
+        let trimmed = loginIdInput.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+
+        guard !trimmed.isEmpty else {
+            loginIdAvailability = .idle
+            return
+        }
+
+        if let cached = loginIdAvailabilityCache[trimmed] {
+            loginIdAvailability = .loaded(cached)
+            return
+        }
+
+        loginIdAvailability = .loading
+        loginIdAvailabilityTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled, let self else { return }
+            await self.performLoginIdAvailabilityCheck(loginId: trimmed)
+        }
+    }
+
+    @MainActor
+    func performLoginIdAvailabilityCheck(loginId: String) async {
+        guard loginIdInput.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ) == loginId else { return }
+
+        do {
+            let available = try await checkLoginIdAvailabilityUseCase
+                .execute(loginId: loginId)
+            loginIdAvailabilityCache[loginId] = available
+            guard loginIdInput.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ) == loginId else { return }
+            loginIdAvailability = .loaded(available)
+        } catch let error as AppError {
+            loginIdAvailability = .failed(error)
+        } catch let error as RepositoryError {
+            loginIdAvailability = .failed(.repository(error))
+        } catch {
+            loginIdAvailability = .failed(
+                .unknown(message: error.localizedDescription)
+            )
+        }
+    }
+}
+
+// MARK: - Permission
+
+extension SignUpByIdPwViewModel {
+
+    /// 시스템 권한 요청을 순차적으로 처리합니다.
+    func requestPermission(
+        notification: Bool,
+        location: Bool,
+        photo: Bool
+    ) async -> [String: Bool] {
+        var request: [String: Bool] = [:]
+
+        if notification {
+            do {
+                let granted = try await UNUserNotificationCenter.current()
+                    .requestAuthorization(options: [.alert, .badge, .sound])
+                request["notification"] = granted
+            } catch {
+                request["notification"] = false
+            }
+            try? await Task.sleep(for: .milliseconds(200))
+        }
+
+        if location {
+            LocationManager.shared.requestAuthorization()
+            try? await Task.sleep(for: .milliseconds(1))
+            request["location"] = LocationManager.shared.isAuthorized
+            try? await Task.sleep(for: .milliseconds(500))
+        }
+
+        if photo {
+            let status = await PHPhotoLibrary
+                .requestAuthorization(for: .readWrite)
+            request["photo"] = (
+                status == .authorized || status == .limited
+            )
+        }
+
+        return request
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
@@ -72,8 +72,8 @@ final class SignUpViewModel {
     /// 이메일 인증 토큰 (코드 검증 후 저장)
     private(set) var emailVerificationToken: String?
 
-    /// 회원가입 상태
-    private(set) var registerState: Loadable<Int> = .idle
+    /// 회원가입 상태 (성공 시 서버 응답 memberId 보관)
+    private(set) var registerState: Loadable<String> = .idle
 
     /// 폼 유효성 검증 상태
     var isFormValid: Bool {

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/Components/LoginByIdPwSection.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/Components/LoginByIdPwSection.swift
@@ -1,0 +1,144 @@
+//
+//  LoginByIdPwSection.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import SwiftUI
+
+/// LoginView 상단의 ID/PW 입력 + 로그인 버튼 섹션
+///
+/// 로그인 ID와 비밀번호 입력 필드, 인라인 에러, "로그인" 버튼, "회원가입" 진입 텍스트 버튼을
+/// 한 묶음으로 제공합니다. 상태(로딩/에러) 관리는 부모 ViewModel이 담당합니다.
+struct LoginByIdPwSection: View {
+
+    // MARK: - Property
+
+    @Binding var loginId: String
+    @Binding var password: String
+    let isLoading: Bool
+    let errorMessage: String?
+    let onLoginTapped: () -> Void
+    let onSignUpTapped: () -> Void
+
+    @FocusState private var focusedField: Field?
+
+    // MARK: - Field
+
+    private enum Field: Hashable {
+        case loginId
+        case password
+    }
+
+    // MARK: - Constant
+
+    private enum Constants {
+        static let loginIdTitle: String = "로그인 ID"
+        static let loginIdPlaceholder: String = "아이디 입력"
+        static let passwordTitle: String = "비밀번호"
+        static let passwordPlaceholder: String = "비밀번호 입력"
+        static let loginButtonTitle: String = "로그인"
+        static let signUpPromptText: String = "아직 계정이 없으신가요?"
+        static let signUpButtonTitle: String = "회원가입"
+        static let dividerText: String = "또는"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            loginIdField
+            passwordField
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .appFont(.footnote, color: .red500)
+                    .padding(.leading, DefaultSpacing.spacing8)
+            }
+
+            loginButton
+            dividerSection
+            signUpButton
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var loginIdField: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            TitleLabel(title: Constants.loginIdTitle, isRequired: true)
+            TextField(
+                "",
+                text: $loginId,
+                prompt: Text(Constants.loginIdPlaceholder).font(.callout)
+            )
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .foregroundStyle(.grey900)
+            .padding(DefaultConstant.defaultTextFieldPadding)
+            .glassEffect(.regular, in: .capsule)
+            .submitLabel(.next)
+            .focused($focusedField, equals: .loginId)
+            .onSubmit { focusedField = .password }
+        }
+    }
+
+    private var passwordField: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            TitleLabel(title: Constants.passwordTitle, isRequired: true)
+            SecureField(
+                "",
+                text: $password,
+                prompt: Text(Constants.passwordPlaceholder).font(.callout)
+            )
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .foregroundStyle(.grey900)
+            .padding(DefaultConstant.defaultTextFieldPadding)
+            .glassEffect(.regular, in: .capsule)
+            .submitLabel(.done)
+            .focused($focusedField, equals: .password)
+            .onSubmit {
+                focusedField = nil
+                onLoginTapped()
+            }
+        }
+    }
+
+    private var loginButton: some View {
+        MainButton(Constants.loginButtonTitle, action: {
+            focusedField = nil
+            onLoginTapped()
+        })
+        .loading(.constant(isLoading))
+        .disabled(loginId.isEmpty || password.isEmpty)
+        .buttonStyle(.glassProminent)
+    }
+
+    private var dividerSection: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Rectangle()
+                .fill(.grey300)
+                .frame(height: 1)
+            Text(Constants.dividerText)
+                .appFont(.footnote, color: .grey500)
+            Rectangle()
+                .fill(.grey300)
+                .frame(height: 1)
+        }
+        .padding(.vertical, DefaultSpacing.spacing4)
+    }
+
+    private var signUpButton: some View {
+        HStack(spacing: DefaultSpacing.spacing4) {
+            Spacer()
+            Text(Constants.signUpPromptText)
+                .appFont(.footnote, color: .grey600)
+            Button(Constants.signUpButtonTitle, action: onSignUpTapped)
+                .appFont(.footnoteEmphasis, color: .indigo500)
+                .buttonStyle(.plain)
+            Spacer()
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -213,7 +213,7 @@ private struct LoginViewPreviewLoginUseCase: LoginUseCaseProtocol {
 private struct LoginViewPreviewFetchMyProfileUseCase: FetchMyProfileUseCaseProtocol {
     func execute() async throws -> HomeProfileResult {
         HomeProfileResult(
-            memberId: 1,
+            memberId: "1",
             schoolId: 1,
             schoolName: "UMC University",
             latestChallengerId: 1,

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginView.swift
@@ -23,6 +23,7 @@ struct LoginView: View {
 
     init(
         loginUseCase: LoginUseCaseProtocol,
+        loginByIdPwUseCase: LoginByIdPwUseCaseProtocol,
         fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol,
         tokenStore: TokenStore,
         errorHandler: ErrorHandler
@@ -30,6 +31,7 @@ struct LoginView: View {
         self._viewModel = .init(
             wrappedValue: LoginViewModel(
                 loginUseCase: loginUseCase,
+                loginByIdPwUseCase: loginByIdPwUseCase,
                 fetchMyProfileUseCase: fetchMyProfileUseCase,
                 tokenStore: tokenStore,
                 errorHandler: errorHandler
@@ -40,21 +42,38 @@ struct LoginView: View {
     // MARK: - Body
 
     var body: some View {
-        VStack {
-            Spacer()
-            TopLogo()
-            Spacer()
-            BottomSocialBtns(
-                isLoading: viewModel.loginState.isLoading,
-                onKakaoTapped: {
-                    Task { await viewModel.loginWithKakao() }
-                },
-                onAppleTapped: {
-                    viewModel.loginWithApple()
-                }
-            )
-            .equatable()
+        ScrollView(.vertical) {
+            VStack(spacing: DefaultSpacing.spacing24) {
+                TopLogo()
+                    .padding(.top, DefaultConstant.defaultSafeTop)
+
+                LoginByIdPwSection(
+                    loginId: $viewModel.loginIdInput,
+                    password: $viewModel.passwordInput,
+                    isLoading: viewModel.loginByIdPwState.isLoading,
+                    errorMessage: viewModel.loginByIdPwErrorMessage,
+                    onLoginTapped: {
+                        Task { await viewModel.loginWithIdPw() }
+                    },
+                    onSignUpTapped: {
+                        appFlow.showSignUpByIdPw()
+                    }
+                )
+                .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+
+                BottomSocialBtns(
+                    isLoading: viewModel.loginState.isLoading,
+                    onKakaoTapped: {
+                        Task { await viewModel.loginWithKakao() }
+                    },
+                    onAppleTapped: {
+                        viewModel.loginWithApple()
+                    }
+                )
+                .equatable()
+            }
         }
+        .scrollDismissesKeyboard(.interactively)
         .onChange(of: viewModel.destination) { _, newDestination in
             guard let newDestination else { return }
             switch newDestination {
@@ -180,6 +199,7 @@ fileprivate struct BottomSocialBtns: View, Equatable {
 #Preview("로그인 화면") {
     LoginView(
         loginUseCase: LoginViewPreviewLoginUseCase(),
+        loginByIdPwUseCase: LoginViewPreviewLoginByIdPwUseCase(),
         fetchMyProfileUseCase: LoginViewPreviewFetchMyProfileUseCase(),
         tokenStore: KeychainTokenStore(),
         errorHandler: ErrorHandler()
@@ -202,6 +222,21 @@ private struct LoginViewPreviewLoginUseCase: LoginUseCaseProtocol {
         fullName: String?
     ) async throws -> OAuthLoginResult {
         .existingMember(
+            tokenPair: TokenPair(
+                accessToken: "preview_access_token",
+                refreshToken: "preview_refresh_token"
+            )
+        )
+    }
+}
+
+private struct LoginViewPreviewLoginByIdPwUseCase: LoginByIdPwUseCaseProtocol {
+    func execute(
+        loginId: String,
+        password: String
+    ) async throws -> LoginByIdPwResult {
+        LoginByIdPwResult(
+            memberId: "preview_member_id",
             tokenPair: TokenPair(
                 accessToken: "preview_access_token",
                 refreshToken: "preview_refresh_token"

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpByIdPwView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpByIdPwView.swift
@@ -1,0 +1,564 @@
+//
+//  SignUpByIdPwView.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+import SwiftUI
+
+/// ID/PW 회원가입 화면 (단일 ScrollView)
+///
+/// 이메일 인증, 로그인 ID, 비밀번호, 이름/닉네임, 학교, 약관 동의를 한 화면에서 입력받고
+/// 모든 검증이 통과하면 가입 버튼이 활성화됩니다. 가입 성공 시 서버가 토큰을 즉시 발급하여
+/// `appFlow.showPendingApproval()`로 전환합니다.
+struct SignUpByIdPwView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: SignUpByIdPwViewModel
+    @State private var lastEmailSnapshot: String = ""
+    @State private var alertPrompt: AlertPrompt?
+    @FocusState private var focusedField: Field?
+
+    @Environment(\.appFlow) private var appFlow
+    @Environment(\.di) private var di
+    @Environment(\.openURL) private var openURL
+    @Environment(ErrorHandler.self) private var errorHandler
+
+    private let fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol
+
+    // MARK: - Field
+
+    private enum Field: Hashable, CaseIterable {
+        case loginId
+        case password
+        case passwordConfirm
+        case name
+        case nickname
+    }
+
+    // MARK: - Constant
+
+    private enum Constants {
+        static let naviSubTitle: String = "동아리 활동을 위해 정보를 입력해주세요."
+        static let spacerSize: CGFloat = 30
+        static let termsTitle: String = "약관 동의"
+        static let allAgreeTitle: String = "전체 동의"
+        static let termsLoadFailedMessage: String = "약관 정보를 불러오지 못했습니다."
+        static let signUpButtonTitle: String = "가입 완료"
+    }
+
+    // MARK: - Init
+
+    init(
+        sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+        verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
+        registerByIdPwUseCase: RegisterByIdPwUseCaseProtocol,
+        checkLoginIdAvailabilityUseCase: CheckLoginIdAvailabilityUseCaseProtocol,
+        fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol,
+        fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol
+    ) {
+        self._viewModel = .init(
+            wrappedValue: SignUpByIdPwViewModel(
+                sendEmailVerificationUseCase: sendEmailVerificationUseCase,
+                verifyEmailCodeUseCase: verifyEmailCodeUseCase,
+                registerByIdPwUseCase: registerByIdPwUseCase,
+                checkLoginIdAvailabilityUseCase: checkLoginIdAvailabilityUseCase,
+                fetchSignUpDataUseCase: fetchSignUpDataUseCase
+            )
+        )
+        self.fetchMyProfileUseCase = fetchMyProfileUseCase
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(.vertical) {
+                VStack(spacing: Constants.spacerSize) {
+                    emailSection
+                    loginIdSection
+                    passwordSection
+                    nameNicknameSection
+                    schoolSection
+                    termsSection
+                }
+                .safeAreaPadding(
+                    .vertical,
+                    DefaultConstant.defaultContentTopMargins
+                )
+                .safeAreaPadding(
+                    .horizontal,
+                    DefaultConstant.defaultSafeHorizon
+                )
+                .navigation(naviTitle: .signUp, displayMode: .large)
+                .navigationSubtitle(Constants.naviSubTitle)
+            }
+            .keyboardToolbar(focusedField: $focusedField)
+            .alertPrompt(item: $alertPrompt)
+            .safeAreaInset(edge: .bottom) {
+                submitButton
+            }
+            .task {
+                await viewModel.fetchSchools()
+                await viewModel.fetchTerms()
+                lastEmailSnapshot = viewModel.emailInput
+            }
+            .onChange(of: viewModel.registerState) { _, newState in
+                handleRegisterStateChange(newState)
+            }
+        }
+    }
+}
+
+// MARK: - Sections
+
+private extension SignUpByIdPwView {
+
+    var emailSection: some View {
+        FormEmailField(
+            title: "이메일",
+            placeholder: "example@example.com",
+            text: $viewModel.emailInput,
+            onVerificationRequested: {
+                try await viewModel.requestEmailVerification()
+            },
+            onVerificationComplete: { code in
+                try await viewModel.verifyEmailCode(code)
+            },
+            submitLabel: .next,
+            onSubmit: {
+                focusedField = .loginId
+            },
+            onEmailChanged: {
+                if lastEmailSnapshot != viewModel.emailInput {
+                    Task { @MainActor in
+                        viewModel.resetEmailVerification()
+                        lastEmailSnapshot = viewModel.emailInput
+                    }
+                }
+            }
+        )
+    }
+
+    var loginIdSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            TitleLabel(title: "로그인 ID", isRequired: true)
+            HStack(spacing: DefaultSpacing.spacing8) {
+                TextField(
+                    "",
+                    text: $viewModel.loginIdInput,
+                    prompt: Text("아이디 입력").font(.callout)
+                )
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .foregroundStyle(.grey900)
+                .padding(DefaultConstant.defaultTextFieldPadding)
+                .glassEffect(.regular, in: .capsule)
+                .submitLabel(.next)
+                .focused($focusedField, equals: .loginId)
+                .onSubmit { focusedField = .password }
+
+                loginIdStatusIndicator
+            }
+            loginIdStatusMessage
+        }
+    }
+
+    @ViewBuilder
+    var loginIdStatusIndicator: some View {
+        switch viewModel.loginIdAvailability {
+        case .loading:
+            ProgressView()
+                .frame(width: 24, height: 24)
+        case .loaded(true):
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .loaded(false), .failed:
+            Image(systemName: "xmark.circle.fill")
+                .foregroundStyle(.red500)
+        case .idle:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    var loginIdStatusMessage: some View {
+        switch viewModel.loginIdAvailability {
+        case .loaded(true):
+            Text("사용 가능한 아이디입니다.")
+                .appFont(.footnote, color: .green)
+                .padding(.leading, DefaultSpacing.spacing8)
+        case .loaded(false):
+            Text("이미 사용 중인 아이디입니다.")
+                .appFont(.footnote, color: .red500)
+                .padding(.leading, DefaultSpacing.spacing8)
+        case .failed(let error):
+            Text(error.userMessage)
+                .appFont(.footnote, color: .red500)
+                .padding(.leading, DefaultSpacing.spacing8)
+        case .idle, .loading:
+            EmptyView()
+        }
+    }
+
+    var passwordSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+                TitleLabel(title: "비밀번호", isRequired: true)
+                SecureField(
+                    "",
+                    text: $viewModel.passwordInput,
+                    prompt: Text("8자 이상 입력").font(.callout)
+                )
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .foregroundStyle(.grey900)
+                .padding(DefaultConstant.defaultTextFieldPadding)
+                .glassEffect(.regular, in: .capsule)
+                .submitLabel(.next)
+                .focused($focusedField, equals: .password)
+                .onSubmit { focusedField = .passwordConfirm }
+
+                if !viewModel.passwordInput.isEmpty,
+                   !viewModel.isPasswordValid {
+                    Text("8자 이상 입력해 주세요.")
+                        .appFont(.footnote, color: .red500)
+                        .padding(.leading, DefaultSpacing.spacing8)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+                TitleLabel(title: "비밀번호 확인", isRequired: true)
+                SecureField(
+                    "",
+                    text: $viewModel.passwordConfirmInput,
+                    prompt: Text("비밀번호 다시 입력").font(.callout)
+                )
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .foregroundStyle(.grey900)
+                .padding(DefaultConstant.defaultTextFieldPadding)
+                .glassEffect(.regular, in: .capsule)
+                .submitLabel(.next)
+                .focused($focusedField, equals: .passwordConfirm)
+                .onSubmit { focusedField = .name }
+
+                if !viewModel.passwordConfirmInput.isEmpty,
+                   !viewModel.isPasswordConfirmed {
+                    Text("비밀번호가 일치하지 않습니다.")
+                        .appFont(.footnote, color: .red500)
+                        .padding(.leading, DefaultSpacing.spacing8)
+                }
+            }
+        }
+    }
+
+    var nameNicknameSection: some View {
+        HStack(alignment: .top, spacing: DefaultSpacing.spacing12) {
+            FormTextField(
+                title: "이름",
+                placeholder: "이름 입력",
+                text: $viewModel.nameInput,
+                isRequired: true,
+                submitLabel: .next,
+                onSubmit: { focusedField = .nickname }
+            )
+            .focused($focusedField, equals: .name)
+
+            FormTextField(
+                title: "닉네임",
+                placeholder: "한글 1~5자",
+                text: $viewModel.nicknameInput,
+                isRequired: true,
+                submitLabel: .done,
+                onSubmit: { focusedField = nil }
+            )
+            .focused($focusedField, equals: .nickname)
+        }
+    }
+
+    @ViewBuilder
+    var schoolSection: some View {
+        switch viewModel.schoolsState {
+        case .idle, .loading:
+            FormPickerField(
+                title: "학교",
+                placeholder: "학교를 선택하세요",
+                selection: .constant(nil as String?),
+                options: [String](),
+                displayText: { $0 }
+            )
+        case .loaded(let schools):
+            FormPickerField(
+                title: "학교",
+                placeholder: "학교를 선택하세요",
+                selection: $viewModel.selectedSchool,
+                options: schools,
+                displayText: { $0.name }
+            )
+        case .failed:
+            FormPickerField(
+                title: "학교",
+                placeholder: "학교 목록을 불러올 수 없습니다",
+                selection: .constant(nil as String?),
+                options: [String](),
+                displayText: { $0 }
+            )
+        }
+    }
+
+    var termsSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            TitleLabel(title: Constants.termsTitle, isRequired: true)
+
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+                allAgreeButton
+                Divider()
+                termsContent
+            }
+            .padding()
+            .glassEffect(
+                .regular,
+                in: .rect(cornerRadius: DefaultConstant.cornerRadius)
+            )
+        }
+    }
+
+    var allAgreeButton: some View {
+        Button(action: {
+            viewModel.toggleAllTerms(!viewModel.isAllTermsAgreed)
+        }) {
+            HStack(spacing: DefaultSpacing.spacing8) {
+                Image(
+                    systemName: viewModel.isAllTermsAgreed
+                    ? "checkmark.circle.fill" : "circle"
+                )
+                .foregroundStyle(
+                    viewModel.isAllTermsAgreed ? .indigo500 : .grey400
+                )
+                Text(Constants.allAgreeTitle)
+                    .appFont(.calloutEmphasis)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    var termsContent: some View {
+        switch viewModel.termsState {
+        case .idle, .loading:
+            ProgressView()
+        case .failed:
+            Text(Constants.termsLoadFailedMessage)
+                .appFont(.footnote, color: .grey500)
+        case .loaded:
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+                ForEach(termRows) { row in
+                    termsRow(row)
+                }
+            }
+        }
+    }
+
+    func termsRow(_ row: SignUpByIdPwTermRow) -> some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Button(action: {
+                viewModel.termsAgreements[row.id]?.toggle()
+            }) {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Image(
+                        systemName: row.isAgreed
+                        ? "checkmark.circle.fill" : "circle"
+                    )
+                    .foregroundStyle(row.isAgreed ? .indigo500 : .grey400)
+                    Text(row.title)
+                        .appFont(.subheadline)
+                    Text(row.isMandatory ? "(필수)" : "(선택)")
+                        .appFont(
+                            .footnote,
+                            color: row.isMandatory ? .red500 : .grey400
+                        )
+                }
+            }
+            .buttonStyle(.plain)
+
+            Spacer(minLength: 0)
+
+            Button("보기", action: { openTerms(row.termsType) })
+                .appFont(.footnote, color: .indigo500)
+                .buttonStyle(.plain)
+        }
+    }
+
+    var submitButton: some View {
+        MainButton(Constants.signUpButtonTitle, action: {
+            focusedField = nil
+            signUpCompleted()
+        })
+        .loading($viewModel.isLoading)
+        .disabled(!viewModel.canSubmit)
+        .buttonStyle(.glassProminent)
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    var termRows: [SignUpByIdPwTermRow] {
+        guard case .loaded(let terms) = viewModel.termsState else { return [] }
+        return terms
+            .filter { $0.termsType == .service || $0.termsType == .privacy }
+            .sorted { $0.termsType.signUpByIdPwOrder < $1.termsType.signUpByIdPwOrder }
+            .map {
+                SignUpByIdPwTermRow(
+                    id: $0.id,
+                    title: $0.termsType.signUpByIdPwTitle,
+                    isMandatory: $0.isMandatory,
+                    isAgreed: viewModel.termsAgreements[$0.id] == true,
+                    termsType: $0.termsType
+                )
+            }
+    }
+}
+
+// MARK: - Actions
+
+private extension SignUpByIdPwView {
+
+    func signUpCompleted() {
+        Task {
+            let results = await viewModel.requestPermission(
+                notification: true,
+                location: true,
+                photo: true
+            )
+
+            #if DEBUG
+            print("[Auth][IdPwSignUp] 권한 요청: \(results)")
+            #endif
+
+            await viewModel.register()
+        }
+    }
+
+    @MainActor
+    func handleRegisterStateChange(_ newState: Loadable<RegisterByIdPwResult>) {
+        switch newState {
+        case .loaded:
+            UserDefaults.standard.set(
+                false,
+                forKey: AppStorageKey.canAutoLogin
+            )
+            Task { @MainActor in
+                let isApproved = await checkApprovalStatus()
+                if isApproved {
+                    appFlow.showMain()
+                } else {
+                    appFlow.showPendingApproval()
+                }
+            }
+        case .failed(let error):
+            handleRegisterFailure(error)
+        case .idle, .loading:
+            break
+        }
+    }
+
+    func checkApprovalStatus() async -> Bool {
+        do {
+            let profile = try await fetchMyProfileUseCase.execute()
+            return isApprovedProfile(profile)
+        } catch {
+            return false
+        }
+    }
+
+    func isApprovedProfile(_ profile: HomeProfileResult) -> Bool {
+        if !profile.generations.isEmpty { return true }
+        for seasonType in profile.seasonTypes {
+            if case .gens(let gens) = seasonType, !gens.isEmpty {
+                return true
+            }
+        }
+        return false
+    }
+
+    @MainActor
+    func handleRegisterFailure(_ error: AppError) {
+        errorHandler.handle(
+            error,
+            context: .init(
+                feature: "Auth",
+                action: "registerByIdPw",
+                retryAction: { [viewModel] in
+                    await viewModel.register()
+                }
+            )
+        )
+    }
+
+    func openTerms(_ termsType: TermsType) {
+        Task {
+            do {
+                let provider = di.resolve(MyPageUseCaseProviding.self)
+                let apiType: String = termsType.signUpByIdPwApiType
+                let termsLink = try await provider.fetchTermsUseCase
+                    .execute(termsType: apiType)
+                guard let url = URL(string: termsLink.link) else {
+                    throw AppError.validation(
+                        .invalidFormat(
+                            field: "termsLink",
+                            expected: "https://..."
+                        )
+                    )
+                }
+                openURL(url)
+            } catch {
+                errorHandler.handle(
+                    error,
+                    context: .init(
+                        feature: "Auth",
+                        action: "openTerms(\(termsType.rawValue))"
+                    )
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Models
+
+private struct SignUpByIdPwTermRow: Identifiable {
+    let id: String
+    let title: String
+    let isMandatory: Bool
+    let isAgreed: Bool
+    let termsType: TermsType
+}
+
+// MARK: - TermsType Display
+
+private extension TermsType {
+    var signUpByIdPwTitle: String {
+        switch self {
+        case .service: return "서비스 이용 약관"
+        case .privacy: return "개인정보처리 방침"
+        case .marketing: return "마케팅 정보 수신 동의"
+        }
+    }
+
+    var signUpByIdPwOrder: Int {
+        switch self {
+        case .service: return 0
+        case .privacy: return 1
+        case .marketing: return 2
+        }
+    }
+
+    var signUpByIdPwApiType: String {
+        switch self {
+        case .service: return LawsType.terms.apiType
+        case .privacy: return LawsType.policy.apiType
+        case .marketing: return rawValue
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
@@ -584,8 +584,8 @@ private struct SignUpPreviewVerifyCodeUseCase: VerifyEmailCodeUseCaseProtocol {
 }
 
 private struct SignUpPreviewRegisterUseCase: RegisterUseCaseProtocol {
-    func execute(request: RegisterRequestDTO) async throws -> Int {
-        1
+    func execute(request: RegisterRequestDTO) async throws -> String {
+        "1"
     }
 }
 

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
@@ -14,8 +14,8 @@ struct ChallengerMemberDTO: Codable {
 
     /// 챌린저 고유 ID
     let challengerId: Int
-    /// 멤버 고유 ID
-    let memberId: Int
+    /// 멤버 고유 ID (서버 응답 String 기준)
+    let memberId: String
     /// 기수 번호 (예: 9, 10)
     let gisu: Int
     /// 서버 기수 식별 ID
@@ -71,7 +71,7 @@ struct ChallengerMemberDTO: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         challengerId = try container.decodeIntFlexibleIfPresent(forKey: .challengerId) ?? 0
-        memberId = try container.decodeIntFlexibleIfPresent(forKey: .memberId) ?? 0
+        memberId = try container.decodeFlexibleStringIfPresent(forKey: .memberId) ?? ""
         gisu = try container.decodeIntFlexibleIfPresent(forKey: .gisu) ?? 0
         gisuId = try container.decodeIntFlexibleIfPresent(forKey: .gisuId) ?? 0
         chapterId = try container.decodeIntFlexibleIfPresent(forKey: .chapterId)
@@ -295,7 +295,7 @@ extension ChallengerMemberDTO {
         let resolvedRoleName = ManagementTeam.highestPriority(in: roles.map(\.roleType))?.korean ?? "챌린저"
 
         return MemberProfileSummary(
-            memberId: String(memberId),
+            memberId: memberId,
             name: name,
             nickname: nickname,
             generation: gisu,

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerSearchDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerSearchDTO.swift
@@ -60,7 +60,8 @@ struct ChallengerSearchResponseDTO: Codable {
 
 /// 챌린저 검색 결과 항목 DTO
 struct ChallengerSearchItemDTO: Codable {
-    let memberId: Int
+    /// 멤버 ID (서버 응답 String 기준)
+    let memberId: String
     let challengerId: Int
     let nickname: String
     let name: String
@@ -81,7 +82,7 @@ struct ChallengerSearchItemDTO: Codable {
     }
 
     init(
-        memberId: Int,
+        memberId: String,
         challengerId: Int,
         nickname: String,
         name: String,
@@ -102,8 +103,9 @@ struct ChallengerSearchItemDTO: Codable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        memberId = try container.decodeIntFlexibleIfPresent(forKey: .memberId) ?? 0
-        challengerId = try container.decodeIntFlexibleIfPresent(forKey: .challengerId) ?? memberId
+        memberId = try container.decodeStringFlexibleIfPresent(forKey: .memberId) ?? ""
+        let fallbackChallengerId = Int(memberId) ?? 0
+        challengerId = try container.decodeIntFlexibleIfPresent(forKey: .challengerId) ?? fallbackChallengerId
         nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         part = try container.decodeIfPresent(UMCPartType.self, forKey: .part) ?? .pm

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/MyProfileDTO.swift
@@ -16,8 +16,8 @@ struct MyProfileResponseDTO: Codable {
 
     // MARK: - Property
 
-    /// 멤버 고유 ID
-    let id: Int
+    /// 멤버 고유 ID (서버 응답 String 기준)
+    let id: String
     /// 이름
     let name: String
     /// 닉네임
@@ -55,7 +55,7 @@ struct MyProfileResponseDTO: Codable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decodeIntFlexibleIfPresent(forKey: .id) ?? 0
+        id = try container.decodeStringFlexibleIfPresent(forKey: .id) ?? ""
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
         email = try container.decodeIfPresent(String.self, forKey: .email) ?? ""
@@ -285,5 +285,18 @@ private extension KeyedDecodingContainer {
             return nil
         }
         return try? decodeIntFlexible(forKey: key)
+    }
+
+    func decodeStringFlexibleIfPresent(forKey key: Key) throws -> String? {
+        if let value = try? decode(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(Int(value))
+        }
+        return nil
     }
 }

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
@@ -16,7 +16,7 @@ final class MockHomeRepository: HomeRepositoryProtocol {
 
     func getMyProfile() async throws -> HomeProfileResult {
         HomeProfileResult(
-            memberId: 0,
+            memberId: "0",
             schoolId: 0,
             schoolName: "UMC 대학교",
             latestChallengerId: nil,

--- a/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ChallengerRole.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/Home/ChallengerRole.swift
@@ -38,8 +38,8 @@ struct GenerationOrganizationContext: Codable, Equatable {
 ///
 /// 프로필 API 한 번 호출로 기수 카드용 데이터와 역할 정보를 함께 반환합니다.
 struct HomeProfileResult: Equatable {
-    /// 멤버 ID
-    let memberId: Int
+    /// 멤버 ID (서버 응답 String 기준)
+    let memberId: String
     /// 학교 ID
     let schoolId: Int
     /// 학교 이름
@@ -64,7 +64,7 @@ struct HomeProfileResult: Equatable {
     let generationOrganizations: [GenerationOrganizationContext]
 
     init(
-        memberId: Int,
+        memberId: String,
         schoolId: Int,
         schoolName: String,
         latestChallengerId: Int?,

--- a/AppProduct/AppProduct/Features/Home/Domain/Models/ScheduleGeneration/ScheduleRegistrationData.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Models/ScheduleGeneration/ScheduleRegistrationData.swift
@@ -36,8 +36,8 @@ struct ChallengerInfo: Identifiable, Equatable, Hashable {
     /// 고유 식별자
     var id: UUID = .init()
     
-    /// member ID (서버 연동 등 식별용)
-    let memberId: Int
+    /// member ID (서버 응답 String 기준)
+    let memberId: String
 
     /// challenger ID (챌린저 엔티티 식별용)
     let challengerId: Int
@@ -69,7 +69,7 @@ struct ChallengerInfo: Identifiable, Equatable, Hashable {
 
     init(
         id: UUID = .init(),
-        memberId: Int,
+        memberId: String,
         challengerId: Int? = nil,
         gen: Int,
         name: String,
@@ -80,7 +80,7 @@ struct ChallengerInfo: Identifiable, Equatable, Hashable {
     ) {
         self.id = id
         self.memberId = memberId
-        self.challengerId = challengerId ?? memberId
+        self.challengerId = challengerId ?? (Int(memberId) ?? 0)
         self.gen = gen
         self.name = name
         self.nickname = nickname

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -144,9 +144,13 @@ class ScheduleRegistrationViewModel {
             guard let (challengers, nextHasNext, nextCursor) = try? await searchChallengersUseCase.execute(query: query) else {
                 break
             }
-            for challenger in challengers where remainingIds.contains(challenger.memberId) {
+            for challenger in challengers {
+                guard let challengerMemberId = Int(challenger.memberId),
+                      remainingIds.contains(challengerMemberId) else {
+                    continue
+                }
                 matched.append(challenger)
-                remainingIds.remove(challenger.memberId)
+                remainingIds.remove(challengerMemberId)
             }
             hasNext = nextHasNext
             cursor = nextCursor
@@ -247,8 +251,8 @@ class ScheduleRegistrationViewModel {
     @MainActor
     func submitSchedule(gisuId: Int, requiresApproval: Bool) async {
         submitState = .loading
-        var memberIds = Array(Set(participatn.map(\.memberId))).sorted()
-        let myMemberId = UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+        var memberIds = Array(Set(participatn.compactMap { Int($0.memberId) })).sorted()
+        let myMemberId = AppStorageKey.legacyMemberIdInt()
         if myMemberId != 0, !memberIds.contains(myMemberId) {
             memberIds.append(myMemberId)
         }
@@ -314,7 +318,7 @@ class ScheduleRegistrationViewModel {
             startDate: dataRange.startDate,
             endDate: dataRange.endDate,
             memo: memo,
-            participantMemberIds: Array(Set(participatn.map(\.memberId))).sorted(),
+            participantMemberIds: Array(Set(participatn.compactMap { Int($0.memberId) })).sorted(),
             tags: sanitizedTags.map(\.rawValue).sorted()
         )
     }
@@ -349,8 +353,8 @@ class ScheduleRegistrationViewModel {
         submitState = .loading
         var participantMemberIds: [Int]? = nil
         if !participatn.isEmpty {
-            var memberIds = Array(Set(participatn.map(\.memberId))).sorted()
-            let myMemberId = UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+            var memberIds = Array(Set(participatn.compactMap { Int($0.memberId) })).sorted()
+            let myMemberId = AppStorageKey.legacyMemberIdInt()
             if myMemberId != 0, !memberIds.contains(myMemberId) {
                 memberIds.append(myMemberId)
             }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/ChallengerFormView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/ChallengerFormView.swift
@@ -33,7 +33,7 @@ struct ChallengerFormView: View {
     let onBottomReached: (() -> Void)?
 
     /// 삭제 불가능한 멤버 ID 집합 (생성자 보호 등)
-    let nonDeletableMemberIds: Set<Int>
+    let nonDeletableMemberIds: Set<String>
     
     // MARK: - Init
     
@@ -52,7 +52,7 @@ struct ChallengerFormView: View {
         selectedIds: Binding<Set<String>> = .constant([]),
         tap: ((ChallengerInfo) -> Void)? = nil,
         onBottomReached: (() -> Void)? = nil,
-        nonDeletableMemberIds: Set<Int> = []
+        nonDeletableMemberIds: Set<String> = []
     ) {
         self._challenger = challenger
         self.isDeletAction = isDeletAction

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/Challenger/SelectedChallengerView.swift
@@ -28,9 +28,9 @@ struct SelectedChallengerView: View {
     @State var searchNavi: Bool = false
 
     /// 현재 사용자의 memberId (삭제 방지용)
-    private var myMemberIdSet: Set<Int> {
-        let id = UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
-        return id != 0 ? [id] : []
+    private var myMemberIdSet: Set<String> {
+        guard let id = AppStorageKey.memberIdString() else { return [] }
+        return [id]
     }
     
     // MARK: - Body

--- a/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Data/DTO/MyPageProfileDTO.swift
@@ -252,7 +252,7 @@ extension MyPageProfileResponseDTO {
             .flatMap { UMCPartType(apiValue: $0) } ?? .admin
 
         let challengerInfo = ChallengerInfo(
-            memberId: id.intValue,
+            memberId: id,
             gen: latestRecord?.gisu.intValue ?? latestRole?.gisu?.intValue ?? 0,
             name: latestRecord?.name ?? name,
             nickname: latestRecord?.nickname ?? nickname,

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyActivePostsView.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Views/MyActivePostsView.swift
@@ -219,7 +219,7 @@ private struct FetchMyPageProfilePreviewUseCase: FetchMyPageProfileUseCaseProtoc
         ProfileData(
             challengeId: 1,
             challangerInfo: ChallengerInfo(
-                memberId: 1,
+                memberId: "1",
                 gen: 8,
                 name: "홍길동",
                 nickname: "길동",

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -40,7 +40,7 @@ final class NoticeDetailViewModel {
     }
 
     var currentMemberId: Int {
-        UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+        AppStorageKey.legacyMemberIdInt()
     }
 
     // MARK: - Core State

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
@@ -44,7 +44,7 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
     // MARK: - User Context
 
     var memberId: Int {
-        UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+        AppStorageKey.legacyMemberIdInt()
     }
 
     var gisuId: Int {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeList/NoticeViewModel.swift
@@ -212,6 +212,6 @@ final class NoticeViewModel {
     }
 
     var currentMemberId: Int {
-        UserDefaults.standard.integer(forKey: AppStorageKey.memberId)
+        AppStorageKey.legacyMemberIdInt()
     }
 }

--- a/AppProduct/AppProduct/Resource/EnvrionmentKey/AppFlowEnvironmentKey.swift
+++ b/AppProduct/AppProduct/Resource/EnvrionmentKey/AppFlowEnvironmentKey.swift
@@ -15,6 +15,8 @@ struct AppFlow {
         String?,
         PostRegisterLoginContext?
     ) -> Void
+    /// ID/PW 회원가입 화면으로 전환합니다 (파라미터 없음 — 폼이 모든 입력을 받음).
+    let showSignUpByIdPw: () -> Void
     let showPendingApproval: () -> Void
     let logout: () -> Void
 
@@ -22,6 +24,7 @@ struct AppFlow {
         showLogin: {},
         showMain: {},
         showSignUp: { _, _, _, _ in },
+        showSignUpByIdPw: {},
         showPendingApproval: {},
         logout: {}
     )

--- a/AppProduct/AppProductTests/AuthTest/IdPwAuthUseCaseTests.swift
+++ b/AppProduct/AppProductTests/AuthTest/IdPwAuthUseCaseTests.swift
@@ -1,0 +1,381 @@
+//
+//  IdPwAuthUseCaseTests.swift
+//  AppProductTests
+//
+//  Created by euijjang97 on 4/29/26.
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+// MARK: - LoginByIdPwUseCaseTests
+
+struct LoginByIdPwUseCaseTests {
+
+    @Test("로그인 성공 시 결과를 반환하고 TokenStore 에 토큰을 저장한다")
+    func loginSuccessSavesTokens() async throws {
+        let repository = StubAuthRepository()
+        let tokenStore = InMemoryTokenStore()
+        let expected = LoginByIdPwResult(
+            memberId: "999",
+            tokenPair: TokenPair(
+                accessToken: "id-pw-access",
+                refreshToken: "id-pw-refresh"
+            )
+        )
+        await repository.setLoginByIdPwResult(.success(expected))
+
+        let useCase = LoginByIdPwUseCase(
+            repository: repository,
+            tokenStore: tokenStore
+        )
+
+        let result = try await useCase.execute(
+            loginId: "reviewer",
+            password: "umc12345!"
+        )
+
+        let saved = await tokenStore.snapshot()
+        let lastRequest = await repository.lastLoginByIdPwRequest
+
+        #expect(result == expected)
+        #expect(saved.accessToken == "id-pw-access")
+        #expect(saved.refreshToken == "id-pw-refresh")
+        #expect(saved.saveCallCount == 1)
+        #expect(lastRequest?.loginId == "reviewer")
+        #expect(lastRequest?.password == "umc12345!")
+    }
+
+    @Test("로그인 실패 시 에러를 그대로 전파하고 토큰을 저장하지 않는다")
+    func loginFailurePropagatesErrorWithoutSavingTokens() async throws {
+        let repository = StubAuthRepository()
+        let tokenStore = InMemoryTokenStore()
+        let serverError = RepositoryError.serverError(
+            code: "INVALID_CREDENTIALS",
+            message: "아이디 또는 비밀번호가 올바르지 않습니다."
+        )
+        await repository.setLoginByIdPwResult(.failure(serverError))
+
+        let useCase = LoginByIdPwUseCase(
+            repository: repository,
+            tokenStore: tokenStore
+        )
+
+        await #expect(throws: RepositoryError.self) {
+            _ = try await useCase.execute(
+                loginId: "wrong",
+                password: "wrong"
+            )
+        }
+
+        let saved = await tokenStore.snapshot()
+        #expect(saved.accessToken == nil)
+        #expect(saved.refreshToken == nil)
+        #expect(saved.saveCallCount == 0)
+    }
+}
+
+// MARK: - RegisterByIdPwUseCaseTests
+
+struct RegisterByIdPwUseCaseTests {
+
+    @Test("회원가입 성공 시 결과를 반환하고 TokenStore 에 토큰을 즉시 저장한다")
+    func registerSuccessSavesTokensImmediately() async throws {
+        let repository = StubAuthRepository()
+        let tokenStore = InMemoryTokenStore()
+        let expected = RegisterByIdPwResult(
+            memberId: "1234",
+            tokenPair: TokenPair(
+                accessToken: "register-access",
+                refreshToken: "register-refresh"
+            )
+        )
+        await repository.setRegisterByIdPwResult(.success(expected))
+
+        let useCase = RegisterByIdPwUseCase(
+            repository: repository,
+            tokenStore: tokenStore
+        )
+
+        let request = makeRegisterRequest()
+        let result = try await useCase.execute(request: request)
+
+        let saved = await tokenStore.snapshot()
+        let lastRequest = await repository.lastRegisterByIdPwRequest
+
+        #expect(result == expected)
+        #expect(saved.accessToken == "register-access")
+        #expect(saved.refreshToken == "register-refresh")
+        #expect(saved.saveCallCount == 1)
+        #expect(lastRequest?.loginId == request.loginId)
+        #expect(lastRequest?.emailVerificationToken == request.emailVerificationToken)
+        #expect(lastRequest?.schoolId == request.schoolId)
+        #expect(lastRequest?.termsAgreements.count == request.termsAgreements.count)
+    }
+
+    @Test("회원가입 실패 시 에러를 그대로 전파하고 토큰을 저장하지 않는다")
+    func registerFailurePropagatesErrorWithoutSavingTokens() async throws {
+        let repository = StubAuthRepository()
+        let tokenStore = InMemoryTokenStore()
+        let serverError = RepositoryError.serverError(
+            code: "DUPLICATE_LOGIN_ID",
+            message: "이미 사용 중인 아이디입니다."
+        )
+        await repository.setRegisterByIdPwResult(.failure(serverError))
+
+        let useCase = RegisterByIdPwUseCase(
+            repository: repository,
+            tokenStore: tokenStore
+        )
+
+        await #expect(throws: RepositoryError.self) {
+            _ = try await useCase.execute(request: makeRegisterRequest())
+        }
+
+        let saved = await tokenStore.snapshot()
+        #expect(saved.accessToken == nil)
+        #expect(saved.refreshToken == nil)
+        #expect(saved.saveCallCount == 0)
+    }
+
+    private func makeRegisterRequest() -> RegisterByIdPwRequestDTO {
+        RegisterByIdPwRequestDTO(
+            emailVerificationToken: "email-token",
+            loginId: "reviewer",
+            name: "리뷰어",
+            nickname: "리뷰",
+            rawPassword: "umc12345!",
+            schoolId: "1",
+            termsAgreements: [
+                RegisterByIdPwTermsAgreementDTO(termsId: "1", agreed: true),
+                RegisterByIdPwTermsAgreementDTO(termsId: "2", agreed: true)
+            ]
+        )
+    }
+}
+
+// MARK: - CheckLoginIdAvailabilityUseCaseTests
+
+struct CheckLoginIdAvailabilityUseCaseTests {
+
+    @Test("Repository 가 사용 가능을 반환하면 true 를 그대로 전달한다")
+    func availableLoginIdPassesThrough() async throws {
+        let repository = StubAuthRepository()
+        await repository.setCheckLoginIdAvailabilityResult(.success(true))
+        let useCase = CheckLoginIdAvailabilityUseCase(repository: repository)
+
+        let result = try await useCase.execute(loginId: "freshUser")
+
+        let lastQuery = await repository.lastCheckLoginIdAvailabilityQuery
+        #expect(result == true)
+        #expect(lastQuery == "freshUser")
+    }
+
+    @Test("Repository 가 사용 불가를 반환하면 false 를 그대로 전달한다")
+    func unavailableLoginIdPassesThrough() async throws {
+        let repository = StubAuthRepository()
+        await repository.setCheckLoginIdAvailabilityResult(.success(false))
+        let useCase = CheckLoginIdAvailabilityUseCase(repository: repository)
+
+        let result = try await useCase.execute(loginId: "reviewer")
+
+        #expect(result == false)
+    }
+
+    @Test("Repository 에러는 그대로 전파된다")
+    func errorPropagates() async throws {
+        let repository = StubAuthRepository()
+        let networkError = RepositoryError.serverError(
+            code: "500",
+            message: "서버 오류"
+        )
+        await repository.setCheckLoginIdAvailabilityResult(.failure(networkError))
+        let useCase = CheckLoginIdAvailabilityUseCase(repository: repository)
+
+        await #expect(throws: RepositoryError.self) {
+            _ = try await useCase.execute(loginId: "anyId")
+        }
+    }
+}
+
+// MARK: - StubAuthRepository
+
+/// 테스트용 AuthRepository 스텁
+///
+/// 필요한 메서드만 핸들러를 설정하고, 나머지는 호출 시 fatalError 로 실패시킵니다.
+private actor StubAuthRepository: AuthRepositoryProtocol {
+
+    // MARK: - Configurable Results
+
+    private var loginByIdPwResult: Result<LoginByIdPwResult, Error>?
+    private var registerByIdPwResult: Result<RegisterByIdPwResult, Error>?
+    private var checkLoginIdAvailabilityResult: Result<Bool, Error>?
+
+    // MARK: - Recorded Inputs
+
+    private(set) var lastLoginByIdPwRequest: LoginByIdPwRequestDTO?
+    private(set) var lastRegisterByIdPwRequest: RegisterByIdPwRequestDTO?
+    private(set) var lastCheckLoginIdAvailabilityQuery: String?
+
+    // MARK: - Setup
+
+    func setLoginByIdPwResult(_ result: Result<LoginByIdPwResult, Error>) {
+        loginByIdPwResult = result
+    }
+
+    func setRegisterByIdPwResult(_ result: Result<RegisterByIdPwResult, Error>) {
+        registerByIdPwResult = result
+    }
+
+    func setCheckLoginIdAvailabilityResult(_ result: Result<Bool, Error>) {
+        checkLoginIdAvailabilityResult = result
+    }
+
+    // MARK: - AuthRepositoryProtocol (tested)
+
+    func loginByIdPw(
+        _ body: LoginByIdPwRequestDTO
+    ) async throws -> LoginByIdPwResult {
+        lastLoginByIdPwRequest = body
+        guard let result = loginByIdPwResult else {
+            fatalError("loginByIdPwResult not configured")
+        }
+        return try result.get()
+    }
+
+    func registerByIdPw(
+        _ body: RegisterByIdPwRequestDTO
+    ) async throws -> RegisterByIdPwResult {
+        lastRegisterByIdPwRequest = body
+        guard let result = registerByIdPwResult else {
+            fatalError("registerByIdPwResult not configured")
+        }
+        return try result.get()
+    }
+
+    func checkLoginIdAvailability(
+        loginId: String
+    ) async throws -> Bool {
+        lastCheckLoginIdAvailabilityQuery = loginId
+        guard let result = checkLoginIdAvailabilityResult else {
+            fatalError("checkLoginIdAvailabilityResult not configured")
+        }
+        return try result.get()
+    }
+
+    // MARK: - AuthRepositoryProtocol (unused stubs)
+
+    func loginKakao(
+        accessToken: String,
+        email: String
+    ) async throws -> OAuthLoginResult {
+        fatalError("loginKakao not used in these tests")
+    }
+
+    func loginApple(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    ) async throws -> OAuthLoginResult {
+        fatalError("loginApple not used in these tests")
+    }
+
+    func renewToken(
+        refreshToken: String
+    ) async throws -> TokenPair {
+        fatalError("renewToken not used in these tests")
+    }
+
+    func getMyOAuth() async throws -> [MemberOAuth] {
+        fatalError("getMyOAuth not used in these tests")
+    }
+
+    func addMemberOAuth(
+        oAuthVerificationToken: String
+    ) async throws -> [MemberOAuth] {
+        fatalError("addMemberOAuth not used in these tests")
+    }
+
+    func deleteMemberOAuth(
+        memberOAuthId: Int,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws {
+        fatalError("deleteMemberOAuth not used in these tests")
+    }
+
+    func sendEmailVerification(
+        email: String
+    ) async throws -> String {
+        fatalError("sendEmailVerification not used in these tests")
+    }
+
+    func verifyEmailCode(
+        emailVerificationId: String,
+        verificationCode: String
+    ) async throws -> String {
+        fatalError("verifyEmailCode not used in these tests")
+    }
+
+    func register(
+        request: RegisterRequestDTO
+    ) async throws -> String {
+        fatalError("register not used in these tests")
+    }
+
+    func registerExistingChallenger(
+        code: String
+    ) async throws {
+        fatalError("registerExistingChallenger not used in these tests")
+    }
+
+    func getSchools() async throws -> [School] {
+        fatalError("getSchools not used in these tests")
+    }
+
+    func getTerms(
+        termsType: String
+    ) async throws -> Terms {
+        fatalError("getTerms not used in these tests")
+    }
+}
+
+// MARK: - InMemoryTokenStore
+
+/// 테스트용 인메모리 TokenStore
+private actor InMemoryTokenStore: TokenStore {
+    private var accessToken: String?
+    private var refreshToken: String?
+    private var saveCallCount: Int = 0
+    private var clearCallCount: Int = 0
+
+    func getAccessToken() async -> String? {
+        accessToken
+    }
+
+    func getRefreshToken() async -> String? {
+        refreshToken
+    }
+
+    func save(accessToken: String, refreshToken: String) async throws {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        saveCallCount += 1
+    }
+
+    func clear() async throws {
+        accessToken = nil
+        refreshToken = nil
+        clearCallCount += 1
+    }
+
+    func snapshot() -> (
+        accessToken: String?,
+        refreshToken: String?,
+        saveCallCount: Int,
+        clearCallCount: Int
+    ) {
+        (accessToken, refreshToken, saveCallCount, clearCallCount)
+    }
+}

--- a/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
+++ b/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
@@ -35,7 +35,7 @@ struct SignUpViewModelTests {
         let snapshot = await loginUseCase.snapshot()
         let state = await MainActor.run { viewModel.registerState }
 
-        #expect(state == .loaded(1))
+        #expect(state == .loaded("1"))
         #expect(snapshot.kakaoCallCount == 1)
         #expect(snapshot.lastKakaoAccessToken == "kakao-access-token")
         #expect(snapshot.lastKakaoEmail == "umc@example.com")
@@ -67,7 +67,7 @@ struct SignUpViewModelTests {
         let snapshot = await loginUseCase.snapshot()
         let state = await MainActor.run { viewModel.registerState }
 
-        #expect(state == .loaded(1))
+        #expect(state == .loaded("1"))
         #expect(snapshot.appleCallCount == 1)
         #expect(snapshot.lastAppleAuthorizationCode == "apple-code")
         #expect(snapshot.lastAppleEmail == "apple@example.com")
@@ -156,8 +156,8 @@ private actor MockLoginUseCase: LoginUseCaseProtocol {
 }
 
 private struct MockRegisterUseCase: RegisterUseCaseProtocol {
-    func execute(request: RegisterRequestDTO) async throws -> Int {
-        1
+    func execute(request: RegisterRequestDTO) async throws -> String {
+        "1"
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

Feature — ID/PW 로그인·회원가입 신규 도입 + 도메인/DTO `memberId` 타입 정합화

## 📷 스크린샷 or 영상(UI 변경 시)

⚠️ UI 변경 포함 — 추가 예정
- 로그인 화면 상단 ID/PW 섹션
- ID/PW 회원가입 화면 (6 섹션: 이메일/ID/비밀번호×2/이름·닉네임/학교/약관)

## 🛠️ 작업내용

총 4-Phase 로 나누어 점진적으로 적용했습니다.

### Phase A — `memberId` Int → String 마이그레이션
- `ChallengerInfo.memberId`, `MemberOAuth.memberId` 등 Auth/Home/MyPage 도메인 모델을 String 으로 통일
- `MemberOAuthDTO` / `MyProfileDTO` / `ChallengerMemeberDTO` 등 서버 응답 매핑을 String 기준으로 정합화
- `AppStorageKey` 에 `memberIdString` / `legacyMemberIdInt` 어댑터 헬퍼 추가
- Activity / Notice 등 Int 유지 호출부에는 경계 변환(`Int(...) ?? 0`) 적용
- `SignUpViewModelTests` / Mock / Preview 데이터 String 기준 정렬

### Phase B — API 레이어
- `AuthRouter` 에 `loginByIdPw` / `registerByIdPw` / `checkLoginIdAvailability` 엔드포인트 추가
- 신규 DTO: `LoginByIdPwRequest/Response`, `RegisterByIdPwRequest/Response`, `CheckLoginIdAvailabilityResponse`
- 신규 도메인 모델: `LoginByIdPwResult`, `RegisterByIdPwResult` (memberId String + TokenPair)
- `AuthRepositoryProtocol` / `AuthRepository` 에 3개 메서드 추가 + Mock 구현 (`reviewer/umc12345!` 시나리오)
- `LoginByIdPwUseCase` / `RegisterByIdPwUseCase` / `CheckLoginIdAvailabilityUseCase` 신설 + Provider 등록

### Phase C — UI
- `AppFlow` 에 `showSignUpByIdPw` 콜백, `AppState` 에 `signUpByIdPw` 케이스 추가
- `LoginView` 상단에 ID/PW 입력 섹션 + "회원가입" 진입 텍스트 버튼 추가
  - `LoginByIdPwSection` 컴포넌트 신설 (TextField/SecureField + 인라인 에러 + MainButton + 구분선)
- `LoginViewModel`: loginIdInput/passwordInput/loginByIdPwState/loginByIdPwErrorMessage 추가
  - `loginWithIdPw()` 액션: 401(서버 메시지) 인라인 노출, 네트워크 오류는 ErrorHandler Alert 위임
- `SignUpByIdPwView` 신설 (단일 ScrollView 6 섹션)
- `SignUpByIdPwViewModel` 신설:
  - 로그인 ID 500ms debounce 중복 검사 + 결과 캐시(`loginIdAvailabilityCache`)
  - 비밀번호 8자/일치, 이름 ≤10자, 닉네임 한글 1~5자, 필수 약관 검증
  - 가입 성공 시 `fetchMyProfile` 로 승인 여부 판정해 main/pendingApproval 분기

### Phase D — 테스트
- `LoginByIdPwUseCaseTests` — 성공 시 토큰 저장, 실패 시 에러 전파 + 토큰 미저장
- `RegisterByIdPwUseCaseTests` — 가입 성공 시 토큰 즉시 저장, 실패 시 에러 전파 + 토큰 미저장
- `CheckLoginIdAvailabilityUseCaseTests` — true/false 통과, 에러 전파
- `StubAuthRepository` (actor) + `InMemoryTokenStore` (actor) 공용 mock 정의

## 📋 추후 진행 상황

- 비밀번호 찾기 / 재설정 플로우 (별도 이슈)
- ID/PW 가입자 약관 동의 결과를 별도 분석 이벤트로 적재

## 📌 리뷰 포인트

- `Features/Auth/Domain/UseCases/Implementations/LoginByIdPwUseCase.swift` — 성공/실패 시 토큰 저장 정책
- `Features/Auth/Presentation/ViewModels/LoginViewModel.swift` — `loginWithIdPw()` 의 인라인 에러 vs Alert 분기
- `Features/Auth/Presentation/ViewModels/SignUpByIdPwViewModel.swift` — debounce 중복 검사 + 캐시 키 정합성, 필드별 검증 규칙
- `Features/Auth/Presentation/Views/SignUpByIdPwView.swift` — 6 섹션 레이아웃 + 접근성/입력 키보드 타입
- `Features/Auth/Data/Router/AuthRouter.swift` — 신규 3개 case 의 path/method/encoding
- `AppProductTests/AuthTest/IdPwAuthUseCaseTests.swift` — actor 기반 stub 의 동시성 안전성
- **memberId 마이그레이션** — `Int → String` 경계 변환이 누락된 호출부가 없는지 (특히 Notice/Activity)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)