### PR TITLE
🐛 [Fix] 회원가입 전체 동의 버튼 체크 애니메이션 불일치 수정 (#783)

### DIFF
--- a/AppProduct/AppProduct/Features/Auth/Presentation/Components/SignUpTermsSection.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Components/SignUpTermsSection.swift
@@ -114,13 +114,16 @@ struct SignUpTermsSection: View {
     /// 전체 동의 버튼
     private var allAgreeButton: some View {
         Button(action: {
-            onToggleAll(!isAllTermsAgreed)
+            withAnimation(.easeInOut(duration: 0.2)) {
+                onToggleAll(!isAllTermsAgreed)
+            }
         }) {
             HStack(spacing: DefaultSpacing.spacing8) {
                 Image(
                     systemName: isAllTermsAgreed
                     ? "checkmark.circle.fill" : "circle"
                 )
+                .contentTransition(.symbolEffect(.replace))
                 .foregroundStyle(isAllTermsAgreed ? .indigo500 : .grey400)
                 Text(Constants.allAgreeTitle)
                     .appFont(.calloutEmphasis)
@@ -151,13 +154,16 @@ struct SignUpTermsSection: View {
     private func termsRow(_ row: SignUpByIdPwTermRow) -> some View {
         HStack(spacing: DefaultSpacing.spacing8) {
             Button(action: {
-                onToggleRow(row.id)
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    onToggleRow(row.id)
+                }
             }) {
                 HStack(spacing: DefaultSpacing.spacing8) {
                     Image(
                         systemName: row.isAgreed
                         ? "checkmark.circle.fill" : "circle"
                     )
+                    .contentTransition(.symbolEffect(.replace))
                     .foregroundStyle(row.isAgreed ? .indigo500 : .grey400)
                     Text(row.title)
                         .appFont(.subheadline)

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpByIdPwViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpByIdPwViewModel.swift
@@ -220,9 +220,7 @@ final class SignUpByIdPwViewModel {
 
     /// 전체 약관 동의/해제 토글
     func toggleAllTerms(_ agreed: Bool) {
-        for key in termsAgreements.keys {
-            termsAgreements[key] = agreed
-        }
+        termsAgreements = termsAgreements.mapValues { _ in agreed }
     }
 
     /// 회원가입 실행

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
@@ -316,9 +316,7 @@ final class SignUpViewModel {
 
     /// 전체 약관 동의/해제 토글
     func toggleAllTerms(_ agreed: Bool) {
-        for key in termsAgreements.keys {
-            termsAgreements[key] = agreed
-        }
+        termsAgreements = termsAgreements.mapValues { _ in agreed }
     }
 
     /// 전체 약관 동의 여부


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix — 회원가입 약관 동의 체크박스의 애니메이션 불일치 수정

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요
그 외에는 스크린샷으로 올려도 무방합니다.
어떤 작업을 하였는지 시각적으로 바로 확인 가능하게 해주세요! -->

## 🛠️ 작업내용

- `SignUpTermsSection` 전체 동의 버튼 및 개별 약관 행에 `withAnimation(.easeInOut(duration: 0.2))` 래핑 추가
- 체크마크 아이콘(`checkmark.circle.fill` ↔ `circle`)에 `.contentTransition(.symbolEffect(.replace))` 적용하여 SF Symbol 전환 애니메이션 부여
- `SignUpByIdPwViewModel.toggleAllTerms(_:)` — `for key in` 루프를 `mapValues`로 단순화하여 딕셔너리 한 번에 갱신 (SwiftUI 변경 감지 일괄 트리거)
- `SignUpViewModel.toggleAllTerms(_:)` — 동일하게 `mapValues` 패턴 적용

## 📋 추후 진행 상황

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

## 📌 리뷰 포인트

- `Features/Auth/Presentation/Components/SignUpTermsSection.swift` — `withAnimation` + `.contentTransition(.symbolEffect(.replace))` 조합이 전체 동의/개별 동의 양쪽에 일관되게 적용되었는지 확인
- `Features/Auth/Presentation/ViewModels/SignUpByIdPwViewModel.swift` — `mapValues`로 변경 시 @Observable 변경 감지가 정상 동작하는지 확인
- `Features/Auth/Presentation/ViewModels/SignUpViewModel.swift` — 동일 패턴 적용 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)