### PR TITLE
🐛 [Fix] 학교 회장 공지 작성 시 schoolCore 서브타이틀 잘못 표시

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
@@ -281,7 +281,11 @@ struct NoticeEditorView: View {
         case .centralAll:
             return "중앙운영진 전체"
         case .schoolCore:
-            return "중앙 + 학교 회장단"
+            let role = ManagementTeam(rawValue: memberRoleRaw)
+            if role?.bindsOwnSchoolForSchoolCoreNotice == true {
+                return normalizedName(from: schoolName, fallback: "본인 학교 회장단")
+            }
+            return "전체 학교 회장단"
         case .schoolPartLeader:
             let role = ManagementTeam(rawValue: memberRoleRaw)
             if role?.bindsOwnSchoolForPartLeaderNotice == true {


### PR DESCRIPTION
## ✨ PR 유형

Fix — UI 문구 오류 수정

## 🛠️ 작업내용

- `managementSubtitle(for: .schoolCore)` 역할별 분기 처리:
  - `bindsOwnSchoolForSchoolCoreNotice == true` (학교 회장단) → 본인 학교명
  - 그 외 (중앙 운영진 등) → '전체 학교 회장단'
- 기존 `"중앙 + 학교 회장단"` 하드코딩 제거 — 학교 회장이 작성할 때 잘못된 대상이 표시되던 문제 해소

## 📌 리뷰 포인트

- `Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift` — `managementSubtitle(for:)` 의 `.schoolCore` 분기 (`.schoolPartLeader` 와 동일 패턴)

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석 처리 작성

Closes #757