### PR TITLE
💄 [Design] 일정 추가 화면 '출석 체크' 섹션 헤더 제거 (#775)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/StudyScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/StudyScheduleRegistrationView.swift
@@ -61,7 +61,7 @@ struct StudyScheduleRegistrationView: View {
                 dateTimeSection
             }
 
-            Section("출석 체크") {
+            Section {
                 attendancePolicySection
             }
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -736,8 +736,6 @@ fileprivate struct AttendancePolicySection: View {
                             .appFont(.footnote, color: .red500)
                     }
                 }
-            } header: {
-                Text("출석 체크")
             }
         }
     }


### PR DESCRIPTION
## ✨ PR 유형

Design — 일정 추가 폼에서 불필요한 섹션 헤더 텍스트 제거

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 출석 체크 섹션 헤더가 제거되어 다른 섹션들과 동일한 headerless 패턴으로 통일됩니다 -->

## 🛠️ 작업내용

- `ScheduleRegistrationView.swift` — `AttendancePolicySection`의 `Section` header (`Text("출석 체크")`) 제거
- `StudyScheduleRegistrationView.swift` — `Section("출석 체크")` → headerless `Section`으로 변경
- 폼 내 모든 섹션이 동일한 headerless 패턴으로 통일

## 📋 추후 진행 상황

- 출석 필수 토글 라벨의 `.black` 하드코딩 색상 → 시맨틱 컬러 교체 검토

## 📌 리뷰 포인트

- `Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift` - Section header 제거 확인
- `Features/Activity/Presentation/Views/Operation/StudyScheduleRegistrationView.swift` - Section header 제거 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

closes #775