### PR TITLE
🐛 [Fix] 서버 권한 보고서 기준 공지 작성/조회 권한 전면 수정 (#734, #735, #736, #737, #738)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
@@ -86,32 +86,65 @@ enum ManagementTeam: String, CaseIterable, Codable, Comparable {
 
     // MARK: - Notice Write Permissions
 
-    /// 중앙운영진 전체(`CENTRAL_MEMBER`) 공지 작성 가능 여부 — 총괄단만
+    /// 중앙운영진 전체(`CENTRAL_MEMBER`) 공지 작성 가능 여부
+    ///
+    /// 서버 스펙: `STAFF_SPECIFIC_GISU` + `targetNoticeTab=CENTRAL_MEMBER` → CENTRAL_CORE
     var canWriteCentralAllNotice: Bool {
-        self == .centralPresident || self == .centralVicePresident
+        self == .superAdmin
+            || self == .centralPresident
+            || self == .centralVicePresident
     }
 
-    /// 중앙+학교회장단(`SCHOOL_CORE`) 공지 작성 가능 여부 — 중앙운영진 이상
+    /// 학교 회장단(`SCHOOL_CORE`) 공지 작성 가능 여부
+    ///
+    /// 서버 스펙:
+    /// - 학교 미지정: CENTRAL_MEMBER(교육/운영팀원) 이상
+    /// - 학교 지정: SCHOOL_CORE(학교 회장/부회장) 이상
     var canWriteSchoolCoreNotice: Bool {
-        level >= ManagementTeam.centralEducationTeamMember.level
+        self == .superAdmin
+            || level >= ManagementTeam.centralEducationTeamMember.level
+            || self == .schoolPresident
+            || self == .schoolVicePresident
     }
 
-    /// 학교 파트장(`SCHOOL_PART_LEADER`) 공지 작성 가능 여부 — 중앙운영진 이상 + 학교 회장단
+    /// 학교 파트장(`SCHOOL_PART_LEADER`) 공지 작성 가능 여부
+    ///
+    /// 서버 스펙:
+    /// - 학교 미지정: CENTRAL_MEMBER(교육/운영팀원) 이상
+    /// - 학교 지정: SCHOOL_CORE(학교 회장/부회장) 이상
+    /// - 파트 지정: CENTRAL_MEMBER 이상
     var canWriteSchoolPartLeaderNotice: Bool {
-        level >= ManagementTeam.centralEducationTeamMember.level
+        self == .superAdmin
+            || level >= ManagementTeam.centralEducationTeamMember.level
             || self == .schoolPresident
             || self == .schoolVicePresident
             || self == .schoolPartLeader
     }
 
-    /// 학교 파트장 공지 작성 시, 본인 학교로 자동 바인딩되는 역할(학교 회장단)
+    /// 학교 파트장 공지 작성 시, 본인 학교로 자동 바인딩되는 역할
     var bindsOwnSchoolForPartLeaderNotice: Bool {
-        self == .schoolPresident || self == .schoolVicePresident || self == .schoolPartLeader
+        self == .schoolPresident
+            || self == .schoolVicePresident
+            || self == .schoolPartLeader
+    }
+
+    /// 학교 회장단 공지 작성 시, 본인 학교로 자동 바인딩되는 역할
+    var bindsOwnSchoolForSchoolCoreNotice: Bool {
+        self == .schoolPresident || self == .schoolVicePresident
+    }
+
+    /// 챌린저 공지 — 지부 범위 작성 가능 여부
+    ///
+    /// 서버 스펙: `SPECIFIC_GISU_SPECIFIC_CHAPTER` / `_WITH_PART` → CHAPTER_PRESIDENT
+    var canWriteChallengerChapterNotice: Bool {
+        self == .superAdmin || self == .chapterPresident
     }
 
     /// 운영진 카테고리 중 하나라도 작성 가능한가
     var canWriteAnyManagementNotice: Bool {
-        canWriteCentralAllNotice || canWriteSchoolCoreNotice || canWriteSchoolPartLeaderNotice
+        canWriteCentralAllNotice
+            || canWriteSchoolCoreNotice
+            || canWriteSchoolPartLeaderNotice
     }
 
     // MARK: - Display

--- a/AppProduct/AppProduct/Features/Notice/Domain/Enums/StaffNoticeTab.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Enums/StaffNoticeTab.swift
@@ -53,8 +53,15 @@ enum StaffNoticeTab: String, CaseIterable, Identifiable, Equatable, Hashable {
     }
 
     /// 특정 역할이 접근 가능한 탭 목록을 반환합니다.
+    ///
+    /// 서버 스펙: 지부장은 SCHOOL_CORE 레벨로 매핑되어 SCHOOL_CORE/SCHOOL_PART_LEADER 열람 가능
     static func accessibleTabs(for role: ManagementTeam?) -> [StaffNoticeTab] {
         guard let role else { return [] }
+
+        if role == .chapterPresident {
+            return allCases.filter { $0.minimumLevel >= ManagementTeam.schoolPresident.level }
+        }
+
         return allCases.filter { role.level >= $0.minimumLevel }
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
@@ -202,9 +202,16 @@ extension NoticeEditorViewModel {
                 targetParts: selectedParts
             )
         case .branch:
+            let resolvedChapterId: Int? = if memberRole?.canWriteChallengerChapterNotice == true,
+                                             selectedBranchId == nil,
+                                             let chapterId = userChapterId, chapterId > 0 {
+                chapterId
+            } else {
+                selectedBranchId
+            }
             return TargetInfoDTO(
                 targetGisuId: currentGeneration,
-                targetChapterId: selectedBranchId,
+                targetChapterId: resolvedChapterId,
                 targetSchoolId: nil,
                 targetParts: selectedParts
             )
@@ -226,22 +233,32 @@ extension NoticeEditorViewModel {
             let managementParts = subCategorySelection.selectedParts.isEmpty
                 ? nil
                 : Array(subCategorySelection.selectedParts)
-            let resolvedSchoolId: Int? = (memberRole?.bindsOwnSchoolForPartLeaderNotice ?? false)
-                ? (schoolId > 0 ? schoolId : nil)
-                : nil
             switch scenario {
-            case .centralAll, .schoolCore:
+            case .centralAll:
                 return TargetInfoDTO(
                     targetGisuId: 0,
                     targetChapterId: nil,
                     targetSchoolId: nil,
                     targetParts: nil as [UMCPartType]?
                 )
-            case .schoolPartLeader:
+            case .schoolCore:
+                let schoolCoreSchoolId: Int? = (memberRole?.bindsOwnSchoolForSchoolCoreNotice ?? false)
+                    ? (schoolId > 0 ? schoolId : nil)
+                    : nil
                 return TargetInfoDTO(
                     targetGisuId: 0,
                     targetChapterId: nil,
-                    targetSchoolId: resolvedSchoolId,
+                    targetSchoolId: schoolCoreSchoolId,
+                    targetParts: nil as [UMCPartType]?
+                )
+            case .schoolPartLeader:
+                let partLeaderSchoolId: Int? = (memberRole?.bindsOwnSchoolForPartLeaderNotice ?? false)
+                    ? (schoolId > 0 ? schoolId : nil)
+                    : nil
+                return TargetInfoDTO(
+                    targetGisuId: 0,
+                    targetChapterId: nil,
+                    targetSchoolId: partLeaderSchoolId,
                     targetParts: managementParts
                 )
             }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
@@ -99,11 +99,25 @@ extension NoticeEditorViewModel {
                 }
             case .branch:
                 if visibleSubCategories.contains(.branch) {
-                    branchOptions = try await (
-                        resolvedGisuId > 0
-                        ? targetUseCase.fetchBranches(gisuId: resolvedGisuId)
-                        : targetUseCase.fetchAllBranches()
-                    )
+                    if memberRole == .chapterPresident, let chapterId = userChapterId, chapterId > 0 {
+                        let allBranches = try await (
+                            resolvedGisuId > 0
+                            ? targetUseCase.fetchBranches(gisuId: resolvedGisuId)
+                            : targetUseCase.fetchAllBranches()
+                        )
+                        branchOptions = allBranches.filter { $0.id == chapterId }
+                        if subCategorySelection.selectedBranch == nil,
+                           let ownChapter = branchOptions.first {
+                            subCategorySelection.selectedBranch = ownChapter
+                            subCategorySelection.selectedSubCategories.insert(.branch)
+                        }
+                    } else {
+                        branchOptions = try await (
+                            resolvedGisuId > 0
+                            ? targetUseCase.fetchBranches(gisuId: resolvedGisuId)
+                            : targetUseCase.fetchAllBranches()
+                        )
+                    }
                 } else {
                     branchOptions = []
                 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
@@ -352,14 +352,29 @@ extension NoticeEditorViewModel {
     // MARK: - Helper
 
     /// 조직 타입/역할에 따라 사용 가능한 메인 카테고리 목록을 반환합니다.
+    ///
+    /// 서버 권한 보고서 기준으로 각 역할이 실제로 작성 가능한 패턴만 노출합니다.
     static func availableCategories(
         for _: OrganizationType?,
         memberRole: ManagementTeam?
     ) -> [EditorMainCategory] {
-        var categories: [EditorMainCategory] = [.all, .central]
+        guard let role = memberRole else { return [] }
 
-        guard let role = memberRole, role.canWriteAnyManagementNotice else {
-            return categories
+        var categories: [EditorMainCategory] = []
+
+        switch role {
+        case .superAdmin, .centralPresident, .centralVicePresident:
+            categories = [.all, .central]
+        case .centralOperatingTeamMember, .centralEducationTeamMember:
+            categories = [.central]
+        case .chapterPresident:
+            categories = [.branch]
+        case .schoolPresident, .schoolVicePresident:
+            categories = [.school]
+        case .schoolPartLeader:
+            categories = [.school]
+        case .schoolEtcAdmin, .challenger:
+            return []
         }
 
         if role.canWriteCentralAllNotice {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/StaffNotice/StaffNoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/StaffNotice/StaffNoticeViewModel.swift
@@ -205,9 +205,15 @@ final class StaffNoticeViewModel {
     }
 
     private func buildRequest(tab: StaffNoticeTab, page: Int) -> NoticeListRequestDTO {
-        NoticeListRequestDTO(
+        let resolvedSchoolId: Int? = if tab.requiresSchoolId, memberRole != .chapterPresident, schoolId > 0 {
+            schoolId
+        } else {
+            nil
+        }
+
+        return NoticeListRequestDTO(
             gisuId: gisuId,
-            schoolId: tab.requiresSchoolId ? (schoolId > 0 ? schoolId : nil) : nil,
+            schoolId: resolvedSchoolId,
             noticeTab: tab.rawValue,
             page: page,
             size: Pagination.pageSize,

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/StaffNoticeView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/StaffNoticeView.swift
@@ -256,6 +256,11 @@ struct StaffNoticeView: View {
         }
     }
 
+    /// 지부장은 운영진 공지 작성 불가 (읽기 전용)
+    private var isReadOnlyStaffAccess: Bool {
+        viewModel.memberRole == .chapterPresident
+    }
+
     // MARK: - User Context
 
     private func applyUserContext() {


### PR DESCRIPTION
## ✨ PR 유형

서버 공지사항 권한 구조 보고서 기준으로 iOS 앱의 공지 작성/조회 권한을 전면 감사 및 수정

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (권한 로직만 수정)

## 🛠️ 작업내용

### #734 — SUPER_ADMIN 작성 권한 누락
- `ManagementTeam.canWriteCentralAllNotice` / `canWriteSchoolCoreNotice` / `canWriteSchoolPartLeaderNotice`에 `superAdmin` 케이스 추가

### #735 — 지부장 본인 지부만 선택 제한
- `NoticeEditorViewModel+Targeting.loadTargetOptions()` `.branch` 케이스에서 지부장일 때 `branchOptions`를 본인 지부(`userChapterId`)로 필터링 및 자동 선택
- `availableCategories(for:memberRole:)` 역할별 카테고리 분기 추가 (지부장 → `.branch`만 노출)
- `NoticeEditorViewModel+Submit` `.branch` 케이스에서 지부장 `chapterId` 자동 바인딩

### #736 — 교내 회장단 학교 자동 바인딩
- `ManagementTeam.bindsOwnSchoolForSchoolCoreNotice` 프로퍼티 추가 (schoolPresident / schoolVicePresident)
- `NoticeEditorViewModel+Submit` `.management(.schoolCore)` 케이스를 `.centralAll`과 분리하여 학교 회장단 schoolId 자동 바인딩
- `ManagementTeam.canWriteSchoolCoreNotice`에 schoolPresident / schoolVicePresident 추가

### #737 — 지부장 운영진 공지 조회 schoolId 처리
- `StaffNoticeViewModel.buildRequest(tab:page:)` 에서 지부장일 때 `schoolId` 제외 (서버 토큰 기반 필터링)
- `StaffNoticeTab.accessibleTabs(for:)` 에서 지부장을 SCHOOL_CORE 레벨로 매핑하여 SCHOOL_CORE / SCHOOL_PART_LEADER 탭 열람 가능

### #738 — schoolEtcAdmin 작성 권한 차단
- `availableCategories(for:memberRole:)` 에서 `schoolEtcAdmin` / `challenger` → 빈 배열 반환 (작성 UI 진입 차단)

## 📋 추후 진행 상황

- 서버 API 응답 기반 E2E 테스트 (역할별 공지 작성/조회 시나리오)

## 📌 리뷰 포인트

- `Core/Common/Enum/ManagementTeam.swift` — 역할별 작성 권한 프로퍼티가 서버 스펙과 일치하는지 확인
- `Features/Notice/Domain/Enums/StaffNoticeTab.swift` — 지부장 탭 접근 로직 (level 기반이 아닌 특수 케이스 처리)
- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift` — 역할별 카테고리 분기 및 지부장 branchOptions 필터링
- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift` — TargetInfoDTO 빌드 시 역할별 schoolId/chapterId 바인딩
- `Features/Notice/Presentation/ViewModels/StaffNotice/StaffNoticeViewModel.swift` — 지부장 조회 시 schoolId 제외 로직

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

Closes #734
Closes #735
Closes #736
Closes #737
Closes #738