### PR TITLE
🔧[Chore] Stella overrides에 TMap 외부 API 무시 등록 (#689)

### DIFF
--- a/Stella/Fixtures/overrides.yml
+++ b/Stella/Fixtures/overrides.yml
@@ -1,1 +1,10 @@
-overrides: []
+overrides:
+  # TMap은 SK에서 제공하는 외부 API로, UMC OpenAPI 스펙에 포함되지 않습니다.
+  # API coverage 스캔 시 unmatchedRouterCases 노이즈 제거를 위해 ignore 처리합니다.
+  - routerCase: TMapGeocodingRouter.geocode
+    ignore: true
+    reason: external API (SK TMap), not part of UMC OpenAPI
+
+  - routerCase: TMapGeocodingRouter.searchPoi
+    ignore: true
+    reason: external API (SK TMap), not part of UMC OpenAPI

--- a/Stella/README.md
+++ b/Stella/README.md
@@ -81,6 +81,16 @@ open "dist/Stella.app"
 
 각 파일은 `*.example` 템플릿을 복사해 사용하면 됩니다.
 
+### 외부 API(Third-party) 처리
+
+UMC OpenAPI 스펙에 포함되지 않는 외부 서비스 API(예: SK TMap, KakaoMap, FCM 등)는 scan 시 `unmatchedRouterCases`로 잡혀 노이즈가 됩니다. 해당 Router case를 `Fixtures/overrides.yml`에 `ignore: true`로 등록하면 coverage 리포트에서 제외됩니다.
+
+```yaml
+- routerCase: TMapGeocodingRouter.geocode
+  ignore: true
+  reason: external API (SK TMap), not part of UMC OpenAPI
+```
+
 스냅샷 JSON 스키마는 `Sources/StellaCore/Snapshot/CoverageSnapshot.swift` 를 기준으로 합니다.
 
 ## CI / GitHub Pages


### PR DESCRIPTION
## ✨ PR 유형

Chore — Stella(Contract Tester) overrides 에 외부(Third-party) API 무시 등록 및 가이드 문서 보강

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음 (테스트 도구 설정)

## 🛠️ 작업내용

- `Stella/Fixtures/overrides.yml` 에 다음 항목을 `ignore: true` 로 등록
  - `TMapGeocodingRouter.geocode`
  - `TMapGeocodingRouter.searchPoi`
- `Stella/README.md` 에 외부 API(Third-party) 처리 가이드 단락 추가
  - "백엔드 OpenAPI 스펙 비교 대상이 아닌 외부 API 는 ignore 처리한다" 정책 명시

## 📋 추후 진행 상황

- 다른 외부 API(예: Kakao Map, 푸시 등)가 추가될 때 동일 패턴으로 등록

## 📌 리뷰 포인트

- `Stella/Fixtures/overrides.yml` — TMap 두 case 가 정확히 ignore 처리되었는지
- `Stella/README.md` — 외부 API 처리 정책 문구가 팀 합의 수준인지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)