### PR TITLE
✨ [Feat] 운영진 공지 작성 UI 진입점 및 카테고리 선택 완성 (#727)

### DIFF
--- a/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
@@ -74,7 +74,7 @@ enum NavigationDestination: Hashable {
         /// 공지 상세
         case detail(detailItem: NoticeDetail)
         /// 공지 작성/편집
-        case editor(mode: NoticeEditorMode, selectedGisuId: Int?)
+        case editor(mode: NoticeEditorMode, selectedGisuId: Int?, initialCategory: EditorMainCategory? = nil)
         /// 운영진 공지
         case staffNotice
     }

--- a/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
@@ -109,8 +109,8 @@ private extension NavigationRoutingView {
                 errorHandler: errorHandler,
                 model: detailItem
             )
-        case .editor(let mode, let selectedGisuId):
-            NoticeEditorView(container: di, mode: mode, selectedGisuId: selectedGisuId)
+        case .editor(let mode, let selectedGisuId, let initialCategory):
+            NoticeEditorView(container: di, mode: mode, selectedGisuId: selectedGisuId, initialCategory: initialCategory)
         case .staffNotice:
             StaffNoticeView(container: di, errorHandler: errorHandler)
         }

--- a/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeEditorModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Models/NoticeEditorModel.swift
@@ -346,6 +346,7 @@ struct VoteFormData: Equatable {
 }
 
 
+#if DEBUG
 // MARK: - EditorMockData
 /// 공지 에디터 프리뷰/디버그용 목 데이터
 enum EditorMockData {
@@ -395,6 +396,7 @@ enum EditorMockData {
         .init(id: 501, name: "중앙대"), .init(id: 502, name: "충남대"), .init(id: 503, name: "한양대")
     ]
 }
+#endif
 
 // MARK: - NoticeEditorMode
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
@@ -230,13 +230,15 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
         container: DIContainer,
         mode: NoticeEditorMode = .create,
         selectedGisuId: Int? = nil,
-        initialCategory: EditorMainCategory? = nil
+        initialCategory: EditorMainCategory? = nil,
+        memberRoleRaw: String? = nil
     ) {
         self.container = container
         self.mode = mode
         self.userGisuId = selectedGisuId
 
-        let categories: [EditorMainCategory] = [.all, .central]
+        let role = memberRoleRaw.flatMap { ManagementTeam(rawValue: $0) }
+        let categories = Self.availableCategories(for: nil, memberRole: role)
         availableCategories = categories
         selectedCategory = initialCategory.flatMap { categories.contains($0) ? $0 : nil } ?? categories.first ?? .all
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
@@ -76,7 +76,8 @@ struct NoticeEditorView: View {
                 container: container,
                 mode: mode,
                 selectedGisuId: selectedGisuId,
-                initialCategory: initialCategory
+                initialCategory: initialCategory,
+                memberRoleRaw: UserDefaults.standard.string(forKey: AppStorageKey.memberRole)
             )
         )
     }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/StaffNoticeView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/StaffNoticeView.swift
@@ -57,6 +57,7 @@ struct StaffNoticeView: View {
         static let noAccessSystemImage: String = "lock.shield"
         static let noAccessDescription: String = "운영진만 접근할 수 있는 공지 영역입니다"
         static let chipSpacing: CGFloat = DefaultSpacing.spacing8
+        static let defaultNavigationTitle: String = "운영진 공지"
     }
 
     // MARK: - Body
@@ -69,8 +70,9 @@ struct StaffNoticeView: View {
                 mainContent
             }
         }
-        .navigationTitle(viewModel.selectedTab?.labelText ?? "운영진 공지")
+        .navigationTitle(viewModel.selectedTab?.labelText ?? Constants.defaultNavigationTitle)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar { staffToolbarContent }
         .task {
             applyUserContext()
             await viewModel.fetchNotices()
@@ -216,6 +218,41 @@ struct StaffNoticeView: View {
         }
         .task(id: item.id) {
             await viewModel.loadNextPageIfNeeded(currentItem: item)
+        }
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var staffToolbarContent: some ToolbarContent {
+        if let category = writableCategoryForSelectedTab {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    pathStore.noticePath.append(
+                        .notice(.editor(mode: .create, selectedGisuId: gisuId, initialCategory: category))
+                    )
+                } label: {
+                    Image(systemName: "square.and.pencil")
+                        .imageScale(.medium)
+                }
+                .accessibilityLabel("운영진 공지 작성")
+            }
+        }
+    }
+
+    private var writableCategoryForSelectedTab: EditorMainCategory? {
+        guard let tab = viewModel.selectedTab,
+              let role = viewModel.memberRole else { return nil }
+
+        switch tab {
+        case .centralMember where role.canWriteCentralAllNotice:
+            return .management(.centralAll)
+        case .schoolCore where role.canWriteSchoolCoreNotice:
+            return .management(.schoolCore)
+        case .schoolPartLeader where role.canWriteSchoolPartLeaderNotice:
+            return .management(.schoolPartLeader)
+        default:
+            return nil
         }
     }
 


### PR DESCRIPTION
## ✨ PR 유형

운영진 공지 작성 기능의 UI 진입점 추가 및 카테고리 프리셀렉트 지원

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- StaffNoticeView toolbar에 작성 버튼이 추가되었습니다. 스크린샷/영상을 첨부해주세요. -->

## 🛠️ 작업내용

- `NavigationDestination.Notice.editor` case에 `initialCategory` 파라미터 추가
- `NavigationRoutingView`에서 `initialCategory`를 `NoticeEditorView`로 전달
- `NoticeEditorViewModel.init`에 `memberRoleRaw` 파라미터 추가, 하드코딩 `[.all, .central]`을 `availableCategories(for:memberRole:)` 호출로 교체
- `NoticeEditorView.init`에서 `UserDefaults`를 통해 `memberRoleRaw`를 ViewModel에 전달
- `StaffNoticeView`에 탭별 작성 권한 기반 조건부 toolbar 작성 버튼(`square.and.pencil`) 추가
- 작성 버튼 탭 시 해당 `ManagementNoticeCategory`가 프리셀렉트된 에디터로 네비게이션
- `EditorMockData`를 `#if DEBUG` 가드로 감싸기
- `navigationTitle` 폴백 문자열을 `Constants`로 이동

## 📋 추후 진행 상황

- 에디터에서 운영진 공지 작성 후 목록 자동 갱신 확인
- 일반 공지 목록에서 진입 시에도 역할에 따라 management 카테고리 노출 확인

## 📌 리뷰 포인트

- `Features/Notice/Presentation/Views/StaffNoticeView.swift` - `writableCategoryForSelectedTab` 권한 매핑 로직 및 toolbar 조건부 노출
- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift` - init에서 `availableCategories(for:memberRole:)` 호출로 동적 카테고리 계산
- `Core/Navigation/NavigationDestination.swift` - `initialCategory` 기본값 `nil`로 기존 호출부 호환성 유지 여부

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)