### PR TITLE
♻️[Refactor] Workbook V1→V2 마이그레이션 — 매핑 명확 3개 case 우선 (#687)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/BestWorkbookSelectionRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/BestWorkbookSelectionRequestDTO.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// 베스트 워크북 선정 요청 DTO
 ///
-/// `PATCH /api/v1/workbooks/challenger/{challengerWorkbookId}/best`
+/// `PATCH /api/v2/curriculums/challenger-workbooks/weekly-best/{weeklyBestWorkbookId}`
 struct BestWorkbookSelectionRequestDTO: Codable, Sendable, Equatable {
     let bestReason: String
 }

--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/WorkbookReviewRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/WorkbookReviewRequestDTO.swift
@@ -9,8 +9,9 @@ import Foundation
 
 /// 챌린저 워크북 검토 요청 DTO
 ///
-/// `POST /api/v1/workbooks/challenger/{challengerWorkbookId}/review`
+/// `POST /api/v2/curriculums/challenger-workbooks/missions/feedback`
 struct WorkbookReviewRequestDTO: Codable, Sendable, Equatable {
+    let challengerWorkbookId: Int
     let status: String
     let feedback: String
 }

--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/WorkbookSubmissionDetailDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/WorkbookSubmissionDetailDTO.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// 챌린저 워크북 제출 URL 조회 응답 DTO
 ///
-/// `GET /api/v1/workbooks/challenger/{challengerWorkbookId}/submissions`
+/// `GET /api/v2/curriculums/challenger-workbooks/{challengerWorkbookId}`
 struct WorkbookSubmissionDetailDTO: Codable, Sendable, Equatable {
     let challengerWorkbookId: Int
     let submission: String?

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
@@ -331,8 +331,8 @@ final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
         let status = isApproved ? "PASS" : "FAIL"
         let response = try await adapter.request(
             StudyRouter.reviewWorkbook(
-                challengerWorkbookId: challengerWorkbookId,
                 body: WorkbookReviewRequestDTO(
+                    challengerWorkbookId: challengerWorkbookId,
                     status: status,
                     feedback: feedback
                 )
@@ -356,7 +356,7 @@ final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
     ) async throws {
         let response = try await adapter.request(
             StudyRouter.selectBestWorkbook(
-                challengerWorkbookId: challengerWorkbookId,
+                weeklyBestWorkbookId: challengerWorkbookId,
                 body: BestWorkbookSelectionRequestDTO(bestReason: bestReason)
             )
         )

--- a/AppProduct/AppProduct/Features/Activity/Data/Router/StudyRouter.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Router/StudyRouter.swift
@@ -25,8 +25,8 @@ enum StudyRouter {
         size: Int
     )
     case getWorkbookSubmission(challengerWorkbookId: Int)
-    case reviewWorkbook(challengerWorkbookId: Int, body: WorkbookReviewRequestDTO)
-    case selectBestWorkbook(challengerWorkbookId: Int, body: BestWorkbookSelectionRequestDTO)
+    case reviewWorkbook(body: WorkbookReviewRequestDTO)
+    case selectBestWorkbook(weeklyBestWorkbookId: Int, body: BestWorkbookSelectionRequestDTO)
     case createStudyGroup(body: StudyGroupCreateRequestDTO)
     case updateStudyGroup(groupId: Int, body: StudyGroupUpdateRequestDTO)
     case deleteStudyGroup(groupId: Int)
@@ -48,25 +48,28 @@ extension StudyRouter: BaseTargetType {
         case .getCurriculum:
             return "/api/v2/curriculums/overview"
         case .getCurriculumWeeks:
+            // TODO: [#687] 백엔드 V2 매핑 미확정 — 협의 후 마이그레이션 예정
             return "/api/v1/curriculums/weeks"
         case .linkStudyGroupSchedule:
             return "/api/v1/study-groups/schedules"
         case .getMyStudyGroups:
             return "/api/v1/study-groups/managed"
         case .getStudyGroupNames:
+            // TODO: [#687] 백엔드 V2 매핑 미확정 — 협의 후 마이그레이션 예정
             return "/api/v1/study-groups/names"
         case .getStudyGroupDetail(let groupId):
             return "/api/v1/study-groups/\(groupId)"
         case .getMemberProfile(let memberId):
             return "/api/v1/member/profile/\(memberId)"
         case .getWorkbookSubmissions:
+            // TODO: [#687] 백엔드 V2 매핑 미확정 — 협의 후 마이그레이션 예정
             return "/api/v1/curriculums/workbook-submissions"
         case .getWorkbookSubmission(let challengerWorkbookId):
-            return "/api/v1/workbooks/challenger/\(challengerWorkbookId)/submissions"
-        case .reviewWorkbook(let challengerWorkbookId, _):
-            return "/api/v1/workbooks/challenger/\(challengerWorkbookId)/review"
-        case .selectBestWorkbook(let challengerWorkbookId, _):
-            return "/api/v1/workbooks/challenger/\(challengerWorkbookId)/best"
+            return "/api/v2/curriculums/challenger-workbooks/\(challengerWorkbookId)"
+        case .reviewWorkbook:
+            return "/api/v2/curriculums/challenger-workbooks/missions/feedback"
+        case .selectBestWorkbook(let weeklyBestWorkbookId, _):
+            return "/api/v2/curriculums/challenger-workbooks/weekly-best/\(weeklyBestWorkbookId)"
         case .createStudyGroup:
             return "/api/v1/study-groups"
         case .updateStudyGroup(let groupId, _):
@@ -182,7 +185,7 @@ extension StudyRouter: BaseTargetType {
              .getMemberProfile,
              .getWorkbookSubmission:
             return .requestPlain
-        case .reviewWorkbook(_, let body):
+        case .reviewWorkbook(let body):
             return .requestJSONEncodable(body)
         case .selectBestWorkbook(_, let body):
             return .requestJSONEncodable(body)


### PR DESCRIPTION
## ✨ PR 유형

Refactor — Workbook 관련 V1 API 호출을 V2 스펙으로 단계 이관 (매핑이 명확한 case 만 1차 적용)

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음 (네트워크 라우터/DTO 변경)

## 🛠️ 작업내용

### V2 적용 대상 (이번 PR)
- `getWorkbookSubmission` → V2 `challenger-workbooks/{challengerWorkbookId}`
- `reviewWorkbook` → V2 `challenger-workbooks/missions/feedback` (path 변수 → body 이동)
- `selectBestWorkbook` → V2 `challenger-workbooks/weekly-best/{weeklyBestWorkbookId}`

### DTO/Router 정리
- `WorkbookReviewRequestDTO` 에 `challengerWorkbookId` 필드 추가 (V2 body 스펙)
- `StudyRouter.reviewWorkbook` case 에서 path 변수 제거, body 만 보유
- `StudyRouter.selectBestWorkbook` case 라벨을 `weeklyBestWorkbookId` 로 V2 정합화

### 보류 case (TODO 주석)
다음 3개 case 는 V2 매핑이 아직 확정되지 않아 본 PR 범위에서 제외하고 TODO 주석으로 표시:
- `getCurriculumWeeks`
- `getWorkbookSubmissions`
- `getStudyGroupNames`

## 📋 추후 진행 상황

- 위 보류 3개 case 의 V2 매핑이 백엔드에서 확정되면 별도 PR 로 진행
- StudyRouter 전체 V1 제거 마이그레이션 완료 후 V1 잔존 path 삭제

## 📌 리뷰 포인트

- `Features/Activity/Data/Router/StudyRouter.swift` — V2 적용된 3개 case 의 path / method / 파라미터 위치
- `Features/Activity/Data/DTOs/WorkbookReviewRequestDTO.swift` — `challengerWorkbookId` body 위치 정합성
- `Features/Activity/Data/DTOs/BestWorkbookSelectionRequestDTO.swift` — V2 라벨 변경
- `Features/Activity/Data/Repositories/StudyRepository.swift` — 호출부가 신규 라벨/스펙과 정합한지
- 보류 case 의 TODO 주석이 누락 없이 달려있는지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)