### PR TITLE
🐛 [Fix] 챌린저 모드 구성원 목록 무한스크롤 미작동 (#777)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
@@ -106,11 +106,26 @@ struct ChallengerMemberListView: View {
                         }) {
                             CoreMemberManagementList(memberManagementItem: item, mode: .challenger)
                         }
+                        .onAppear {
+                            if item.id == group.members.last?.id,
+                               group.part == viewModel.groupedMembers.last?.part {
+                                Task { await viewModel.fetchNextPage() }
+                            }
+                        }
                     }
                 } header: {
                     Text(group.part.name)
                         .appFont(.title3Emphasis, color: .black)
                 }
+            }
+
+            if viewModel.isLoadingNextPage {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .listRowSeparator(.hidden)
             }
         }
     }


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix — 챌린저 모드 구성원 목록에서 무한스크롤이 동작하지 않는 버그 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 챌린저 모드 구성원 목록에서 스크롤 하단 진입 시 추가 페이지 로드 확인 필요 -->

## 🛠️ 작업내용

- `ChallengerMemberListView`에 `.onAppear` 기반 `fetchNextPage()` 트리거 추가
- 마지막 그룹의 마지막 아이템이 화면에 나타나면 다음 페이지 자동 로드
- 페이지 로딩 중 하단 `ProgressView` 표시 추가
- `OperatorMemberManagementView`와 동일한 무한스크롤 패턴 적용

## 📋 추후 진행 상황

- 없음 (단건 버그 수정)

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift` - `memberList`의 `.onAppear` 트리거 조건과 `ProgressView` 표시 로직이 `OperatorMemberManagementView`와 동일한 패턴인지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)