### PR TITLE
✨[Feat] 멤버 상세 출석 이력 — V2 일정 API 클라 필터링으로 복원 (#690)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -210,6 +210,38 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         return allGenerationsText(from: profile, fallback: "")
     }
 
+    /// V2 일정 출석 현황에서 특정 멤버의 출석 이력을 조회합니다.
+    ///
+    /// NOTE: [#690] 전체 일정 응답에서 클라이언트 필터링. 데이터 규모가 커지면 페이지네이션 또는 백엔드 멤버 필터 도입 검토.
+    func fetchAttendanceRecords(memberId: Int) async throws -> [MemberAttendanceRecord] {
+        guard memberId > 0 else { return [] }
+
+        let response = try await adapter.request(
+            ScheduleV2Router.getAttendanceList(query: AttendanceListQuery(from: nil, to: nil, attendanceStatus: nil))
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<[ScheduleAttendanceInfoDTO]>.self,
+            from: response.data
+        )
+        let schedules = (try? apiResponse.unwrap()) ?? []
+
+        let sorted = schedules.sorted {
+            ($0.startsAt) < ($1.startsAt)
+        }
+
+        return sorted.enumerated().compactMap { index, schedule in
+            guard let participant = schedule.participants.first(where: { $0.memberId == memberId }) else {
+                return nil
+            }
+            let rawStatus = participant.attendanceStatus ?? "PENDING"
+            return MemberAttendanceRecord(
+                sessionTitle: schedule.name,
+                week: index + 1,
+                status: AttendanceStatus(serverStatus: rawStatus)
+            )
+        }
+    }
+
     func fetchGenerationPointSummaries(
         memberId: Int
     ) async throws -> [GenerationPointSummary] {

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
@@ -176,6 +176,11 @@ final class MockMemberRepository: MemberRepositoryProtocol {
             GenerationPointSummary(gisu: 9, reward: 1, penalty: 0)
         ]
     }
+
+    func fetchAttendanceRecords(memberId: Int) async throws -> [MemberAttendanceRecord] {
+        try await Task.sleep(for: .milliseconds(200))
+        return MockAttendanceRecords.good
+    }
 }
 
 // MARK: - Mock Attendance Records

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
@@ -37,4 +37,10 @@ protocol MemberRepositoryProtocol {
     func fetchGenerationPointSummaries(
         memberId: Int
     ) async throws -> [GenerationPointSummary]
+
+    /// V2 일정 출석 현황에서 특정 멤버의 출석 이력을 조회합니다.
+    ///
+    /// - Parameter memberId: 조회 대상 멤버 ID
+    /// - Returns: 해당 멤버가 포함된 일정별 출석 기록. 결과 없으면 빈 배열 반환.
+    func fetchAttendanceRecords(memberId: Int) async throws -> [MemberAttendanceRecord]
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
@@ -37,4 +37,7 @@ protocol FetchMembersUseCaseProtocol {
     func fetchGenerationPointSummaries(
         memberId: Int
     ) async throws -> [GenerationPointSummary]
+
+    /// V2 일정 출석 현황에서 특정 멤버의 출석 이력을 조회합니다.
+    func fetchAttendanceRecords(memberId: Int) async throws -> [MemberAttendanceRecord]
 }

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
@@ -61,4 +61,8 @@ final class FetchMembersUseCase: FetchMembersUseCaseProtocol {
     ) async throws -> [GenerationPointSummary] {
         try await repository.fetchGenerationPointSummaries(memberId: memberId)
     }
+
+    func fetchAttendanceRecords(memberId: Int) async throws -> [MemberAttendanceRecord] {
+        try await repository.fetchAttendanceRecords(memberId: memberId)
+    }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
@@ -284,8 +284,10 @@ final class MemberListViewModel {
         )
         async let genPointsTask = try? fetchMembersUseCase
             .fetchGenerationPointSummaries(memberId: memberId)
+        async let recordsTask = try? fetchMembersUseCase
+            .fetchAttendanceRecords(memberId: memberId)
 
-        let records: [MemberAttendanceRecord] = []
+        let records = await recordsTask ?? member.attendanceRecords
         let pointHistory = await pointHistoryTask ?? member.penaltyHistory
         let generationPoints = await genPointsTask ?? []
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/ChallengerMemberDetailSheetView.swift
@@ -33,8 +33,9 @@ struct ChallengerMemberDetailSheetView: View {
         static let profileSize: CGSize = .init(width: 60, height: 60)
 
         static let baseHeight: CGFloat = 360
-        static let pendingRecordHeight: CGFloat = 150
-        static let sheetHeight: CGFloat = 560
+        static let emptyRecordHeight: CGFloat = 150
+        static let sheetHeight: CGFloat = 680
+        static let recordRowMinHeight: CGFloat = 44
 
         static let summaryRowVerticalPadding: CGFloat = 12
         static let partTagOpacity: Double = 0.14
@@ -83,14 +84,17 @@ struct ChallengerMemberDetailSheetView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
-                memberInfoView
-                summaryCardView
-                recordView
+            ScrollView {
+                VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
+                    memberInfoView
+                    summaryCardView
+                    recordView
+                }
+                .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+                .safeAreaPadding(.bottom, DefaultConstant.defaultSafeBottom)
             }
-            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
             .scrollContentBackground(.hidden)
-            .presentationDetents([.height(Constants.sheetHeight)])
+            .presentationDetents([.height(Constants.sheetHeight), .large])
         }
     }
 
@@ -213,32 +217,79 @@ struct ChallengerMemberDetailSheetView: View {
 
     /// 출석/활동 기록 섹션
     private var recordView: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
             Label(
                 "출석/활동 기록",
                 systemImage: "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90"
             )
             .appFont(.title3Emphasis)
 
-            attendancePendingView
+            attendanceRecordListView
         }
     }
 
-    /// 출석 이력 준비 중 안내 카드
-    private var attendancePendingView: some View {
+    /// 출석 이력 리스트 (기록 없으면 빈 상태 카드)
+    private var attendanceRecordListView: some View {
+        Group {
+            if member.attendanceRecords.isEmpty {
+                attendanceEmptyView
+            } else {
+                VStack(spacing: .zero) {
+                    ForEach(Array(member.attendanceRecords.enumerated()), id: \.element.id) { index, record in
+                        attendanceRecordRow(record: record)
+                        if index < member.attendanceRecords.count - 1 {
+                            Divider()
+                                .padding(.horizontal, Constants.listPadding.leading)
+                        }
+                    }
+                }
+                .background(
+                    .white,
+                    in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+                )
+                .glass()
+            }
+        }
+    }
+
+    /// 출석 이력이 없을 때 빈 상태 카드
+    private var attendanceEmptyView: some View {
         VStack(spacing: DefaultSpacing.spacing8) {
-            Image(systemName: "clock.badge.exclamationmark")
+            Image(systemName: "calendar.badge.checkmark")
                 .appFont(.title1, color: .grey500)
-            Text("출석 이력 준비 중")
+            Text("출석 이력이 없습니다")
                 .appFont(.subheadlineEmphasis, color: .grey500)
-            Text("V2 출석 도메인 마이그레이션 후 다시 제공될 예정입니다.")
-                .appFont(.footnote, color: .grey500)
-                .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
-        .frame(height: Constants.pendingRecordHeight)
+        .frame(height: Constants.emptyRecordHeight)
         .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
         .glass()
+    }
+
+    /// 출석 이력 개별 행
+    private func attendanceRecordRow(record: MemberAttendanceRecord) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                Text("\(record.week)주차")
+                    .appFont(.footnote, color: .grey500)
+                Text(record.sessionTitle)
+                    .appFont(.subheadlineEmphasis)
+                    .lineLimit(1)
+            }
+            Spacer()
+            attendanceStatusBadge(status: record.status)
+        }
+        .padding(Constants.listPadding)
+        .frame(minHeight: Constants.recordRowMinHeight)
+    }
+
+    /// 출석 상태 배지
+    private func attendanceStatusBadge(status: AttendanceStatus) -> some View {
+        Text(status.displayText)
+            .appFont(.caption1Emphasis, color: .white)
+            .padding(.horizontal, DefaultSpacing.spacing8)
+            .padding(.vertical, DefaultSpacing.spacing4)
+            .background(status.backgroundColor, in: Capsule())
     }
 
     // MARK: - Function


### PR DESCRIPTION
## ✨ PR 유형

Feature — Schedule V1 제거로 잠시 비활성화되었던 "멤버 상세 출석 이력" 카드를 V2 일정 API + 클라이언트 필터링으로 복원

## 📷 스크린샷 or 영상(UI 변경 시)

⚠️ UI 변경 — 멤버 상세 시트의 출석 이력 영역이 placeholder → 실제 리스트 / 빈 상태 카드로 전환

스크린샷 추가 예정.

## 🛠️ 작업내용

- `MemberRepository.fetchAttendanceRecords(memberId:)` V2 호출 추가
- `ScheduleV2Router.getAttendanceList` 응답 `participants[]` 에서 memberId 매칭 항목만 추출 (클라이언트 필터링)
- `MemberListViewModel.fetchMemberDetail` 의 `recordsTask` 재배치
- `ChallengerMemberDetailSheetView` placeholder 카드 → 실제 리스트 렌더링
- 빈 결과 시 "출석 이력이 없습니다" 빈 상태 카드 표시

## 📋 추후 진행 상황

- ⚠️ NOTE: 현재 응답 페이로드 전체를 받아 클라이언트에서 필터링하는 구조 — 일정/참여자 규모가 커질 경우 페이지네이션 또는 백엔드 멤버 필터 도입 후속 검토 필요

## 📌 리뷰 포인트

- `Features/Home/Data/Repositories/MemberRepository.swift` — `fetchAttendanceRecords` 의 V2 호출 + 필터링 로직
- `Features/Home/Domain/UseCases/Implementations/FetchMembersUseCase.swift` — UseCase 시그니처
- `Features/Home/Domain/Interfaces/MemberRepositoryProtocol.swift` — 프로토콜 확장
- `Features/Home/Presentation/ViewModels/Member/MemberListViewModel.swift` — `recordsTask` 의 생명주기/취소
- `Features/Home/Presentation/Views/Member/ChallengerMemberDetailSheetView.swift` — 리스트/빈 상태 분기

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)