### PR TITLE
♻️ [Refactor] NoticeRepositoryProtocol 이식

### DIFF
--- a/UMCApp/Features/Notice/Data/Sources/NoticeRepositoryProtocol.swift
+++ b/UMCApp/Features/Notice/Data/Sources/NoticeRepositoryProtocol.swift
@@ -1,0 +1,102 @@
+//
+//  NoticeRepositoryProtocol.swift
+//  NoticeDomain
+//
+//  Created by 이예지 on 5/17/26.
+//
+
+import Foundation
+import NoticeDomain
+
+/// 공지사항 데이터 접근 계층 인터페이스
+///
+/// 공지사항 CRUD, 열람 현황, 투표, 리마인더 등 데이터 소스 접근을 추상화합니다.
+public protocol NoticeRepositoryProtocol {
+    
+    // MARK: - 공지 생성
+    /// 공지사항 전체 생성
+    func createNotice(
+        body: PostNoticeRequestDTO,
+        // TODO: 투표
+        links: [String],
+        imageIds: [String]
+    ) async throws -> NoticeDetail
+    
+    /// 공지사항 글 생성
+    func postNotice(body: PostNoticeRequestDTO) async throws -> NoticeItemModel
+    
+    /// 공지사항 투표 추가
+    func addVote(
+        noticeId: String,
+        body: AddVoteRequestDTO
+    ) async throws -> AddVoteResponseDTO
+    
+    /// 공지사항 링크 추가
+    func addLink(noticeId: String, links: [String]) async throws -> NoticeItemModel
+    
+    /// 공지사항 이미지 추가
+    func addImage(noticeId: String, imageIds: [String]) async throws -> NoticeItemModel
+    
+    /// 공지사항 리마인더 발송
+    func sendReminder(noticeId: String, targetIds: [Int]) async throws
+    
+    /// 공지사항 읽음 처리
+    func readNotice(noticeId: String) async throws
+
+    /// 투표 응답(사용자 선택 전송)
+    func submitVoteResponse(noticeId: String, optionIds: [Int]) async throws
+
+    /// 투표 응답 수정
+    func updateVoteResponse(noticeId: String, optionIds: [Int]) async throws
+    
+    // MARK: - 공지 수정
+    /// 공지사항 수정 (제목, 본문)
+    func updateNotice(
+        noticeId: String,
+        body: UpdateNoticeRequestDTO
+    ) async throws -> NoticeDetail
+    
+    /// 공지사항 링크 수정
+    func updateLinks(
+        noticeId: String,
+        links: [String]
+    ) async throws -> NoticeDetail
+    
+    /// 공지사항 이미지 수정
+    func updateImages(
+        noticeId: String,
+        imageIds: [String]
+    ) async throws -> NoticeDetail
+    
+    // MARK: - 공지 조회
+    /// 공지사항 전체 조회
+    func getAllNotices(request: NoticeListQuery) async throws -> NoticePageDTO<NoticeDTO>
+    
+    /// 공지사항 상세 조회
+    func getDetailNotice(noticeId: String) async throws -> NoticeDetail
+    
+    /// 공지 열람 통계 조회
+    func getReadStatics(noticeId: String) async throws -> NoticeReadStaticsDTO
+    
+    /// 공지 열람 현황 상세 조회
+    func getReadStatusList(
+        noticeId: String,
+        cursorId: Int,
+        filterType: String,
+        organizationIds: [Int],
+        status: String
+    ) async throws -> NoticeReadStatusResponseDTO
+    
+    /// 공지사항 검색
+    func searchNotice(
+        keyword: String,
+        request: NoticeListQuery
+    ) async throws -> NoticePageDTO<NoticeDTO>
+    
+    // MARK: - 공지 삭제
+    /// 공지사항 삭제
+    func deleteNotice(noticeId: String) async throws
+
+    /// 공지사항에 연결된 투표 삭제
+    func deleteVote(noticeId: String) async throws
+}

--- a/UMCApp/Features/Notice/Data/Sources/NoticeRepositoryProtocol.swift
+++ b/UMCApp/Features/Notice/Data/Sources/NoticeRepositoryProtocol.swift
@@ -25,6 +25,7 @@ public protocol NoticeRepositoryProtocol {
     /// 공지사항 글 생성
     func postNotice(body: PostNoticeRequestDTO) async throws -> NoticeItemModel
     
+    // TODO: Data DTO 직접 노출 — Domain 모델 반환으로 점진 교체 예정
     /// 공지사항 투표 추가
     func addVote(
         noticeId: String,
@@ -38,22 +39,22 @@ public protocol NoticeRepositoryProtocol {
     func addImage(noticeId: String, imageIds: [String]) async throws -> NoticeItemModel
     
     /// 공지사항 리마인더 발송
-    func sendReminder(noticeId: String, targetIds: [Int]) async throws
+    func sendReminder(noticeId: String, targetIds: [String]) async throws
     
     /// 공지사항 읽음 처리
     func readNotice(noticeId: String) async throws
 
     /// 투표 응답(사용자 선택 전송)
-    func submitVoteResponse(noticeId: String, optionIds: [Int]) async throws
+    func submitVoteResponse(noticeId: String, optionIds: [String]) async throws
 
     /// 투표 응답 수정
-    func updateVoteResponse(noticeId: String, optionIds: [Int]) async throws
+    func updateVoteResponse(noticeId: String, optionIds: [String]) async throws
     
     // MARK: - 공지 수정
     /// 공지사항 수정 (제목, 본문)
     func updateNotice(
         noticeId: String,
-        body: UpdateNoticeRequestDTO
+        body: NoticePatchRequestDTO
     ) async throws -> NoticeDetail
     
     /// 공지사항 링크 수정
@@ -69,24 +70,29 @@ public protocol NoticeRepositoryProtocol {
     ) async throws -> NoticeDetail
     
     // MARK: - 공지 조회
+    // TODO: Data DTO 직접 노출 — Domain 모델 반환으로 점진 교체 예정
     /// 공지사항 전체 조회
     func getAllNotices(request: NoticeListQuery) async throws -> NoticePageDTO<NoticeDTO>
-    
+
     /// 공지사항 상세 조회
     func getDetailNotice(noticeId: String) async throws -> NoticeDetail
-    
+
+    // TODO: Data DTO 직접 노출 — Domain 모델 반환으로 점진 교체 예정
+    // NOTE: 메서드명 `getReadStatics`는 서버 엔드포인트(read-statics) 오타 의심 — 서버 스펙 확정 후 getReadStatistics로 일괄 교체 예정
     /// 공지 열람 통계 조회
     func getReadStatics(noticeId: String) async throws -> NoticeReadStaticsDTO
-    
+
+    // TODO: Data DTO 직접 노출 — Domain 모델 반환으로 점진 교체 예정
     /// 공지 열람 현황 상세 조회
     func getReadStatusList(
         noticeId: String,
-        cursorId: Int,
+        cursorId: String,
         filterType: String,
-        organizationIds: [Int],
+        organizationIds: [String],
         status: String
     ) async throws -> NoticeReadStatusResponseDTO
-    
+
+    // TODO: Data DTO 직접 노출 — Domain 모델 반환으로 점진 교체 예정
     /// 공지사항 검색
     func searchNotice(
         keyword: String,


### PR DESCRIPTION
## ✨ PR 유형

리팩토링 - AppProduct의 `NoticeRepositoryProtocol`을 UMCApp Data 레이어로 이식

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

- `NoticeRepositoryProtocol` 이식
  - 위치: `UMCApp/Features/Notice/Data/Sources/NoticeRepositoryProtocol.swift`
  - Domain 레이어 대신 Data 레이어에 배치 (Domain → Data 의존성 역전 원칙 준수)
    - 해당 프로토콜이 `NoticePageDTO`, `NoticeReadStaticsDTO` 등 Data 레이어 타입을 반환 타입으로 사용하므로, Domain 모듈에 위치할 수 없음
  - `public protocol`로 접근 제어자 변경
  - 모든 `noticeId: Int` → `noticeId: String` 변경
  - `request: NoticeListRequestDTO` → `query: NoticeListQuery` 변경 (2개 메서드)
  - `import NoticeDomain` 추가 (도메인 모델 타입 참조용)

## 📋 추후 진행 상황

- NoticeRepository 구현체 이식 (read 파트)
- 향후 프로토콜 반환 타입을 Domain 타입으로 점진적 교체 (DTO 노출 최소화)

## 📌 리뷰 포인트

- `Features/Notice/Data/` — Data 레이어에 Protocol을 배치한 이유 확인 필요 (Domain이 Data 타입을 참조할 수 없으므로)
- `NoticeRepositoryProtocol` — `getReadStatusList` 파라미터가 아직 DTO/원시 타입 혼재, 추후 Query DTO로 분리 예정

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)