### PR TITLE
♻️ [Refactor] Notice Router 및 Query DTO 작성

### DIFF
--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/ChaptersWithSchoolsQuery.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/ChaptersWithSchoolsQuery.swift
@@ -1,0 +1,30 @@
+//
+//  ChaptersWithSchoolsQuery.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+
+/// 기수별 지부 및 소속 학교 목록 조회 Query DTO
+///
+/// `GET /api/v1/chapters/with-schools`
+public struct ChaptersWithSchoolsQuery {
+
+    // MARK: - Property
+
+    /// 기수 ID
+    public let gisuId: String
+
+    // MARK: - Init
+
+    public init(gisuId: String) {
+        self.gisuId = gisuId
+    }
+
+    /// Query Parameter Dictionary 변환
+    public var toParameters: [String: Any] {
+        ["gisuId": gisuId]
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeListQuery.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeListQuery.swift
@@ -1,0 +1,63 @@
+//
+//  NoticeListQuery.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+import UMCFoundation
+
+/// 공지 목록/검색 조회 Query DTO
+///
+///`GET /api/v1/notices`, `GET /api/v1/notices/search`
+
+public struct NoticeListQuery: Encodable {
+    public let gisuId: String
+    public let chapterId: String?
+    public let schoolId: String?
+    public let part: UMCPartType?
+    public let page: Int
+    public let size: Int
+    public let sort: [String]
+    
+    public init(
+        gisuId: String,
+        chapterId: String?,
+        schoolId: String?,
+        part: UMCPartType?,
+        page: Int,
+        size: Int,
+        sort: [String]
+    ) {
+        self.gisuId = gisuId
+        self.chapterId = chapterId
+        self.schoolId = schoolId
+        self.part = part
+        self.page = page
+        self.size = size
+        self.sort = sort
+    }
+    
+    public var toParameters: [String: Any] {
+        var params: [String: Any] = [
+            "gisuId": gisuId,
+            "page": page,
+            "size": size,
+        ]
+        if !sort.isEmpty {
+            params["sort"] = sort
+        }
+        if let chapterId = chapterId {
+            params["chapterId"] = chapterId
+        }
+        if let schoolId = schoolId {
+            params["schoolId"] = schoolId
+        }
+        if let part = part {
+            params["part"] = part.apiValue
+        }
+        return params
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeSearchQuery.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeSearchQuery.swift
@@ -1,0 +1,80 @@
+//
+//  NoticeSearchQuery.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+import UMCFoundation
+
+/// 공지사항 검색 Query DTO
+///
+/// `GET /api/v1/notices/search`
+public struct NoticeSearchQuery {
+
+    // MARK: - Property
+
+    /// 검색 키워드
+    public let keyword: String
+    /// 기수 ID
+    public let gisuId: String
+    /// 지부 ID
+    public let chapterId: String?
+    /// 학교 ID
+    public let schoolId: String?
+    /// 파트
+    public let part: UMCPartType?
+    /// 페이지 번호
+    public let page: Int
+    /// 페이지 크기
+    public let size: Int
+    /// 정렬 기준
+    public let sort: [String]
+
+    // MARK: - Init
+
+    public init(
+        keyword: String,
+        gisuId: String,
+        chapterId: String?,
+        schoolId: String?,
+        part: UMCPartType?,
+        page: Int,
+        size: Int,
+        sort: [String]
+    ) {
+        self.keyword = keyword
+        self.gisuId = gisuId
+        self.chapterId = chapterId
+        self.schoolId = schoolId
+        self.part = part
+        self.page = page
+        self.size = size
+        self.sort = sort
+    }
+
+    /// Query Parameter Dictionary 변환
+    public var toParameters: [String: Any] {
+        var params: [String: Any] = [
+            "keyword": keyword,
+            "gisuId": gisuId,
+            "page": page,
+            "size": size
+        ]
+        if !sort.isEmpty {
+            params["sort"] = sort
+        }
+        if let chapterId {
+            params["chapterId"] = chapterId
+        }
+        if let schoolId {
+            params["schoolId"] = schoolId
+        }
+        if let part {
+            params["part"] = part.apiValue
+        }
+        return params
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/Router/NoticeEditorTargetRouter.swift
+++ b/UMCApp/Features/Notice/Data/Sources/Router/NoticeEditorTargetRouter.swift
@@ -19,7 +19,7 @@ public enum NoticeEditorTargetRouter: BaseTargetType {
     /// 전체 학교 목록 조회
     case getAllSchools
     /// 기수별 지부 및 소속 학교 목록 조회
-    case getChaptersWithSchools(gisuId: String)
+    case getChaptersWithSchools(query: ChaptersWithSchoolsQuery)
     /// 지부 단건 조회
     case getChapter(chapterId: String)
 
@@ -52,9 +52,9 @@ public enum NoticeEditorTargetRouter: BaseTargetType {
         switch self {
         case .getAllChapters, .getAllSchools:
             return .requestPlain
-        case .getChaptersWithSchools(let gisuId):
+        case .getChaptersWithSchools(let query):
             return .requestParameters(
-                parameters: ["gisuId": gisuId],
+                parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
         case .getChapter:

--- a/UMCApp/Features/Notice/Data/Sources/Router/NoticeEditorTargetRouter.swift
+++ b/UMCApp/Features/Notice/Data/Sources/Router/NoticeEditorTargetRouter.swift
@@ -1,0 +1,64 @@
+//
+//  NoticeEditorTargetRouter.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import Moya
+import CoreNetwork
+
+/// 공지 에디터 타겟(지부/학교) 목록 조회용 API 라우터
+public enum NoticeEditorTargetRouter: BaseTargetType {
+
+    // MARK: - Case
+
+    /// 전체 지부 목록 조회
+    case getAllChapters
+    /// 전체 학교 목록 조회
+    case getAllSchools
+    /// 기수별 지부 및 소속 학교 목록 조회
+    case getChaptersWithSchools(gisuId: String)
+    /// 지부 단건 조회
+    case getChapter(chapterId: String)
+
+    // MARK: - BaseTargetType
+
+    /// API 경로
+    public var path: String {
+        switch self {
+        case .getAllChapters:
+            return "/api/v1/chapters"
+        case .getAllSchools:
+            return "/api/v1/schools/all"
+        case .getChaptersWithSchools:
+            return "/api/v1/chapters/with-schools"
+        case .getChapter(let chapterId):
+            return "/api/v1/chapters/\(chapterId)"
+        }
+    }
+
+    /// HTTP 메서드
+    public var method: Moya.Method {
+        switch self {
+        case .getAllChapters, .getAllSchools, .getChaptersWithSchools, .getChapter:
+            return .get
+        }
+    }
+
+    /// 요청 파라미터 구성
+    public var task: Task {
+        switch self {
+        case .getAllChapters, .getAllSchools:
+            return .requestPlain
+        case .getChaptersWithSchools(let gisuId):
+            return .requestParameters(
+                parameters: ["gisuId": gisuId],
+                encoding: URLEncoding.queryString
+            )
+        case .getChapter:
+            return .requestPlain
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Data/Sources/Router/NoticeRouter.swift
+++ b/UMCApp/Features/Notice/Data/Sources/Router/NoticeRouter.swift
@@ -9,7 +9,6 @@ import Foundation
 import Moya
 import CoreNetwork
 
-// get post put patch delete
 /// Notice 관련 API 엔드포인트 정의
 public enum NoticeRouter: BaseTargetType {
     
@@ -27,10 +26,7 @@ public enum NoticeRouter: BaseTargetType {
         query: NoticeReadStatusListQuery
     )
     /// 공지사항 검색
-    case searchNotice(
-        keyword: String,
-        request: NoticeListQuery
-    )
+    case searchNotice(query: NoticeSearchQuery)
     
     // POST Method
     /// 공지사항 생성
@@ -72,7 +68,7 @@ public enum NoticeRouter: BaseTargetType {
     /// 공지사항 수정
     case updateNotice(
         noticeId: String,
-        body: UpdateNoticeRequestDTO
+        body: NoticePatchRequestDTO
     )
     /// 공지사항 링크 수정
     case updateLink(
@@ -101,6 +97,7 @@ public enum NoticeRouter: BaseTargetType {
         case .getDetailNotice(let noticeId):
             return "/api/v1/notices/\(noticeId)"
         case .getNoticeReadStatusCount(let noticeId):
+            // FIXME: 서버 스펙 확인 필요 (read-statics 오타 의심)
             return "/api/v1/notices/\(noticeId)/read-statics"
         case .getNoticeReadStatusList(let noticeId, _):
             return "/api/v1/notices/\(noticeId)/read-status"
@@ -140,9 +137,14 @@ public enum NoticeRouter: BaseTargetType {
     /// 각 케이스에 대응하는 HTTP 메서드
     public var method: Moya.Method {
         switch self {
-        case .getAllNotices, .getDetailNotice, .getNoticeReadStatusCount, .getNoticeReadStatusList, .searchNotice:
+        case .getAllNotices,
+             .getDetailNotice,
+             .getNoticeReadStatusCount,
+             .getNoticeReadStatusList,
+             .searchNotice:
             return .get
-        case .postNotice, .addVote, .addLink, .addImage, .sendReminder, .readNotice, .submitVoteResponse:
+        case .postNotice, .addVote, .addLink, .addImage,
+             .sendReminder, .readNotice, .submitVoteResponse:
             return .post
         case .updateVoteResponse:
             return .put
@@ -172,11 +174,9 @@ public enum NoticeRouter: BaseTargetType {
                 parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
-        case .searchNotice(let keyword, let request):
-            var params = request.toParameters
-            params["keyword"] = keyword
+        case .searchNotice(let query):
             return .requestParameters(
-                parameters: params,
+                parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
         case .postNotice(let body):

--- a/UMCApp/Features/Notice/Data/Sources/Router/NoticeRouter.swift
+++ b/UMCApp/Features/Notice/Data/Sources/Router/NoticeRouter.swift
@@ -1,0 +1,209 @@
+//
+//  NoticeRouter.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import Moya
+import CoreNetwork
+
+// get post put patch delete
+/// Notice 관련 API 엔드포인트 정의
+public enum NoticeRouter: BaseTargetType {
+    
+    // MARK: - Cases
+    
+    /// 공지사항 전체 조회
+    case getAllNotices(request: NoticeListQuery)
+    /// 공지사항 상세 조회
+    case getDetailNotice(noticeId: String)
+    /// 공지 열람 현황 통계 조회 (수치)
+    case getNoticeReadStatusCount(noticeId: String)
+    /// 공지 열람 현황 상세 조회 (사용자 리스트)
+    case getNoticeReadStatusList(
+        noticeId: String,
+        query: NoticeReadStatusListQuery
+    )
+    /// 공지사항 검색
+    case searchNotice(
+        keyword: String,
+        request: NoticeListQuery
+    )
+    
+    // POST Method
+    /// 공지사항 생성
+    case postNotice(body: PostNoticeRequestDTO)
+    /// 공지사항 투표 추가
+    case addVote(
+        noticeId: String,
+        body: AddVoteRequestDTO
+    )
+    /// 공지사항 링크 추가
+    case addLink(
+        noticeId: String,
+        body: NoticeLinksRequestDTO
+    )
+    /// 공지사항 이미지 추가
+    case addImage(
+        noticeId: String,
+        body: NoticeImagesRequestDTO
+    )
+    /// 공지사항 리마인더 발송
+    case sendReminder(
+        noticeId: String,
+        body: NoticeReminderRequestDTO
+    )
+    /// 공지사항 읽음 처리
+    case readNotice(noticeId: String)
+    /// 투표 응답(사용자 선택 전송)
+    case submitVoteResponse(
+        noticeId: String,
+        body: NoticeVoteResponseRequestDTO
+    )
+    /// 투표 응답 수정
+    case updateVoteResponse(
+        noticeId: String,
+        body: NoticeVoteResponseRequestDTO
+    )
+    
+    // PATCH Method
+    /// 공지사항 수정
+    case updateNotice(
+        noticeId: String,
+        body: UpdateNoticeRequestDTO
+    )
+    /// 공지사항 링크 수정
+    case updateLink(
+        noticeId: String,
+        body: NoticeLinksRequestDTO
+    )
+    /// 공지사항 이미지 수정
+    case updateImage(
+        noticeId: String,
+        body: NoticeImagesRequestDTO
+    )
+    
+    // DELETE Method
+    /// 공지사항 삭제
+    case deleteNotice(noticeId: String)
+    /// 공지사항 연결 투표 삭제
+    case deleteVote(noticeId: String)
+    
+    // MARK: - Path
+
+    /// 각 케이스에 대응하는 API 엔드포인트 경로
+    public var path: String {
+        switch self {
+        case .getAllNotices:
+            return "/api/v1/notices"
+        case .getDetailNotice(let noticeId):
+            return "/api/v1/notices/\(noticeId)"
+        case .getNoticeReadStatusCount(let noticeId):
+            return "/api/v1/notices/\(noticeId)/read-statics"
+        case .getNoticeReadStatusList(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/read-status"
+        case .searchNotice:
+            return "/api/v1/notices/search"
+        case .postNotice:
+            return "/api/v1/notices"
+        case .addVote(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/votes"
+        case .addLink(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/links"
+        case .addImage(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/images"
+        case .sendReminder(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/reminders"
+        case .readNotice(let noticeId):
+            return "/api/v1/notices/\(noticeId)/read"
+        case .submitVoteResponse(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/votes/responses"
+        case .updateVoteResponse(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/votes/responses"
+        case .updateNotice(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)"
+        case .updateLink(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/links"
+        case .updateImage(let noticeId, _):
+            return "/api/v1/notices/\(noticeId)/images"
+        case .deleteNotice(let noticeId):
+            return "/api/v1/notices/\(noticeId)"
+        case .deleteVote(let noticeId):
+            return "/api/v1/notices/\(noticeId)/vote"
+        }
+    }
+    
+    // MARK: - Method
+
+    /// 각 케이스에 대응하는 HTTP 메서드
+    public var method: Moya.Method {
+        switch self {
+        case .getAllNotices, .getDetailNotice, .getNoticeReadStatusCount, .getNoticeReadStatusList, .searchNotice:
+            return .get
+        case .postNotice, .addVote, .addLink, .addImage, .sendReminder, .readNotice, .submitVoteResponse:
+            return .post
+        case .updateVoteResponse:
+            return .put
+        case .updateNotice, .updateLink, .updateImage:
+            return .patch
+        case .deleteNotice, .deleteVote:
+            return .delete
+        }
+    }
+    
+    // MARK: - Task
+
+    /// 각 케이스에 대응하는 요청 파라미터 및 인코딩 방식
+    public var task: Moya.Task {
+        switch self {
+        case .getAllNotices(let request):
+            return .requestParameters(
+                parameters: request.toParameters,
+                encoding: URLEncoding.queryString
+            )
+        case .getDetailNotice:
+            return .requestPlain
+        case .getNoticeReadStatusCount:
+            return .requestPlain
+        case .getNoticeReadStatusList(_, let query):
+            return .requestParameters(
+                parameters: query.toParameters,
+                encoding: URLEncoding.queryString
+            )
+        case .searchNotice(let keyword, let request):
+            var params = request.toParameters
+            params["keyword"] = keyword
+            return .requestParameters(
+                parameters: params,
+                encoding: URLEncoding.queryString
+            )
+        case .postNotice(let body):
+            return .requestJSONEncodable(body)
+        case .addVote(_, let body):
+            return .requestJSONEncodable(body)
+        case .addLink(_, let body):
+            return .requestJSONEncodable(body)
+        case .addImage(_, let body):
+            return .requestJSONEncodable(body)
+        case .sendReminder(_, let body):
+            return .requestJSONEncodable(body)
+        case .readNotice:
+            return .requestPlain
+        case .submitVoteResponse(_, let body):
+            return .requestJSONEncodable(body)
+        case .updateVoteResponse(_, let body):
+            return .requestJSONEncodable(body)
+        case .updateNotice(_, let body):
+            return .requestJSONEncodable(body)
+        case .updateLink(_, let body):
+            return .requestJSONEncodable(body)
+        case .updateImage(_, let body):
+            return .requestJSONEncodable(body)
+        case .deleteNotice, .deleteVote:
+            return .requestPlain
+        }
+    }
+}
+


### PR DESCRIPTION
## ✨ PR 유형

기존 AppProduct의 Notice Data Layer Router를 UMCApp으로 이식하고, Notice 목록/검색 조회용 Query DTO를 작성합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음

## 🛠️ 작업내용

- `NoticeEditorTargetRouter` 작성: 지부/학교 목록 조회 엔드포인트 (BaseTargetType 기반)
- `NoticeListQuery` 작성: 공지 목록/검색 조회용 Query DTO (AppProduct Home의 NoticeListRequestDTO에서 분리, ID 타입 String으로 통일)
- `NoticeRouter` 작성: 공지 전체 API 엔드포인트 (목록/상세/열람현황/검색/생성/수정/삭제/투표/리마인더)

**AppProduct 대비 주요 변경사항**
- `noticeId`, `gisuId`, `chapterId`, `schoolId` 타입 Int → String (도메인 모델 일관성)
- `internal import Alamofire` 제거, `import CoreNetwork`로 대체

## 📋 추후 진행 상황

- Notice Repository 구현체 작성

## 📌 리뷰 포인트

- `NoticeRouter`: path 변수 타입이 String으로 바뀐 것이 기존 AppProduct와 다름 — 호출부(Repository)에서 변환 없이 도메인 ID를 그대로 넘길 수 있는지 확인
- `NoticeListQuery`: `gisuId` 등 ID 필드가 String인데 `toParameters`의 URL 인코딩 결과가 서버 스펙과 일치하는지 확인
- `NoticeEditorTargetRouter`: `getChaptersWithSchools(gisuId:)` 쿼리 파라미터 타입 변경 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)