### PR TITLE
🐛 [Fix] 로그아웃 시 AppStorage 역할/조직 정보 잔존 문제 해결 (#766)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
@@ -58,6 +58,40 @@ enum AppStorageKey {
     static let organizationId: String = "organizationId"
     /// 공지 탭에서 현재 선택한 기수 ID (공지 작성 진입 시 사용)
     static let noticeSelectedGisuId: String = "noticeSelectedGisuId"
+
+    // MARK: - Session Lifecycle
+
+    /// 로그인 세션 단위로 보관되는 키 목록입니다.
+    ///
+    /// 로그아웃 시 일괄 삭제되어, 다른 계정으로 재로그인할 때 이전 계정의
+    /// 프로필/역할/조직 정보가 잔존하지 않도록 합니다.
+    ///
+    /// 디바이스 단위 정보(FCM 토큰, 최근 검색어 등)는 포함하지 않습니다.
+    static let sessionScopedKeys: [String] = [
+        canAutoLogin,
+        gisuId,
+        memberId,
+        challengerId,
+        schoolId,
+        schoolName,
+        chapterId,
+        chapterName,
+        responsiblePart,
+        memberRole,
+        memberRoles,
+        generationOrganizations,
+        organizationType,
+        organizationId,
+        noticeSelectedGisuId
+    ]
+
+    /// 세션 단위 AppStorage 값을 일괄 삭제합니다.
+    ///
+    /// 로그아웃 / 회원 탈퇴 / 세션 만료 처리 시 호출해야 합니다.
+    /// `UserDefaults` 접근은 thread-safe하므로 actor 격리 없이 호출 가능합니다.
+    nonisolated static func clearSessionScopedValues(in defaults: UserDefaults = .standard) {
+        sessionScopedKeys.forEach { defaults.removeObject(forKey: $0) }
+    }
 }
 
 // MARK: - Member ID 어댑터

--- a/AppProduct/AppProduct/Core/NetworkAdapter/NetworkClient/NetworkClient.swift
+++ b/AppProduct/AppProduct/Core/NetworkAdapter/NetworkClient/NetworkClient.swift
@@ -276,12 +276,15 @@ actor NetworkClient {
     ///
     /// 1. 진행 중인 토큰 갱신 Task 취소
     /// 2. 저장된 모든 토큰 삭제
+    /// 3. 세션 단위 `AppStorage` 값(역할/조직/기수 등) 일괄 삭제
     ///
     /// - Throws: TokenStore.clear() 실패 시 에러 발생
     ///
     /// - Important:
     ///   - 로그아웃 후 API 요청 시 인증 에러 발생
     ///   - 로그인 화면으로 이동 필요
+    ///   - `AppStorage` 의 역할/조직 정보를 함께 비워, 다른 계정으로
+    ///     재로그인할 때 이전 사용자의 권한이 잔존하지 않도록 보장
     ///
     /// - Usage:
     /// ```swift
@@ -299,6 +302,7 @@ actor NetworkClient {
         refreshTask?.cancel()
         refreshTask = nil
         try await tokenStore.clear()
+        AppStorageKey.clearSessionScopedValues()
 
         #if DEBUG
         print("로그아웃 완료")


### PR DESCRIPTION
## ✨ PR 유형

Fix — 로그아웃 시 AppStorage 세션 데이터가 남아 다른 계정 로그인 후 권한이 잘못 적용되던 버그 수정

closes #766

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음. 동작만 변경 (로그아웃 → 재로그인 시 역할 즉시 갱신).

## 🛠️ 작업내용

- `AppStorageKey` 에 세션 단위 키 목록(`sessionScopedKeys`) 정의
- `clearSessionScopedValues(in:)` 헬퍼 추가 (`nonisolated`, UserDefaults thread-safe)
- `NetworkClient.logout()` 마지막 단계에서 세션 단위 AppStorage 일괄 삭제
- 디바이스 단위 정보(FCM 토큰, 최근 검색어)는 의도적으로 유지

## 📋 추후 진행 상황

- 로그인/회원가입 직후 `HomeViewModel.fetchHomeProfile()` 이 다시 호출되어 새 사용자 정보가 AppStorage 에 채워지는 동선은 그대로 유지됨
- 필요 시 `UserSessionManager.reset()` 도 logout 시 호출하도록 후속 작업 검토 가능

## 📌 리뷰 포인트

- `AppProduct/Core/Common/Enum/AppStorageKey.swift` — sessionScopedKeys 목록에 누락된 키가 없는지 확인 (특히 신규 추가 키)
- `AppProduct/Core/NetworkAdapter/NetworkClient/NetworkClient.swift:298` — actor `logout()` 에서 nonisolated 헬퍼 호출이 안전한지
- 세션 단위 / 디바이스 단위 분류가 의도와 맞는지 (FCM 토큰은 유지가 맞음 — 디바이스 재등록 비용 + 푸시 수신 끊김 방지)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)