### PR TITLE
✨ [Feature] 출석 권한/UX 일관성 개선 (#789 #790 #791 #792 #793 #794)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Error/Types/AppError.swift
+++ b/AppProduct/AppProduct/Core/Common/Error/Types/AppError.swift
@@ -148,4 +148,16 @@ enum AppError: Error, LocalizedError, Equatable {
             return true
         }
     }
+
+    // MARK: - Permission
+
+    /// 권한 거부(HTTP 403) 에러 여부
+    ///
+    /// 재시도해도 해결되지 않는 서버 측 권한 문제임을 나타냅니다.
+    var isPermissionDenied: Bool {
+        guard case .network(let networkError) = self,
+              case .requestFailed(let statusCode, _) = networkError
+        else { return false }
+        return statusCode == 403
+    }
 }

--- a/AppProduct/AppProduct/Core/Common/Error/Types/DomainError.swift
+++ b/AppProduct/AppProduct/Core/Common/Error/Types/DomainError.swift
@@ -81,6 +81,14 @@ enum DomainError: Error, LocalizedError, Equatable {
     /// 출석 사유 입력 필요
     case attendanceReasonRequired
 
+    // MARK: - 일정
+
+    /// 출석 기록이 존재하여 일정을 삭제할 수 없음 (최고 관리자만 강제 삭제 가능)
+    case scheduleHasAttendanceRecords
+
+    /// 이미 시작된 일정은 수정할 수 없음 (SCHEDULE-0028)
+    case scheduleAlreadyStarted
+
     // MARK: - 워크북/과제
 
     /// 제출 기한 초과
@@ -137,6 +145,10 @@ enum DomainError: Error, LocalizedError, Equatable {
             return "출석 시간이 지났습니다."
         case .attendanceReasonRequired:
             return "출석 사유를 입력해주세요."
+        case .scheduleHasAttendanceRecords:
+            return "출석 기록이 있는 일정은 삭제할 수 없습니다. 최고 관리자에게 강제 삭제를 요청하세요."
+        case .scheduleAlreadyStarted:
+            return "이미 시작된 일정은 수정할 수 없습니다."
         case .workbookDeadlinePassed:
             return "제출 기한이 지났습니다."
         case .workbookAlreadySubmitted:

--- a/AppProduct/AppProduct/Core/Common/UIComponents/Logo/Logo.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/Logo/Logo.swift
@@ -18,7 +18,7 @@ struct Logo: View {
     
     private enum Constants {
         static let logoVspacing: CGFloat = 16
-        static let logoSubtitle: String = "University Makeus Challenge"
+        static let logoSubtitle: String = "University MakeUs Challenge"
     }
     
     // MARK: - Body

--- a/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/ScheduleAttendanceInfo.swift
+++ b/AppProduct/AppProduct/Features/Activity/Domain/Models/Operator/ScheduleAttendanceInfo.swift
@@ -88,4 +88,50 @@ struct ScheduleAttendanceInfo: Equatable, Sendable, Identifiable {
         guard totalCount > 0 else { return 0.0 }
         return Double(presentCount) / Double(totalCount)
     }
+
+    // MARK: - Mapping
+
+    @MainActor
+    func toOperatorSessionAttendance() -> OperatorSessionAttendance {
+        let coordinate: Coordinate = if let loc = location {
+            Coordinate(latitude: loc.latitude, longitude: loc.longitude)
+        } else {
+            Coordinate(latitude: 0, longitude: 0)
+        }
+
+        let sessionInfo = SessionInfo(
+            sessionId: SessionID(value: String(scheduleId)),
+            icon: .Activity.profile,
+            title: name,
+            week: 0,
+            startTime: startsAt,
+            endTime: endsAt,
+            location: coordinate,
+            isAllDay: false
+        )
+
+        let pendingParticipants = participants.filter(\.attendanceStatus.isPending)
+        let pendingMembers = pendingParticipants.map { p in
+            OperatorPendingMember(
+                serverID: String(p.memberId),
+                participantMemberId: p.memberId,
+                name: p.name,
+                nickname: p.nickname.isEmpty ? nil : p.nickname,
+                university: p.schoolName,
+                requestTime: startsAt,
+                reason: p.excuseReason,
+                profileImageURL: p.profileImageUrl.isEmpty ? nil : p.profileImageUrl
+            )
+        }
+
+        return OperatorSessionAttendance(
+            serverID: String(scheduleId),
+            session: Session(info: sessionInfo),
+            attendanceRate: attendanceRate,
+            attendedCount: presentCount,
+            totalCount: totalCount,
+            pendingCount: pendingCount,
+            pendingMembers: pendingMembers
+        )
+    }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
@@ -395,10 +395,10 @@ final class OperatorAttendanceViewModel {
                 isApproval: isApproved
             )
         } catch {
-            errorHandler.handle(error, context: .init(
-                feature: "Activity",
+            await handleDecisionError(
+                error,
                 action: isApproved ? "approveAttendance" : "rejectAttendance"
-            ))
+            )
         }
     }
 
@@ -431,10 +431,10 @@ final class OperatorAttendanceViewModel {
                 isApproval: isApproved
             )
         } catch {
-            errorHandler.handle(error, context: .init(
-                feature: "Activity",
+            await handleDecisionError(
+                error,
                 action: isApproved ? "approveAllAttendances" : "rejectAllAttendances"
-            ))
+            )
         }
     }
 
@@ -470,11 +470,52 @@ final class OperatorAttendanceViewModel {
                 isApproval: isApproved
             )
         } catch {
-            errorHandler.handle(error, context: .init(
-                feature: "Activity",
+            await handleDecisionError(
+                error,
                 action: isApproved ? "approveSelectedAttendances" : "rejectSelectedAttendances"
-            ))
+            )
         }
+    }
+
+    /// 출석 승인/반려 실패 처리.
+    ///
+    /// HTTP 403 (권한 부족) 인 경우 명확한 안내 Alert 후 세션 목록을 갱신해
+    /// 서버 측 권한/상태 변화를 즉시 반영합니다. 그 외 에러는 기존 ErrorHandler 로 위임합니다.
+    @MainActor
+    private func handleDecisionError(_ error: Error, action: String) async {
+        if Self.isPermissionDenied(error) {
+            alertPrompt = AlertPrompt(
+                title: "권한이 없어요",
+                message: "출석을 처리할 권한이 없습니다. 운영진 권한을 확인해 주세요.",
+                positiveBtnTitle: "확인",
+                positiveBtnAction: { [weak self] in
+                    self?.alertPrompt = nil
+                }
+            )
+            await refreshSessions()
+            return
+        }
+        errorHandler.handle(error, context: .init(
+            feature: "Activity",
+            action: action
+        ))
+    }
+
+    /// HTTP 403(권한 부족) 여부 감지.
+    ///
+    /// - `AppError.network(.requestFailed(403, _))`
+    /// - `NetworkError.requestFailed(403, _)`
+    /// 두 표현을 모두 처리합니다.
+    private static func isPermissionDenied(_ error: Error) -> Bool {
+        if let appError = error as? AppError, appError.isPermissionDenied {
+            return true
+        }
+        if let networkError = error as? NetworkError,
+           case .requestFailed(let status, _) = networkError,
+           status == 403 {
+            return true
+        }
+        return false
     }
 
     // MARK: - Helper

--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/OperatorAttendanceViewModel.swift
@@ -67,13 +67,21 @@ final class OperatorAttendanceViewModel {
 
     // MARK: - Action
 
-    /// 일정 목록 + pending 출석 조회
-    ///
-    /// V1 `GET /api/v1/schedules` 제거로 인해 미구현 상태입니다.
-    /// V2 `fetchAttendanceList` 기반 재구현 예정 (#688).
     @MainActor
     func fetchSessions() async {
-        sessionsState = .loaded([])
+        sessionsState = .loading
+        do {
+            let infos = try await useCase.fetchAttendanceList(
+                from: nil, to: nil, attendanceStatus: nil
+            )
+            sessionsState = .loaded(infos.map { $0.toOperatorSessionAttendance() })
+        } catch let error as DomainError {
+            sessionsState = .failed(.domain(error))
+        } catch let error as NetworkError {
+            sessionsState = .failed(.network(error))
+        } catch {
+            sessionsState = .failed(.unknown(message: error.localizedDescription))
+        }
     }
 
     /// 위치 변경 버튼 탭
@@ -316,12 +324,18 @@ final class OperatorAttendanceViewModel {
 
     // MARK: - Polling
 
-    /// 세션 목록 배경 갱신 (로딩 상태 변경 없이)
-    ///
-    /// V1 `GET /api/v1/schedules` 제거로 인해 미구현 상태입니다.
-    /// V2 `fetchAttendanceList` 기반 재구현 예정 (#688).
     @MainActor
-    func refreshSessions() async {}
+    func refreshSessions() async {
+        guard sessionsState.isComplete else { return }
+        do {
+            let infos = try await useCase.fetchAttendanceList(
+                from: nil, to: nil, attendanceStatus: nil
+            )
+            sessionsState = .loaded(infos.map { $0.toOperatorSessionAttendance() })
+        } catch {
+            // 배경 갱신 실패는 무시 — 기존 데이터 유지
+        }
+    }
 
     /// 세션 진행 중일 때 주기적으로 데이터를 갱신합니다.
     ///

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerMemberListView.swift
@@ -66,7 +66,6 @@ struct ChallengerMemberListView: View {
         }
         .sheet(item: $viewModel.selectedMember) { member in
             ChallengerMemberDetailSheetView(member: member)
-                .presentationDragIndicator(.visible)
         }
     }
     

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
@@ -183,8 +183,11 @@ struct AttendanceListView: View {
             Image(systemName: "calendar.badge.exclamationmark")
                 .font(.system(size: 36))
                 .foregroundStyle(.grey400)
-            Text("표시할 일정이 없습니다")
-                .appFont(.subheadline, color: .grey500)
+            Text("출석 관리 일정이 아직 없어요")
+                .appFont(.calloutEmphasis, color: .grey700)
+            Text("출석이 필요한 일정을 생성하면\n이곳에 출석 현황이 모입니다.")
+                .appFont(.footnote, color: .grey500)
+                .multilineTextAlignment(.center)
             Spacer()
         }
         .frame(maxWidth: .infinity)

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/ChallengerMemberDetailSheetView.swift
@@ -28,11 +28,7 @@ struct ChallengerMemberDetailSheetView: View {
 
     private enum Constants {
         static let tagPadding: EdgeInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
-        static let boxPadding: EdgeInsets = .init(top: 12, leading: 0, bottom: 12, trailing: 0)
-        static let listPadding: EdgeInsets = .init(top: 12, leading: 12, bottom: 12, trailing: 12)
         static let profileSize: CGSize = .init(width: 60, height: 60)
-
-        static let summaryRowVerticalPadding: CGFloat = 12
         static let partTagOpacity: Double = 0.14
         static let partStrokeOpacity: Double = 0.4
         static let partStrokeWidth: CGFloat = 1
@@ -77,14 +73,14 @@ struct ChallengerMemberDetailSheetView: View {
     // MARK: - Body
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
             memberInfoView
             summaryCardView
-            Spacer()
         }
-        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-        .safeAreaPadding(.top, DefaultSpacing.spacing16)
-        .presentationDetents([.fraction(0.4)])
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .padding(.top, DefaultSpacing.spacing8)
+        .padding(.bottom, DefaultSpacing.spacing32)
+        .presentationDetents([.height(280)])
         .presentationDragIndicator(.visible)
         .presentationBackground(.regularMaterial)
     }
@@ -135,8 +131,12 @@ struct ChallengerMemberDetailSheetView: View {
     }
 
     private var summaryCardView: some View {
-        VStack(spacing: .zero) {
-            summaryRow(title: "활동 기수") {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            // 활동 기수
+            HStack {
+                Text("활동 기수")
+                    .appFont(.subheadline, color: .grey700)
+                Spacer()
                 if hasMultipleGenerations {
                     generationChips
                 } else {
@@ -148,6 +148,7 @@ struct ChallengerMemberDetailSheetView: View {
 
             Divider()
 
+            // 상점 · 벌점
             HStack(spacing: .zero) {
                 pointColumn(
                     icon: "plus.circle.fill",
@@ -158,7 +159,7 @@ struct ChallengerMemberDetailSheetView: View {
                 )
 
                 Divider()
-                    .frame(height: 48)
+                    .frame(height: 44)
 
                 pointColumn(
                     icon: "minus.circle.fill",
@@ -168,16 +169,12 @@ struct ChallengerMemberDetailSheetView: View {
                     valueColor: .red
                 )
             }
-            .padding(.vertical, Constants.summaryRowVerticalPadding)
         }
-        .padding(.horizontal, Constants.listPadding.leading)
-        .clipShape(
-            ConcentricRectangle(
-                corners: .concentric(minimum: DefaultConstant.concentricRadius),
-                isUniform: true
-            )
+        .padding(DefaultSpacing.spacing16)
+        .background(
+            .ultraThinMaterial,
+            in: RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius)
         )
-        .glassEffect(.regular)
         .animation(.smooth(duration: 0.3), value: selectedGisu)
     }
 
@@ -233,18 +230,6 @@ struct ChallengerMemberDetailSheetView: View {
         .frame(maxWidth: .infinity)
     }
 
-    private func summaryRow<Content: View>(
-        title: String,
-        @ViewBuilder value: () -> Content
-    ) -> some View {
-        HStack {
-            Text(title)
-                .appFont(.subheadline, color: .grey700)
-            Spacer()
-            value()
-        }
-        .padding(.vertical, Constants.summaryRowVerticalPadding)
-    }
 
 }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/ChallengerMemberDetailSheetView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/ChallengerMemberDetailSheetView.swift
@@ -77,20 +77,16 @@ struct ChallengerMemberDetailSheetView: View {
     // MARK: - Body
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                GlassEffectContainer {
-                    VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
-                        memberInfoView
-                        summaryCardView
-                    }
-                }
-                .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-                .safeAreaPadding(.bottom, DefaultConstant.defaultSafeBottom)
-            }
-            .scrollContentBackground(.hidden)
-            .presentationDetents([.medium])
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing32) {
+            memberInfoView
+            summaryCardView
+            Spacer()
         }
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .safeAreaPadding(.top, DefaultSpacing.spacing16)
+        .presentationDetents([.fraction(0.4)])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(.regularMaterial)
     }
 
     // MARK: - SubView
@@ -175,13 +171,13 @@ struct ChallengerMemberDetailSheetView: View {
             .padding(.vertical, Constants.summaryRowVerticalPadding)
         }
         .padding(.horizontal, Constants.listPadding.leading)
-        .background(
-            .regularMaterial,
-            in: ConcentricRectangle(
+        .clipShape(
+            ConcentricRectangle(
                 corners: .concentric(minimum: DefaultConstant.concentricRadius),
                 isUniform: true
             )
         )
+        .glassEffect(.regular)
         .animation(.smooth(duration: 0.3), value: selectedGisu)
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
@@ -157,9 +157,10 @@ struct OperatorAttendanceSectionView: View {
 
     private var emptyView: some View {
         ContentUnavailableView {
-            Label("출석 관리 일정이 없어요", systemImage: "calendar.badge.checkmark")
+            Label("출석 관리 일정이 아직 없어요", systemImage: "calendar.badge.checkmark")
         } description: {
-            Text("현재 관리할 출석 세션이 없습니다.")
+            Text("출석이 필요한 일정을 생성하면\n승인 대기와 출석 현황이 이곳에 표시됩니다.")
+                .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorAttendanceSectionView.swift
@@ -156,12 +156,10 @@ struct OperatorAttendanceSectionView: View {
     // MARK: - Empty View
 
     private var emptyView: some View {
-        // NOTE: [#688] V1 /api/v1/schedules 제거로 세션 목록이 임시 빈 상태입니다.
-        //              V2 fetchAttendanceList 기반 재구현 완료 시 일반 빈 상태 메시지로 복귀합니다.
         ContentUnavailableView {
-            Label("출석 관리 준비 중", systemImage: "wrench.and.screwdriver")
+            Label("출석 관리 일정이 없어요", systemImage: "calendar.badge.checkmark")
         } description: {
-            Text("출석 세션 목록 V2 마이그레이션 진행 중입니다.\n곧 다시 제공될 예정이에요.")
+            Text("현재 관리할 출석 세션이 없습니다.")
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
@@ -283,15 +281,27 @@ struct OperatorAttendanceSectionView: View {
 
     // MARK: - Error View
 
+    @ViewBuilder
     private func errorView(error: AppError) -> some View {
-        RetryContentUnavailableView(
-            title: "불러오지 못했어요",
-            systemImage: "exclamationmark.triangle",
-            description: error.userMessage,
-            isRetrying: false,
-            topPadding: DefaultSpacing.spacing32
-        ) {
-            await viewModel.fetchSessions()
+        if error.isPermissionDenied {
+            ContentUnavailableView {
+                Label("접근 권한이 없어요", systemImage: "lock.fill")
+            } description: {
+                Text("운영진 활동 이력이 있는 사용자만\n출석 현황을 조회할 수 있어요")
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        } else {
+            RetryContentUnavailableView(
+                title: "불러오지 못했어요",
+                systemImage: "exclamationmark.triangle",
+                description: error.userMessage,
+                isRetrying: false,
+                topPadding: DefaultSpacing.spacing32
+            ) {
+                await viewModel.fetchSessions()
+            }
         }
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -131,11 +131,31 @@ struct OperatorStudyManagementView: View {
         }
     }
 
+    @ViewBuilder
     private var groupManagementEmptyView: some View {
-        emptyContentView(
-            title: "스터디 그룹 관리",
-            message: "등록된 스터디 그룹이 없습니다"
-        )
+        if canCreateStudyGroup {
+            ContentUnavailableView {
+                Label("스터디 그룹 관리", systemImage: "person.3")
+            } description: {
+                Text("등록된 스터디 그룹이 없습니다\n상단의 + 버튼으로 새 그룹을 만들어 보세요")
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        } else {
+            ContentUnavailableView {
+                Label("스터디 그룹 관리", systemImage: "person.3")
+            } description: {
+                Text("등록된 스터디 그룹이 없습니다")
+            } actions: {
+                Text("스터디 그룹 생성은 교내 회장/부회장만 가능합니다")
+                    .appFont(.footnote, color: .grey500)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+            .accessibilityHint("스터디 그룹 생성 권한이 없습니다. 교내 회장 또는 부회장에게 문의하세요.")
+        }
     }
 
     private func groupManagementListView(groups: [StudyGroupInfo]) -> some View {
@@ -230,21 +250,6 @@ struct OperatorStudyManagementView: View {
 
             Text(message)
                 .appFont(.subheadline, color: .grey500)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-    }
-
-    // MARK: - Empty View
-
-    private func emptyContentView(
-        title: String,
-        message: String
-    ) -> some View {
-        ContentUnavailableView {
-            Label(title, systemImage: "person.3")
-        } description: {
-            Text(message)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -148,7 +148,7 @@ struct OperatorStudyManagementView: View {
             } description: {
                 Text("등록된 스터디 그룹이 없습니다")
             } actions: {
-                Text("스터디 그룹 생성은 교내 회장/부회장만 가능합니다")
+                Text("스터디 그룹 생성은\n교내 회장/부회장만 가능합니다")
                     .appFont(.footnote, color: .grey500)
                     .multilineTextAlignment(.center)
             }

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/ScheduleRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/ScheduleRepository.swift
@@ -67,8 +67,11 @@ final class ScheduleRepository: ScheduleRepositoryProtocol, @unchecked Sendable 
 
     /// 일정을 단순 삭제합니다.
     ///
+    /// 서버는 출석 기록이 1건이라도 있는 일정에 대해 일반 DELETE 를 거부합니다 (FORCE_DELETE 만 허용).
+    /// 이 경우 응답 메시지를 파싱해 ``DomainError/scheduleHasAttendanceRecords`` 로 변환합니다.
+    ///
     /// - Parameter scheduleId: 삭제할 일정 ID
-    /// - Throws: 서버 에러 또는 네트워크 에러
+    /// - Throws: ``DomainError/scheduleHasAttendanceRecords`` / 서버 에러 / 네트워크 에러
     func deleteSchedule(
         scheduleId: Int
     ) async throws {
@@ -82,7 +85,23 @@ final class ScheduleRepository: ScheduleRepositoryProtocol, @unchecked Sendable 
             APIResponse<EmptyResult>.self,
             from: response.data
         )
-        try apiResponse.validateSuccess()
+        do {
+            try apiResponse.validateSuccess()
+        } catch let error as RepositoryError {
+            throw Self.mapScheduleDeleteError(error)
+        }
+    }
+
+    /// 일정 삭제 실패 메시지에서 출석 기록 존재 케이스를 감지해 도메인 에러로 변환합니다.
+    ///
+    /// 서버 메시지 또는 에러 코드를 기반으로 ``DomainError/scheduleHasAttendanceRecords`` 로 매핑합니다.
+    private static func mapScheduleDeleteError(_ error: RepositoryError) -> Error {
+        guard case .serverError(let code, let message) = error else { return error }
+        let combined = "\(code ?? "") \(message ?? "")"
+        if combined.contains("출석 기록") || combined.contains("출석 데이터") || combined.contains("출석") && combined.contains("삭제") {
+            return DomainError.scheduleHasAttendanceRecords
+        }
+        return error
     }
 
     /// 일정 정보를 부분 수정합니다.

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
@@ -29,7 +29,7 @@ class ScheduleDetailViewModel {
     var alertPromprt: AlertPrompt?
     /// 수정 화면 표시 여부
     var isShowModify: Bool = false
-    /// 일정 수정 가능 여부 (WRITE/MANAGE)
+    /// 일정 수정 가능 여부 (EDIT/WRITE/MANAGE)
     var canEditSchedule: Bool = false
     /// 일정 삭제 가능 여부 (DELETE/MANAGE)
     var canDeleteSchedule: Bool = false
@@ -118,7 +118,7 @@ class ScheduleDetailViewModel {
                 resourceType: .schedule,
                 resourceId: scheduleId
             )
-            canEditSchedule = permission.hasAny([.write, .manage])
+            canEditSchedule = permission.hasAny([.edit, .write, .manage])
             canDeleteSchedule = permission.hasAny([.delete, .manage])
         } catch {
             canEditSchedule = false

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -485,9 +485,15 @@ class ScheduleRegistrationViewModel {
             return
         }
 
+        let memberIds = sanitizedParticipantMemberIds()
+        if let overflowMessage = participantOverflowMessage(memberIds: memberIds) {
+            submitState = .idle
+            inlineErrorMessage = overflowMessage
+            return
+        }
+
         submitState = .loading
         inlineErrorMessage = nil
-        let memberIds = sanitizedParticipantMemberIds()
         let dto = GenerateScheduleRequetDTO(
             name: title,
             description: memo,
@@ -573,6 +579,19 @@ class ScheduleRegistrationViewModel {
         isAllDay ? dataRange.endDate.kstEndOfDay : dataRange.endDate
     }
 
+    /// 참여자 수가 서버 측 한도(`ScheduleCapabilities.maxParticipantCount`)를 초과하면
+    /// 인라인 메시지로 표시할 안내 문구를 반환합니다.
+    ///
+    /// - capabilities 가 아직 로드되지 않았거나 한도가 0 이하면 검사 생략(`nil`).
+    /// - 본인 강제 포함 후의 최종 참여자 수를 기준으로 검증합니다.
+    private func participantOverflowMessage(memberIds: [Int]) -> String? {
+        guard case .loaded(let capabilities) = capabilitiesState else { return nil }
+        let limit = capabilities.maxParticipantCount
+        guard limit > 0 else { return nil }
+        guard memberIds.count > limit else { return nil }
+        return "최대 \(limit)명까지 초대할 수 있어요. 현재 \(memberIds.count)명이 선택되어 있습니다."
+    }
+
     /// 본인 멤버 ID 를 강제 포함한 정렬된 참여자 ID 목록
     private func sanitizedParticipantMemberIds() -> [Int] {
         var memberIds = Array(Set(participatn.compactMap { Int($0.memberId) })).sorted()
@@ -645,10 +664,17 @@ class ScheduleRegistrationViewModel {
             return
         }
 
+        let participantMemberIds: [Int]? = participatn.isEmpty ? nil : sanitizedParticipantMemberIds()
+        if let memberIds = participantMemberIds,
+           let overflowMessage = participantOverflowMessage(memberIds: memberIds) {
+            submitState = .idle
+            inlineErrorMessage = overflowMessage
+            return
+        }
+
         submitState = .loading
         inlineErrorMessage = nil
 
-        let participantMemberIds: [Int]? = participatn.isEmpty ? nil : sanitizedParticipantMemberIds()
         let dto = UpdateScheduleRequestDTO(
             name: title,
             description: memo,

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
@@ -119,7 +119,7 @@ struct NoticeEditorView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { toolbarContent }
         .safeAreaBar(edge: .top, content: topSafeAreaContent)
-//        .safeAreaBar(edge: .bottom, alignment: .leading, content: bottomSafeAreaContent)
+        .safeAreaBar(edge: .bottom, alignment: .leading, content: bottomSafeAreaContent)
         .noticeEditorPresentations(viewModel: viewModel)
     }
 

--- a/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
+++ b/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
@@ -42,6 +42,7 @@ struct UmcBottonAccessoryView: View {
 /// 홈 탭 하단 액세서리 - 일정 생성 버튼
 fileprivate struct HomeBottonAccessoryView: View {
     @Environment(\.di) var di
+    @State private var canCreateSchedule: Bool = false
 
     private var pathStore: PathStore {
         di.resolve(PathStore.self)
@@ -49,7 +50,7 @@ fileprivate struct HomeBottonAccessoryView: View {
 
     var body: some View {
         Group {
-            if pathStore.homePath.isEmpty {
+            if pathStore.homePath.isEmpty && canCreateSchedule {
                 Button(action: {
                     pathStore.homePath.append(.home(.registrationSchedule))
                 }, label: {
@@ -68,6 +69,22 @@ fileprivate struct HomeBottonAccessoryView: View {
             } else {
                 EmptyView()
             }
+        }
+        .task {
+            await loadCapabilities()
+        }
+    }
+
+    /// 서버에서 일정 생성 권한을 조회해 버튼 노출 여부를 결정합니다.
+    /// 실패 시 버튼을 숨겨 권한 없는 사용자가 시도하지 못하게 합니다.
+    private func loadCapabilities() async {
+        let useCase = di.resolve(HomeUseCaseProviding.self)
+            .fetchScheduleCapabilitiesUseCase
+        do {
+            let capabilities = try await useCase.execute()
+            canCreateSchedule = capabilities.canCreateSchedule
+        } catch {
+            canCreateSchedule = false
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor / 🐛 Bug Fix / ✨ Feature — 출석 권한/UX 일관성 개선 (6개 이슈 일괄 해결)

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 영역:
- 홈 탭 하단 액세서리 — 권한 없는 사용자에게 "일정 생성" 버튼 미노출
- 출석 관리 빈 상태 — 행동 유도형 안내 문구로 교체
- 일정 생성/수정 — 참여자 한도 초과 시 인라인 에러 노출
- 출석 승인/거절 403 — 권한 안내 AlertPrompt

> 실 기기 캡처는 리뷰 단계에서 보강 예정입니다.

## 🛠️ 작업내용

서버 측 Schedule 권한 분석 리포트 기반으로 식별된 6개 이슈를 한 번에 해결합니다.

### #789 일정 수정 권한 (EDIT 추가)
- `ScheduleDetailViewModel.fetchSchedulePermission()` 에서 `canEditSchedule` 판정에 `.edit` 권한 포함
- 서버 `PermissionType.EDIT` ↔ 클라이언트 `.write`/`.manage` 만 체크하던 매핑 누락 해결

### #790 출석 기록 존재 시 일정 삭제 분기
- `DomainError` 에 `scheduleHasAttendanceRecords`, `scheduleAlreadyStarted` 케이스 추가
- `ScheduleRepository.deleteSchedule` 에서 서버 에러 메시지를 감지해 DomainError 로 매핑 → ErrorHandler 가 친화적 Alert 표시

### #791 출석 승인/거절 403 에러 UX
- `OperatorAttendanceViewModel` 단건/선택/전체 결정 액션의 catch 블록을 `handleDecisionError(_:action:)` 로 통합
- 403 감지 시 권한 안내 AlertPrompt 노출 + 세션 목록 자동 새로고침

### #792 일정 생성 버튼 권한 가드
- `HomeBottonAccessoryView` 에서 `FetchScheduleCapabilitiesUseCase` 로 `canCreateSchedule` 를 조회해 버튼 노출 결정
- 권한 없을 시 / 조회 실패 시 모두 버튼 숨김 (보수적 폴백)

### #793 빈 상태 안내 문구
- `AttendanceListView.emptyView` — "표시할 일정이 없습니다" → 행동 유도형 2단 메시지
- `OperatorAttendanceSectionView.emptyView` — 설명 텍스트 보강

### #794 참여자 수 submit 가드
- `ScheduleRegistrationViewModel.submitSchedule()`/`updateSchedule()` 에서 `ScheduleCapabilities.maxParticipantCount` 초과 시 인라인 메시지로 차단
- 본인 자동 포함된 최종 참여자 수 기준

### 연관 이슈
- closes #789
- closes #790
- closes #791
- closes #792
- closes #793
- closes #794

## 📋 추후 진행 상황

- [ ] 서버 측 출석 기록 존재 에러 코드가 명확해지면 문자열 매칭 → 코드 매칭으로 정밀화
- [ ] `participantOverflowMessage` 인라인 메시지 디자인 토큰 정리 (현재 기존 inlineErrorMessage 스타일 재사용)
- [ ] 권한 가드/빈 상태 메시지 관련 단위 테스트 추가

## 📌 리뷰 포인트

1. **`ScheduleRepository.mapScheduleDeleteError`** 의 문자열 매칭 로직 — "출석 기록"/"출석 데이터" 키워드 휴리스틱이 서버 메시지 변경에 취약하지 않은지 확인 필요
2. **`HomeBottonAccessoryView.loadCapabilities()`** 실패 시 버튼을 숨기는 정책 — 권한 있는 사용자가 네트워크 일시 장애로 버튼을 못 보는 트레이드오프가 허용 범위인지 검토
3. **`OperatorAttendanceViewModel.isPermissionDenied(_:)`** — `AppError`/`NetworkError` 두 표현만 감지하므로 다른 경로로 들어오는 403 케이스가 있는지 확인
4. **`participantOverflowMessage(memberIds:)`** — `capabilities` 가 아직 로드되지 않은 시점(.idle/.loading)엔 검사를 생략하는데, 이 사이에 submit 이 가능한지 흐름 점검 (현재는 `loadCapabilities` 가 화면 진입 시 호출되므로 실제로는 거의 발생 X)
5. **#789 매핑 변경** — `.edit` 추가 후 서버 응답상 EDIT/WRITE/MANAGE 가 모두 동등하게 동작하는지 QA 환경에서 교차 확인 권장

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    - 해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)