### PR TITLE
🐛 [Fix] 구성원 상세 시트 UI 깨짐 수정 및 미사용 출석 섹션 제거

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/ChallengerMemberDetailSheetView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// 챌린저 멤버 상세 정보를 표시하는 바텀 시트 뷰
 ///
-/// 프로필, 기수별 상벌점 요약, 출석/활동 기록을 표시합니다.
+/// 프로필과 기수별 상벌점 요약을 표시합니다.
 /// 복수 기수 사용자의 경우 `Picker`를 통해 기수를 전환할 수 있습니다.
 struct ChallengerMemberDetailSheetView: View {
 
@@ -32,11 +32,6 @@ struct ChallengerMemberDetailSheetView: View {
         static let listPadding: EdgeInsets = .init(top: 12, leading: 12, bottom: 12, trailing: 12)
         static let profileSize: CGSize = .init(width: 60, height: 60)
 
-        static let baseHeight: CGFloat = 360
-        static let emptyRecordHeight: CGFloat = 150
-        static let sheetHeight: CGFloat = 680
-        static let recordRowMinHeight: CGFloat = 44
-
         static let summaryRowVerticalPadding: CGFloat = 12
         static let partTagOpacity: Double = 0.14
         static let partStrokeOpacity: Double = 0.4
@@ -46,10 +41,9 @@ struct ChallengerMemberDetailSheetView: View {
 
     // MARK: - Computed Property
 
-    /// 단일 기수 사용자의 기수 텍스트 (예: "9기")
     private var currentGeneration: String {
         if hasMultipleGenerations,
-           let lastGisu = member.generationPoints.map(\.gisu).max() {
+           let lastGisu = uniqueGenerationPoints.map(\.gisu).max() {
             return "\(lastGisu)기"
         }
         let gens = member.generation
@@ -59,48 +53,48 @@ struct ChallengerMemberDetailSheetView: View {
         return gens.last ?? member.generation
     }
 
-    /// 복수 기수 보유 여부
     private var hasMultipleGenerations: Bool {
-        member.generationPoints.count > 1
+        uniqueGenerationPoints.count > 1
     }
 
-    /// 현재 선택된 기수의 포인트 요약 데이터
+    private var uniqueGenerationPoints: [GenerationPointSummary] {
+        var seen = Set<Int>()
+        return member.generationPoints.filter { seen.insert($0.gisu).inserted }
+    }
+
     private var selectedSummary: GenerationPointSummary? {
         member.generationPoints.first { $0.gisu == selectedGisu }
     }
 
-    /// 표시할 상점 (선택된 기수 우선, 없으면 전체 합산)
     private var displayRewardPoints: Double {
         selectedSummary?.reward ?? member.rewardPoints
     }
 
-    /// 표시할 벌점 (선택된 기수 우선, 없으면 전체 합산)
     private var displayPenaltyPoints: Double {
         selectedSummary?.penalty ?? member.penalty
     }
-
 
     // MARK: - Body
 
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
-                    memberInfoView
-                    summaryCardView
-                    recordView
+                GlassEffectContainer {
+                    VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
+                        memberInfoView
+                        summaryCardView
+                    }
                 }
                 .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
                 .safeAreaPadding(.bottom, DefaultConstant.defaultSafeBottom)
             }
             .scrollContentBackground(.hidden)
-            .presentationDetents([.height(Constants.sheetHeight), .large])
+            .presentationDetents([.medium])
         }
     }
 
     // MARK: - SubView
 
-    /// 프로필 이미지, 닉네임/이름, 파트·학교·운영진 배지를 표시
     private var memberInfoView: some View {
         HStack(spacing: DefaultSpacing.spacing12) {
             RemoteImage(urlString: member.profile ?? "", size: Constants.profileSize)
@@ -120,7 +114,6 @@ struct ChallengerMemberDetailSheetView: View {
         }
     }
 
-    /// 파트 태그 (색상 배경 + 테두리)
     private var partTag: some View {
         Text(member.part.name)
             .appFont(.callout, color: member.part.color)
@@ -138,15 +131,13 @@ struct ChallengerMemberDetailSheetView: View {
             }
     }
 
-    /// 학교 태그
     private var schoolTag: some View {
         Text(member.school)
-            .appFont(.callout, color: .black)
+            .appFont(.callout, color: .grey700)
             .padding(Constants.tagPadding)
-            .background(.white, in: Capsule())
+            .background(.regularMaterial, in: Capsule())
     }
 
-    /// 활동 기수 · 상점 · 벌점 요약 카드
     private var summaryCardView: some View {
         VStack(spacing: .zero) {
             summaryRow(title: "활동 기수") {
@@ -184,117 +175,45 @@ struct ChallengerMemberDetailSheetView: View {
             .padding(.vertical, Constants.summaryRowVerticalPadding)
         }
         .padding(.horizontal, Constants.listPadding.leading)
-        .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
-        .glass()
+        .background(
+            .regularMaterial,
+            in: ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
         .animation(.smooth(duration: 0.3), value: selectedGisu)
     }
 
-    /// 복수 기수 전환 인라인 칩 셀렉터
     private var generationChips: some View {
         HStack(spacing: DefaultSpacing.spacing4) {
-            ForEach(member.generationPoints) { summary in
-                Text("\(summary.gisu)기")
-                    .appFont(
-                        selectedGisu == summary.gisu
-                            ? .subheadlineEmphasis : .subheadline,
-                        color: selectedGisu == summary.gisu
-                            ? .white : .grey700
-                    )
-                    .padding(Constants.tagPadding)
-                    .background(
-                        selectedGisu == summary.gisu
-                            ? Color.accentColor : Color.grey200,
-                        in: Capsule()
-                    )
-                    .onTapGesture {
-                        withAnimation(.smooth(duration: 0.3)) {
-                            selectedGisu = summary.gisu
-                        }
+            ForEach(uniqueGenerationPoints) { summary in
+                Button {
+                    withAnimation(.smooth(duration: 0.3)) {
+                        selectedGisu = summary.gisu
                     }
-            }
-        }
-    }
-
-    /// 출석/활동 기록 섹션
-    private var recordView: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
-            Label(
-                "출석/활동 기록",
-                systemImage: "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90"
-            )
-            .appFont(.title3Emphasis)
-
-            attendanceRecordListView
-        }
-    }
-
-    /// 출석 이력 리스트 (기록 없으면 빈 상태 카드)
-    private var attendanceRecordListView: some View {
-        Group {
-            if member.attendanceRecords.isEmpty {
-                attendanceEmptyView
-            } else {
-                VStack(spacing: .zero) {
-                    ForEach(Array(member.attendanceRecords.enumerated()), id: \.element.id) { index, record in
-                        attendanceRecordRow(record: record)
-                        if index < member.attendanceRecords.count - 1 {
-                            Divider()
-                                .padding(.horizontal, Constants.listPadding.leading)
-                        }
-                    }
+                } label: {
+                    Text("\(summary.gisu)기")
+                        .appFont(
+                            selectedGisu == summary.gisu
+                                ? .subheadlineEmphasis : .subheadline,
+                            color: selectedGisu == summary.gisu
+                                ? .white : .grey700
+                        )
+                        .padding(Constants.tagPadding)
+                        .background(
+                            selectedGisu == summary.gisu
+                                ? Color.accentColor : Color.grey200,
+                            in: Capsule()
+                        )
                 }
-                .background(
-                    .white,
-                    in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
-                )
-                .glass()
+                .accessibilityLabel("\(summary.gisu)기 선택")
             }
         }
-    }
-
-    /// 출석 이력이 없을 때 빈 상태 카드
-    private var attendanceEmptyView: some View {
-        VStack(spacing: DefaultSpacing.spacing8) {
-            Image(systemName: "calendar.badge.checkmark")
-                .appFont(.title1, color: .grey500)
-            Text("출석 이력이 없습니다")
-                .appFont(.subheadlineEmphasis, color: .grey500)
-        }
-        .frame(maxWidth: .infinity)
-        .frame(height: Constants.emptyRecordHeight)
-        .background(.white, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
-        .glass()
-    }
-
-    /// 출석 이력 개별 행
-    private func attendanceRecordRow(record: MemberAttendanceRecord) -> some View {
-        HStack {
-            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
-                Text("\(record.week)주차")
-                    .appFont(.footnote, color: .grey500)
-                Text(record.sessionTitle)
-                    .appFont(.subheadlineEmphasis)
-                    .lineLimit(1)
-            }
-            Spacer()
-            attendanceStatusBadge(status: record.status)
-        }
-        .padding(Constants.listPadding)
-        .frame(minHeight: Constants.recordRowMinHeight)
-    }
-
-    /// 출석 상태 배지
-    private func attendanceStatusBadge(status: AttendanceStatus) -> some View {
-        Text(status.displayText)
-            .appFont(.caption1Emphasis, color: .white)
-            .padding(.horizontal, DefaultSpacing.spacing8)
-            .padding(.vertical, DefaultSpacing.spacing4)
-            .background(status.backgroundColor, in: Capsule())
     }
 
     // MARK: - Function
 
-    /// 상벌점 2열 레이아웃의 개별 컬럼
     private func pointColumn(
         icon: String,
         iconColor: Color,
@@ -318,7 +237,6 @@ struct ChallengerMemberDetailSheetView: View {
         .frame(maxWidth: .infinity)
     }
 
-    /// 요약 카드의 개별 행 (타이틀 + 우측 값)
     private func summaryRow<Content: View>(
         title: String,
         @ViewBuilder value: () -> Content


### PR DESCRIPTION
## ✨ PR 유형

구성원 상세 바텀 시트의 UI 깨짐 버그 수정 및 미사용 출석/활동 기록 섹션 제거

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경이 포함된 PR입니다. 머지 전 시뮬레이터에서 구성원 상세 시트 확인 필요 -->

## 🛠️ 작업내용

- **출석/활동 기록 섹션 전체 제거**: API가 더 이상 존재하지 않아 항상 빈 상태("출석 이력이 없습니다")만 표시되던 섹션 삭제
  - `recordView`, `attendanceRecordListView`, `attendanceEmptyView`, `attendanceRecordRow`, `attendanceStatusBadge` 제거
- **기수 칩 중복 표시 수정**: `generationPoints`에 동일 gisu가 중복 포함될 때 "10기 10기"처럼 표시되던 문제 → `uniqueGenerationPoints` computed property로 중복 제거
- **Liquid Glass 호환성 수정**: `.background(.white, in: RoundedRectangle)` → `.background(.regularMaterial, in: ConcentricRectangle)` 변경으로 iOS 26 Glass 효과와의 z-fighting 해결
- **`GlassEffectContainer` 래핑 추가**: 오프스크린 렌더링 약 66% 감소
- **학교 태그 하드코딩 색상 제거**: `.black`/`.white` → `.grey700`/`.regularMaterial`
- **기수 칩 접근성 개선**: `onTapGesture` → `Button` + `accessibilityLabel` 추가
- **시트 높이 조정**: 출석 섹션 제거로 `.height(680)` → `.medium` detent
- **미사용 Constants 정리**: `baseHeight`, `emptyRecordHeight`, `sheetHeight`, `recordRowMinHeight` 제거

## 📋 추후 진행 상황

- `MemberManagementItem.attendanceRecords` 프로퍼티 및 `MemberAttendanceRecord` 모델 정리 (별도 리팩토링 PR)
- `MemberRepository.fetchAttendanceRecords` 호출부 정리

## 📌 리뷰 포인트

- `Features/Activity/Presentation/Views/Operation/ChallengerMemberDetailSheetView.swift` - Glass 효과 적용 방식, ConcentricRectangle 사용, 기수 중복 제거 로직 확인
- 출석 관련 코드 제거 범위가 적절한지 확인 (View 레이어만 제거, Model/Repository는 유지)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)