### PR TITLE
🐛 [Fix] Apple 로그인 Request에 clientType 필드 추가

### DIFF
--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginAppleRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginAppleRequestDTO.swift
@@ -20,21 +20,29 @@ struct LoginAppleRequestDTO: Encodable {
     let email: String?
     /// Apple 계정 이름 (최초 로그인 시)
     let fullName: String?
+    /// 클라이언트 플랫폼 (`ANDROID` / `IOS` / `WEB`)
+    ///
+    /// Apple은 플랫폼별로 다른 `client_id`(iOS Bundle ID vs Web Services ID)를
+    /// 사용하기 때문에 서버가 토큰 교환 시 식별이 필요합니다.
+    let clientType: String
 
     init(
         authorizationCode: String,
         email: String?,
-        fullName: String?
+        fullName: String?,
+        clientType: String
     ) {
         self.authorizationCode = authorizationCode
         self.email = (email?.isEmpty == false) ? email : nil
         self.fullName = (fullName?.isEmpty == false) ? fullName : nil
+        self.clientType = clientType
     }
 
     private enum CodingKeys: String, CodingKey {
         case authorizationCode
         case email
         case fullName
+        case clientType
     }
 
     func encode(to encoder: Encoder) throws {
@@ -42,5 +50,6 @@ struct LoginAppleRequestDTO: Encodable {
         try container.encode(authorizationCode, forKey: .authorizationCode)
         try container.encodeIfPresent(email, forKey: .email)
         try container.encodeIfPresent(fullName, forKey: .fullName)
+        try container.encode(clientType, forKey: .clientType)
     }
 }

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -78,7 +78,8 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
                 body: LoginAppleRequestDTO(
                     authorizationCode: authorizationCode,
                     email: email,
-                    fullName: fullName
+                    fullName: fullName,
+                    clientType: "IOS"
                 )
             )
         )


### PR DESCRIPTION
## ✨ PR 유형

Fix — 서버 스펙 변경(`POST /api/v1/auth/login/apple`)에 맞춰 `clientType` 필드 누락 버그 수정 (#712)

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음 — Request DTO 페이로드만 변경됐고 UI 변경은 없습니다. 실기기/Apple Sandbox 계정에서 Apple 로그인 정상 동작 여부는 리뷰어 분이 확인 부탁드립니다.

## 🛠️ 작업내용

- `LoginAppleRequestDTO`에 `clientType: String` 필드 추가 (`CodingKeys` / `encode(to:)` 모두 반영)
- `AuthRepository.loginApple` 호출부에서 `clientType: "IOS"` 고정 전달
- iOS 앱이므로 `"IOS"` 하드코딩 — 플랫폼별 Apple `client_id`(iOS Bundle ID vs Web Services ID) 식별을 위해 서버에서 필수로 요구

## 📋 추후 진행 상황

- 별도 후속 작업 없음
- 동일 패턴이 향후 다른 OAuth 플로우에도 적용될 가능성이 있으면, `clientType`을 `enum`(`"IOS" | "ANDROID" | "WEB"`)으로 승격하는 것을 고려할 수 있음 (현재는 단일 호출처라 String 유지)

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Features/Auth/Data/DTOs/LoginAppleRequestDTO.swift` — `clientType` 필드가 `encode(to:)`에서 `encode`(필수)로 직렬화되는지, `email`/`fullName`은 기존대로 `encodeIfPresent`(옵셔널) 유지되는지 확인
- `AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift:78` — 호출부에서 `clientType: "IOS"` 고정값이 전달되는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

Closes #712