### PR TITLE
♻️ [Refactor] NoticeDTO 이식

### DIFF
--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeImagesRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeImagesRequestDTO.swift
@@ -1,0 +1,18 @@
+//
+//  NoticeImagesRequestDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+/// 공지 이미지 추가/수정 요청 DTO
+///
+/// - `POST /api/v1/notices/{noticeId}/images`
+/// - `PATCH /api/v1/notices/{noticeId}/images`
+public struct NoticeImagesRequestDTO: Encodable {
+    /// 첨부 이미지 ID 목록
+    public let imageIds: [String]
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeLinksRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeLinksRequestDTO.swift
@@ -1,0 +1,18 @@
+//
+//  NoticeLinksRequestDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+/// 공지 링크 추가/수정 요청 DTO
+///
+/// - `POST /api/v1/notices/{noticeId}/links`
+/// - `PATCH /api/v1/notices/{noticeId}/links`
+public struct NoticeLinksRequestDTO: Encodable {
+    /// 첨부 링크 URL 목록
+    public let links: [String]
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticePatchRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticePatchRequestDTO.swift
@@ -9,7 +9,7 @@ import Foundation
 import NoticeDomain
 
 /// 공지사항 수정 요청 DTO
-public struct UpdateNoticeRequestDTO: Encodable {
+public struct NoticePatchRequestDTO: Encodable {
     public let title: String
     public let content: String
 }

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticePatchRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticePatchRequestDTO.swift
@@ -1,0 +1,15 @@
+//
+//  NoticePatchRequestDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+/// 공지사항 수정 요청 DTO
+public struct UpdateNoticeRequestDTO: Encodable {
+    public let title: String
+    public let content: String
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticePostRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticePostRequestDTO.swift
@@ -1,0 +1,150 @@
+//
+//  NoticePostRequestDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - Post Notice
+/// 공지 생성 요청 DTO
+public struct PostNoticeRequestDTO: Codable {
+    /// 공지 제목
+    public let title: String
+    /// 공지 본문
+    public let content: String
+    /// 알림 발송 여부
+    public let shouldNotify: Bool
+    /// 공지 대상 정보
+    public let targetInfo: TargetInfoDTO
+}
+
+// MARK: - Create Notice Response
+/// 공지 생성 응답 DTO
+public struct NoticeCreateResponseDTO: Codable {
+    /// 생성된 공지 ID
+    public let noticeId: String
+
+    private enum CodingKeys: String, CodingKey {
+        case noticeId
+    }
+
+    /// noticeId가 String 또는 Int로 올 수 있어 유연하게 디코딩
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let id = try? container.decode(String.self, forKey: .noticeId) {
+            self.noticeId = id
+        } else if let id = try? container.decode(Int.self, forKey: .noticeId) {
+            self.noticeId = String(id)
+        } else {
+            self.noticeId = ""
+        }
+    }
+}
+
+// MARK: - Add Images Response
+/// 공지 이미지 추가 응답 DTO
+public struct NoticeAddImagesResponseDTO: Codable {
+    /// 추가된 이미지 ID 목록
+    public let imageIds: [String]
+
+    private enum CodingKeys: String, CodingKey {
+        case imageIds
+    }
+
+    /// imageIds가 [String] 또는 [Int]로 올 수 있어 유연하게 디코딩
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let ids = try? container.decode([String].self, forKey: .imageIds) {
+            self.imageIds = ids
+            return
+        }
+        if let ids = try? container.decode([Int].self, forKey: .imageIds) {
+            self.imageIds = ids.map(String.init)
+            return
+        }
+        self.imageIds = []
+    }
+}
+
+// MARK: - TargetInfoDTO
+
+public struct TargetInfoDTO: Codable {
+    public let targetGisuId: Int
+    public let targetChapterId: Int?
+    public let targetSchoolId: Int?
+    public let targetParts: [UMCPartType]?
+
+    private enum CodingKeys: String, CodingKey {
+        case targetGisuId
+        case targetChapterId
+        case targetSchoolId
+        case targetParts
+    }
+
+    public init(
+        targetGisuId: Int,
+        targetChapterId: Int?,
+        targetSchoolId: Int?,
+        targetParts: UMCPartType?
+    ) {
+        self.targetGisuId = targetGisuId
+        self.targetChapterId = targetChapterId
+        self.targetSchoolId = targetSchoolId
+        self.targetParts = targetParts.map { [$0] }
+    }
+
+    public init(
+        targetGisuId: Int,
+        targetChapterId: Int?,
+        targetSchoolId: Int?,
+        targetParts: [UMCPartType]?
+    ) {
+        self.targetGisuId = targetGisuId
+        self.targetChapterId = targetChapterId
+        self.targetSchoolId = targetSchoolId
+        self.targetParts = targetParts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.targetGisuId = try container.decodeIntFlexibleIfPresent(forKey: .targetGisuId) ?? 0
+        self.targetChapterId = try container.decodeIntFlexibleIfPresent(forKey: .targetChapterId)
+        self.targetSchoolId = try container.decodeIntFlexibleIfPresent(forKey: .targetSchoolId)
+        self.targetParts = try container.decodeIfPresent([UMCPartType].self, forKey: .targetParts)
+    }
+
+    /// 공지 생성/수정 요청 인코딩 시 null 규칙을 맞춥니다.
+    /// - targetGisuId <= 0: null
+    /// - targetParts 비어있음: null
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        if targetGisuId > 0 {
+            try container.encode(targetGisuId, forKey: .targetGisuId)
+        } else {
+            try container.encodeNil(forKey: .targetGisuId)
+        }
+
+        try container.encodeIfPresent(targetChapterId, forKey: .targetChapterId)
+        try container.encodeIfPresent(targetSchoolId, forKey: .targetSchoolId)
+
+        if let targetParts, !targetParts.isEmpty {
+            try container.encode(targetParts, forKey: .targetParts)
+        } else {
+            try container.encodeNil(forKey: .targetParts)
+        }
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if (try? decodeNil(forKey: key)) == true { return nil }
+        if let value = try? decode(Int.self, forKey: key) { return value }
+        if let value = try? decode(Double.self, forKey: key) { return Int(value) }
+        if let value = try? decode(String.self, forKey: key) { return Int(value) }
+        return nil
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticePostRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticePostRequestDTO.swift
@@ -10,7 +10,7 @@ import UMCFoundation
 
 // MARK: - Post Notice
 /// 공지 생성 요청 DTO
-public struct PostNoticeRequestDTO: Codable {
+public struct PostNoticeRequestDTO: Encodable {
     /// 공지 제목
     public let title: String
     /// 공지 본문
@@ -72,9 +72,9 @@ public struct NoticeAddImagesResponseDTO: Codable {
 // MARK: - TargetInfoDTO
 
 public struct TargetInfoDTO: Codable {
-    public let targetGisuId: Int
-    public let targetChapterId: Int?
-    public let targetSchoolId: Int?
+    public let targetGisuId: String
+    public let targetChapterId: String?
+    public let targetSchoolId: String?
     public let targetParts: [UMCPartType]?
 
     private enum CodingKeys: String, CodingKey {
@@ -85,9 +85,9 @@ public struct TargetInfoDTO: Codable {
     }
 
     public init(
-        targetGisuId: Int,
-        targetChapterId: Int?,
-        targetSchoolId: Int?,
+        targetGisuId: String,
+        targetChapterId: String?,
+        targetSchoolId: String?,
         targetParts: UMCPartType?
     ) {
         self.targetGisuId = targetGisuId
@@ -97,9 +97,9 @@ public struct TargetInfoDTO: Codable {
     }
 
     public init(
-        targetGisuId: Int,
-        targetChapterId: Int?,
-        targetSchoolId: Int?,
+        targetGisuId: String,
+        targetChapterId: String?,
+        targetSchoolId: String?,
         targetParts: [UMCPartType]?
     ) {
         self.targetGisuId = targetGisuId
@@ -110,26 +110,36 @@ public struct TargetInfoDTO: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.targetGisuId = try container.decodeIntFlexibleIfPresent(forKey: .targetGisuId) ?? 0
-        self.targetChapterId = try container.decodeIntFlexibleIfPresent(forKey: .targetChapterId)
-        self.targetSchoolId = try container.decodeIntFlexibleIfPresent(forKey: .targetSchoolId)
+        self.targetGisuId = container.decodeFlexibleOptionalString(forKey: .targetGisuId) ?? "0"
+        self.targetChapterId = container.decodeFlexibleOptionalString(forKey: .targetChapterId)
+        self.targetSchoolId = container.decodeFlexibleOptionalString(forKey: .targetSchoolId)
         self.targetParts = try container.decodeIfPresent([UMCPartType].self, forKey: .targetParts)
     }
 
     /// 공지 생성/수정 요청 인코딩 시 null 규칙을 맞춥니다.
-    /// - targetGisuId <= 0: null
+    /// - targetGisuId가 "0" 이하(빈 문자열 또는 0): null
     /// - targetParts 비어있음: null
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        if targetGisuId > 0 {
-            try container.encode(targetGisuId, forKey: .targetGisuId)
+        let gisuIdInt = Int(targetGisuId) ?? 0
+        if gisuIdInt > 0 {
+            try container.encode(gisuIdInt, forKey: .targetGisuId)
         } else {
             try container.encodeNil(forKey: .targetGisuId)
         }
 
-        try container.encodeIfPresent(targetChapterId, forKey: .targetChapterId)
-        try container.encodeIfPresent(targetSchoolId, forKey: .targetSchoolId)
+        if let chapterId = targetChapterId, let intVal = Int(chapterId) {
+            try container.encode(intVal, forKey: .targetChapterId)
+        } else {
+            try container.encodeNil(forKey: .targetChapterId)
+        }
+
+        if let schoolId = targetSchoolId, let intVal = Int(schoolId) {
+            try container.encode(intVal, forKey: .targetSchoolId)
+        } else {
+            try container.encodeNil(forKey: .targetSchoolId)
+        }
 
         if let targetParts, !targetParts.isEmpty {
             try container.encode(targetParts, forKey: .targetParts)
@@ -140,11 +150,16 @@ public struct TargetInfoDTO: Codable {
 }
 
 private extension KeyedDecodingContainer {
-    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
-        if (try? decodeNil(forKey: key)) == true { return nil }
-        if let value = try? decode(Int.self, forKey: key) { return value }
-        if let value = try? decode(Double.self, forKey: key) { return Int(value) }
-        if let value = try? decode(String.self, forKey: key) { return Int(value) }
+    func decodeFlexibleOptionalString(forKey key: Key) -> String? {
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(Int(value))
+        }
         return nil
     }
 }

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeReadStatusListQuery.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeReadStatusListQuery.swift
@@ -1,0 +1,33 @@
+//
+//  NoticeReadStatusListQuery.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+/// 공지 열람 현황 상세 조회 Query DTO
+///
+/// `GET /api/v1/notices/{noticeId}/read-status`
+public struct NoticeReadStatusListQuery: Encodable {
+    /// 이전 페이지의 마지막 항목 ID (커서 기반)
+    public let cursorId: Int
+    /// 필터 타입 (운영진 / 챌린저 등)
+    public let filterType: String
+    /// 조직(지부/학교) ID 목록
+    public let organizationIds: [Int]
+    /// 열람 상태 필터 (READ / UNREAD)
+    public let status: String
+
+    /// Query Parameter Dictionary 변환
+    public var toParameters: [String: Any] {
+        [
+            "cursorId": cursorId,
+            "filterType": filterType,
+            "organizationIds": organizationIds,
+            "status": status
+        ]
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeReadStatusListQuery.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeReadStatusListQuery.swift
@@ -13,11 +13,11 @@ import NoticeDomain
 /// `GET /api/v1/notices/{noticeId}/read-status`
 public struct NoticeReadStatusListQuery: Encodable {
     /// 이전 페이지의 마지막 항목 ID (커서 기반)
-    public let cursorId: Int
+    public let cursorId: String
     /// 필터 타입 (운영진 / 챌린저 등)
     public let filterType: String
     /// 조직(지부/학교) ID 목록
-    public let organizationIds: [Int]
+    public let organizationIds: [String]
     /// 열람 상태 필터 (READ / UNREAD)
     public let status: String
 

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeReminderRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeReminderRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  NoticeReminderRequestDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+/// 공지 리마인더 발송 요청 DTO
+///
+/// `POST /api/v1/notices/{noticeId}/reminders`
+public struct NoticeReminderRequestDTO: Encodable {
+    /// 알림을 다시 보낼 대상 멤버 ID 목록
+    public let targetIds: [Int]
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeReminderRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeReminderRequestDTO.swift
@@ -13,5 +13,5 @@ import NoticeDomain
 /// `POST /api/v1/notices/{noticeId}/reminders`
 public struct NoticeReminderRequestDTO: Encodable {
     /// 알림을 다시 보낼 대상 멤버 ID 목록
-    public let targetIds: [Int]
+    public let targetIds: [String]
 }

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeVoteResponseRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeVoteResponseRequestDTO.swift
@@ -1,0 +1,18 @@
+//
+//  NoticeVoteResponseRequestDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+/// 공지 투표 응답(제출/수정) 요청 DTO
+///
+/// - `POST /api/v1/notices/{noticeId}/votes/responses`
+/// - `PUT /api/v1/notices/{noticeId}/votes/responses`
+public struct NoticeVoteResponseRequestDTO: Encodable {
+    /// 사용자가 선택한 옵션 ID 목록
+    public let optionIds: [Int]
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeVoteResponseRequestDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeVoteResponseRequestDTO.swift
@@ -14,5 +14,5 @@ import NoticeDomain
 /// - `PUT /api/v1/notices/{noticeId}/votes/responses`
 public struct NoticeVoteResponseRequestDTO: Encodable {
     /// 사용자가 선택한 옵션 ID 목록
-    public let optionIds: [Int]
+    public let optionIds: [String]
 }

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/VoteDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/VoteDTO.swift
@@ -1,0 +1,55 @@
+//
+//  VoteDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+// MARK: - 투표 추가 Request DTO
+
+/// 공지사항 투표 추가 요청 DTO
+public struct AddVoteRequestDTO: Codable {
+    public let title: String
+    public let isAnonymous: Bool
+    public let allowMultipleChoice: Bool
+    public let startsAt: String
+    public let endsAtExclusive: String
+    public let options: [String]
+}
+
+// MARK: - 투표 추가 Response DTO
+
+/// 공지사항 투표 추가 응답 DTO
+public struct AddVoteResponseDTO: Codable {
+    public let noticeVoteId: String
+    public let voteId: String
+
+    private enum CodingKeys: String, CodingKey {
+        case noticeVoteId
+        case voteId
+    }
+
+    /// noticeVoteId, voteId가 String 또는 Int로 올 수 있어 유연하게 디코딩
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let value = try? container.decode(String.self, forKey: .noticeVoteId) {
+            self.noticeVoteId = value
+        } else if let value = try? container.decode(Int.self, forKey: .noticeVoteId) {
+            self.noticeVoteId = String(value)
+        } else {
+            self.noticeVoteId = ""
+        }
+
+        if let value = try? container.decode(String.self, forKey: .voteId) {
+            self.voteId = value
+        } else if let value = try? container.decode(Int.self, forKey: .voteId) {
+            self.voteId = String(value)
+        } else {
+            self.voteId = ""
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/VoteDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/VoteDTO.swift
@@ -11,7 +11,7 @@ import NoticeDomain
 // MARK: - 투표 추가 Request DTO
 
 /// 공지사항 투표 추가 요청 DTO
-public struct AddVoteRequestDTO: Codable {
+public struct AddVoteRequestDTO: Encodable {
     public let title: String
     public let isAnonymous: Bool
     public let allowMultipleChoice: Bool

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDTO.swift
@@ -1,0 +1,235 @@
+//
+//  NoticeDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+import UMCFoundation
+
+// MARK: - Notice DTO
+/// 공지 리스트카드 DTO
+public struct NoticeDTO: Codable {
+    public let id: String
+    public let title: String
+    public let content: String
+    public let shouldSendNotification: Bool
+    public let viewCount: String
+    public let createdAt: String
+    public let targetInfo: NoticeTargetInfoDTO
+    public let authorChallengerId: String?
+    public let authorMemberId: String?
+    public let authorNickname: String
+    public let authorName: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case content
+        case shouldSendNotification
+        case viewCount
+        case createdAt
+        case targetInfo
+        case authorChallengerId
+        case authorMemberId
+        case authorNickname
+        case authorName
+    }
+
+    /// 커스텀 디코더: 서버 응답의 타입 불일치(Int/String)를 유연하게 처리합니다.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeFlexibleString(forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        content = try container.decode(String.self, forKey: .content)
+        shouldSendNotification = try container.decodeIfPresent(Bool.self, forKey: .shouldSendNotification) ?? false
+        viewCount = try container.decodeFlexibleString(forKey: .viewCount)
+        createdAt = try container.decode(String.self, forKey: .createdAt)
+        targetInfo = try container.decode(NoticeTargetInfoDTO.self, forKey: .targetInfo)
+        authorChallengerId = try? container.decode(String.self, forKey: .authorChallengerId)
+        authorMemberId = try? container.decode(String.self, forKey: .authorMemberId)
+        authorNickname = try container.decodeIfPresent(String.self, forKey: .authorNickname) ?? ""
+        authorName = try container.decodeIfPresent(String.self, forKey: .authorName) ?? ""
+    }
+}
+
+// MARK: - Mapping
+extension NoticeDTO {
+    /// NoticeDTO → NoticeItemModel 변환 (공지 목록용)
+    func toItemModel(
+        generationOverride: String? = nil,
+        scopeDisplayNameOverride: String? = nil
+    ) -> NoticeItemModel {
+        let generation = generationOverride ?? String(targetInfo.generationValue)
+        let scope = targetInfo.resolvedScope
+        let category = targetInfo.resolvedCategory
+        let scopeDisplayName = scopeDisplayNameOverride ?? targetInfo.resolvedScopeDisplayName
+        let targetsAllGenerations = (Int(generation) ?? 0) <= 0 && targetInfo.targetsAllGenerations
+        
+        let resolvedAuthorName = resolvedAuthorName(authorName)
+
+        return NoticeItemModel(
+            noticeId: id,
+            generation: generation,
+            scope: scope,
+            category: category,
+            mustRead: false,
+            isAlert: shouldSendNotification,
+            date: createdAt.toISO8601Date(),
+            title: title,
+            content: content,
+            writer: resolvedAuthorName,
+            authorNickname: authorNickname.isEmpty ? nil : authorNickname,
+            authorName: resolvedAuthorName == "알 수 없음" ? nil : resolvedAuthorName,
+            links: [],  // 기본 조회에는 없음
+            images: [],  // 기본 조회에는 없음
+            vote: nil,
+            viewCount: viewCount,
+            scopeDisplayName: scopeDisplayName,
+            targetsAllGenerations: targetsAllGenerations,
+            parts: targetInfo.resolvedParts,
+            isRead: false
+        )
+    }
+}
+
+private func resolvedAuthorName(_ authorName: String) -> String {
+    let trimmedAuthorName = authorName.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmedAuthorName.isEmpty ? "알 수 없음" : trimmedAuthorName
+}
+
+// MARK: - TargetInfo DTO
+/// 공지 목록/검색 응답용 targetInfo DTO
+///
+/// 숫자 필드는 서버 스펙에 맞춰 String으로 처리합니다.
+public struct NoticeTargetInfoDTO: Codable {
+    public let targetGisu: String?
+    public let targetGisuId: String
+    public let targetChapterId: String?
+    public let targetSchoolId: String?
+    public let targetChapterName: String?
+    public let targetSchoolName: String?
+    public let chapterName: String?
+    public let schoolName: String?
+    public let targetParts: [UMCPartType]?
+
+    private enum CodingKeys: String, CodingKey {
+        case targetGisu
+        case targetGisuId
+        case targetChapterId
+        case targetSchoolId
+        case targetChapterName
+        case targetSchoolName
+        case chapterName
+        case schoolName
+        case targetParts
+    }
+
+    public init(
+        targetGisu: String? = nil,
+        targetGisuId: String,
+        targetChapterId: String?,
+        targetSchoolId: String?,
+        targetChapterName: String? = nil,
+        targetSchoolName: String? = nil,
+        chapterName: String? = nil,
+        schoolName: String? = nil,
+        targetParts: [UMCPartType]?
+    ) {
+        self.targetGisu = targetGisu
+        self.targetGisuId = targetGisuId
+        self.targetChapterId = targetChapterId
+        self.targetSchoolId = targetSchoolId
+        self.targetChapterName = targetChapterName
+        self.targetSchoolName = targetSchoolName
+        self.chapterName = chapterName
+        self.schoolName = schoolName
+        self.targetParts = targetParts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        targetGisu = container.decodeFlexibleOptionalString(forKey: .targetGisu)
+        targetGisuId = container.decodeFlexibleOptionalString(forKey: .targetGisuId) ?? "0"
+        targetChapterId = container.decodeFlexibleOptionalString(forKey: .targetChapterId)
+        targetSchoolId = container.decodeFlexibleOptionalString(forKey: .targetSchoolId)
+        targetChapterName = container.decodeFlexibleOptionalString(forKey: .targetChapterName)
+        targetSchoolName = container.decodeFlexibleOptionalString(forKey: .targetSchoolName)
+        chapterName = container.decodeFlexibleOptionalString(forKey: .chapterName)
+        schoolName = container.decodeFlexibleOptionalString(forKey: .schoolName)
+        targetParts = try container.decodeIfPresent([UMCPartType].self, forKey: .targetParts)
+    }
+
+    public var resolvedChapterName: String? {
+        let candidates = [targetChapterName, chapterName]
+        return candidates
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { !$0.isEmpty })
+    }
+
+    public var resolvedSchoolName: String? {
+        let candidates = [targetSchoolName, schoolName]
+        return candidates
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { !$0.isEmpty })
+    }
+
+    public var targetsAllGenerations: Bool {
+        generationValue <= 0
+    }
+}
+
+// MARK: - Helper
+private extension String {
+    /// ISO8601 문자열을 Date로 변환합니다.
+    /// - Note: 소수점 초 포함/미포함 포맷을 모두 지원합니다.
+    func toISO8601Date() -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let parsed = formatter.date(from: self) {
+            return parsed
+        }
+
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: self) ?? Date()
+    }
+}
+
+// MARK: - Flexible Decoding Helpers
+
+private extension KeyedDecodingContainer {
+    /// String/Int/Double 타입을 모두 String으로 디코딩합니다.
+    func decodeFlexibleString(forKey key: Key) throws -> String {
+        if let value = try? decode(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(value)
+        }
+        throw DecodingError.typeMismatch(
+            String.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected String/Int/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeFlexibleOptionalString(forKey key: Key) -> String? {
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(Int(value))
+        }
+        return nil
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDetailContentDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDetailContentDTO.swift
@@ -1,0 +1,210 @@
+//
+//  NoticeDetailContentDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+public struct NoticeDetailVoteDTO: Codable {
+    public let voteId: String
+    public let title: String
+    public let isAnonymous: Bool
+    public let allowMultipleChoice: Bool
+    public let startsAt: String
+    public let endsAtExclusive: String
+    public let options: [NoticeDetailVoteOptionDTO]
+    public let mySelectedOptionIds: [String]
+    public let status: String?
+    public let totalParticipants: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case voteId
+        case title
+        case isAnonymous
+        case allowMultipleChoice
+        case startsAt
+        case endsAtExclusive
+        case options
+        case mySelectedOptionIds
+        case status
+        case totalParticipants
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.voteId = try container.decodeStringFlexible(forKey: .voteId)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.isAnonymous = try container.decode(Bool.self, forKey: .isAnonymous)
+        self.allowMultipleChoice = try container.decode(Bool.self, forKey: .allowMultipleChoice)
+        self.startsAt = try container.decode(String.self, forKey: .startsAt)
+        self.endsAtExclusive = try container.decode(String.self, forKey: .endsAtExclusive)
+        self.options = try container.decode([NoticeDetailVoteOptionDTO].self, forKey: .options)
+        self.mySelectedOptionIds = try container.decodeStringArrayFlexible(forKey: .mySelectedOptionIds)
+        self.status = try container.decodeIfPresent(String.self, forKey: .status)
+        self.totalParticipants = try container.decodeIntFlexibleIfPresent(forKey: .totalParticipants)
+    }
+
+    public func toDomain() -> NoticeVote {
+        let startDate = parseISO8601(startsAt)
+        let endDate = parseISO8601(endsAtExclusive)
+        let resolvedStatus: VoteStatus = status
+            .flatMap { VoteStatus(rawValue: $0) }
+            ?? VoteStatus.fallback(now: .now, startsAt: startDate, endsAt: endDate)
+
+        return NoticeVote(
+            id: voteId,
+            question: title,
+            options: options.map { $0.toDomain() },
+            startDate: startDate,
+            endDate: endDate,
+            allowMultipleChoices: allowMultipleChoice,
+            isAnonymous: isAnonymous,
+            userVotedOptionIds: mySelectedOptionIds,
+            status: resolvedStatus,
+            totalParticipants: totalParticipants.map(String.init)
+        )
+    }
+}
+
+public struct NoticeDetailVoteOptionDTO: Codable {
+    public let optionId: String
+    public let content: String
+    public let voteCount: String
+    public let selectedMemberIds: [String]
+    public let voteRate: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case optionId
+        case content
+        case voteCount
+        case selectedMemberIds
+        case voteRate
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.optionId = try container.decodeStringFlexible(forKey: .optionId)
+        self.content = try container.decode(String.self, forKey: .content)
+        self.voteCount = try container.decodeStringFlexible(forKey: .voteCount)
+        self.selectedMemberIds = (try? container.decodeStringArrayFlexible(forKey: .selectedMemberIds)) ?? []
+        self.voteRate = try container.decodeStringFlexibleIfPresent(forKey: .voteRate)
+    }
+
+    public func toDomain() -> VoteOption {
+        VoteOption(
+            id: optionId,
+            title: content,
+            voteCount: voteCount,
+            selectedMemberIds: selectedMemberIds,
+            voteRate: voteRate
+        )
+    }
+}
+
+public struct NoticeDetailImageDTO: Codable {
+    public let id: String
+    public let url: String
+    public let displayOrder: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case url
+        case displayOrder
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decodeStringFlexible(forKey: .id)
+        self.url = try container.decode(String.self, forKey: .url)
+        self.displayOrder = try container.decodeStringFlexible(forKey: .displayOrder)
+    }
+}
+
+public struct NoticeDetailLinkDTO: Codable {
+    public let id: String
+    public let url: String
+    public let displayOrder: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case url
+        case displayOrder
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decodeStringFlexible(forKey: .id)
+        self.url = try container.decode(String.self, forKey: .url)
+        self.displayOrder = try container.decodeStringFlexible(forKey: .displayOrder)
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeStringFlexible(forKey key: Key) throws -> String {
+        if let value = try? decode(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(Int(value))
+        }
+        throw DecodingError.typeMismatch(
+            String.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected String/Int/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    func decodeStringArrayFlexible(forKey key: Key) throws -> [String] {
+        if let values = try? decode([String].self, forKey: key) {
+            return values
+        }
+        if let values = try? decode([Int].self, forKey: key) {
+            return values.map(String.init)
+        }
+        return []
+    }
+
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if let value = try? decodeIfPresent(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try? decodeIfPresent(Double.self, forKey: key) {
+            return Int(value)
+        }
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return Int(value)
+        }
+        return nil
+    }
+
+    func decodeStringFlexibleIfPresent(forKey key: Key) throws -> String? {
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decodeIfPresent(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decodeIfPresent(Double.self, forKey: key) {
+            return String(value)
+        }
+        return nil
+    }
+}
+
+private func parseISO8601(_ value: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let parsed = formatter.date(from: value) {
+        return parsed
+    }
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.date(from: value) ?? Date()
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDetailContentDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDetailContentDTO.swift
@@ -8,6 +8,12 @@
 import Foundation
 import NoticeDomain
 
+// MARK: - Vote DTO
+
+/// 공지 상세의 투표 정보 DTO
+///
+/// 투표 상태(`status`)는 서버가 제공하지 않을 경우
+/// `startsAt` / `endsAtExclusive`를 기준으로 클라이언트에서 추론합니다.
 public struct NoticeDetailVoteDTO: Codable {
     public let voteId: String
     public let title: String
@@ -47,6 +53,7 @@ public struct NoticeDetailVoteDTO: Codable {
         self.totalParticipants = try container.decodeIntFlexibleIfPresent(forKey: .totalParticipants)
     }
 
+    /// DTO → `NoticeVote` 도메인 모델 변환
     public func toDomain() -> NoticeVote {
         let startDate = parseISO8601(startsAt)
         let endDate = parseISO8601(endsAtExclusive)
@@ -69,6 +76,9 @@ public struct NoticeDetailVoteDTO: Codable {
     }
 }
 
+// MARK: - Vote Option DTO
+
+/// 투표 옵션 단건 DTO
 public struct NoticeDetailVoteOptionDTO: Codable {
     public let optionId: String
     public let content: String
@@ -92,7 +102,8 @@ public struct NoticeDetailVoteOptionDTO: Codable {
         self.selectedMemberIds = (try? container.decodeStringArrayFlexible(forKey: .selectedMemberIds)) ?? []
         self.voteRate = try container.decodeStringFlexibleIfPresent(forKey: .voteRate)
     }
-
+    
+    /// DTO → `VoteOption` 도메인 모델 변환
     public func toDomain() -> VoteOption {
         VoteOption(
             id: optionId,
@@ -104,6 +115,9 @@ public struct NoticeDetailVoteOptionDTO: Codable {
     }
 }
 
+// MARK: - Image DTO
+
+/// 공지 첨부 이미지 단건 DTO
 public struct NoticeDetailImageDTO: Codable {
     public let id: String
     public let url: String
@@ -123,6 +137,9 @@ public struct NoticeDetailImageDTO: Codable {
     }
 }
 
+// MARK: - Link DTO
+
+/// 공지 첨부 링크 단건 DTO
 public struct NoticeDetailLinkDTO: Codable {
     public let id: String
     public let url: String
@@ -142,7 +159,10 @@ public struct NoticeDetailLinkDTO: Codable {
     }
 }
 
+// MARK: - Decoding Helpers
+
 private extension KeyedDecodingContainer {
+    /// String / Int / Double 타입을 모두 String으로 디코딩
     func decodeStringFlexible(forKey key: Key) throws -> String {
         if let value = try? decode(String.self, forKey: key) {
             return value
@@ -162,6 +182,7 @@ private extension KeyedDecodingContainer {
         )
     }
 
+    /// String / Int 배열을 모두 [String]으로 디코딩
     func decodeStringArrayFlexible(forKey key: Key) throws -> [String] {
         if let values = try? decode([String].self, forKey: key) {
             return values
@@ -172,6 +193,7 @@ private extension KeyedDecodingContainer {
         return []
     }
 
+    /// Int / Double / String 중 하나로 디코딩하여 Int?를 반환
     func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
         if let value = try? decodeIfPresent(Int.self, forKey: key) {
             return value
@@ -185,6 +207,7 @@ private extension KeyedDecodingContainer {
         return nil
     }
 
+    /// String / Int / Double 중 하나로 디코딩하여 String?을 반환
     func decodeStringFlexibleIfPresent(forKey key: Key) throws -> String? {
         if let value = try? decodeIfPresent(String.self, forKey: key) {
             return value

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDetailDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDetailDTO.swift
@@ -1,0 +1,225 @@
+//
+//  NoticeDetailDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+// MARK: - NoticeDetailDTO
+
+/// 공지 상세화면 DTO
+public struct NoticeDetailDTO: Codable {
+
+    // MARK: - Property
+
+    public let id: String
+    public let title: String
+    public let content: String
+    public let shouldSendNotification: Bool?
+    public let viewCount: String
+    public let createdAt: String
+    public let updatedAt: String?
+    public let targetInfo: NoticeTargetInfoDTO
+    public let authorChallengerId: String?
+    public let authorMemberId: String?
+    public let authorNickname: String?
+    public let authorName: String?
+    public let authorProfileImageUrl: String?
+
+    // 상세 추가 필드
+    public let vote: NoticeDetailVoteDTO?
+    public let images: [NoticeDetailImageDTO]
+    public let links: [NoticeDetailLinkDTO]
+    public let scope: String?
+    public let category: String?
+    public let isMustRead: Bool?
+    public let hasPermission: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case content
+        case shouldSendNotification
+        case viewCount
+        case createdAt
+        case updatedAt
+        case targetInfo
+        case authorChallengerId
+        case authorMemberId
+        case authorNickname
+        case authorName
+        case authorProfileImageUrl
+        case vote
+        case images
+        case links
+        case scope
+        case category
+        case isMustRead
+        case hasPermission
+    }
+
+    /// 커스텀 디코더: 필드 누락·타입 불일치를 방어적으로 처리합니다.
+    ///
+    /// 서버 응답이 불완전할 경우에도 앱 크래시를 방지하기 위해
+    /// 각 필드에 대해 개별적으로 디코딩을 시도하고 기본값으로 폴백합니다.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decodeStringFlexible(forKey: .id)
+        title = try container.decodeStringOrEmpty(forKey: .title)
+        content = try container.decodeStringOrEmpty(forKey: .content)
+        shouldSendNotification = try? container.decode(Bool.self, forKey: .shouldSendNotification)
+        viewCount = try container.decodeStringFlexible(forKey: .viewCount)
+        createdAt = try container.decodeStringOrEmpty(forKey: .createdAt)
+        updatedAt = try? container.decodeIfPresent(String.self, forKey: .updatedAt)
+        targetInfo = (try? container.decode(NoticeTargetInfoDTO.self, forKey: .targetInfo))
+            ?? NoticeTargetInfoDTO(targetGisuId: "0", targetChapterId: nil, targetSchoolId: nil, targetParts: nil)
+        authorChallengerId = try? container.decodeStringOrNil(forKey: .authorChallengerId)
+        authorMemberId = try? container.decodeStringOrNil(forKey: .authorMemberId)
+        authorNickname = try? container.decodeStringOrNil(forKey: .authorNickname)
+        authorName = try? container.decodeStringOrNil(forKey: .authorName)
+        authorProfileImageUrl = try? container.decodeStringOrNil(forKey: .authorProfileImageUrl)
+
+        vote = try? container.decodeIfPresent(NoticeDetailVoteDTO.self, forKey: .vote)
+        images = (try? container.decode([NoticeDetailImageDTO].self, forKey: .images)) ?? []
+        links = (try? container.decode([NoticeDetailLinkDTO].self, forKey: .links)) ?? []
+
+        scope = try? container.decodeStringOrNil(forKey: .scope)
+        category = try? container.decodeStringOrNil(forKey: .category)
+        isMustRead = try? container.decodeIfPresent(Bool.self, forKey: .isMustRead)
+        hasPermission = try? container.decodeIfPresent(Bool.self, forKey: .hasPermission)
+    }
+}
+
+// MARK: - toDomain 변환
+
+extension NoticeDetailDTO {
+    /// NoticeDetailDTO → NoticeDetail 도메인 모델 변환
+    ///
+    /// scope/category가 nil인 경우 targetInfo 기반으로 추론합니다.
+    func toDomain() -> NoticeDetail {
+        let generation = String(targetInfo.generationValue)
+
+        // scope 문자열이 없으면 targetInfo 기반으로 추론
+        let noticeScope: NoticeScope
+        if let scope {
+            switch scope.uppercased() {
+            case "CENTRAL": noticeScope = .central
+            case "BRANCH": noticeScope = .branch
+            case "CAMPUS": noticeScope = .campus
+            default: noticeScope = .central
+            }
+        } else {
+            noticeScope = targetInfo.resolvedScope
+        }
+
+        // category 문자열이 없으면 targetInfo 기반으로 추론
+        let noticeCategory: NoticeCategory = {
+            if let category {
+                switch category.uppercased() {
+                case "PART":
+                    return targetInfo.resolvedCategory
+                case "GENERAL":
+                    return .general
+                default:
+                    return .general
+                }
+            } else {
+                return targetInfo.resolvedCategory
+            }
+        }()
+
+        let targetAudience = targetInfo.toTargetAudience(scope: noticeScope)
+
+        let mappedVote = vote?.toDomain()
+        let mappedImages = images.map { NoticeAttachmentImage(id: $0.id, url: $0.url) }
+        let imageURLs = mappedImages.map(\.url)
+        let linkURLs = links.map(\.url)
+        let resolvedAuthorName = resolvedAuthorName()
+
+        return NoticeDetail(
+            id: id,
+            generation: generation,
+            scope: noticeScope,
+            category: noticeCategory,
+            isMustRead: isMustRead ?? false,
+            title: title,
+            content: content,
+            authorID: authorChallengerId ?? "0",
+            authorMemberId: authorMemberId,
+            authorNickname: authorNickname,
+            authorName: resolvedAuthorName,
+            authorImageURL: authorProfileImageUrl,
+            createdAt: createdAt.toISO8601Date(),
+            updatedAt: updatedAt?.toISO8601Date(),
+            targetAudience: targetAudience,
+            hasPermission: hasPermission ?? false,
+            images: imageURLs,
+            imageItems: mappedImages,
+            links: linkURLs,
+            vote: mappedVote
+        )
+    }
+
+    private func resolvedAuthorName() -> String {
+        let trimmedAuthorName = authorName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedAuthorName.isEmpty ? "알 수 없음" : trimmedAuthorName
+    }
+}
+
+// MARK: - String ISO8601 변환
+
+private extension String {
+    /// ISO8601 문자열을 Date로 변환
+    ///
+    /// fractionalSeconds 포함 포맷을 우선 시도하고, 실패 시 기본 포맷으로 재시도합니다.
+    func toISO8601Date() -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let parsed = formatter.date(from: self) {
+            return parsed
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: self) ?? Date()
+    }
+}
+
+// MARK: - Flexible Decoding Helpers
+
+private extension KeyedDecodingContainer {
+    /// String/Int/Double 타입을 모두 String으로 디코딩합니다.
+    func decodeStringFlexible(forKey key: Key) throws -> String {
+        if let value = try? decode(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(value)
+        }
+        throw DecodingError.valueNotFound(
+            String.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Expected String value for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    /// 디코딩 실패 시 빈 문자열을 반환합니다.
+    func decodeStringOrEmpty(forKey key: Key) throws -> String {
+        return (try? decodeStringFlexible(forKey: key)) ?? ""
+    }
+
+    /// 명시적 null 또는 디코딩 실패 시 nil을 반환합니다.
+    func decodeStringOrNil(forKey key: Key) throws -> String? {
+        if try decodeNil(forKey: key) {
+            return nil
+        }
+        return try? decodeStringFlexible(forKey: key)
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeEditorTargetDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeEditorTargetDTO.swift
@@ -8,12 +8,19 @@
 import Foundation
 import NoticeDomain
 
-import Foundation
-
 // MARK: - Chapter List Response
 /// 지부 목록 조회 응답 DTO
 public struct ChapterListResponseDTO: Codable {
     public let chapters: [ChapterDTO]
+
+    private enum CodingKeys: String, CodingKey {
+        case chapters
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.chapters = try container.decode([ChapterDTO].self, forKey: .chapters)
+    }
 }
 
 // MARK: - Chapter
@@ -21,12 +28,32 @@ public struct ChapterListResponseDTO: Codable {
 public struct ChapterDTO: Codable {
     public let id: String
     public let name: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = container.decodeFlexibleOptionalString(forKey: .id) ?? ""
+        self.name = try container.decode(String.self, forKey: .name)
+    }
 }
 
 // MARK: - School List Response
 /// 학교 목록 조회 응답 DTO
 public struct NoticeEditorSchoolListResponseDTO: Codable {
     public let schools: [NoticeEditorSchoolDTO]
+
+    private enum CodingKeys: String, CodingKey {
+        case schools
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.schools = try container.decode([NoticeEditorSchoolDTO].self, forKey: .schools)
+    }
 }
 
 // MARK: - School
@@ -44,13 +71,7 @@ public struct NoticeEditorSchoolDTO: Codable {
     /// String/Int 혼합 응답을 유연하게 처리합니다.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let id = try? container.decode(String.self, forKey: .schoolId) {
-            self.schoolId = id
-        } else if let id = try? container.decode(Int.self, forKey: .schoolId) {
-            self.schoolId = String(id)
-        } else {
-            self.schoolId = ""
-        }
+        self.schoolId = container.decodeFlexibleOptionalString(forKey: .schoolId) ?? ""
         self.schoolName = try container.decode(String.self, forKey: .schoolName)
     }
 }
@@ -59,6 +80,15 @@ public struct NoticeEditorSchoolDTO: Codable {
 /// 기수별 지부/학교 목록 조회 응답 DTO
 public struct ChapterWithSchoolsResponseDTO: Codable {
     public let chapters: [ChapterWithSchoolsDTO]
+
+    private enum CodingKeys: String, CodingKey {
+        case chapters
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.chapters = try container.decode([ChapterWithSchoolsDTO].self, forKey: .chapters)
+    }
 }
 
 // MARK: - Chapter With Schools
@@ -78,14 +108,25 @@ public struct ChapterWithSchoolsDTO: Codable {
     /// String/Int 혼합 응답을 유연하게 처리합니다.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let id = try? container.decode(String.self, forKey: .chapterId) {
-            self.chapterId = id
-        } else if let id = try? container.decode(Int.self, forKey: .chapterId) {
-            self.chapterId = String(id)
-        } else {
-            self.chapterId = ""
-        }
+        self.chapterId = container.decodeFlexibleOptionalString(forKey: .chapterId) ?? ""
         self.chapterName = try container.decode(String.self, forKey: .chapterName)
         self.schools = try container.decode([NoticeEditorSchoolDTO].self, forKey: .schools)
+    }
+}
+
+// MARK: - Flexible Decoding Helpers
+
+private extension KeyedDecodingContainer {
+    func decodeFlexibleOptionalString(forKey key: Key) -> String? {
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(Int(value))
+        }
+        return nil
     }
 }

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeEditorTargetDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeEditorTargetDTO.swift
@@ -1,0 +1,91 @@
+//
+//  NoticeEditorTargetDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+import Foundation
+
+// MARK: - Chapter List Response
+/// 지부 목록 조회 응답 DTO
+public struct ChapterListResponseDTO: Codable {
+    public let chapters: [ChapterDTO]
+}
+
+// MARK: - Chapter
+/// 지부 정보 DTO
+public struct ChapterDTO: Codable {
+    public let id: String
+    public let name: String
+}
+
+// MARK: - School List Response
+/// 학교 목록 조회 응답 DTO
+public struct NoticeEditorSchoolListResponseDTO: Codable {
+    public let schools: [NoticeEditorSchoolDTO]
+}
+
+// MARK: - School
+/// 학교 정보 DTO
+public struct NoticeEditorSchoolDTO: Codable {
+    public let schoolId: String
+    public let schoolName: String
+
+    private enum CodingKeys: String, CodingKey {
+        case schoolId
+        case schoolName
+    }
+
+    // MARK: - Init
+    /// String/Int 혼합 응답을 유연하게 처리합니다.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let id = try? container.decode(String.self, forKey: .schoolId) {
+            self.schoolId = id
+        } else if let id = try? container.decode(Int.self, forKey: .schoolId) {
+            self.schoolId = String(id)
+        } else {
+            self.schoolId = ""
+        }
+        self.schoolName = try container.decode(String.self, forKey: .schoolName)
+    }
+}
+
+// MARK: - Chapter With Schools Response
+/// 기수별 지부/학교 목록 조회 응답 DTO
+public struct ChapterWithSchoolsResponseDTO: Codable {
+    public let chapters: [ChapterWithSchoolsDTO]
+}
+
+// MARK: - Chapter With Schools
+/// 지부 + 소속 학교 목록 DTO
+public struct ChapterWithSchoolsDTO: Codable {
+    public let chapterId: String
+    public let chapterName: String
+    public let schools: [NoticeEditorSchoolDTO]
+
+    private enum CodingKeys: String, CodingKey {
+        case chapterId
+        case chapterName
+        case schools
+    }
+
+    // MARK: - Init
+    /// String/Int 혼합 응답을 유연하게 처리합니다.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let id = try? container.decode(String.self, forKey: .chapterId) {
+            self.chapterId = id
+        } else if let id = try? container.decode(Int.self, forKey: .chapterId) {
+            self.chapterId = String(id)
+        } else {
+            self.chapterId = ""
+        }
+        self.chapterName = try container.decode(String.self, forKey: .chapterName)
+        self.schools = try container.decode([NoticeEditorSchoolDTO].self, forKey: .schools)
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticePageDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticePageDTO.swift
@@ -1,0 +1,64 @@
+//
+//  NoticePageDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+/// 공지 목록/검색 전용 페이지 응답 DTO
+///
+/// 백엔드에서 숫자 필드를 문자열로 내려주는 스펙에 맞춰
+/// page/size/totalElements/totalPages를 String으로 처리합니다.
+public struct NoticePageDTO<T: Codable>: Codable {
+    public let content: [T]
+    public let page: String
+    public let size: String
+    public let totalElements: String
+    public let totalPages: String
+    public let hasNext: Bool
+    public let hasPrevious: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case content
+        case page
+        case size
+        case totalElements
+        case totalPages
+        case hasNext
+        case hasPrevious
+    }
+
+    /// 테스트/프리뷰용 멤버와이즈 이니셜라이저
+    public init(
+        content: [T],
+        page: String,
+        size: String,
+        totalElements: String,
+        totalPages: String,
+        hasNext: Bool,
+        hasPrevious: Bool?
+    ) {
+        self.content = content
+        self.page = page
+        self.size = size
+        self.totalElements = totalElements
+        self.totalPages = totalPages
+        self.hasNext = hasNext
+        self.hasPrevious = hasPrevious
+    }
+
+    /// 커스텀 디코더: 서버 응답의 페이징 메타데이터를 안전하게 파싱합니다.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.content = try container.decode([T].self, forKey: .content)
+        self.page = try container.decode(String.self, forKey: .page)
+        self.size = try container.decode(String.self, forKey: .size)
+        self.totalElements = try container.decode(String.self, forKey: .totalElements)
+        self.totalPages = try container.decode(String.self, forKey: .totalPages)
+        self.hasNext = try container.decode(Bool.self, forKey: .hasNext)
+        self.hasPrevious = try container.decodeIfPresent(Bool.self, forKey: .hasPrevious)
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeReadStatusDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeReadStatusDTO.swift
@@ -1,0 +1,192 @@
+//
+//  NoticeReadStatusDTO.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+import UMCFoundation
+
+// MARK: - 공지 열람 통계 DTO
+
+/// 공지 열람 통계 응답 DTO
+public struct NoticeReadStaticsDTO: Codable {
+    public let totalCount: String
+    public let readCount: String
+    public let unreadCount: String
+    public let readRate: String
+
+    /// 테스트/프리뷰 및 낙관적 UI 갱신용 멤버와이즈 이니셜라이저
+    public init(totalCount: String, readCount: String, unreadCount: String, readRate: String) {
+        self.totalCount = totalCount
+        self.readCount = readCount
+        self.unreadCount = unreadCount
+        self.readRate = readRate
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case totalCount
+        case readCount
+        case unreadCount
+        case readRate
+    }
+
+    /// 커스텀 디코더: 서버 응답의 숫자/문자열 타입 불일치를 유연하게 처리합니다.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.totalCount = container.decodeFlexibleString(forKey: .totalCount)
+        self.readCount = container.decodeFlexibleString(forKey: .readCount)
+        self.unreadCount = container.decodeFlexibleString(forKey: .unreadCount)
+        self.readRate = container.decodeFlexibleString(forKey: .readRate)
+    }
+}
+
+// MARK: - 공지 열람 현황 상세 DTO
+
+/// 공지 열람 현황 사용자 정보 DTO
+public struct NoticeReadStatusUserDTO: Codable {
+    public let challengerId: String
+    public let name: String
+    public let nickname: String?
+    public let profileImageUrl: String?
+    public let part: String
+    public let schoolId: String
+    public let schoolName: String
+    public let chapterId: String
+    public let chapterName: String
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerId
+        case name
+        case nickname
+        case profileImageUrl
+        case part
+        case schoolId
+        case schoolName
+        case chapterId
+        case chapterName
+    }
+
+    private enum AlternateNicknameCodingKeys: String, CodingKey {
+        case nickName
+        case authorNickname
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.challengerId = container.decodeFlexibleString(forKey: .challengerId)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.nickname = try Self.decodeNickname(
+            from: decoder,
+            primaryContainer: container
+        )
+        self.profileImageUrl = try? container.decodeIfPresent(String.self, forKey: .profileImageUrl)
+        self.part = try container.decode(String.self, forKey: .part)
+        self.schoolId = container.decodeFlexibleString(forKey: .schoolId)
+        self.schoolName = try container.decode(String.self, forKey: .schoolName)
+        self.chapterId = container.decodeFlexibleString(forKey: .chapterId)
+        self.chapterName = try container.decode(String.self, forKey: .chapterName)
+    }
+
+    private static func decodeNickname(
+        from decoder: Decoder,
+        primaryContainer: KeyedDecodingContainer<CodingKeys>
+    ) throws -> String? {
+        if let nickname = primaryContainer.decodeFirstNonEmptyString(forKeys: [.nickname]) {
+            return nickname
+        }
+
+        let alternateContainer = try decoder.container(keyedBy: AlternateNicknameCodingKeys.self)
+        return alternateContainer.decodeFirstNonEmptyString(forKeys: [.nickName, .authorNickname])
+    }
+}
+
+/// 공지 열람 현황 응답 DTO (Cursor 기반 페이징)
+public struct NoticeReadStatusResponseDTO: Codable {
+    public let content: [NoticeReadStatusUserDTO]
+    public let nextCursor: String
+    public let hasNext: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case content
+        case nextCursor
+        case hasNext
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.content = try container.decode([NoticeReadStatusUserDTO].self, forKey: .content)
+        self.nextCursor = container.decodeFlexibleOptionalString(forKey: .nextCursor) ?? ""
+        self.hasNext = try container.decode(Bool.self, forKey: .hasNext)
+    }
+}
+
+// MARK: - toDomain 변환
+
+extension NoticeReadStatusUserDTO {
+    /// DTO → ReadStatusUser 도메인 모델 변환
+    /// - Parameter isRead: 읽음/미읽음 상태 (API 호출 시 status 파라미터로 결정됨)
+    func toDomain(isRead: Bool) -> ReadStatusUser {
+        // part String → UMCPartType enum 변환
+        let userPart = UMCPartType(apiValue: part)
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNickname = nickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let resolvedNickname = trimmedNickname.isEmpty ? trimmedName : trimmedNickname
+        
+        return ReadStatusUser(
+            id: challengerId,
+            name: trimmedName,
+            nickName: resolvedNickname,
+            part: userPart?.name ?? "알 수 없음",
+            branch: chapterName,
+            campus: schoolName,
+            profileImageURL: profileImageUrl,
+            isRead: isRead
+        )
+    }
+}
+
+// MARK: - Flexible Decoding Helpers
+
+private extension KeyedDecodingContainer {
+    /// String, Int, Double 타입 중 하나로 디코딩하여 String으로 반환 (실패 시 빈 문자열)
+    func decodeFlexibleString(forKey key: Key) -> String {
+        if let value = try? decode(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(value)
+        }
+        return ""
+    }
+
+    /// String, Int, Double 타입 중 하나로 디코딩하여 Optional String으로 반환
+    func decodeFlexibleOptionalString(forKey key: Key) -> String? {
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decode(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decode(Double.self, forKey: key) {
+            return String(value)
+        }
+        return nil
+    }
+
+    func decodeFirstNonEmptyString(forKeys keys: [Key]) -> String? {
+        for key in keys {
+            guard let rawValue = decodeFlexibleOptionalString(forKey: key) else { continue }
+            let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeTargetInfoMapper.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeTargetInfoMapper.swift
@@ -1,0 +1,78 @@
+//
+//  NoticeTargetInfoMapper.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+import UMCFoundation
+
+/// NoticeTargetInfoDTO → 도메인 모델 변환 유틸리티
+extension NoticeTargetInfoDTO {
+
+    // MARK: - Computed Property
+    /// 기수 ID를 Int로 변환 (실패 시 0)
+    var generationValue: Int {
+        if let targetGisu, let generation = Int(targetGisu), generation > 0 {
+            return generation
+        }
+        return 0
+    }
+
+    /// targetInfo 기반으로 공지 출처(scope)를 추론합니다.
+    var resolvedScope: NoticeScope {
+        if targetSchoolId != nil {
+            return .campus
+        }
+        if targetChapterId != nil {
+            return .branch
+        }
+        return .central
+    }
+
+    /// targetInfo 기반으로 공지 카테고리를 추론합니다.
+    var resolvedCategory: NoticeCategory {
+        if let part = targetParts?.first {
+            return .part(part)
+        }
+        return .general
+    }
+
+    /// 일반 공지(scope=branch) 칩 표기용 이름을 제공합니다.
+    var resolvedScopeDisplayName: String? {
+        switch resolvedScope {
+        case .branch:
+            return resolvedChapterName
+        case .central, .campus:
+            return nil
+        }
+    }
+
+    var resolvedParts: [UMCPartType] {
+        targetParts ?? []
+    }
+
+    /// iOS-01 "UMC 공지" 필터에 포함되는지 여부를 반환합니다.
+    ///
+    /// 서버-01(전체 기수 전체 공지), 서버-03(특정 기수 전체 공지)만 허용합니다.
+    var isUMCWideGeneralNotice: Bool {
+        targetChapterId == nil && targetSchoolId == nil && resolvedParts.isEmpty
+    }
+
+    // MARK: - Function
+    /// TargetAudience 도메인 모델로 변환합니다.
+    func toTargetAudience(scope: NoticeScope? = nil) -> TargetAudience {
+        let targetScope = scope ?? resolvedScope
+        return TargetAudience(
+            generation: String(generationValue),
+            scope: targetScope,
+            parts: resolvedParts,
+            chapterId: targetChapterId,
+            schoolId: targetSchoolId,
+            branches: targetScope == .branch ? [resolvedChapterName].compactMap { $0 } : [],
+            schools: targetScope == .campus ? [resolvedSchoolName].compactMap { $0 } : []
+        )
+    }
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
@@ -1,5 +1,5 @@
 //
-//  NoticeDetailModel.swift
+//  NoticeDetail.swift
 //  NoticeDomain
 //
 //  Created by 이예지 on 5/8/26.
@@ -395,6 +395,26 @@ public struct ReadStatusUser: Equatable, Identifiable {
             campus: campus,
             isRead: isRead
         )
+    }
+    
+    public init(
+        id: String,
+        name: String,
+        nickName: String,
+        part: String,
+        branch: String,
+        campus: String,
+        profileImageURL: String?,
+        isRead: Bool
+    ) {
+        self.id = id
+        self.name = name
+        self.nickName = nickName
+        self.part = part
+        self.branch = branch
+        self.campus = campus
+        self.profileImageURL = profileImageURL
+        self.isRead = isRead
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

기존 AppProduct의 Notice Data Layer DTO를 UMCApp으로 이식합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음

## 🛠️ 작업내용

**Response DTO**
- NoticeDTO, NoticeTargetInfoDTO 이식
- NoticeTargetInfoMapper 이식 (toDomain 매핑, UMCApp 도메인 타입에 맞게 조정)
- NoticeDetailDTO 이식
- NoticeDetailContentDTO 이식 (Vote / VoteOption / Image / Link)
- NoticePageDTO 이식
- NoticeReadStatusDTO 이식 (통계 / 열람 현황 사용자)
- NoticeEditorTargetDTO 이식 (Chapter / School 목록)

**Request DTO**
- NoticePostRequestDTO 이식 (TargetInfoDTO: Home에서 이동)
- NoticePatchRequestDTO 이식
- NoticeImagesRequestDTO 이식
- NoticeLinksRequestDTO 이식
- NoticeReminderRequestDTO 이식
- NoticeVoteResponseRequestDTO 이식
- VoteDTO 이식 (AddVoteRequestDTO / AddVoteResponseDTO)
- NoticeReadStatusListQuery 이식

**Domain 수정**
- ReadStatusUser에 public init 추가 (Data 모듈에서 접근 가능하도록)

**AppProduct → UMCApp 주요 타입 조정**
- `generation`, `viewCount`: Int → String
- `voteCount`, `voteRate`, `totalParticipants`: Int/Double → String
- `TargetAudience.chapterId`, `schoolId`: Int? → String? (직접 String 필드 사용)

## 📋 추후 진행 상황

- Notice Router 이식
- Notice Repository 구현체 이식

## 📌 리뷰 포인트

- `NoticeTargetInfoMapper`: `toTargetAudience()`에서 generation/chapterId/schoolId 타입 변환 로직 확인
- `NoticeDetailContentDTO`: VoteOption의 voteRate를 Double?→String?로 DTO 단에서 처리
- `NoticePostRequestDTO`: TargetInfoDTO 출처 (AppProduct/Home → Notice Data로 이동)
- `ReadStatusUser`: public init 추가로 인한 모듈 간 접근 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)