### PR TITLE
🐛 [Fix] 스플래시 로고 텍스트 오타 수정 (Makeus → MakeUs)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/UIComponents/Logo/Logo.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/Logo/Logo.swift
@@ -18,7 +18,7 @@ struct Logo: View {
     
     private enum Constants {
         static let logoVspacing: CGFloat = 16
-        static let logoSubtitle: String = "University Makeus Challenge"
+        static let logoSubtitle: String = "University MakeUs Challenge"
     }
     
     // MARK: - Body


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix — 스플래시 화면 및 Logo 컴포넌트의 서브타이틀 오타 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 텍스트 한 글자(s → s) 변경이라 별도 스크린샷 생략 -->

## 🛠️ 작업내용

- `Logo` 컴포넌트의 서브타이틀 문자열 오타 수정
  - `"University Makeus Challenge"` → `"University MakeUs Challenge"`
- 스플래시 화면 및 Logo 컴포넌트를 사용하는 모든 화면(로그인 등)에 자동 반영

## 📋 추후 진행 상황

- 없음 (단순 오타 수정)

## 📌 리뷰 포인트

- 브랜드 표기 `MakeUs` 대소문자 규칙이 디자인 가이드와 일치하는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
