### PR TITLE
🐛 [Fix] 운영진 공지 작성 시 targetNoticeTab 필드 누락 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
@@ -152,36 +152,44 @@ struct TargetInfoDTO: Codable {
     let targetChapterId: Int?
     let targetSchoolId: Int?
     let targetParts: [UMCPartType]?
+    /// 운영진 공지 탭 식별자 (CENTRAL_MEMBER / SCHOOL_CORE / SCHOOL_PART_LEADER).
+    /// 챌린저 공지 작성 시 nil.
+    let targetNoticeTab: String?
 
     private enum CodingKeys: String, CodingKey {
         case targetGisuId
         case targetChapterId
         case targetSchoolId
         case targetParts
+        case targetNoticeTab
     }
 
     init(
         targetGisuId: Int,
         targetChapterId: Int?,
         targetSchoolId: Int?,
-        targetParts: UMCPartType?
+        targetParts: UMCPartType?,
+        targetNoticeTab: String? = nil
     ) {
         self.targetGisuId = targetGisuId
         self.targetChapterId = targetChapterId
         self.targetSchoolId = targetSchoolId
         self.targetParts = targetParts.map { [$0] }
+        self.targetNoticeTab = targetNoticeTab
     }
 
     init(
         targetGisuId: Int,
         targetChapterId: Int?,
         targetSchoolId: Int?,
-        targetParts: [UMCPartType]?
+        targetParts: [UMCPartType]?,
+        targetNoticeTab: String? = nil
     ) {
         self.targetGisuId = targetGisuId
         self.targetChapterId = targetChapterId
         self.targetSchoolId = targetSchoolId
         self.targetParts = targetParts
+        self.targetNoticeTab = targetNoticeTab
     }
 
     init(from decoder: Decoder) throws {
@@ -190,6 +198,7 @@ struct TargetInfoDTO: Codable {
         self.targetChapterId = try container.decodeIntFlexibleIfPresent(forKey: .targetChapterId)
         self.targetSchoolId = try container.decodeIntFlexibleIfPresent(forKey: .targetSchoolId)
         self.targetParts = try container.decodeIfPresent([UMCPartType].self, forKey: .targetParts)
+        self.targetNoticeTab = try container.decodeIfPresent(String.self, forKey: .targetNoticeTab)
     }
 
     /// 공지 생성/수정 요청 인코딩 시 null 규칙을 맞춥니다.
@@ -212,6 +221,8 @@ struct TargetInfoDTO: Codable {
         } else {
             try container.encodeNil(forKey: .targetParts)
         }
+
+        try container.encodeIfPresent(targetNoticeTab, forKey: .targetNoticeTab)
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
@@ -239,7 +239,8 @@ extension NoticeEditorViewModel {
                     targetGisuId: 0,
                     targetChapterId: nil,
                     targetSchoolId: nil,
-                    targetParts: nil as [UMCPartType]?
+                    targetParts: nil as [UMCPartType]?,
+                    targetNoticeTab: StaffNoticeTab.centralMember.rawValue
                 )
             case .schoolCore:
                 let schoolCoreSchoolId: Int? = (memberRole?.bindsOwnSchoolForSchoolCoreNotice ?? false)
@@ -249,7 +250,8 @@ extension NoticeEditorViewModel {
                     targetGisuId: 0,
                     targetChapterId: nil,
                     targetSchoolId: schoolCoreSchoolId,
-                    targetParts: nil as [UMCPartType]?
+                    targetParts: nil as [UMCPartType]?,
+                    targetNoticeTab: StaffNoticeTab.schoolCore.rawValue
                 )
             case .schoolPartLeader:
                 let partLeaderSchoolId: Int? = (memberRole?.bindsOwnSchoolForPartLeaderNotice ?? false)
@@ -259,7 +261,8 @@ extension NoticeEditorViewModel {
                     targetGisuId: 0,
                     targetChapterId: nil,
                     targetSchoolId: partLeaderSchoolId,
-                    targetParts: managementParts
+                    targetParts: managementParts,
+                    targetNoticeTab: StaffNoticeTab.schoolPartLeader.rawValue
                 )
             }
         }


### PR DESCRIPTION
## ✨ PR 유형

Fix — 서버 API 거절 유발 버그 수정

## 🛠️ 작업내용

- `TargetInfoDTO` 에 `targetNoticeTab: String?` 필드 추가 (Codable 호환)
- `.management` 시나리오 → `targetNoticeTab` 매핑 추가
  - `.centralAll` → `CENTRAL_MEMBER`
  - `.schoolCore` → `SCHOOL_CORE`
  - `.schoolPartLeader` → `SCHOOL_PART_LEADER`
- 챌린저 공지는 `nil` 유지하여 `encodeIfPresent` 로 누락 처리

## 📌 리뷰 포인트

- `Features/Home/Data/DTO/NoticeListDTO.swift` — `TargetInfoDTO` 필드/이니셜라이저/encode/decode 동기화
- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift` — `buildTargetInfo()` 의 `.management` 케이스

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석 처리 작성

Closes #758