### PR TITLE
🐛 [Fix] 운영진 공지 targetGisuId 0 하드코딩 제거

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
@@ -233,10 +233,11 @@ extension NoticeEditorViewModel {
             let managementParts = subCategorySelection.selectedParts.isEmpty
                 ? nil
                 : Array(subCategorySelection.selectedParts)
+            // 서버 스펙: 운영진 공지는 기수 필수. 작성자의 현재 기수를 사용.
             switch scenario {
             case .centralAll:
                 return TargetInfoDTO(
-                    targetGisuId: 0,
+                    targetGisuId: currentGeneration,
                     targetChapterId: nil,
                     targetSchoolId: nil,
                     targetParts: nil as [UMCPartType]?
@@ -246,7 +247,7 @@ extension NoticeEditorViewModel {
                     ? (schoolId > 0 ? schoolId : nil)
                     : nil
                 return TargetInfoDTO(
-                    targetGisuId: 0,
+                    targetGisuId: currentGeneration,
                     targetChapterId: nil,
                     targetSchoolId: schoolCoreSchoolId,
                     targetParts: nil as [UMCPartType]?
@@ -256,7 +257,7 @@ extension NoticeEditorViewModel {
                     ? (schoolId > 0 ? schoolId : nil)
                     : nil
                 return TargetInfoDTO(
-                    targetGisuId: 0,
+                    targetGisuId: currentGeneration,
                     targetChapterId: nil,
                     targetSchoolId: partLeaderSchoolId,
                     targetParts: managementParts

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
@@ -209,7 +209,7 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
 
     /// 저장 가능 여부
     ///
-    /// 생성: 제목/내용 필수
+    /// 생성: 제목/내용 필수 (+ 운영진 공지는 기수 필수)
     /// 수정: 제목/내용 필수 + 실제 변경사항 존재
     var canSubmit: Bool {
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -218,6 +218,10 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
 
         switch mode {
         case .create:
+            // 서버 스펙: 운영진 공지는 기수 필수
+            if case .management = selectedCategory, resolvedGisuId <= 0 {
+                return false
+            }
             return hasRequiredFields
         case .edit:
             return hasRequiredFields && hasEditableChanges


### PR DESCRIPTION
## ✨ PR 유형

Fix — 서버 거절 유발 버그 수정

## 🛠️ 작업내용

- `buildTargetInfo()` 의 `.management` 3개 케이스에서 `currentGeneration` (작성자 본인 기수) 사용
- `canSubmit` 에 운영진 공지의 `resolvedGisuId > 0` 검증 추가 → 기수 미해결 시 저장 버튼 비활성
- 서버 스펙 '운영진 공지 기수 필수' 위반 해소

## 📌 리뷰 포인트

- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift` — `.management` 케이스 기수 매핑
- `Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift` — `canSubmit` 운영진 공지 분기

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석 처리 작성

Closes #759