### PR TITLE
✨ [Feat] 구성원 목록 페이지네이션 적용 (size 200 → 20 + 무한스크롤)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -47,83 +47,62 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         guard !descriptors.isEmpty else {
             return []
         }
+        return try await enrichDescriptors(descriptors)
+    }
 
-        let profileByMemberID = await fetchMemberProfiles(
-            memberIDs: descriptors.map(\.memberId)
-        )
-
-        let preferredGisuID = resolvedGisuID
-        let members = descriptors.map { descriptor in
-            let profile = profileByMemberID[descriptor.memberId]
-            let record = profile.flatMap {
-                resolveRecord(
-                    from: $0,
-                    memberId: descriptor.memberId,
-                    preferredGisuId: preferredGisuID
-                )
-            }
-            let allPoints = record?.resolvedPoints ?? []
-
-            let penaltyPoints = allPoints.filter {
-                let typeStr = $0.pointType.uppercased()
-                let resolved = ChallengerPointType(rawValue: typeStr)
-                return resolved == nil || !(resolved!.isReward)
-            }
-            let rewardPointsList = allPoints.filter {
-                let typeStr = $0.pointType.uppercased()
-                let resolved = ChallengerPointType(rawValue: typeStr)
-                return resolved?.isReward == true
-            }
-
-            let totalPenalty: Double
-            let penaltyHistories: [OperatorMemberPenaltyHistory]
-
-            if penaltyPoints.isEmpty {
-                totalPenalty = descriptor.fallbackPenalty
-                penaltyHistories = []
-            } else {
-                totalPenalty = penaltyPoints.reduce(0) { $0 + abs($1.point) }
-                penaltyHistories = makePenaltyHistories(from: penaltyPoints)
-            }
-
-            let totalReward = rewardPointsList.reduce(0) { $0 + abs($1.point) }
-
-            return MemberManagementItem(
-                memberID: descriptor.memberId,
-                challengerID: resolvedChallengerID(
-                    descriptor: descriptor,
-                    record: record
-                ),
-                profile: profile?.profileImageLink ?? descriptor.profileImageURL,
-                name: profile?.name.nonEmpty ?? descriptor.name,
-                nickname: profile?.nickname.nonEmpty ?? descriptor.name,
-                generation: allGenerationsText(
-                    from: profile,
-                    fallback: descriptor.generation
-                ),
-                school: profile?.schoolName.nonEmpty ?? descriptor.schoolName,
-                position: descriptor.position,
-                part: descriptor.part,
-                penalty: totalPenalty,
-                rewardPoints: totalReward,
-                badge: false,
-                managementTeam: resolvedManagementTeam(
-                    profile: profile,
-                    record: record,
-                    fallback: descriptor.managementTeam
-                ),
-                attendanceRecords: [],
-                penaltyHistory: penaltyHistories,
-                canViewPenaltyHistory: descriptor.memberId == currentMemberID
+    func fetchMembersPage(page: Int) async throws -> MemberPage {
+        guard let schoolId = resolvedSchoolID else {
+            let allMembers = try await fetchMembers()
+            return MemberPage(
+                members: allMembers,
+                hasNext: false,
+                currentPage: 0
             )
         }
 
-        return members.sorted { lhs, rhs in
-            if lhs.part.sortOrder == rhs.part.sortOrder {
-                return lhs.name < rhs.name
-            }
-            return lhs.part.sortOrder < rhs.part.sortOrder
+        let response = try await adapter.request(
+            StudyRouter.searchChallengersOffset(
+                page: page,
+                size: Constants.searchPageSize,
+                schoolId: schoolId
+            )
+        )
+        let searchResult = try decodeSearchOffsetResult(from: response.data)
+        let pageResult = searchResult.page
+
+        let descriptors = pageResult.content.compactMap { item
+            -> GroupMemberDescriptor? in
+            guard item.memberId > 0 else { return nil }
+            let part = UMCPartType(apiValue: item.part) ?? .pm
+            let managementTeam = ManagementTeam.highestPriority(
+                in: item.roleTypes
+            ) ?? .challenger
+            let generation = resolvedGeneration(
+                generation: item.generation,
+                gisu: item.gisu
+            )
+            return GroupMemberDescriptor(
+                memberId: item.memberId,
+                challengerId: item.challengerId > 0
+                    ? item.challengerId : nil,
+                name: item.name,
+                profileImageURL: item.profileImageLink,
+                schoolName: item.schoolName,
+                generation: generation,
+                part: part,
+                position: managementTeam.korean,
+                managementTeam: managementTeam,
+                fallbackPenalty: max(0, item.pointSum)
+            )
         }
+
+        let members = try await enrichDescriptors(descriptors)
+
+        return MemberPage(
+            members: members,
+            hasNext: pageResult.hasNext,
+            currentPage: pageResult.page
+        )
     }
 
     /// 챌린저에게 포인트를 부여합니다.
@@ -309,7 +288,7 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
 
 private extension MemberRepository {
     enum Constants {
-        static let searchPageSize = 200
+        static let searchPageSize = 20
         static let managedStudyGroupsPageSize = 100
     }
 
@@ -324,6 +303,87 @@ private extension MemberRepository {
         let position: String
         let managementTeam: ManagementTeam
         let fallbackPenalty: Double
+    }
+
+    func enrichDescriptors(
+        _ descriptors: [GroupMemberDescriptor]
+    ) async throws -> [MemberManagementItem] {
+        let profileByMemberID = await fetchMemberProfiles(
+            memberIDs: descriptors.map(\.memberId)
+        )
+
+        let preferredGisuID = resolvedGisuID
+        let members = descriptors.map { descriptor in
+            let profile = profileByMemberID[descriptor.memberId]
+            let record = profile.flatMap {
+                resolveRecord(
+                    from: $0,
+                    memberId: descriptor.memberId,
+                    preferredGisuId: preferredGisuID
+                )
+            }
+            let allPoints = record?.resolvedPoints ?? []
+
+            let penaltyPoints = allPoints.filter {
+                let typeStr = $0.pointType.uppercased()
+                let resolved = ChallengerPointType(rawValue: typeStr)
+                return resolved == nil || !(resolved!.isReward)
+            }
+            let rewardPointsList = allPoints.filter {
+                let typeStr = $0.pointType.uppercased()
+                let resolved = ChallengerPointType(rawValue: typeStr)
+                return resolved?.isReward == true
+            }
+
+            let totalPenalty: Double
+            let penaltyHistories: [OperatorMemberPenaltyHistory]
+
+            if penaltyPoints.isEmpty {
+                totalPenalty = descriptor.fallbackPenalty
+                penaltyHistories = []
+            } else {
+                totalPenalty = penaltyPoints.reduce(0) { $0 + abs($1.point) }
+                penaltyHistories = makePenaltyHistories(from: penaltyPoints)
+            }
+
+            let totalReward = rewardPointsList.reduce(0) { $0 + abs($1.point) }
+
+            return MemberManagementItem(
+                memberID: descriptor.memberId,
+                challengerID: resolvedChallengerID(
+                    descriptor: descriptor,
+                    record: record
+                ),
+                profile: profile?.profileImageLink ?? descriptor.profileImageURL,
+                name: profile?.name.nonEmpty ?? descriptor.name,
+                nickname: profile?.nickname.nonEmpty ?? descriptor.name,
+                generation: allGenerationsText(
+                    from: profile,
+                    fallback: descriptor.generation
+                ),
+                school: profile?.schoolName.nonEmpty ?? descriptor.schoolName,
+                position: descriptor.position,
+                part: descriptor.part,
+                penalty: totalPenalty,
+                rewardPoints: totalReward,
+                badge: false,
+                managementTeam: resolvedManagementTeam(
+                    profile: profile,
+                    record: record,
+                    fallback: descriptor.managementTeam
+                ),
+                attendanceRecords: [],
+                penaltyHistory: penaltyHistories,
+                canViewPenaltyHistory: descriptor.memberId == currentMemberID
+            )
+        }
+
+        return members.sorted { lhs, rhs in
+            if lhs.part.sortOrder == rhs.part.sortOrder {
+                return lhs.name < rhs.name
+            }
+            return lhs.part.sortOrder < rhs.part.sortOrder
+        }
     }
 
     func fetchMemberDescriptors() async throws -> [GroupMemberDescriptor] {

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
@@ -142,6 +142,15 @@ final class MockMemberRepository: MemberRepositoryProtocol {
         ]
     }
 
+    func fetchMembersPage(page: Int) async throws -> MemberPage {
+        let allMembers = try await fetchMembers()
+        return MemberPage(
+            members: allMembers,
+            hasNext: false,
+            currentPage: 0
+        )
+    }
+
     func grantPoint(
         challengerId: Int,
         pointType: ChallengerPointType,

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
@@ -12,6 +12,9 @@ protocol MemberRepositoryProtocol {
     /// 멤버 목록 조회
     func fetchMembers() async throws -> [MemberManagementItem]
 
+    /// 멤버 목록 페이지 단위 조회
+    func fetchMembersPage(page: Int) async throws -> MemberPage
+
     /// 챌린저에게 포인트를 부여합니다.
     func grantPoint(
         challengerId: Int,

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberPage.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberPage.swift
@@ -1,0 +1,14 @@
+//
+//  MemberPage.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/17/26.
+//
+
+import Foundation
+
+struct MemberPage: Equatable {
+    let members: [MemberManagementItem]
+    let hasNext: Bool
+    let currentPage: Int
+}

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
@@ -12,6 +12,9 @@ protocol FetchMembersUseCaseProtocol {
     /// 멤버 목록 조회
     func execute() async throws -> [MemberManagementItem]
 
+    /// 멤버 목록 페이지 단위 조회
+    func executePage(page: Int) async throws -> MemberPage
+
     /// 챌린저에게 포인트를 부여합니다.
     func grantPoint(
         challengerId: Int,

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
@@ -22,6 +22,10 @@ final class FetchMembersUseCase: FetchMembersUseCaseProtocol {
         try await repository.fetchMembers()
     }
 
+    func executePage(page: Int) async throws -> MemberPage {
+        try await repository.fetchMembersPage(page: page)
+    }
+
     func grantPoint(
         challengerId: Int,
         pointType: ChallengerPointType,

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
@@ -25,6 +25,9 @@ final class MemberListViewModel {
     private(set) var isSubmittingPoint: Bool = false
     private(set) var isDeletingPoint: Bool = false
     private(set) var isLoadingMemberDetail: Bool = false
+    private(set) var isLoadingNextPage: Bool = false
+    private(set) var hasMorePages: Bool = true
+    private var currentPage: Int = 0
 
     // MARK: - Init
 
@@ -75,13 +78,17 @@ final class MemberListViewModel {
 
     // MARK: - Action
 
-    /// 멤버 전체 목록을 조회합니다.
+    /// 멤버 첫 페이지를 조회합니다.
     @MainActor
     func fetchMembers() async {
         membersState = .loading
+        currentPage = 0
+        hasMorePages = true
         do {
-            let members = try await fetchMembersUseCase.execute()
-            membersState = .loaded(members)
+            let page = try await fetchMembersUseCase.executePage(page: 0)
+            membersState = .loaded(page.members)
+            hasMorePages = page.hasNext
+            currentPage = page.currentPage
         } catch let error as AppError {
             membersState = .failed(error)
         } catch let error as DomainError {
@@ -94,6 +101,31 @@ final class MemberListViewModel {
             membersState = .failed(
                 .unknown(message: error.localizedDescription)
             )
+        }
+    }
+
+    /// 다음 페이지를 조회하여 기존 목록에 추가합니다.
+    @MainActor
+    func fetchNextPage() async {
+        guard hasMorePages, !isLoadingNextPage else { return }
+        guard case .loaded(let existing) = membersState else { return }
+
+        isLoadingNextPage = true
+        defer { isLoadingNextPage = false }
+
+        do {
+            let nextPage = currentPage + 1
+            let page = try await fetchMembersUseCase.executePage(
+                page: nextPage
+            )
+            let deduplicatedMembers = page.members.filter { newMember in
+                !existing.contains { $0.memberID == newMember.memberID }
+            }
+            membersState = .loaded(existing + deduplicatedMembers)
+            hasMorePages = page.hasNext
+            currentPage = page.currentPage
+        } catch {
+            // 다음 페이지 실패 시 기존 데이터 유지
         }
     }
 
@@ -248,10 +280,17 @@ final class MemberListViewModel {
     private func reloadMembersAndReselect(
         member: MemberManagementItem
     ) async throws {
-        let updatedMembers = try await fetchMembersUseCase.execute()
-        membersState = .loaded(updatedMembers)
+        var allMembers: [MemberManagementItem] = []
+        var page = 0
+        while page <= currentPage {
+            let result = try await fetchMembersUseCase.executePage(page: page)
+            allMembers.append(contentsOf: result.members)
+            if !result.hasNext { break }
+            page += 1
+        }
+        membersState = .loaded(allMembers)
         guard let resolvedMember = resolveMember(
-            in: updatedMembers,
+            in: allMembers,
             from: member
         ) else {
             selectedMember = nil

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorMemberManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorMemberManagementView.swift
@@ -126,11 +126,26 @@ struct OperatorMemberManagementView: View {
                         }) {
                             CoreMemberManagementList(memberManagementItem: item, mode: .management)
                         }
+                        .onAppear {
+                            if item.id == group.members.last?.id,
+                               group.part == viewModel.groupedMembers.last?.part {
+                                Task { await viewModel.fetchNextPage() }
+                            }
+                        }
                     }
                 } header: {
                     Text(group.part.name)
                         .appFont(.title3Emphasis, color: .black)
                 }
+            }
+
+            if viewModel.isLoadingNextPage {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .listRowSeparator(.hidden)
             }
         }
     }


### PR DESCRIPTION
## Summary
- 구성원 목록 API 호출 시 `size=200`으로 전체를 한번에 불러오던 방식을 `size=20` 페이지 단위 로딩으로 변경
- 리스트 끝 도달 시 자동으로 다음 페이지를 로드하는 무한스크롤 적용
- `MemberRepository`의 descriptor → item 변환 로직을 `enrichDescriptors`로 추출하여 기존 `fetchMembers()`와 신규 `fetchMembersPage()` 간 코드 재사용

## Changes
| 레이어 | 파일 | 변경 내용 |
|--------|------|----------|
| Domain | `MemberPage.swift` | 페이지네이션 결과 모델 (`members`, `hasNext`, `currentPage`) |
| Domain | `MemberRepositoryProtocol.swift` | `fetchMembersPage(page:)` 추가 |
| Domain | `FetchMembersUseCaseProtocol.swift` | `executePage(page:)` 추가 |
| Domain | `FetchMembersUseCase.swift` | UseCase 구현 |
| Data | `MemberRepository.swift` | `searchPageSize` 200→20, `fetchMembersPage` 구현, `enrichDescriptors` 추출 |
| Data | `MockMemberRepository.swift` | Mock 구현 추가 |
| Presentation | `MemberListViewModel.swift` | 페이지 상태 관리 (`currentPage`, `hasMorePages`, `isLoadingNextPage`), `fetchNextPage()` |
| Presentation | `OperatorMemberManagementView.swift` | 마지막 아이템 `onAppear`에서 다음 페이지 트리거, 로딩 인디케이터 |

## Test plan
- [ ] 활동탭 → 구성원 진입 시 20건만 초기 로딩되는지 확인
- [ ] 스크롤 끝 도달 시 다음 페이지 자동 로딩 확인
- [ ] 마지막 페이지 도달 후 추가 요청이 발생하지 않는지 확인
- [ ] 하단 로딩 인디케이터 표시 확인
- [ ] 포인트 부여/삭제 후 목록 정상 갱신 확인
- [ ] 검색 필터 정상 동작 확인

Closes #772