### PR TITLE
✨ [Feat] 구성원 목록 페이지네이션 적용 (size 200 → 20 + 무한스크롤)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/MemberRepository.swift
@@ -47,83 +47,62 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
         guard !descriptors.isEmpty else {
             return []
         }
+        return try await enrichDescriptors(descriptors)
+    }
 
-        let profileByMemberID = await fetchMemberProfiles(
-            memberIDs: descriptors.map(\.memberId)
-        )
-
-        let preferredGisuID = resolvedGisuID
-        let members = descriptors.map { descriptor in
-            let profile = profileByMemberID[descriptor.memberId]
-            let record = profile.flatMap {
-                resolveRecord(
-                    from: $0,
-                    memberId: descriptor.memberId,
-                    preferredGisuId: preferredGisuID
-                )
-            }
-            let allPoints = record?.resolvedPoints ?? []
-
-            let penaltyPoints = allPoints.filter {
-                let typeStr = $0.pointType.uppercased()
-                let resolved = ChallengerPointType(rawValue: typeStr)
-                return resolved == nil || !(resolved!.isReward)
-            }
-            let rewardPointsList = allPoints.filter {
-                let typeStr = $0.pointType.uppercased()
-                let resolved = ChallengerPointType(rawValue: typeStr)
-                return resolved?.isReward == true
-            }
-
-            let totalPenalty: Double
-            let penaltyHistories: [OperatorMemberPenaltyHistory]
-
-            if penaltyPoints.isEmpty {
-                totalPenalty = descriptor.fallbackPenalty
-                penaltyHistories = []
-            } else {
-                totalPenalty = penaltyPoints.reduce(0) { $0 + abs($1.point) }
-                penaltyHistories = makePenaltyHistories(from: penaltyPoints)
-            }
-
-            let totalReward = rewardPointsList.reduce(0) { $0 + abs($1.point) }
-
-            return MemberManagementItem(
-                memberID: descriptor.memberId,
-                challengerID: resolvedChallengerID(
-                    descriptor: descriptor,
-                    record: record
-                ),
-                profile: profile?.profileImageLink ?? descriptor.profileImageURL,
-                name: profile?.name.nonEmpty ?? descriptor.name,
-                nickname: profile?.nickname.nonEmpty ?? descriptor.name,
-                generation: allGenerationsText(
-                    from: profile,
-                    fallback: descriptor.generation
-                ),
-                school: profile?.schoolName.nonEmpty ?? descriptor.schoolName,
-                position: descriptor.position,
-                part: descriptor.part,
-                penalty: totalPenalty,
-                rewardPoints: totalReward,
-                badge: false,
-                managementTeam: resolvedManagementTeam(
-                    profile: profile,
-                    record: record,
-                    fallback: descriptor.managementTeam
-                ),
-                attendanceRecords: [],
-                penaltyHistory: penaltyHistories,
-                canViewPenaltyHistory: descriptor.memberId == currentMemberID
+    func fetchMembersPage(page: Int) async throws -> MemberPage {
+        guard let schoolId = resolvedSchoolID else {
+            let allMembers = try await fetchMembers()
+            return MemberPage(
+                members: allMembers,
+                hasNext: false,
+                currentPage: 0
             )
         }
 
-        return members.sorted { lhs, rhs in
-            if lhs.part.sortOrder == rhs.part.sortOrder {
-                return lhs.name < rhs.name
-            }
-            return lhs.part.sortOrder < rhs.part.sortOrder
+        let response = try await adapter.request(
+            StudyRouter.searchChallengersOffset(
+                page: page,
+                size: Constants.searchPageSize,
+                schoolId: schoolId
+            )
+        )
+        let searchResult = try decodeSearchOffsetResult(from: response.data)
+        let pageResult = searchResult.page
+
+        let descriptors = pageResult.content.compactMap { item
+            -> GroupMemberDescriptor? in
+            guard item.memberId > 0 else { return nil }
+            let part = UMCPartType(apiValue: item.part) ?? .pm
+            let managementTeam = ManagementTeam.highestPriority(
+                in: item.roleTypes
+            ) ?? .challenger
+            let generation = resolvedGeneration(
+                generation: item.generation,
+                gisu: item.gisu
+            )
+            return GroupMemberDescriptor(
+                memberId: item.memberId,
+                challengerId: item.challengerId > 0
+                    ? item.challengerId : nil,
+                name: item.name,
+                profileImageURL: item.profileImageLink,
+                schoolName: item.schoolName,
+                generation: generation,
+                part: part,
+                position: managementTeam.korean,
+                managementTeam: managementTeam,
+                fallbackPenalty: max(0, item.pointSum)
+            )
         }
+
+        let members = try await enrichDescriptors(descriptors)
+
+        return MemberPage(
+            members: members,
+            hasNext: pageResult.hasNext,
+            currentPage: pageResult.page
+        )
     }
 
     /// 챌린저에게 포인트를 부여합니다.
@@ -309,7 +288,7 @@ final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
 
 private extension MemberRepository {
     enum Constants {
-        static let searchPageSize = 200
+        static let searchPageSize = 20
         static let managedStudyGroupsPageSize = 100
     }
 
@@ -324,6 +303,87 @@ private extension MemberRepository {
         let position: String
         let managementTeam: ManagementTeam
         let fallbackPenalty: Double
+    }
+
+    func enrichDescriptors(
+        _ descriptors: [GroupMemberDescriptor]
+    ) async throws -> [MemberManagementItem] {
+        let profileByMemberID = await fetchMemberProfiles(
+            memberIDs: descriptors.map(\.memberId)
+        )
+
+        let preferredGisuID = resolvedGisuID
+        let members = descriptors.map { descriptor in
+            let profile = profileByMemberID[descriptor.memberId]
+            let record = profile.flatMap {
+                resolveRecord(
+                    from: $0,
+                    memberId: descriptor.memberId,
+                    preferredGisuId: preferredGisuID
+                )
+            }
+            let allPoints = record?.resolvedPoints ?? []
+
+            let penaltyPoints = allPoints.filter {
+                let typeStr = $0.pointType.uppercased()
+                let resolved = ChallengerPointType(rawValue: typeStr)
+                return resolved == nil || !(resolved!.isReward)
+            }
+            let rewardPointsList = allPoints.filter {
+                let typeStr = $0.pointType.uppercased()
+                let resolved = ChallengerPointType(rawValue: typeStr)
+                return resolved?.isReward == true
+            }
+
+            let totalPenalty: Double
+            let penaltyHistories: [OperatorMemberPenaltyHistory]
+
+            if penaltyPoints.isEmpty {
+                totalPenalty = descriptor.fallbackPenalty
+                penaltyHistories = []
+            } else {
+                totalPenalty = penaltyPoints.reduce(0) { $0 + abs($1.point) }
+                penaltyHistories = makePenaltyHistories(from: penaltyPoints)
+            }
+
+            let totalReward = rewardPointsList.reduce(0) { $0 + abs($1.point) }
+
+            return MemberManagementItem(
+                memberID: descriptor.memberId,
+                challengerID: resolvedChallengerID(
+                    descriptor: descriptor,
+                    record: record
+                ),
+                profile: profile?.profileImageLink ?? descriptor.profileImageURL,
+                name: profile?.name.nonEmpty ?? descriptor.name,
+                nickname: profile?.nickname.nonEmpty ?? descriptor.name,
+                generation: allGenerationsText(
+                    from: profile,
+                    fallback: descriptor.generation
+                ),
+                school: profile?.schoolName.nonEmpty ?? descriptor.schoolName,
+                position: descriptor.position,
+                part: descriptor.part,
+                penalty: totalPenalty,
+                rewardPoints: totalReward,
+                badge: false,
+                managementTeam: resolvedManagementTeam(
+                    profile: profile,
+                    record: record,
+                    fallback: descriptor.managementTeam
+                ),
+                attendanceRecords: [],
+                penaltyHistory: penaltyHistories,
+                canViewPenaltyHistory: descriptor.memberId == currentMemberID
+            )
+        }
+
+        return members.sorted { lhs, rhs in
+            if lhs.part.sortOrder == rhs.part.sortOrder {
+                return lhs.name < rhs.name
+            }
+            return lhs.part.sortOrder < rhs.part.sortOrder
+        }
     }
 
     func fetchMemberDescriptors() async throws -> [GroupMemberDescriptor] {

--- a/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
+++ b/AppProduct/AppProduct/Features/Activity/Data/Repositories/Mock/MockMemberRepository.swift
@@ -142,6 +142,15 @@ final class MockMemberRepository: MemberRepositoryProtocol {
         ]
     }
 
+    func fetchMembersPage(page: Int) async throws -> MemberPage {
+        let allMembers = try await fetchMembers()
+        return MemberPage(
+            members: allMembers,
+            hasNext: false,
+            currentPage: 0
+        )
+    }
+
     func grantPoint(
         challengerId: Int,
         pointType: ChallengerPointType,

--- a/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Interfaces/MemberRepositoryProtocol.swift
@@ -12,6 +12,9 @@ protocol MemberRepositoryProtocol {
     /// 멤버 목록 조회
     func fetchMembers() async throws -> [MemberManagementItem]
 
+    /// 멤버 목록 페이지 단위 조회
+    func fetchMembersPage(page: Int) async throws -> MemberPage
+
     /// 챌린저에게 포인트를 부여합니다.
     func grantPoint(
         challengerId: Int,

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberPage.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/MemberManagement/MemberPage.swift
@@ -1,0 +1,14 @@
+//
+//  MemberPage.swift
+//  AppProduct
+//
+//  Created by JEONG on 5/17/26.
+//
+
+import Foundation
+
+struct MemberPage: Equatable {
+    let members: [MemberManagementItem]
+    let hasNext: Bool
+    let currentPage: Int
+}

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/FetchMembersUseCaseProtocol.swift
@@ -12,6 +12,9 @@ protocol FetchMembersUseCaseProtocol {
     /// 멤버 목록 조회
     func execute() async throws -> [MemberManagementItem]
 
+    /// 멤버 목록 페이지 단위 조회
+    func executePage(page: Int) async throws -> MemberPage
+
     /// 챌린저에게 포인트를 부여합니다.
     func grantPoint(
         challengerId: Int,

--- a/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/UseCases/Implementations/FetchMembersUseCase.swift
@@ -22,6 +22,10 @@ final class FetchMembersUseCase: FetchMembersUseCaseProtocol {
         try await repository.fetchMembers()
     }
 
+    func executePage(page: Int) async throws -> MemberPage {
+        try await repository.fetchMembersPage(page: page)
+    }
+
     func grantPoint(
         challengerId: Int,
         pointType: ChallengerPointType,

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift
@@ -25,6 +25,9 @@ final class MemberListViewModel {
     private(set) var isSubmittingPoint: Bool = false
     private(set) var isDeletingPoint: Bool = false
     private(set) var isLoadingMemberDetail: Bool = false
+    private(set) var isLoadingNextPage: Bool = false
+    private(set) var hasMorePages: Bool = true
+    private var currentPage: Int = 0
 
     // MARK: - Init
 
@@ -75,13 +78,17 @@ final class MemberListViewModel {
 
     // MARK: - Action
 
-    /// 멤버 전체 목록을 조회합니다.
+    /// 멤버 첫 페이지를 조회합니다.
     @MainActor
     func fetchMembers() async {
         membersState = .loading
+        currentPage = 0
+        hasMorePages = true
         do {
-            let members = try await fetchMembersUseCase.execute()
-            membersState = .loaded(members)
+            let page = try await fetchMembersUseCase.executePage(page: 0)
+            membersState = .loaded(page.members)
+            hasMorePages = page.hasNext
+            currentPage = page.currentPage
         } catch let error as AppError {
             membersState = .failed(error)
         } catch let error as DomainError {
@@ -94,6 +101,31 @@ final class MemberListViewModel {
             membersState = .failed(
                 .unknown(message: error.localizedDescription)
             )
+        }
+    }
+
+    /// 다음 페이지를 조회하여 기존 목록에 추가합니다.
+    @MainActor
+    func fetchNextPage() async {
+        guard hasMorePages, !isLoadingNextPage else { return }
+        guard case .loaded(let existing) = membersState else { return }
+
+        isLoadingNextPage = true
+        defer { isLoadingNextPage = false }
+
+        do {
+            let nextPage = currentPage + 1
+            let page = try await fetchMembersUseCase.executePage(
+                page: nextPage
+            )
+            let deduplicatedMembers = page.members.filter { newMember in
+                !existing.contains { $0.memberID == newMember.memberID }
+            }
+            membersState = .loaded(existing + deduplicatedMembers)
+            hasMorePages = page.hasNext
+            currentPage = page.currentPage
+        } catch {
+            // 다음 페이지 실패 시 기존 데이터 유지
         }
     }
 
@@ -248,10 +280,17 @@ final class MemberListViewModel {
     private func reloadMembersAndReselect(
         member: MemberManagementItem
     ) async throws {
-        let updatedMembers = try await fetchMembersUseCase.execute()
-        membersState = .loaded(updatedMembers)
+        var allMembers: [MemberManagementItem] = []
+        var page = 0
+        while page <= currentPage {
+            let result = try await fetchMembersUseCase.executePage(page: page)
+            allMembers.append(contentsOf: result.members)
+            if !result.hasNext { break }
+            page += 1
+        }
+        membersState = .loaded(allMembers)
         guard let resolvedMember = resolveMember(
-            in: updatedMembers,
+            in: allMembers,
             from: member
         ) else {
             selectedMember = nil

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorMemberManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorMemberManagementView.swift
@@ -126,11 +126,26 @@ struct OperatorMemberManagementView: View {
                         }) {
                             CoreMemberManagementList(memberManagementItem: item, mode: .management)
                         }
+                        .onAppear {
+                            if item.id == group.members.last?.id,
+                               group.part == viewModel.groupedMembers.last?.part {
+                                Task { await viewModel.fetchNextPage() }
+                            }
+                        }
                     }
                 } header: {
                     Text(group.part.name)
                         .appFont(.title3Emphasis, color: .black)
                 }
+            }
+
+            if viewModel.isLoadingNextPage {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .listRowSeparator(.hidden)
             }
         }
     }


### PR DESCRIPTION
## ✨ PR 유형

구성원 목록 API 호출 시 전체 데이터를 한번에 불러오던 방식을 페이지 단위 로딩(무한스크롤)으로 개선

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 리스트 하단 스크롤 시 다음 페이지 로딩 인디케이터 표시 영상 첨부 필요 -->

## 🛠️ 작업내용

- `MemberRepository.Constants.searchPageSize` 200 → 20으로 변경
- `MemberPage` 도메인 모델 추가 (`members`, `hasNext`, `currentPage`)
- `MemberRepositoryProtocol`에 `fetchMembersPage(page:)` 추가
- `FetchMembersUseCaseProtocol`에 `executePage(page:)` 추가
- `MemberRepository`에서 `enrichDescriptors` 메서드 추출하여 `fetchMembers()`와 `fetchMembersPage()` 간 코드 재사용
- `MemberListViewModel`에 페이지 상태 관리 (`currentPage`, `hasMorePages`, `isLoadingNextPage`) 및 `fetchNextPage()` 추가
- `OperatorMemberManagementView`에서 마지막 아이템 `onAppear` 시 다음 페이지 트리거 + 하단 `ProgressView` 표시
- `MockMemberRepository`에 `fetchMembersPage` 구현 추가

## 📋 추후 진행 상황

- 레거시 경로(schoolId 없는 경우) 페이지네이션 별도 대응 검토

## 📌 리뷰 포인트

- `Features/Activity/Data/Repositories/MemberRepository.swift` - `enrichDescriptors` 추출 및 `fetchMembersPage` 단일 페이지 조회 로직
- `Features/Activity/Presentation/ViewModels/Member/MemberListViewModel.swift` - `fetchNextPage()` 중복 방지 로직, `reloadMembersAndReselect` 페이지 순회 방식
- `Features/Activity/Presentation/Views/Operation/OperatorMemberManagementView.swift` - 마지막 아이템 감지 조건 (`group.part == last?.part`)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

Closes #772