### PR TITLE
✨ [Feat] 운영진 공지 작성 지원 + targetNoticeTab/mustRead 필드 반영 (#724)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
@@ -79,6 +79,35 @@ enum ManagementTeam: String, CaseIterable, Codable, Comparable {
         roles.max()
     }
 
+    // MARK: - Notice Write Permissions
+
+    /// 중앙운영진 전체(`CENTRAL_MEMBER`) 공지 작성 가능 여부 — 총괄단만
+    var canWriteCentralAllNotice: Bool {
+        self == .centralPresident || self == .centralVicePresident
+    }
+
+    /// 중앙+학교회장단(`SCHOOL_CORE`) 공지 작성 가능 여부 — 중앙운영진 이상
+    var canWriteSchoolCoreNotice: Bool {
+        level >= ManagementTeam.centralEducationTeamMember.level
+    }
+
+    /// 학교 파트장(`SCHOOL_PART_LEADER`) 공지 작성 가능 여부 — 중앙운영진 이상 + 학교 회장단
+    var canWriteSchoolPartLeaderNotice: Bool {
+        level >= ManagementTeam.centralEducationTeamMember.level
+            || self == .schoolPresident
+            || self == .schoolVicePresident
+    }
+
+    /// 학교 파트장 공지 작성 시, 본인 학교로 자동 바인딩되는 역할(학교 회장단)
+    var bindsOwnSchoolForPartLeaderNotice: Bool {
+        self == .schoolPresident || self == .schoolVicePresident
+    }
+
+    /// 운영진 카테고리 중 하나라도 작성 가능한가
+    var canWriteAnyManagementNotice: Bool {
+        canWriteCentralAllNotice || canWriteSchoolCoreNotice || canWriteSchoolPartLeaderNotice
+    }
+
     // MARK: - Display
 
     /// 한글 표시명

--- a/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
@@ -102,7 +102,13 @@ struct NoticeListResponseDTO: Codable {
         self.viewCount = try container.decodeStringFlexibleIfPresent(forKey: .viewCount) ?? "0"
         self.createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt) ?? ""
         self.targetInfo = try container.decodeIfPresent(TargetInfoDTO.self, forKey: .targetInfo)
-            ?? TargetInfoDTO(targetGisuId: 0, targetChapterId: nil, targetSchoolId: nil, targetParts: nil as [UMCPartType]?)
+            ?? TargetInfoDTO(
+                targetGisuId: 0,
+                targetChapterId: nil,
+                targetSchoolId: nil,
+                targetParts: nil as [UMCPartType]?,
+                targetNoticeTab: "CHALLENGER"
+            )
         self.authorChallengerId = try container.decodeStringFlexibleIfPresent(forKey: .authorChallengerId) ?? "0"
         self.authorNickname = try container.decodeIfPresent(String.self, forKey: .authorNickname) ?? ""
         self.authorName = try container.decodeIfPresent(String.self, forKey: .authorName) ?? ""
@@ -141,36 +147,42 @@ struct TargetInfoDTO: Codable {
     let targetChapterId: Int?
     let targetSchoolId: Int?
     let targetParts: [UMCPartType]?
+    let targetNoticeTab: String
 
     private enum CodingKeys: String, CodingKey {
         case targetGisuId
         case targetChapterId
         case targetSchoolId
         case targetParts
+        case targetNoticeTab
     }
 
     init(
         targetGisuId: Int,
         targetChapterId: Int?,
         targetSchoolId: Int?,
-        targetParts: UMCPartType?
+        targetParts: UMCPartType?,
+        targetNoticeTab: String = "CHALLENGER"
     ) {
         self.targetGisuId = targetGisuId
         self.targetChapterId = targetChapterId
         self.targetSchoolId = targetSchoolId
         self.targetParts = targetParts.map { [$0] }
+        self.targetNoticeTab = targetNoticeTab
     }
 
     init(
         targetGisuId: Int,
         targetChapterId: Int?,
         targetSchoolId: Int?,
-        targetParts: [UMCPartType]?
+        targetParts: [UMCPartType]?,
+        targetNoticeTab: String = "CHALLENGER"
     ) {
         self.targetGisuId = targetGisuId
         self.targetChapterId = targetChapterId
         self.targetSchoolId = targetSchoolId
         self.targetParts = targetParts
+        self.targetNoticeTab = targetNoticeTab
     }
 
     init(from decoder: Decoder) throws {
@@ -179,11 +191,13 @@ struct TargetInfoDTO: Codable {
         self.targetChapterId = try container.decodeIntFlexibleIfPresent(forKey: .targetChapterId)
         self.targetSchoolId = try container.decodeIntFlexibleIfPresent(forKey: .targetSchoolId)
         self.targetParts = try container.decodeIfPresent([UMCPartType].self, forKey: .targetParts)
+        self.targetNoticeTab = try container.decodeIfPresent(String.self, forKey: .targetNoticeTab) ?? "CHALLENGER"
     }
 
     /// 공지 생성/수정 요청 인코딩 시 null 규칙을 맞춥니다.
     /// - targetGisuId <= 0: null
     /// - targetParts 비어있음: null
+    /// - targetNoticeTab: 항상 포함
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
@@ -201,6 +215,8 @@ struct TargetInfoDTO: Codable {
         } else {
             try container.encodeNil(forKey: .targetParts)
         }
+
+        try container.encode(targetNoticeTab, forKey: .targetNoticeTab)
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticePatchRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticePatchRequestDTO.swift
@@ -11,5 +11,7 @@ import Foundation
 struct UpdateNoticeRequestDTO: Encodable {
     let title: String
     let content: String
+    /// 필독 공지 여부
+    let mustRead: Bool
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticePostRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Notice/Data/DTOs/NoticePostRequestDTO.swift
@@ -18,6 +18,8 @@ struct PostNoticeRequestDTO: Codable {
     let shouldNotify: Bool
     /// 공지 대상 정보
     let targetInfo: TargetInfoDTO
+    /// 필독 공지 여부
+    let mustRead: Bool
 }
 
 // MARK: - Create Notice Response

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeEditorModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeEditorModel.swift
@@ -7,6 +7,47 @@
 
 import Foundation
 
+// MARK: - ManagementNoticeCategory
+
+/// 운영진 공지 시나리오
+enum ManagementNoticeCategory: Identifiable, Equatable, Hashable, CaseIterable {
+    case centralAll
+    case schoolCore
+    case schoolPartLeader
+
+    var id: String {
+        switch self {
+        case .centralAll: return "centralAll"
+        case .schoolCore: return "schoolCore"
+        case .schoolPartLeader: return "schoolPartLeader"
+        }
+    }
+
+    var labelText: String {
+        switch self {
+        case .centralAll: return "중앙운영진"
+        case .schoolCore: return "학교 회장단"
+        case .schoolPartLeader: return "학교 파트장"
+        }
+    }
+
+    var labelIcon: String {
+        switch self {
+        case .centralAll: return "person.3.sequence.fill"
+        case .schoolCore: return "person.2.badge.gearshape"
+        case .schoolPartLeader: return "person.crop.rectangle.stack"
+        }
+    }
+
+    var serverNoticeTab: String {
+        switch self {
+        case .centralAll: return "CENTRAL_MEMBER"
+        case .schoolCore: return "SCHOOL_CORE"
+        case .schoolPartLeader: return "SCHOOL_PART_LEADER"
+        }
+    }
+}
+
 // MARK: - EditorMainCategory
 /// 공지 에디터 메인 카테고리
 enum EditorMainCategory: Identifiable, Equatable, Hashable {
@@ -15,6 +56,7 @@ enum EditorMainCategory: Identifiable, Equatable, Hashable {
     case branch
     case school
     case part(UMCPartType)
+    case management(ManagementNoticeCategory)
 
     /// 고유 식별자
     var id: String {
@@ -24,6 +66,7 @@ enum EditorMainCategory: Identifiable, Equatable, Hashable {
         case .branch: return "branch"
         case .school: return "school"
         case .part(let part): return "part_\(part.apiValue)"
+        case .management(let category): return "management_\(category.id)"
         }
     }
 
@@ -35,6 +78,7 @@ enum EditorMainCategory: Identifiable, Equatable, Hashable {
         case .branch: return "지부"
         case .school: return "학교"
         case .part(let part): return NoticePart(umcPartType: part)?.displayName ?? part.name
+        case .management(let category): return category.labelText
         }
     }
 
@@ -46,6 +90,7 @@ enum EditorMainCategory: Identifiable, Equatable, Hashable {
         case .branch: return "mappin.and.ellipse"
         case .school: return "graduationcap"
         case .part: return "person.3.fill"
+        case .management(let category): return category.labelIcon
         }
     }
 
@@ -62,6 +107,11 @@ enum EditorMainCategory: Identifiable, Equatable, Hashable {
             return [.school, .part]
         case .part:
             return []
+        case .management(let category):
+            switch category {
+            case .centralAll, .schoolCore: return []
+            case .schoolPartLeader: return [.part]
+            }
         }
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift
@@ -72,7 +72,7 @@ final class NoticeUseCase: NoticeUseCaseProtocol {
         return prepared.fileId
     }
     
-    // MARK: 공지 생성 (PATCH)
+    // MARK: 공지 생성 (POST)
     /// 공지 생성
     func createNotice(
         title: String,
@@ -80,21 +80,32 @@ final class NoticeUseCase: NoticeUseCaseProtocol {
         shouldNotify: Bool,
         targetInfo: TargetInfoDTO,
         links: [String] = [],
-        imageIds: [String] = []
+        imageIds: [String] = [],
+        noticeTab: String,
+        mustRead: Bool
     ) async throws -> NoticeDetail {
         guard !title.isEmpty else {
             throw DomainError.custom(message: "제목을 입력해주세요")
         }
-        
+
         guard !content.isEmpty else {
             throw DomainError.custom(message: "내용을 입력해주세요")
         }
-        
+
+        let resolvedTargetInfo = TargetInfoDTO(
+            targetGisuId: targetInfo.targetGisuId,
+            targetChapterId: targetInfo.targetChapterId,
+            targetSchoolId: targetInfo.targetSchoolId,
+            targetParts: targetInfo.targetParts,
+            targetNoticeTab: noticeTab
+        )
+
         let requestDTO = PostNoticeRequestDTO(
             title: title,
             content: content,
             shouldNotify: shouldNotify,
-            targetInfo: targetInfo
+            targetInfo: resolvedTargetInfo,
+            mustRead: mustRead
         )
         return try await repository.createNotice(
             body: requestDTO,
@@ -203,19 +214,21 @@ final class NoticeUseCase: NoticeUseCaseProtocol {
     func updateNotice(
         noticeId: Int,
         title: String,
-        content: String
+        content: String,
+        mustRead: Bool
     ) async throws -> NoticeDetail {
         guard !title.isEmpty else {
             throw DomainError.custom(message: "제목을 입력해주세요")
         }
-        
+
         guard !content.isEmpty else {
             throw DomainError.custom(message: "내용을 입력해주세요")
         }
-        
+
         let requestDTO = UpdateNoticeRequestDTO(
             title: title,
-            content: content
+            content: content,
+            mustRead: mustRead
         )
         return try await repository.updateNotice(noticeId: noticeId, body: requestDTO)
     }

--- a/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/UseCases/NoticeUseCaseProtocol.swift
@@ -29,6 +29,8 @@ protocol NoticeUseCaseProtocol {
     ///   - targetInfo: 수신 대상 정보
     ///   - links: 링크 목록
     ///   - imageIds: 이미지 ID 목록
+    ///   - noticeTab: 공지 탭 구분 (CHALLENGER/CENTRAL_MEMBER/SCHOOL_CORE/SCHOOL_PART_LEADER)
+    ///   - mustRead: 필독 공지 여부
     /// - Returns: 생성된 공지 상세 정보
     func createNotice(
         title: String,
@@ -36,7 +38,9 @@ protocol NoticeUseCaseProtocol {
         shouldNotify: Bool,
         targetInfo: TargetInfoDTO,
         links: [String],
-        imageIds: [String]
+        imageIds: [String],
+        noticeTab: String,
+        mustRead: Bool
     ) async throws -> NoticeDetail
     
     /// 공지사항 투표 추가 (POST)
@@ -106,11 +110,13 @@ protocol NoticeUseCaseProtocol {
     ///   - noticeId: 공지 ID
     ///   - title: 수정할 제목
     ///   - content: 수정할 본문
+    ///   - mustRead: 필독 공지 여부
     /// - Returns: 수정된 공지 상세 정보
     func updateNotice(
         noticeId: Int,
         title: String,
-        content: String
+        content: String,
+        mustRead: Bool
     ) async throws -> NoticeDetail
     
     /// 공지사항 링크 수정

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -473,7 +473,8 @@ extension NoticeDetailViewModel {
             let updatedNotice = try await noticeUseCase.updateNotice(
                 noticeId: noticeID,
                 title: title,
-                content: content
+                content: content,
+                mustRead: false
             )
             let normalizedNotice = normalizeTargetGenerationIfNeeded(in: updatedNotice)
             noticeState = .loaded(normalizedNotice)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
@@ -39,13 +39,22 @@ extension NoticeEditorViewModel {
             let targetInfo = buildTargetInfo()
             let links = sanitizedLinksForRequest()
 
+            let resolvedNoticeTab: String = {
+                if case .management(let scenario) = selectedCategory {
+                    return scenario.serverNoticeTab
+                }
+                return "CHALLENGER"
+            }()
+
             let notice = try await noticeUseCase.createNotice(
                 title: title,
                 content: content,
                 shouldNotify: allowAlert,
                 targetInfo: targetInfo,
                 links: links,
-                imageIds: imageIds
+                imageIds: imageIds,
+                noticeTab: resolvedNoticeTab,
+                mustRead: false
             )
 
             if shouldSendVoteRequest, let noticeId = Int(notice.id) {
@@ -89,7 +98,8 @@ extension NoticeEditorViewModel {
                 latestNotice = try await noticeUseCase.updateNotice(
                     noticeId: noticeId,
                     title: title,
-                    content: content
+                    content: content,
+                    mustRead: false
                 )
                 didUpdateAnyField = true
             }
@@ -222,6 +232,31 @@ extension NoticeEditorViewModel {
                 targetSchoolId: nil,
                 targetParts: [part]
             )
+        case .management(let scenario):
+            let managementParts = subCategorySelection.selectedParts.isEmpty
+                ? nil
+                : Array(subCategorySelection.selectedParts)
+            let resolvedSchoolId: Int? = (memberRole?.bindsOwnSchoolForPartLeaderNotice ?? false)
+                ? (schoolId > 0 ? schoolId : nil)
+                : nil
+            switch scenario {
+            case .centralAll, .schoolCore:
+                return TargetInfoDTO(
+                    targetGisuId: 0,
+                    targetChapterId: nil,
+                    targetSchoolId: nil,
+                    targetParts: nil as [UMCPartType]?,
+                    targetNoticeTab: scenario.serverNoticeTab
+                )
+            case .schoolPartLeader:
+                return TargetInfoDTO(
+                    targetGisuId: 0,
+                    targetChapterId: nil,
+                    targetSchoolId: resolvedSchoolId,
+                    targetParts: managementParts,
+                    targetNoticeTab: scenario.serverNoticeTab
+                )
+            }
         }
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
@@ -129,6 +129,9 @@ extension NoticeEditorViewModel {
             case .part:
                 branchOptions = []
                 schoolOptions = []
+            case .management:
+                branchOptions = []
+                schoolOptions = []
             }
             targetOptionsState = .loaded(true)
         } catch let error as DomainError {
@@ -353,8 +356,23 @@ extension NoticeEditorViewModel {
         for _: OrganizationType?,
         memberRole: ManagementTeam?
     ) -> [EditorMainCategory] {
-        _ = memberRole
-        return [.all, .central]
+        var categories: [EditorMainCategory] = [.all, .central]
+
+        guard let role = memberRole, role.canWriteAnyManagementNotice else {
+            return categories
+        }
+
+        if role.canWriteCentralAllNotice {
+            categories.append(.management(.centralAll))
+        }
+        if role.canWriteSchoolCoreNotice {
+            categories.append(.management(.schoolCore))
+        }
+        if role.canWriteSchoolPartLeaderNotice {
+            categories.append(.management(.schoolPartLeader))
+        }
+
+        return categories
     }
 
     /// 레거시 시그니처 유지용 래퍼입니다.
@@ -398,6 +416,11 @@ private extension NoticeEditorViewModel {
             return [.school, .part]
         case .part:
             return []
+        case .management(let scenario):
+            switch scenario {
+            case .centralAll, .schoolCore: return []
+            case .schoolPartLeader: return [.part]
+            }
         }
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
@@ -261,12 +261,32 @@ struct NoticeEditorView: View {
                 return normalizedName(from: schoolName, fallback: "학교")
             case .all, .central, .part:
                 return ""
+            case .management(let scenario):
+                return managementSubtitle(for: scenario)
             }
         }
 
         switch viewModel.selectedCategory {
         case .all, .central, .school, .branch, .part:
             return ""
+        case .management(let scenario):
+            return managementSubtitle(for: scenario)
+        }
+    }
+
+    /// 운영진 시나리오별 서브타이틀 — 자동 바인딩되는 대상 정보를 사용자에게 명시
+    private func managementSubtitle(for scenario: ManagementNoticeCategory) -> String {
+        switch scenario {
+        case .centralAll:
+            return "중앙운영진 전체"
+        case .schoolCore:
+            return "중앙 + 학교 회장단"
+        case .schoolPartLeader:
+            let role = ManagementTeam(rawValue: memberRoleRaw)
+            if role?.bindsOwnSchoolForPartLeaderNotice == true {
+                return normalizedName(from: schoolName, fallback: "본인 학교 파트장")
+            }
+            return "전체 학교 파트장"
         }
     }
 


### PR DESCRIPTION
## ✨ PR 유형

Feature — 운영진 공지(중앙운영진 전체 / 중앙+학교 회장단 / 학교 파트장) 작성 지원 + 서버 신규 필드(`targetNoticeTab`, `mustRead`) 반영

이슈: #724

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 상단 카테고리 메뉴에 권한별로 운영진 카테고리가 추가되며, 선택 시 자동 바인딩 대상이 navigationSubtitle에 노출됩니다. 시뮬레이터 영상/스크린샷 첨부 예정 -->

## 🛠️ 작업내용

### Stage A — DTO / UseCase (호환 가능 필드 확장)
- `TargetInfoDTO`에 `targetNoticeTab: String` 추가 (기본값 `"CHALLENGER"`, 인코딩 시 항상 포함)
- `PostNoticeRequestDTO` / `UpdateNoticeRequestDTO`에 `mustRead: Bool` 추가 (앱은 항상 `false`)
- `NoticeUseCaseProtocol.createNotice` 시그니처에 `noticeTab`, `mustRead` 파라미터 추가
- `NoticeUseCaseProtocol.updateNotice` 시그니처에 `mustRead` 파라미터 추가
- Submit / Detail ViewModel 호출부 업데이트 (앱 측 `mustRead: false` 고정)

### Stage B — 운영진 공지 작성 UI
- `ManagementNoticeCategory` enum 신설 (`.centralAll` / `.schoolCore` / `.schoolPartLeader`) — 각 케이스가 `serverNoticeTab` 보유
- `EditorMainCategory`에 `.management(ManagementNoticeCategory)` 케이스 추가 (모든 switch 분기 처리)
- `ManagementTeam`에 공지 작성 권한 헬퍼 추가:
  - `canWriteCentralAllNotice` — 총괄/부총괄만
  - `canWriteSchoolCoreNotice` — 중앙운영진 이상
  - `canWriteSchoolPartLeaderNotice` — 중앙운영진 이상 + 학교 회장/부회장
  - `bindsOwnSchoolForPartLeaderNotice` — 학교 회장/부회장 (본인 학교 자동 바인딩)
- `availableCategories(for:memberRole:)`가 권한에 따라 운영진 카테고리를 동적 추가
- `buildTargetInfo()`의 `.management` 분기:
  - `.centralAll` / `.schoolCore` → 모든 타깃 필드 `nil`
  - `.schoolPartLeader` → `targetChapterId`는 **항상 `nil`**, `targetSchoolId`는 학교 회장단인 경우 자동 바인딩, `targetParts`는 사용자 선택
- 수정 모드는 기존 `!viewModel.isEditMode` 가드로 카테고리/대상 read-only 유지
- 운영진 카테고리 선택 시 `navigationSubtitle`로 자동 바인딩 대상 안내 (`"중앙운영진 전체"` / `"중앙 + 학교 회장단"` / 학교명 또는 `"전체 학교 파트장"`)

## 📋 추후 진행 상황

디자인 에이전트 리뷰에서 디자인팀 확인이 필요한 항목으로 분류된 사항은 별도 PR로 분리합니다.

- 운영진 카테고리 SF Symbol fill/outline 통일 (현재 혼용)
- 카테고리 메뉴에서 챌린저/운영진 그룹 사이 `Section` divider 도입
- 학교 파트장 자동 바인딩 미해당 시 보조 문구 ("전체 학교 파트장") 카피 컨펌

## 📌 리뷰 포인트

- `AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift` — `TargetInfoDTO.targetNoticeTab` 디코딩/인코딩 (기본값 `"CHALLENGER"`, 항상 인코딩 포함)
- `AppProduct/Features/Notice/Data/DTOs/NoticePostRequestDTO.swift`, `NoticePatchRequestDTO.swift` — `mustRead` 필드 추가
- `AppProduct/Features/Notice/Domain/UseCases/Implementations/NoticeUseCase.swift` — `createNotice`에서 `noticeTab` 으로 `TargetInfoDTO`를 재구성하는 로직
- `AppProduct/Core/Common/Enum/ManagementTeam.swift` — 권한 헬퍼 정의 (총괄/중앙운영진/학교 회장단 매트릭스)
- `AppProduct/Features/Notice/Domain/Models/NoticeEditorModel.swift` — `EditorMainCategory.management(...)` 및 `ManagementNoticeCategory` 정의 (`serverNoticeTab` 매핑 정확성)
- `AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift` — 권한 기반 동적 카테고리 노출
- `AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift` — `buildTargetInfo()` 운영진 분기, **`targetChapterId`가 모든 운영진 케이스에서 `nil`** 인지 확인
- `AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift` — `managementSubtitle(for:)` 자동 바인딩 대상 표시

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)