### PR TITLE
💄 [Design] 운영진 공지 권한 안내 화면 UX 보정 (#770 후속)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Error/Types/DomainError.swift
+++ b/AppProduct/AppProduct/Core/Common/Error/Types/DomainError.swift
@@ -100,6 +100,9 @@ enum DomainError: Error, LocalizedError, Equatable {
     /// 현재 운영 중이 아닌 기수라 커리큘럼 조회 불가
     case curriculumUnavailableForGeneration
 
+    /// 서버에 커리큘럼이 아직 등록되지 않음 (CURRICULUM-0001)
+    case curriculumNotRegistered
+
     // MARK: - 커뮤니티
 
     /// 게시글을 찾을 수 없음
@@ -144,6 +147,8 @@ enum DomainError: Error, LocalizedError, Equatable {
             return "링크를 입력해주세요."
         case .curriculumUnavailableForGeneration:
             return "현재 운영중인 기수가 아니어서 커리큘럼을 조회할 수 없습니다."
+        case .curriculumNotRegistered:
+            return "아직 커리큘럼이 등록되지 않았어요. 조금만 기다려주세요!"
         case .postNotFound:
             return "게시글을 찾을 수 없습니다."
         case .cannotDeletePost:

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/StudyRepository.swift
@@ -43,9 +43,20 @@ final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
             throw DomainError.curriculumUnavailableForGeneration
         }
         let part = resolvedPartAPIValue
-        let response = try await adapter.request(
-            StudyRouter.getCurriculum(gisuId: gisuId, part: part, weekNo: weekNo)
-        )
+        let response: Moya.Response
+        do {
+            response = try await adapter.request(
+                StudyRouter.getCurriculum(gisuId: gisuId, part: part, weekNo: weekNo)
+            )
+        } catch let error as NetworkError {
+            if case .requestFailed(_, let data) = error,
+               let data,
+               let body = try? JSONDecoder().decode(APIResponse<EmptyResult>.self, from: data),
+               body.code == "CURRICULUM-0001" {
+                throw DomainError.curriculumNotRegistered
+            }
+            throw error
+        }
         let apiResponse = try decoder.decode(
             APIResponse<CurriculumDTO>.self,
             from: response.data

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerStudyView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerStudyView.swift
@@ -72,7 +72,14 @@ struct ChallengerStudyView: View {
 
     @ViewBuilder
     private func errorView(error: AppError, viewModel: ChallengerStudyViewModel) -> some View {
-        if case .domain(.curriculumUnavailableForGeneration) = error {
+        if case .domain(.curriculumNotRegistered) = error {
+            ContentUnavailableView {
+                Label("커리큘럼 준비 중", systemImage: "clock.badge.questionmark")
+            } description: {
+                Text(error.userMessage)
+                    .multilineTextAlignment(.center)
+            }
+        } else if case .domain(.curriculumUnavailableForGeneration) = error {
             ContentUnavailableView {
                 Label("커리큘럼 조회 불가", systemImage: "info.circle")
             } description: {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/StaffNotice/StaffNoticeViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/StaffNotice/StaffNoticeViewModel.swift
@@ -88,7 +88,10 @@ final class StaffNoticeViewModel {
         selectedTab = tab
         isSearchMode = false
         searchQuery = ""
-        hasNoAccessFromServer = false
+        if hasNoAccessFromServer {
+            hasNoAccessFromServer = false
+            noticeItems = .loading
+        }
         Task {
             await fetchNotices()
         }
@@ -100,8 +103,9 @@ final class StaffNoticeViewModel {
     func fetchNotices(page: Int = 0) async {
         guard let selectedTab else { return }
 
-        if page == 0 {
+        if page == 0, hasNoAccessFromServer {
             hasNoAccessFromServer = false
+            noticeItems = .loading
         }
 
         await performPagedFetch(page: page, tab: selectedTab) { request in

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/Components/NoAccessContentView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/Components/NoAccessContentView.swift
@@ -11,40 +11,19 @@ import SwiftUI
 
 struct NoAccessContentView: View {
 
-    // MARK: - Property
-
-    let onGoBack: () -> Void
-    let onRefresh: () async -> Void
-
     // MARK: - Constants
 
     fileprivate enum Constants {
         static let iconSystemName: String = "person.badge.shield.checkmark"
         static let iconSize: CGFloat = 56
         static let title: String = "접근 권한이 없어요"
-        static let description: String = "이 공지는 특정 운영진에게만 보여요.\n권한이 바뀌었다면 새로고침해 보세요."
-        static let primaryActionTitle: String = "공지 목록으로 돌아가기"
-        static let secondaryActionTitle: String = "권한 정보 새로고침"
+        static let description: String = "이 공지는 특정 운영진에게만 보여요.\n권한이 바뀌었다면 잠시 후 다시 확인해 주세요."
         static let accessibilityCombinedLabel: String = "접근 권한이 없어요. 이 공지는 특정 운영진에게만 보입니다."
-        static let accessibilityCombinedHint: String = "권한이 바뀐 경우 새로고침 버튼을 두 번 탭하세요."
-        static let secondaryActionHint: String = "운영진 권한을 다시 확인합니다."
     }
 
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: 0) {
-            messageBlock
-            Spacer().frame(height: DefaultSpacing.spacing24)
-            actionButtons
-        }
-        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-    }
-
-    // MARK: - Sub Views
-
-    private var messageBlock: some View {
         VStack(spacing: 0) {
             lockIcon
             Spacer().frame(height: DefaultSpacing.spacing16)
@@ -58,34 +37,18 @@ struct NoAccessContentView: View {
                 .multilineTextAlignment(.center)
                 .lineLimit(3)
         }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Constants.accessibilityCombinedLabel)
-        .accessibilityHint(Constants.accessibilityCombinedHint)
     }
+
+    // MARK: - Sub Views
 
     private var lockIcon: some View {
         Image(systemName: Constants.iconSystemName)
             .font(.system(size: Constants.iconSize))
             .foregroundStyle(Color.grey400)
             .accessibilityHidden(true)
-    }
-
-    private var actionButtons: some View {
-        VStack(spacing: DefaultSpacing.spacing12) {
-            MainButton(Constants.primaryActionTitle) {
-                onGoBack()
-            }
-            .buttonStyle(.glassProminent)
-
-            Button {
-                Task { await onRefresh() }
-            } label: {
-                Text(Constants.secondaryActionTitle)
-                    .appFont(.footnote)
-                    .foregroundStyle(Color.indigo500)
-                    .padding(.vertical, DefaultSpacing.spacing8)
-            }
-            .accessibilityHint(Constants.secondaryActionHint)
-        }
     }
 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/StaffNoticeView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/StaffNoticeView.swift
@@ -198,15 +198,7 @@ struct StaffNoticeView: View {
     }
 
     private var noAccessContent: some View {
-        NoAccessContentView(
-            onGoBack: {
-                pathStore.noticePath.removeLast()
-            },
-            onRefresh: {
-                viewModel.hasNoAccessFromServer = false
-                await viewModel.fetchNotices()
-            }
-        )
+        NoAccessContentView()
     }
 
     // MARK: - Row

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/StaffNoticeView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/StaffNoticeView.swift
@@ -61,7 +61,7 @@ struct StaffNoticeView: View {
 
     var body: some View {
         Group {
-            if viewModel.accessibleTabs.isEmpty || viewModel.hasNoAccessFromServer {
+            if viewModel.accessibleTabs.isEmpty {
                 noAccessContent
             } else {
                 mainContent
@@ -124,13 +124,17 @@ struct StaffNoticeView: View {
 
     @ViewBuilder
     private var content: some View {
-        switch viewModel.noticeItems {
-        case .idle, .loading:
-            progressContent
-        case .loaded(let items):
-            noticeContent(items)
-        case .failed:
-            failedContent()
+        if viewModel.hasNoAccessFromServer {
+            noAccessContent
+        } else {
+            switch viewModel.noticeItems {
+            case .idle, .loading:
+                progressContent
+            case .loaded(let items):
+                noticeContent(items)
+            case .failed:
+                failedContent()
+            }
         }
     }
 


### PR DESCRIPTION
## ✨ PR 유형

Design — [#770](https://github.com/UMC-PRODUCT/umc-product-iOS/pull/770) 후속. 권한 안내 화면의 어색한 전환과 불필요한 액션을 정리합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 운영진 공지 진입 → 403 응답 시 칩이 유지된 채로 안내 노출되는 흐름 첨부 예정 -->

## 🛠️ 작업내용

- `NoAccessContentView`에서 "공지 목록으로 돌아가기" Primary 버튼과 "권한 정보 새로고침" Secondary 텍스트 버튼 제거
- 아이콘 + 타이틀 + 안내 텍스트 3요소만 남겨 시각적 무게 정돈
- 설명 카피를 "잠시 후 다시 확인해 주세요" 톤으로 부드럽게 조정
- `StaffNoticeView` 분기 구조 변경
  - 진입 시 칩이 잠깐 보이다가 화면 전체가 권한 안내로 swap 되던 어색한 전환 제거
  - 서버 403(`hasNoAccessFromServer = true`)이면 탭 칩은 유지하고 콘텐츠 영역만 `NoAccessContentView`로 교체
  - 클라이언트 권한 미달(`accessibleTabs.isEmpty`)은 기존대로 전체 화면 단위 안내 유지

## 📋 추후 진행 상황

- 권한 미스매치가 자주 발생할 경우 진입 시점의 role refresh 로직 추가 검토

## 📌 리뷰 포인트

- `AppProduct/Features/Notice/Presentation/Views/Components/NoAccessContentView.swift` — 콜백 제거 후 표시 전용 컴포넌트로 단순화. API 표면이 깔끔해졌는지 확인
- `AppProduct/Features/Notice/Presentation/Views/StaffNoticeView.swift` — `body` 분기와 `content` 내부의 `hasNoAccessFromServer` 우선 처리. 칩 유지/전환 자연스러움 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)