### PR TITLE
🐛 [Fix] 지부장 운영진 공지 탭 가시성 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Domain/Enums/StaffNoticeTab.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Enums/StaffNoticeTab.swift
@@ -54,12 +54,13 @@ enum StaffNoticeTab: String, CaseIterable, Identifiable, Equatable, Hashable {
 
     /// 특정 역할이 접근 가능한 탭 목록을 반환합니다.
     ///
-    /// 서버 스펙: 지부장은 SCHOOL_CORE 레벨로 매핑되어 SCHOOL_CORE/SCHOOL_PART_LEADER 열람 가능
+    /// 서버 스펙: 지부장은 SCHOOL_CORE viewerRole로 매핑되어
+    /// SCHOOL_CORE / SCHOOL_PART_LEADER 만 열람 가능 (CENTRAL_MEMBER는 비노출).
     static func accessibleTabs(for role: ManagementTeam?) -> [StaffNoticeTab] {
         guard let role else { return [] }
 
         if role == .chapterPresident {
-            return allCases.filter { $0.minimumLevel >= ManagementTeam.schoolPresident.level }
+            return [.schoolCore, .schoolPartLeader]
         }
 
         return allCases.filter { role.level >= $0.minimumLevel }


### PR DESCRIPTION
## ✨ PR 유형

Fix — 권한 노출 위반 수정

## 🛠️ 작업내용

- `StaffNoticeTab.accessibleTabs(for: .chapterPresident)` 가 `[.schoolCore, .schoolPartLeader]` 를 명시적으로 반환하도록 변경
- 기존 `filter { $0.minimumLevel >= 50 }` 는 `[.centralMember, .schoolCore]` 를 반환하여 **양방향 위반**이었음:
  - 보이면 안 되는 `CENTRAL_MEMBER` 탭 노출
  - 봐야 하는 `SCHOOL_PART_LEADER` 탭 누락

## 📌 리뷰 포인트

- `Features/Notice/Domain/Enums/StaffNoticeTab.swift` — `accessibleTabs(for:)` 의 `chapterPresident` 분기
- 학교 회장(`schoolPresident`) 은 기존 `filter` 로직 그대로 — `[schoolCore, schoolPartLeader]` 반환됨 확인

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석 처리 작성

Closes #760