### PR TITLE
💄 [Design] ID/PW 로그인 화면 회원가입 링크를 자동로그인 행으로 이동

### DIFF
--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginByIdPwView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginByIdPwView.swift
@@ -45,9 +45,8 @@ struct LoginByIdPwView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
                 inputSection
-                autoLoginToggle
+                autoLoginRow
                 loginButton
-                bottomActions
             }
             .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
             .padding(.top, DefaultConstant.defaultSafeTop)
@@ -111,6 +110,14 @@ struct LoginByIdPwView: View {
         }
     }
 
+    private var autoLoginRow: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            autoLoginToggle
+            Spacer()
+            signUpLink
+        }
+    }
+
     private var autoLoginToggle: some View {
         Button {
             viewModel.isAutoLoginEnabled.toggle()
@@ -127,7 +134,6 @@ struct LoginByIdPwView: View {
                 .foregroundStyle(viewModel.isAutoLoginEnabled ? .indigo500 : .grey400)
                 Text(Constants.autoLoginLabel)
                     .appFont(.subheadline, color: .grey600)
-                Spacer()
             }
             .frame(minHeight: Constants.minTouchTarget)
             .contentShape(Rectangle())
@@ -141,6 +147,16 @@ struct LoginByIdPwView: View {
         .accessibilityAddTraits(.isButton)
     }
 
+    private var signUpLink: some View {
+        NavigationLink(value: NavigationDestination.auth(.signUpByIdPw)) {
+            Text(Constants.signUpTitle)
+                .appFont(.footnote, color: .grey500)
+        }
+        .buttonStyle(.plain)
+        .frame(minHeight: Constants.minTouchTarget)
+        .accessibilityHint(Text("회원가입 화면으로 이동합니다"))
+    }
+
     private var loginButton: some View {
         MainButton(Constants.loginButtonTitle) {
             loginIdFocused = false
@@ -150,16 +166,6 @@ struct LoginByIdPwView: View {
         .loading(.constant(viewModel.loginByIdPwState.isLoading))
         .disabled(viewModel.loginByIdPwState.isLoading)
         .buttonStyle(.gradientCapsule)
-    }
-
-    private var bottomActions: some View {
-        NavigationLink(value: NavigationDestination.auth(.signUpByIdPw)) {
-            Text(Constants.signUpTitle)
-                .appFont(.footnote, color: .grey500)
-        }
-        .buttonStyle(.plain)
-        .frame(maxWidth: .infinity, minHeight: Constants.minTouchTarget, alignment: .trailing)
-        .accessibilityHint(Text("회원가입 화면으로 이동합니다"))
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

Design — ID/PW 로그인 화면 회원가입 진입 링크 위치 조정. PR #716 머지 후 후속 미세 개선입니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경입니다 — Before/After 스크린샷 첨부 부탁드립니다 -->

**Before**
```
[ ☐  자동로그인               ]
[       로그인 버튼            ]
                      회원가입
```

**After**
```
[ ☐  자동로그인       회원가입 ]
[       로그인 버튼            ]
```

## 🛠️ 작업내용

- `autoLoginRow` HStack 신설 — 자동로그인 토글 + Spacer + 회원가입 링크 한 줄 구성
- `bottomActions` 제거 — 로그인 버튼 하단 단독 회원가입 링크 제거
- `signUpLink` 분리 — 자동로그인 토글과 별도 터치 타깃 유지 (각 접근성 라벨 보존)
- 로그인 버튼과 회원가입 링크 사이 간격 단축 → 시선 흐름 개선

## 📋 추후 진행 상황

- 회원가입 진입 빈도 측정 후 한 줄 배치 효과 검증
- 자동로그인/회원가입 동일 행 패턴을 다른 진입 화면에도 일관 적용 검토

## 📌 리뷰 포인트

- `AppProduct/Features/Auth/Presentation/Views/LoginByIdPwView.swift` — `autoLoginRow` HStack 신설, `signUpLink` 분리, `bottomActions` 제거 확인
  - 자동로그인 토글과 회원가입 링크가 **별도 Button**으로 분리되어 있는지 (접근성 / 터치 타깃 충돌 없음)
  - `Constants.minTouchTarget` (44pt) 가 회원가입 링크에도 유지되는지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)