### PR TITLE
🐛 [Fix] 공지 작성 권한 — 서버 권한 보고서 대비 3건 정렬 (#768)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift
@@ -113,19 +113,19 @@ enum ManagementTeam: String, CaseIterable, Codable, Comparable {
     /// - 학교 미지정: CENTRAL_MEMBER(교육/운영팀원) 이상
     /// - 학교 지정: SCHOOL_CORE(학교 회장/부회장) 이상
     /// - 파트 지정: CENTRAL_MEMBER 이상
+    ///
+    /// 학교 파트장(`SCHOOL_PART_LEADER`) 본인은 작성 권한이 없습니다.
     var canWriteSchoolPartLeaderNotice: Bool {
         self == .superAdmin
             || level >= ManagementTeam.centralEducationTeamMember.level
             || self == .schoolPresident
             || self == .schoolVicePresident
-            || self == .schoolPartLeader
     }
 
     /// 학교 파트장 공지 작성 시, 본인 학교로 자동 바인딩되는 역할
     var bindsOwnSchoolForPartLeaderNotice: Bool {
         self == .schoolPresident
             || self == .schoolVicePresident
-            || self == .schoolPartLeader
     }
 
     /// 학교 회장단 공지 작성 시, 본인 학교로 자동 바인딩되는 역할

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift
@@ -429,20 +429,26 @@ extension NoticeEditorViewModel {
 private extension NoticeEditorViewModel {
 
     /// 메인 카테고리와 역할 조합에 따라 노출 가능한 서브카테고리를 반환합니다.
+    ///
+    /// 서버 권한 보고서 정렬:
+    /// - `.all`: ALL_GISU_ALL_TARGET 패턴 — 서브 타겟 없음
+    /// - `.school`: SCHOOL_CORE는 학교 단위, SCHOOL_PART_LEADER는 파트 지정 필요
     static func allowedSubCategories(
         for category: EditorMainCategory,
         memberRole: ManagementTeam?
     ) -> [EditorSubCategory] {
-        _ = memberRole
         switch category {
         case .all:
-            return [.school]
+            return []
         case .central:
             return [.branch, .school, .part]
         case .branch:
             return [.all, .part]
         case .school:
-            return [.school, .part]
+            if memberRole == .schoolPartLeader {
+                return [.school, .part]
+            }
+            return [.school]
         case .part:
             return []
         case .management(let scenario):


### PR DESCRIPTION
## ✨ PR 유형

Fix — 서버 권한 보고서와 어긋난 공지 작성 권한 3건 정렬

Closes #768

## 🛠️ 작업내용

### 1. \`SCHOOL_PART_LEADER\` 공지 — 파트장 본인 작성 권한 제거
- \`ManagementTeam.canWriteSchoolPartLeaderNotice\` 에서 \`self == .schoolPartLeader\` 케이스 제거
- 연관 정리: \`bindsOwnSchoolForPartLeaderNotice\` 에서도 \`schoolPartLeader\` 제거
- PR #729 에서 추가되었던 파트장 작성 권한을 서버 스펙(SCHOOL_CORE / CENTRAL_MEMBER 이상)에 맞춰 되돌림

### 2. \`.all\` 메인 카테고리 서브 비활성화
- \`allowedSubCategories\` 의 \`.all\` → \`[]\`
- 서버 \`ALL_GISU_ALL_TARGET\` 패턴은 학교/지부/파트 모두 미지정이어야 함

### 3. \`.school\` 카테고리 서브를 역할 기준 분기
- \`schoolPresident\` / \`schoolVicePresident\` → \`[.school]\` (학교 단위)
- \`schoolPartLeader\` → \`[.school, .part]\` (본인 파트 지정 필요)
- \`memberRole\` 파라미터를 폐기하던 \`_ = memberRole\` 제거

## 📌 리뷰 포인트

- \`AppProduct/AppProduct/Core/Common/Enum/ManagementTeam.swift\` — \`canWriteSchoolPartLeaderNotice\` / \`bindsOwnSchoolForPartLeaderNotice\` 변경이 서버 권한 보고서와 일치하는지
- \`AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Targeting.swift\` — \`allowedSubCategories\` 의 \`.all\` / \`.school\` 분기 로직

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 빌드 검증 (iPhone 17 Pro / iOS 26.5) 완료