### PR TITLE
🐛[Fix] PointType/ChallengerPointType 백엔드 18-case 동기화 + 미지값 fallback (#699)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/DTOs/ChallengerPointCreateRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/DTOs/ChallengerPointCreateRequestDTO.swift
@@ -21,7 +21,9 @@ enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identifiable 
     case bestWorkbook = "BEST_WORKBOOK"
     case warning = "WARNING"
     case out = "OUT"
+    case custom = "CUSTOM"
     case blogChallenge = "BLOG_CHALLENGE"
+    case bestWorkbookV2 = "BEST_WORKBOOK_V2"
     case umcEventReview = "UMC_EVENT_REVIEW"
     case peerReviewSubmission = "PEER_REVIEW_SUBMISSION"
     case noWorkbookMission = "NO_WORKBOOK_MISSION"
@@ -34,7 +36,6 @@ enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identifiable 
     case partLeadFeedbackLate = "PART_LEAD_FEEDBACK_LATE"
     case schoolCoreMeetingAbsent = "SCHOOL_CORE_MEETING_ABSENT"
     case schoolCoreTaskNotCompleted = "SCHOOL_CORE_TASK_NOT_COMPLETED"
-    case custom = "CUSTOM"
 
     var id: String { rawValue }
 
@@ -43,7 +44,10 @@ enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identifiable 
         case .bestWorkbook: return "우수 워크북"
         case .warning: return "경고"
         case .out: return "아웃"
+        case .custom: return "기타"
         case .blogChallenge: return "블로그 챌린지"
+        // TODO: 백엔드/디자인팀 정식 표기 미확정 — 잠정 "우수 워크북 V2"
+        case .bestWorkbookV2: return "우수 워크북 V2"
         case .umcEventReview: return "UMC 행사 후기"
         case .peerReviewSubmission: return "동료 평가 제출"
         case .noWorkbookMission: return "워크북 미제출"
@@ -56,7 +60,6 @@ enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identifiable 
         case .partLeadFeedbackLate: return "파트장 피드백 지연"
         case .schoolCoreMeetingAbsent: return "회장단 회의 결석"
         case .schoolCoreTaskNotCompleted: return "회장단 업무 미완료"
-        case .custom: return "기타"
         }
     }
 
@@ -65,7 +68,9 @@ enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identifiable 
         case .bestWorkbook: return 2
         case .warning: return 1
         case .out: return 1
+        case .custom: return 0
         case .blogChallenge: return 3
+        case .bestWorkbookV2: return 2
         case .umcEventReview: return 1
         case .peerReviewSubmission: return 1
         case .noWorkbookMission: return -4
@@ -78,7 +83,6 @@ enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identifiable 
         case .partLeadFeedbackLate: return -4
         case .schoolCoreMeetingAbsent: return -4
         case .schoolCoreTaskNotCompleted: return -4
-        case .custom: return 0
         }
     }
 
@@ -93,7 +97,7 @@ enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identifiable 
 
     var minimumRequiredLevel: Int {
         switch self {
-        case .bestWorkbook, .blogChallenge, .umcEventReview, .peerReviewSubmission:
+        case .bestWorkbook, .bestWorkbookV2, .blogChallenge, .umcEventReview, .peerReviewSubmission:
             return 20
         case .noWorkbookMission, .studyLate, .studyAbsent,
              .eventLate, .eventEarlyLeave, .eventLateCancel, .eventNoShow:

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/ChallengerMemeberDTO.swift
@@ -178,7 +178,8 @@ struct ChallengerPointDTO: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decodeIntFlexibleIfPresent(forKey: .id) ?? 0
-        pointType = try container.decodeIfPresent(PointType.self, forKey: .pointType) ?? .warning
+        let rawPointType = try container.decodeIfPresent(String.self, forKey: .pointType)
+        pointType = rawPointType.flatMap { PointType(rawValue: $0) } ?? .warning
         if let pointValue = try? container.decode(Double.self, forKey: .point) {
             point = pointValue
         } else if let intValue = try? container.decode(Int.self, forKey: .point) {
@@ -208,7 +209,9 @@ enum PointType: String, Codable {
     case bestWorkbook = "BEST_WORKBOOK"
     case warning = "WARNING"
     case out = "OUT"
+    case custom = "CUSTOM"
     case blogChallenge = "BLOG_CHALLENGE"
+    case bestWorkbookV2 = "BEST_WORKBOOK_V2"
     case umcEventReview = "UMC_EVENT_REVIEW"
     case peerReviewSubmission = "PEER_REVIEW_SUBMISSION"
     case noWorkbookMission = "NO_WORKBOOK_MISSION"
@@ -221,11 +224,10 @@ enum PointType: String, Codable {
     case partLeadFeedbackLate = "PART_LEAD_FEEDBACK_LATE"
     case schoolCoreMeetingAbsent = "SCHOOL_CORE_MEETING_ABSENT"
     case schoolCoreTaskNotCompleted = "SCHOOL_CORE_TASK_NOT_COMPLETED"
-    case custom = "CUSTOM"
 
     var isPenalty: Bool {
         switch self {
-        case .bestWorkbook, .blogChallenge, .umcEventReview, .peerReviewSubmission:
+        case .bestWorkbook, .bestWorkbookV2, .blogChallenge, .umcEventReview, .peerReviewSubmission:
             return false
         default:
             return true


### PR DESCRIPTION
## ✨ PR 유형

Fix — 포인트 enum 이 백엔드 명세(18 cases)와 어긋나 일부 응답에서 디코딩 실패하던 문제 수정 + 미지값 fallback 도입

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음 (도메인 enum / DTO 디코딩 수정)

## 🛠️ 작업내용

- `PointType` / `ChallengerPointType` 에 `bestWorkbookV2` case 추가
- 두 enum 의 케이스 **순서**를 백엔드 명세(18개) 그대로 재정렬
- `isPenalty` / `isReward` / `displayName` / `availableTypes` 매핑 갱신
- `ChallengerPointDTO.init(from:)` 에 unknown raw value fallback 도입 (향후 신규 case 추가 시 크래시 방지)

> #698 supersedes — 동일 주제의 이전 PR 을 본 PR 로 대체합니다.

## 📋 추후 진행 상황

- 백엔드에서 새 케이스 추가 시 fallback 으로 안전하게 흡수되지만, displayName/필터 누락 가능 — 정기적으로 명세와 동기화

## 📌 리뷰 포인트

- `Features/Home/Data/DTO/ChallengerMemeberDTO.swift` — `ChallengerPointType` 케이스 순서/매핑이 백엔드 명세와 1:1 일치하는지
- `Features/Activity/Data/DTOs/ChallengerPointCreateRequestDTO.swift` — `PointType` 정합성 + unknown fallback 동작
- 미지값 fallback 이 의도치 않게 모든 디코딩 실패를 가리지 않는지 (특정 case 만 대상)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)