### PR TITLE
✨ [Feat]: 파트장(SCHOOL_PART_LEADER) 운영진 공지 작성 권한 추가 (#729)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
@@ -101,11 +101,12 @@ enum ManagementTeam: String, CaseIterable, Codable, Comparable {
         level >= ManagementTeam.centralEducationTeamMember.level
             || self == .schoolPresident
             || self == .schoolVicePresident
+            || self == .schoolPartLeader
     }
 
     /// 학교 파트장 공지 작성 시, 본인 학교로 자동 바인딩되는 역할(학교 회장단)
     var bindsOwnSchoolForPartLeaderNotice: Bool {
-        self == .schoolPresident || self == .schoolVicePresident
+        self == .schoolPresident || self == .schoolVicePresident || self == .schoolPartLeader
     }
 
     /// 운영진 카테고리 중 하나라도 작성 가능한가


### PR DESCRIPTION
## Summary

서버는 파트장(SCHOOL_PART_LEADER)에게 "특정 기수 + 본인 학교 + 파트" 범위의 공지 작성 권한을 부여하지만, iOS 앱에서는 `canWriteSchoolPartLeaderNotice`가 파트장을 포함하지 않아 작성 버튼이 노출되지 않던 권한 불일치를 해결합니다.

Closes #729

## Changes

`AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift` 2곳 수정:

- `canWriteSchoolPartLeaderNotice`에 `|| self == .schoolPartLeader` 추가
- `bindsOwnSchoolForPartLeaderNotice`에 `|| self == .schoolPartLeader` 추가 — 본인 학교 자동 바인딩

`NoticeEditorViewModel+Targeting.swift`의 `allowedSubCategories(for:memberRole:)`는 이미 `.management(.schoolPartLeader)` 케이스가 `[.part]`만 반환하므로 추가 수정 불필요.

## Server Permission Matrix (참고)

| 공지 대상 조합 | 서버 요구 역할 |
|---|---|
| 특정 기수 + 학교 + 파트 | School Admin (파트장 이상) |

본인 학교 범위를 벗어난 공지는 서버가 최종 검증하여 차단합니다.

## Test plan

- [ ] 파트장 계정으로 로그인 후 운영진 공지 탭 → schoolPartLeader 탭에서 우측 상단 작성 버튼 노출 확인
- [ ] 작성 화면 진입 시 본인 학교가 자동 선택되어 있는지 확인
- [ ] 파트(part) 선택 후 공지 작성 → 정상 등록 확인
- [ ] 회장/부회장/중앙 교육국원 이상 역할에서 기존 동작 유지 확인
- [ ] 챌린저 등 권한 없는 역할에서 작성 버튼 미노출 확인