### PR TITLE
🐛 [Fix] 스플래시 로고 텍스트 오타 수정 (Makeus → MakeUs) #782

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
@@ -17,7 +17,7 @@ struct AttendanceDetailView: View {
 
     // MARK: - Property
 
-    @Environment(NavigationRouter.self) private var router
+    @Environment(\.di) private var di
     @State private var viewModel: AttendanceDetailViewModel
 
     // MARK: - Init
@@ -84,7 +84,7 @@ struct AttendanceDetailView: View {
 
             if viewModel.isScheduleDeleted {
                 Button("이전으로") {
-                    router.pop()
+                    di.resolve(PathStore.self).activityPath.removeLast()
                 }
                 .buttonStyle(.borderedProminent)
             } else {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
@@ -17,7 +17,7 @@ struct AttendanceListView: View {
 
     // MARK: - Property
 
-    @Environment(NavigationRouter.self) private var router
+    @Environment(\.di) private var di
     @State private var viewModel: AttendanceListViewModel
 
     // MARK: - Init
@@ -214,7 +214,7 @@ struct AttendanceListView: View {
             LazyVStack(spacing: DefaultSpacing.spacing12) {
                 ForEach(infos) { info in
                     Button {
-                        router.push(to: .activity(.attendanceDetail(scheduleId: info.scheduleId)))
+                        di.resolve(PathStore.self).activityPath.append(.activity(.attendanceDetail(scheduleId: info.scheduleId)))
                     } label: {
                         AttendanceListRow(info: info)
                     }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
@@ -15,7 +15,7 @@ struct OperatorAttendanceSectionView: View {
 
     // MARK: - Property
 
-    @Environment(NavigationRouter.self) private var router
+    @Environment(\.di) private var di
     @State private var viewModel: OperatorAttendanceViewModel
     @State private var selectedPendingSessionId: UUID?
     @Environment(\.scenePhase) private var scenePhase
@@ -189,7 +189,7 @@ struct OperatorAttendanceSectionView: View {
 
     private var attendanceListEntryButton: some View {
         Button {
-            router.push(to: .activity(.attendanceList))
+            di.resolve(PathStore.self).activityPath.append(.activity(.attendanceList))
         } label: {
             HStack(spacing: DefaultSpacing.spacing12) {
                 Image(systemName: "checklist")

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -20,10 +20,6 @@ struct ScheduleRegistrationView: View {
 
     @Environment(\.dismiss) var dismiss
 
-    /// 현재 로그인 사용자의 역할입니다.
-    @AppStorage(AppStorageKey.memberRole) private var memberRole: ManagementTeam = .challenger
-    /// 운영진 생성 플로우에서 출석부 생성 여부 확인 다이얼로그 표시 상태입니다.
-    @State private var showApprovalConfirmationDialog: Bool = false
     /// 화면이 생성 모드인지 수정 모드인지 구분합니다.
     private let mode: Mode
 
@@ -180,8 +176,7 @@ struct ScheduleRegistrationView: View {
 
     /// 생성 모드에서 노출되는 우측 상단 추가 버튼입니다.
     ///
-    /// 로딩 중에는 아이콘 대신 `ProgressView`를 노출하고, 운영진인 경우
-    /// 탭 시 출석부 생성 여부를 확인하는 `confirmationDialog`를 띄웁니다.
+    /// 로딩 중에는 아이콘 대신 `ProgressView`를 노출합니다.
     private var createToolbarButton: some View {
         Button {
             guard !isActionDisabled, !isSubmitting else { return }
@@ -200,44 +195,6 @@ struct ScheduleRegistrationView: View {
         }
         .tint((isActionDisabled || isSubmitting) ? .grey300 : .indigo500)
         .disabled(isActionDisabled || isSubmitting)
-        .confirmationDialog(
-            "일정 생성",
-            isPresented: $showApprovalConfirmationDialog,
-            titleVisibility: .visible
-        ) {
-            approvalConfirmationActions()
-        } message: {
-            approvalConfirmationMessage()
-        }
-    }
-
-    /// 운영진 생성 플로우에서 표시할 확인 다이얼로그 액션 목록입니다.
-    ///
-    /// V2 마이그레이션 이후 출석 정책 입력 UI 가 분리될 때까지 두 선택지 모두
-    /// 동일하게 출석 정책 없이 일정을 생성합니다.
-    @ViewBuilder
-    private func approvalConfirmationActions() -> some View {
-        if memberRole != .challenger {
-            Button("출석부 생성합니다", role: .destructive) {
-                Task {
-                    await viewModel.submitSchedule()
-                }
-            }
-
-            Button("일정만 생성할게요") {
-                Task {
-                    await viewModel.submitSchedule()
-                }
-            }
-        }
-    }
-
-    /// 출석부 생성 여부를 묻는 확인 다이얼로그 안내 문구입니다.
-    @ViewBuilder
-    private func approvalConfirmationMessage() -> some View {
-        if memberRole != .challenger {
-            Text("출석을 체크하시겠습니까?")
-        }
     }
 
     /// 일정 생성 또는 수정 요청이 진행 중인지 여부입니다.
@@ -274,16 +231,9 @@ struct ScheduleRegistrationView: View {
 
     // MARK: - Function
 
-    /// 생성 모드의 추가 버튼 탭 동작을 처리합니다.
-    ///
-    /// 챌린저는 출석부 없이 바로 일정을 생성하고, 운영진은 출석부 동시 생성 여부를 먼저 확인합니다.
     private func submitCreateAction() {
-        if memberRole == .challenger {
-            Task {
-                await viewModel.submitSchedule()
-            }
-        } else {
-            showApprovalConfirmationDialog = true
+        Task {
+            await viewModel.submitSchedule()
         }
     }
 


### PR DESCRIPTION
## ✨ PR 유형

Bug Fix — 활동 출석 체크 운영진 모드 NavigationRouter 누락 크래시 수정 및 일정 생성 시 불필요한 출석 확인 다이얼로그 제거

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요
그 외에는 스크린샷으로 올려도 무방합니다.
어떤 작업을 하였는지 시각적으로 바로 확인 가능하게 해주세요! -->

## 🛠️ 작업내용

- 운영진 모드 출석 관련 뷰 3개에서 `@Environment(NavigationRouter.self)` → `@Environment(\.di)` + `PathStore` 직접 접근으로 변경하여 NavigationRouter 누락 크래시 수정
  - `AttendanceDetailView` — 삭제된 일정 "이전으로" 버튼 pop 동작
  - `AttendanceListView` — 출석 상세 화면 push 동작
  - `OperatorAttendanceSectionView` — 출석 목록 화면 push 동작
- `ScheduleRegistrationView`에서 운영진 일정 생성 시 표시되던 불필요한 출석 확인 `confirmationDialog` 제거
  - `showApprovalConfirmationDialog` 상태, `approvalConfirmationActions()`, `approvalConfirmationMessage()` 삭제
  - `memberRole` AppStorage 의존 제거
  - `submitCreateAction()` 분기 로직 단순화 (챌린저/운영진 구분 없이 바로 생성)

## 📋 추후 진행 상황

- V2 마이그레이션 이후 출석 정책 입력 UI 분리 시 재설계 예정

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift` — NavigationRouter → PathStore 전환 시 pop 동작 정상 여부
- `Features/Activity/Presentation/Views/Operation/AttendanceListView.swift` — push 경로가 기존과 동일한지 확인
- `Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift` — push 경로가 기존과 동일한지 확인
- `Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift` — confirmationDialog 제거 후 생성 플로우에 누락 없는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)