### PR TITLE
✨ [Feat] 이메일 인증 purpose 분리 및 비밀번호 찾기 기능 구현 (#788)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Error/Types/AuthError.swift
+++ b/AppProduct/AppProduct/Core/Common/Error/Types/AuthError.swift
@@ -39,6 +39,15 @@ enum AuthError: Error, LocalizedError, Equatable {
     /// 인증 코드 만료
     case verificationCodeExpired
 
+    /// 이미 가입된 이메일 (회원가입 시)
+    case emailAlreadyExists
+
+    /// 이메일 인증 발송 throttle (60초 이내 재요청)
+    case emailVerificationThrottled
+
+    /// 잘못된 이메일 형식 (서버 검증 실패)
+    case invalidEmailFormat
+
     // MARK: - LocalizedError
 
     var errorDescription: String? {
@@ -63,6 +72,12 @@ enum AuthError: Error, LocalizedError, Equatable {
             return "인증 번호가 올바르지 않습니다."
         case .verificationCodeExpired:
             return "인증 번호가 만료되었습니다."
+        case .emailAlreadyExists:
+            return "이미 가입된 이메일입니다."
+        case .emailVerificationThrottled:
+            return "잠시 후 다시 시도해주세요."
+        case .invalidEmailFormat:
+            return "유효하지 않은 이메일 형식입니다."
         }
     }
 
@@ -79,6 +94,12 @@ enum AuthError: Error, LocalizedError, Equatable {
             return "인증 번호를 다시 확인해주세요."
         case .verificationCodeExpired:
             return "인증 번호가 만료되었어요. 다시 요청해주세요."
+        case .emailAlreadyExists:
+            return "이미 가입된 이메일이에요."
+        case .emailVerificationThrottled:
+            return "60초 후에 다시 요청해주세요."
+        case .invalidEmailFormat:
+            return "유효하지 않은 이메일 형식이에요."
         default:
             return errorDescription ?? ""
         }

--- a/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
+++ b/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
@@ -82,7 +82,7 @@ private struct PreviewFetchMyProfileUseCase: FetchMyProfileUseCaseProtocol {
 
 /// Preview 전용 UseCase들
 private struct PreviewSendEmailUseCase: SendEmailVerificationUseCaseProtocol {
-    func execute(email: String) async throws -> String {
+    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
         "preview_verification_id"
     }
 }

--- a/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
@@ -55,6 +55,8 @@ enum NavigationDestination: Hashable {
         case loginByIdPw
         /// ID/PW 회원가입 화면
         case signUpByIdPw
+        /// 비밀번호 찾기 화면
+        case resetPassword
     }
 
     /// 홈(Home) 관련 화면 목적지

--- a/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
@@ -69,11 +69,20 @@ private extension NavigationRoutingView {
             let authProvider = di.resolve(AuthUseCaseProviding.self)
             SignUpByIdPwView(
                 sendEmailVerificationUseCase: authProvider.sendEmailVerificationUseCase,
+                resendEmailVerificationUseCase: authProvider.resendEmailVerificationUseCase,
                 verifyEmailCodeUseCase: authProvider.verifyEmailCodeUseCase,
                 registerByEmailUseCase: authProvider.registerByEmailUseCase,
                 checkEmailAvailabilityUseCase: authProvider.checkEmailAvailabilityUseCase,
                 fetchSignUpDataUseCase: authProvider.fetchSignUpDataUseCase,
                 fetchMyProfileUseCase: di.resolve(HomeUseCaseProviding.self).fetchMyProfileUseCase
+            )
+        case .resetPassword:
+            let authProvider = di.resolve(AuthUseCaseProviding.self)
+            ResetPasswordView(
+                sendEmailVerificationUseCase: authProvider.sendEmailVerificationUseCase,
+                resendEmailVerificationUseCase: authProvider.resendEmailVerificationUseCase,
+                verifyEmailCodeUseCase: authProvider.verifyEmailCodeUseCase,
+                resetPasswordUseCase: authProvider.resetPasswordUseCase
             )
         }
     }

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/ResendEmailVerificationRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/ResendEmailVerificationRequestDTO.swift
@@ -1,0 +1,14 @@
+//
+//  ResendEmailVerificationRequestDTO.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 이메일 인증 코드 재전송 요청 DTO
+///
+/// `POST /api/v1/auth/email-verification/resend`
+struct ResendEmailVerificationRequestDTO: Encodable {
+    /// 재전송 대상 이메일 인증 ID
+    let emailVerificationId: String
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/ResetPasswordRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/ResetPasswordRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  ResetPasswordRequestDTO.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 비밀번호 초기화 요청 DTO
+///
+/// `PATCH /api/v1/auth/password/reset`
+/// `purpose=PASSWORD_RESET`으로 발급된 토큰만 사용 가능.
+struct ResetPasswordRequestDTO: Encodable {
+    /// 비밀번호 초기화용 이메일 인증 토큰
+    let emailVerificationToken: String
+    /// 새 비밀번호 (평문)
+    let newPassword: String
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/SendEmailVerificationRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/SendEmailVerificationRequestDTO.swift
@@ -13,4 +13,6 @@ import Foundation
 struct SendEmailVerificationRequestDTO: Encodable {
     /// 인증할 이메일 주소
     let email: String
+    /// 인증 목적 ("REGISTER" | "PASSWORD_RESET")
+    let purpose: String
 }

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -242,21 +242,83 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
 
     /// 이메일 인증 코드를 발송합니다.
     ///
-    /// - Parameter email: 인증할 이메일 주소
+    /// - Parameters:
+    ///   - email: 인증할 이메일 주소
+    ///   - purpose: 인증 목적 (회원가입/비밀번호 초기화)
     /// - Returns: 발급된 이메일 인증 ID
     func sendEmailVerification(
-        email: String
+        email: String,
+        purpose: EmailVerificationPurpose
     ) async throws -> String {
-        let response = try await adapter.requestWithoutAuth(
-            AuthRouter.sendEmailVerification(
-                body: SendEmailVerificationRequestDTO(email: email)
+        do {
+            let response = try await adapter.requestWithoutAuth(
+                AuthRouter.sendEmailVerification(
+                    body: SendEmailVerificationRequestDTO(
+                        email: email,
+                        purpose: purpose.rawValue
+                    )
+                )
             )
-        )
-        let apiResponse = try decoder.decode(
-            APIResponse<EmailVerificationResponseDTO>.self,
-            from: response.data
-        )
-        return try apiResponse.unwrap().emailVerificationId
+            let apiResponse = try decoder.decode(
+                APIResponse<EmailVerificationResponseDTO>.self,
+                from: response.data
+            )
+            return try apiResponse.unwrap().emailVerificationId
+        } catch let error as NetworkError {
+            throw Self.mapEmailVerificationError(from: error) ?? error
+        }
+    }
+
+    /// 이메일 인증 코드를 재전송합니다.
+    ///
+    /// - Parameter emailVerificationId: 발송 시 발급된 인증 ID
+    func resendEmailVerification(
+        emailVerificationId: String
+    ) async throws {
+        do {
+            let response = try await adapter.requestWithoutAuth(
+                AuthRouter.resendEmailVerification(
+                    body: ResendEmailVerificationRequestDTO(
+                        emailVerificationId: emailVerificationId
+                    )
+                )
+            )
+            let apiResponse = try decoder.decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let error as NetworkError {
+            throw Self.mapEmailVerificationError(from: error) ?? error
+        }
+    }
+
+    /// 비밀번호를 초기화합니다.
+    ///
+    /// - Parameters:
+    ///   - emailVerificationToken: `purpose=PASSWORD_RESET`로 발급된 토큰
+    ///   - newPassword: 새 비밀번호 (평문)
+    func resetPassword(
+        emailVerificationToken: String,
+        newPassword: String
+    ) async throws {
+        do {
+            let response = try await adapter.requestWithoutAuth(
+                AuthRouter.resetPassword(
+                    body: ResetPasswordRequestDTO(
+                        emailVerificationToken: emailVerificationToken,
+                        newPassword: newPassword
+                    )
+                )
+            )
+            let apiResponse = try decoder.decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let error as NetworkError {
+            throw Self.parseServerError(from: error) ?? error
+        }
     }
 
     /// 이메일 인증 코드를 검증합니다.
@@ -404,6 +466,34 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
 // MARK: - Private Helpers
 
 private extension AuthRepository {
+    /// 이메일 인증 발송/재전송 에러 코드 → AuthError 매핑
+    ///
+    /// - `AUTHENTICATION-0026 EMAIL_ALREADY_EXISTS` (409): 회원가입 시 이미 가입된 이메일
+    /// - `AUTHENTICATION-0027 EMAIL_VERIFICATION_THROTTLED` (429): 60초 throttle
+    /// - `AUTHENTICATION-0025 INVALID_EMAIL_FORMAT` (400): 잘못된 이메일 형식
+    static func mapEmailVerificationError(from error: NetworkError) -> Error? {
+        guard case .requestFailed(_, let data) = error,
+              let data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        let code = json["code"] as? String
+        let message = (json["message"] as? String) ?? (json["result"] as? String)
+
+        switch code {
+        case "AUTHENTICATION-0026":
+            return AuthError.emailAlreadyExists
+        case "AUTHENTICATION-0027":
+            return AuthError.emailVerificationThrottled
+        case "AUTHENTICATION-0025":
+            return AuthError.invalidEmailFormat
+        default:
+            guard code != nil || message != nil else { return nil }
+            return RepositoryError.serverError(code: code, message: message)
+        }
+    }
+
     static func parseServerError(from error: NetworkError) -> Error? {
         guard case .requestFailed(_, let data) = error,
               let data,

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
@@ -140,10 +140,24 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
     }
 
     func sendEmailVerification(
-        email: String
+        email: String,
+        purpose: EmailVerificationPurpose
     ) async throws -> String {
         try await Task.sleep(for: .milliseconds(500))
         return "mock_verification_id_1"
+    }
+
+    func resendEmailVerification(
+        emailVerificationId: String
+    ) async throws {
+        try await Task.sleep(for: .milliseconds(500))
+    }
+
+    func resetPassword(
+        emailVerificationToken: String,
+        newPassword: String
+    ) async throws {
+        try await Task.sleep(for: .milliseconds(500))
     }
 
     func verifyEmailCode(

--- a/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
@@ -38,8 +38,12 @@ enum AuthRouter: BaseTargetType {
     )
     /// 이메일 인증 발송
     case sendEmailVerification(body: SendEmailVerificationRequestDTO)
+    /// 이메일 인증코드 재전송
+    case resendEmailVerification(body: ResendEmailVerificationRequestDTO)
     /// 이메일 인증코드 검증
     case verifyEmailCode(body: VerifyEmailCodeRequestDTO)
+    /// 비밀번호 초기화
+    case resetPassword(body: ResetPasswordRequestDTO)
     /// 회원가입
     case register(body: RegisterRequestDTO)
     /// 기존 챌린저 코드 인증
@@ -75,8 +79,12 @@ enum AuthRouter: BaseTargetType {
             return "/api/v1/member-oauth/\(memberOAuthId)"
         case .sendEmailVerification:
             return "/api/v1/auth/email-verification"
+        case .resendEmailVerification:
+            return "/api/v1/auth/email-verification/resend"
         case .verifyEmailCode:
             return "/api/v1/auth/email-verification/code"
+        case .resetPassword:
+            return "/api/v1/auth/password/reset"
         case .register:
             return "/api/v1/member/register"
         case .registerExistingChallenger:
@@ -95,8 +103,8 @@ enum AuthRouter: BaseTargetType {
     var method: Moya.Method {
         switch self {
         case .loginKakao, .loginApple, .loginByEmail, .registerByEmail,
-             .renewToken, .sendEmailVerification, .verifyEmailCode,
-             .register, .registerExistingChallenger:
+             .renewToken, .sendEmailVerification, .resendEmailVerification,
+             .verifyEmailCode, .register, .registerExistingChallenger:
             return .post
         case .addMemberOAuth:
             return .post
@@ -107,6 +115,8 @@ enum AuthRouter: BaseTargetType {
             return .get
         case .registerCredential:
             return .post
+        case .resetPassword:
+            return .patch
         }
     }
 
@@ -150,7 +160,11 @@ enum AuthRouter: BaseTargetType {
             )
         case .sendEmailVerification(let body):
             return .requestJSONEncodable(body)
+        case .resendEmailVerification(let body):
+            return .requestJSONEncodable(body)
         case .verifyEmailCode(let body):
+            return .requestJSONEncodable(body)
+        case .resetPassword(let body):
             return .requestJSONEncodable(body)
         case .register(let body):
             return .requestJSONEncodable(body)

--- a/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
@@ -83,11 +83,29 @@ protocol AuthRepositoryProtocol: Sendable {
     ) async throws
 
     /// 이메일 인증 발송
-    /// - Parameter email: 인증할 이메일 주소
+    /// - Parameters:
+    ///   - email: 인증할 이메일 주소
+    ///   - purpose: 인증 목적 (회원가입/비밀번호 초기화)
     /// - Returns: 이메일 인증 ID
     func sendEmailVerification(
-        email: String
+        email: String,
+        purpose: EmailVerificationPurpose
     ) async throws -> String
+
+    /// 이메일 인증 코드 재전송
+    /// - Parameter emailVerificationId: 발송 시 발급된 인증 ID
+    func resendEmailVerification(
+        emailVerificationId: String
+    ) async throws
+
+    /// 비밀번호 초기화
+    /// - Parameters:
+    ///   - emailVerificationToken: `purpose=PASSWORD_RESET`로 발급된 토큰
+    ///   - newPassword: 새 비밀번호 (평문)
+    func resetPassword(
+        emailVerificationToken: String,
+        newPassword: String
+    ) async throws
 
     /// 이메일 인증코드 검증
     /// - Parameters:

--- a/AppProduct/AppProduct/Features/Auth/Domain/Models/EmailVerificationPurpose.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Models/EmailVerificationPurpose.swift
@@ -1,0 +1,17 @@
+//
+//  EmailVerificationPurpose.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 이메일 인증 발송 목적
+///
+/// 서버 `POST /api/v1/auth/email-verification` 요청 시 `purpose` 필드로 전달됩니다.
+/// 발급되는 `emailVerificationToken`의 사용 범위가 목적별로 제한됩니다.
+enum EmailVerificationPurpose: String, Sendable {
+    /// 회원가입
+    case register = "REGISTER"
+    /// 비밀번호 초기화
+    case passwordReset = "PASSWORD_RESET"
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/ResendEmailVerificationUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/ResendEmailVerificationUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  ResendEmailVerificationUseCase.swift
+//  AppProduct
+//
+
+import Foundation
+
+final class ResendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol {
+
+    private let repository: AuthRepositoryProtocol
+
+    init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(emailVerificationId: String) async throws {
+        try await repository.resendEmailVerification(
+            emailVerificationId: emailVerificationId
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/ResetPasswordUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/ResetPasswordUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  ResetPasswordUseCase.swift
+//  AppProduct
+//
+
+import Foundation
+
+final class ResetPasswordUseCase: ResetPasswordUseCaseProtocol {
+
+    private let repository: AuthRepositoryProtocol
+
+    init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(
+        emailVerificationToken: String,
+        newPassword: String
+    ) async throws {
+        try await repository.resetPassword(
+            emailVerificationToken: emailVerificationToken,
+            newPassword: newPassword
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/SendEmailVerificationUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/SendEmailVerificationUseCase.swift
@@ -24,7 +24,13 @@ final class SendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol {
 
     // MARK: - Function
 
-    func execute(email: String) async throws -> String {
-        try await repository.sendEmailVerification(email: email)
+    func execute(
+        email: String,
+        purpose: EmailVerificationPurpose
+    ) async throws -> String {
+        try await repository.sendEmailVerification(
+            email: email,
+            purpose: purpose
+        )
     }
 }

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/ResendEmailVerificationUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/ResendEmailVerificationUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ResendEmailVerificationUseCaseProtocol.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 이메일 인증 코드 재전송 UseCase Protocol
+protocol ResendEmailVerificationUseCaseProtocol {
+    /// 인증 코드 재전송
+    /// - Parameter emailVerificationId: 발송 시 발급된 인증 ID
+    func execute(emailVerificationId: String) async throws
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/ResetPasswordUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/ResetPasswordUseCaseProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  ResetPasswordUseCaseProtocol.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 비밀번호 초기화 UseCase Protocol
+protocol ResetPasswordUseCaseProtocol {
+    /// 비밀번호 초기화 실행
+    /// - Parameters:
+    ///   - emailVerificationToken: `purpose=PASSWORD_RESET`로 발급된 토큰
+    ///   - newPassword: 새 비밀번호 (평문)
+    func execute(
+        emailVerificationToken: String,
+        newPassword: String
+    ) async throws
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/SendEmailVerificationUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/SendEmailVerificationUseCaseProtocol.swift
@@ -12,7 +12,12 @@ import Foundation
 /// 이메일 인증 발송 UseCase Protocol
 protocol SendEmailVerificationUseCaseProtocol {
     /// 이메일 인증 발송
-    /// - Parameter email: 인증할 이메일 주소
+    /// - Parameters:
+    ///   - email: 인증할 이메일 주소
+    ///   - purpose: 인증 목적 (회원가입/비밀번호 초기화)
     /// - Returns: 이메일 인증 ID
-    func execute(email: String) async throws -> String
+    func execute(
+        email: String,
+        purpose: EmailVerificationPurpose
+    ) async throws -> String
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Components/FormEmailField.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Components/FormEmailField.swift
@@ -50,6 +50,11 @@ struct FormEmailField: View {
     /// 인증번호 검증 시 실행될 비동기 클로저 (인증번호를 파라미터로 받음)
     let onVerificationComplete: (String) async throws -> Void
 
+    /// 인증번호 재전송 시 실행될 비동기 클로저
+    ///
+    /// nil이면 재전송 버튼을 표시하지 않습니다.
+    var onResend: (() async throws -> Void)? = nil
+
     /// 필수 입력 여부 (기본값: true)
     var isRequired: Bool = true
 
@@ -70,6 +75,12 @@ struct FormEmailField: View {
 
     /// 입력된 인증번호
     @State private var verificationCode: String = ""
+
+    /// 인증 발송/재전송 throttle 남은 초 (0이면 재전송 가능)
+    @State private var resendCooldownSeconds: Int = 0
+
+    /// 표시할 에러 메시지 (이메일 형식 외 서버 에러용)
+    @State private var customErrorMessage: String? = nil
 
     /// 애니메이션 네임스페이스
     @Namespace var namespace
@@ -129,6 +140,9 @@ struct FormEmailField: View {
 
         /// 성공 아이콘 SF Symbol 이름
         static let successImage: String = "checkmark.circle.fill"
+
+        /// 재전송 throttle 기본 초 (서버와 동일하게 60초)
+        static let resendCooldown: Int = 60
     }
     
     // MARK: - Body
@@ -144,6 +158,10 @@ struct FormEmailField: View {
             // 인증번호 입력 필드
             if verificationState == .codeRequested || verificationState == .verifying {
                 verificationCodeField
+
+                if onResend != nil {
+                    resendButton
+                }
             }
 
             // 성공 메시지
@@ -152,6 +170,22 @@ struct FormEmailField: View {
             }
         })
         .animation(.spring(response: 0.35, dampingFraction: 0.75), value: verificationState)
+        .task(id: verificationState) {
+            // codeRequested 진입 시 60초 카운트다운 시작
+            guard verificationState == .codeRequested else { return }
+            if resendCooldownSeconds == 0 {
+                resendCooldownSeconds = Constants.resendCooldown
+            }
+            while resendCooldownSeconds > 0 {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+                if Task.isCancelled { return }
+                resendCooldownSeconds = max(0, resendCooldownSeconds - 1)
+            }
+        }
     }
     
     /// 이메일 입력 필드 및 인증 버튼
@@ -204,9 +238,31 @@ struct FormEmailField: View {
 
     /// 이메일 형식 오류 메시지
     private var erroMsg: some View {
-        Text(Constants.errorMsg)
+        Text(customErrorMessage ?? Constants.errorMsg)
             .appFont(.footnote, color: .red)
             .padding(.leading, Constants.errorPadding)
+    }
+
+    /// 인증번호 재전송 버튼
+    ///
+    /// 60초 throttle 동안 비활성화되며 남은 시간을 표시합니다.
+    private var resendButton: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Spacer()
+            Button {
+                handleResendTap()
+            } label: {
+                Text(
+                    resendCooldownSeconds > 0
+                    ? "재전송 (\(resendCooldownSeconds)초)"
+                    : "인증번호 재전송"
+                )
+                .appFont(.footnote, color: resendCooldownSeconds > 0 ? .grey500 : .indigo500)
+            }
+            .buttonStyle(.plain)
+            .disabled(resendCooldownSeconds > 0 || verificationState == .verifying)
+        }
+        .padding(.horizontal, Constants.errorPadding)
     }
 
     /// 인증번호 입력 필드
@@ -282,11 +338,13 @@ extension FormEmailField {
     private func handleButtonTap() {
         // 이메일 형식 유효성 검증
         if !isValidEmail {
+            customErrorMessage = nil
             showError = true
             return
         }
 
         showError = false
+        customErrorMessage = nil
 
         switch verificationState {
         case .initial, .failed:
@@ -296,8 +354,10 @@ extension FormEmailField {
                     verificationCode = ""
                     verificationState = .verifying
                     try await onVerificationRequested()
+                    resendCooldownSeconds = Constants.resendCooldown
                     verificationState = .codeRequested
                 } catch {
+                    customErrorMessage = userMessage(for: error)
                     showError = true
                     verificationState = .initial
                 }
@@ -312,6 +372,7 @@ extension FormEmailField {
                     try await onVerificationComplete(verificationCode)
                     verificationState = .verified
                 } catch {
+                    customErrorMessage = userMessage(for: error)
                     verificationState = .failed
                     showError = true
                 }
@@ -325,6 +386,36 @@ extension FormEmailField {
         }
     }
 
+    /// 재전송 버튼 탭 핸들러
+    ///
+    /// 60초 카운트다운이 끝났을 때 호출되며, 성공 시 카운트다운을 재시작합니다.
+    private func handleResendTap() {
+        guard let onResend, resendCooldownSeconds == 0 else { return }
+        Task {
+            do {
+                customErrorMessage = nil
+                showError = false
+                try await onResend()
+                verificationCode = ""
+                resendCooldownSeconds = Constants.resendCooldown
+            } catch {
+                customErrorMessage = userMessage(for: error)
+                showError = true
+            }
+        }
+    }
+
+    /// 에러 → 사용자 표시 문구
+    private func userMessage(for error: Error) -> String {
+        if let appError = error as? AppError {
+            return appError.userMessage
+        }
+        if let authError = error as? AuthError {
+            return authError.userMessage
+        }
+        return Constants.errorMsg
+    }
+
     /// 이메일 변경 시 인증 상태를 초기화합니다.
     ///
     /// 인증 요청 이후 이메일이 수정되면 이전 인증번호/성공 상태는 더 이상 유효하지 않으므로
@@ -333,5 +424,7 @@ extension FormEmailField {
         guard verificationState != .initial else { return }
         verificationCode = ""
         verificationState = .initial
+        resendCooldownSeconds = 0
+        customErrorMessage = nil
     }
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Components/SignUpEmailSection.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Components/SignUpEmailSection.swift
@@ -26,6 +26,9 @@ struct SignUpEmailSection: View {
     /// 인증번호 확인 요청 — 실패 시 `throw`
     let onVerificationComplete: (String) async throws -> Void
 
+    /// 인증번호 재전송 요청 — 실패 시 `throw`
+    let onResend: () async throws -> Void
+
     /// 이메일 값이 변경될 때 부모에게 알리는 콜백.
     /// 부모는 이 콜백 안에서 인증 상태 리셋 여부를 직접 판단합니다.
     let onEmailChanged: () -> Void
@@ -42,6 +45,7 @@ struct SignUpEmailSection: View {
             text: $email,
             onVerificationRequested: onVerificationRequested,
             onVerificationComplete: onVerificationComplete,
+            onResend: onResend,
             submitLabel: .next,
             onSubmit: onSubmit,
             onEmailChanged: onEmailChanged

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
@@ -25,8 +25,12 @@ protocol AuthUseCaseProviding {
     var deleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol { get }
     /// 이메일 인증 발송 UseCase
     var sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol { get }
+    /// 이메일 인증 코드 재전송 UseCase
+    var resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol { get }
     /// 이메일 인증코드 검증 UseCase
     var verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol { get }
+    /// 비밀번호 초기화 UseCase
+    var resetPasswordUseCase: ResetPasswordUseCaseProtocol { get }
     /// 회원가입 UseCase
     var registerUseCase: RegisterUseCaseProtocol { get }
     /// 기존 챌린저 인증 코드 등록 UseCase
@@ -52,7 +56,9 @@ final class AuthUseCaseProvider: AuthUseCaseProviding {
     let addMemberOAuthUseCase: AddMemberOAuthUseCaseProtocol
     let deleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol
     let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
+    let resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
     let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
+    let resetPasswordUseCase: ResetPasswordUseCaseProtocol
     let registerUseCase: RegisterUseCaseProtocol
     let registerExistingChallengerUseCase: RegisterExistingChallengerUseCaseProtocol
     let fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
@@ -93,7 +99,13 @@ final class AuthUseCaseProvider: AuthUseCaseProviding {
         self.sendEmailVerificationUseCase = SendEmailVerificationUseCase(
             repository: repository
         )
+        self.resendEmailVerificationUseCase = ResendEmailVerificationUseCase(
+            repository: repository
+        )
         self.verifyEmailCodeUseCase = VerifyEmailCodeUseCase(
+            repository: repository
+        )
+        self.resetPasswordUseCase = ResetPasswordUseCase(
             repository: repository
         )
         self.registerUseCase = RegisterUseCase(

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/ResetPasswordViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/ResetPasswordViewModel.swift
@@ -1,0 +1,134 @@
+//
+//  ResetPasswordViewModel.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 비밀번호 찾기 화면의 상태와 로직을 관리하는 ViewModel
+///
+/// 흐름: 이메일 입력 → 인증코드 입력 → 새 비밀번호 입력 → 변경 완료
+/// `purpose=PASSWORD_RESET`으로 발급된 `emailVerificationToken`만 사용합니다.
+@Observable
+@MainActor
+final class ResetPasswordViewModel {
+
+    // MARK: - Property
+
+    private let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
+    private let resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
+    private let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
+    private let resetPasswordUseCase: ResetPasswordUseCaseProtocol
+
+    /// 이메일 입력
+    var emailInput: String = ""
+    /// 새 비밀번호 입력
+    var newPasswordInput: String = ""
+    /// 새 비밀번호 확인 입력
+    var newPasswordConfirmInput: String = ""
+
+    private(set) var emailVerificationId: String?
+    private(set) var emailVerificationToken: String?
+    private(set) var isEmailVerified: Bool = false
+
+    /// 비밀번호 변경 결과
+    private(set) var resetState: Loadable<Bool> = .idle
+
+    // MARK: - Init
+
+    init(
+        sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+        resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
+        verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
+        resetPasswordUseCase: ResetPasswordUseCaseProtocol
+    ) {
+        self.sendEmailVerificationUseCase = sendEmailVerificationUseCase
+        self.resendEmailVerificationUseCase = resendEmailVerificationUseCase
+        self.verifyEmailCodeUseCase = verifyEmailCodeUseCase
+        self.resetPasswordUseCase = resetPasswordUseCase
+    }
+
+    // MARK: - Validation
+
+    /// 새 비밀번호 8자 이상 검증
+    var isPasswordValid: Bool {
+        newPasswordInput.count >= 8
+    }
+
+    /// 비밀번호 확인 일치 검증
+    var isPasswordConfirmed: Bool {
+        !newPasswordInput.isEmpty &&
+        newPasswordInput == newPasswordConfirmInput
+    }
+
+    /// 비밀번호 변경 버튼 활성 조건
+    var canSubmit: Bool {
+        isEmailVerified &&
+        emailVerificationToken != nil &&
+        isPasswordValid &&
+        isPasswordConfirmed
+    }
+
+    // MARK: - Function
+
+    /// 이메일 인증번호 요청 (purpose=PASSWORD_RESET)
+    func requestEmailVerification() async throws {
+        let id = try await sendEmailVerificationUseCase
+            .execute(email: emailInput, purpose: .passwordReset)
+        emailVerificationId = id
+    }
+
+    /// 이메일 인증번호 재전송
+    func resendEmailVerification() async throws {
+        guard let emailVerificationId else {
+            try await requestEmailVerification()
+            return
+        }
+        try await resendEmailVerificationUseCase.execute(
+            emailVerificationId: emailVerificationId
+        )
+    }
+
+    /// 이메일 인증코드 검증
+    func verifyEmailCode(_ code: String) async throws {
+        guard let emailVerificationId else { return }
+        let token = try await verifyEmailCodeUseCase.execute(
+            emailVerificationId: emailVerificationId,
+            verificationCode: code
+        )
+        emailVerificationToken = token
+        isEmailVerified = true
+    }
+
+    /// 이메일 변경 시 인증 상태 초기화
+    func resetEmailVerification() {
+        isEmailVerified = false
+        emailVerificationId = nil
+        emailVerificationToken = nil
+    }
+
+    /// 비밀번호 변경 실행
+    func resetPassword() async {
+        guard canSubmit, let emailVerificationToken else { return }
+        resetState = .loading
+        do {
+            try await resetPasswordUseCase.execute(
+                emailVerificationToken: emailVerificationToken,
+                newPassword: newPasswordInput
+            )
+            resetState = .loaded(true)
+        } catch let error as AppError {
+            resetState = .failed(error)
+        } catch let error as AuthError {
+            resetState = .failed(.auth(error))
+        } catch let error as RepositoryError {
+            resetState = .failed(.repository(error))
+        } catch let error as NetworkError {
+            resetState = .failed(.network(error))
+        } catch {
+            resetState = .failed(
+                .unknown(message: error.localizedDescription)
+            )
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpByIdPwViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpByIdPwViewModel.swift
@@ -19,6 +19,7 @@ final class SignUpByIdPwViewModel {
     // MARK: - Property
 
     private let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
+    private let resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
     private let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
     private let registerByEmailUseCase: RegisterByEmailUseCaseProtocol
     private let checkEmailAvailabilityUseCase: CheckEmailAvailabilityUseCaseProtocol
@@ -60,12 +61,14 @@ final class SignUpByIdPwViewModel {
 
     init(
         sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+        resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
         verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
         registerByEmailUseCase: RegisterByEmailUseCaseProtocol,
         checkEmailAvailabilityUseCase: CheckEmailAvailabilityUseCaseProtocol,
         fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
     ) {
         self.sendEmailVerificationUseCase = sendEmailVerificationUseCase
+        self.resendEmailVerificationUseCase = resendEmailVerificationUseCase
         self.verifyEmailCodeUseCase = verifyEmailCodeUseCase
         self.registerByEmailUseCase = registerByEmailUseCase
         self.checkEmailAvailabilityUseCase = checkEmailAvailabilityUseCase
@@ -187,8 +190,20 @@ final class SignUpByIdPwViewModel {
     @MainActor
     func requestEmailVerification() async throws {
         let id = try await sendEmailVerificationUseCase
-            .execute(email: emailInput)
+            .execute(email: emailInput, purpose: .register)
         emailVerificationId = id
+    }
+
+    /// 이메일 인증번호 재전송
+    @MainActor
+    func resendEmailVerification() async throws {
+        guard let emailVerificationId else {
+            try await requestEmailVerification()
+            return
+        }
+        try await resendEmailVerificationUseCase.execute(
+            emailVerificationId: emailVerificationId
+        )
     }
 
     /// 이메일 인증번호 검증

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
@@ -179,7 +179,7 @@ final class SignUpViewModel {
     @MainActor
     func requestEmailVerification() async throws {
         let id = try await sendEmailVerificationUseCase
-            .execute(email: email)
+            .execute(email: email, purpose: .register)
         emailVerificationId = id
     }
 

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginByIdPwView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginByIdPwView.swift
@@ -115,8 +115,21 @@ struct LoginByIdPwView: View {
         HStack(spacing: DefaultSpacing.spacing8) {
             autoLoginToggle
             Spacer()
+            resetPasswordLink
+            Text("|")
+                .appFont(.footnote, color: .grey400)
             signUpLink
         }
+    }
+
+    private var resetPasswordLink: some View {
+        NavigationLink(value: NavigationDestination.auth(.resetPassword)) {
+            Text(Constants.resetPasswordTitle)
+                .appFont(.footnote, color: .grey500)
+        }
+        .buttonStyle(.plain)
+        .frame(minHeight: Constants.minTouchTarget)
+        .accessibilityHint(Text("비밀번호 찾기 화면으로 이동합니다"))
     }
 
     private var autoLoginToggle: some View {
@@ -181,6 +194,7 @@ fileprivate enum Constants {
     static let autoLoginLabel: String = "자동로그인"
     static let loginButtonTitle: String = "로그인"
     static let signUpTitle: String = "회원가입"
+    static let resetPasswordTitle: String = "비밀번호 찾기"
 
     static let checkboxSize: CGFloat = 20
     static let minTouchTarget: CGFloat = 44

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/ResetPasswordView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/ResetPasswordView.swift
@@ -1,0 +1,153 @@
+//
+//  ResetPasswordView.swift
+//  AppProduct
+//
+
+import SwiftUI
+
+/// 비밀번호 찾기 화면
+///
+/// 흐름: 이메일 입력/인증 → 새 비밀번호 입력 → 변경 완료 시 로그인 화면으로 복귀.
+struct ResetPasswordView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: ResetPasswordViewModel
+    @State private var alertPrompt: AlertPrompt?
+    @FocusState private var newPasswordFocused: Bool
+    @FocusState private var newPasswordConfirmFocused: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Init
+
+    init(
+        sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+        resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
+        verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
+        resetPasswordUseCase: ResetPasswordUseCaseProtocol
+    ) {
+        self._viewModel = .init(
+            wrappedValue: ResetPasswordViewModel(
+                sendEmailVerificationUseCase: sendEmailVerificationUseCase,
+                resendEmailVerificationUseCase: resendEmailVerificationUseCase,
+                verifyEmailCodeUseCase: verifyEmailCodeUseCase,
+                resetPasswordUseCase: resetPasswordUseCase
+            )
+        )
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
+                FormEmailField(
+                    title: "이메일",
+                    placeholder: "example@example.com",
+                    text: $viewModel.emailInput,
+                    onVerificationRequested: {
+                        try await viewModel.requestEmailVerification()
+                    },
+                    onVerificationComplete: { code in
+                        try await viewModel.verifyEmailCode(code)
+                    },
+                    onResend: {
+                        try await viewModel.resendEmailVerification()
+                    },
+                    submitLabel: .next,
+                    onSubmit: { newPasswordFocused = true },
+                    onEmailChanged: { viewModel.resetEmailVerification() }
+                )
+
+                Text(Constants.deliveryNotice)
+                    .appFont(.footnote, color: .grey500)
+
+                if viewModel.isEmailVerified {
+                    passwordSection
+                }
+            }
+            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+            .padding(.top, DefaultConstant.defaultSafeTop)
+            .padding(.bottom, DefaultConstant.defaultSafeBottom)
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .navigationTitle(Constants.navTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .safeAreaInset(edge: .bottom) {
+            submitButton
+        }
+        .alertPrompt(item: $alertPrompt)
+        .onChange(of: viewModel.resetState) { _, newValue in
+            if case .loaded = newValue {
+                alertPrompt = AlertPrompt(
+                    title: "비밀번호 변경 완료",
+                    message: "변경된 비밀번호로 로그인해주세요.",
+                    positiveBtnTitle: "확인",
+                    positiveBtnAction: { dismiss() },
+                    negativeBtnTitle: nil
+                )
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var passwordSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+            UnderlineTextField(
+                label: "새 비밀번호",
+                placeholder: "8자 이상 입력해주세요",
+                text: $viewModel.newPasswordInput,
+                isSecure: true,
+                submitLabel: .next,
+                onSubmit: { newPasswordConfirmFocused = true },
+                focusBinding: $newPasswordFocused,
+                guideMessage: viewModel.isPasswordValid || viewModel.newPasswordInput.isEmpty
+                    ? nil
+                    : "8자 이상 입력해주세요"
+            )
+
+            UnderlineTextField(
+                label: "새 비밀번호 확인",
+                placeholder: "한 번 더 입력해주세요",
+                text: $viewModel.newPasswordConfirmInput,
+                isSecure: true,
+                submitLabel: .done,
+                onSubmit: {
+                    newPasswordConfirmFocused = false
+                    Task { await viewModel.resetPassword() }
+                },
+                focusBinding: $newPasswordConfirmFocused,
+                guideMessage: viewModel.isPasswordConfirmed || viewModel.newPasswordConfirmInput.isEmpty
+                    ? nil
+                    : "비밀번호가 일치하지 않습니다"
+            )
+
+            if case .failed(let error) = viewModel.resetState {
+                Text(error.userMessage)
+                    .appFont(.footnote, color: .red500)
+            }
+        }
+    }
+
+    private var submitButton: some View {
+        MainButton(Constants.submitTitle) {
+            newPasswordFocused = false
+            newPasswordConfirmFocused = false
+            Task { await viewModel.resetPassword() }
+        }
+        .loading(.constant(viewModel.resetState.isLoading))
+        .disabled(!viewModel.canSubmit || viewModel.resetState.isLoading)
+        .buttonStyle(.gradientCapsule)
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .padding(.bottom, DefaultConstant.defaultSafeBottom)
+    }
+}
+
+// MARK: - Constants
+
+fileprivate enum Constants {
+    static let navTitle: String = "비밀번호 찾기"
+    static let deliveryNotice: String = "메일이 도착하지 않으면 가입 여부를 확인해주세요."
+    static let submitTitle: String = "비밀번호 변경"
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpByIdPwView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpByIdPwView.swift
@@ -47,6 +47,7 @@ struct SignUpByIdPwView: View {
 
     init(
         sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+        resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
         verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
         registerByEmailUseCase: RegisterByEmailUseCaseProtocol,
         checkEmailAvailabilityUseCase: CheckEmailAvailabilityUseCaseProtocol,
@@ -56,6 +57,7 @@ struct SignUpByIdPwView: View {
         self._viewModel = .init(
             wrappedValue: SignUpByIdPwViewModel(
                 sendEmailVerificationUseCase: sendEmailVerificationUseCase,
+                resendEmailVerificationUseCase: resendEmailVerificationUseCase,
                 verifyEmailCodeUseCase: verifyEmailCodeUseCase,
                 registerByEmailUseCase: registerByEmailUseCase,
                 checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase,
@@ -77,6 +79,9 @@ struct SignUpByIdPwView: View {
                     },
                     onVerificationComplete: { code in
                         try await viewModel.verifyEmailCode(code)
+                    },
+                    onResend: {
+                        try await viewModel.resendEmailVerification()
                     },
                     onEmailChanged: handleEmailChange,
                     onSubmit: { focusedField = .password }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
@@ -568,7 +568,7 @@ private func signUpPreview(shouldFailTerms: Bool = false) -> some View {
 }
 
 private struct SignUpPreviewSendEmailUseCase: SendEmailVerificationUseCaseProtocol {
-    func execute(email: String) async throws -> String {
+    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
         "preview_verification_id"
     }
 }

--- a/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
+++ b/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
@@ -162,7 +162,7 @@ private struct MockRegisterUseCase: RegisterUseCaseProtocol {
 }
 
 private struct MockSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol {
-    func execute(email: String) async throws -> String {
+    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
         "email-verification-id"
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Feature — 이메일 인증 API 스펙 변경 대응 + 비밀번호 찾기(재설정) 기능 신규 구현

연관 이슈: #788

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 로그인 화면 진입점 + 비밀번호 찾기 플로우 + 회원가입 재전송 타이머 영상 첨부 예정 -->

## 🛠️ 작업내용

### API 스펙 대응 (Breaking)
- `POST /api/v1/auth/email-verification` 에 `purpose` (REGISTER / PASSWORD_RESET) 파라미터 추가
- `POST /api/v1/auth/email-verification/resend` 신규 연동 (인증코드 재전송 전용 엔드포인트)
- `PATCH /api/v1/auth/password/reset` 신규 연동
- 신규 에러 코드 매핑 추가
  - `AUTHENTICATION-0025` INVALID_EMAIL_FORMAT (400)
  - `AUTHENTICATION-0026` EMAIL_ALREADY_EXISTS (409)
  - `AUTHENTICATION-0027` EMAIL_VERIFICATION_THROTTLED (429)

### Domain / Data 레이어
- `EmailVerificationPurpose` 도메인 enum 신규
- `SendEmailVerificationRequestDTO` 에 `purpose` 필드 추가
- `ResendEmailVerificationRequestDTO`, `ResetPasswordRequestDTO` 신규
- `AuthRouter` 에 `resendEmailVerification`, `resetPassword` case 추가
- `AuthRepository.mapEmailVerificationError(from:)` 헬퍼로 서버 에러 코드 → `AuthError` 중앙 매핑
- `ResendEmailVerificationUseCase`, `ResetPasswordUseCase` 신규 + Provider 등록

### Presentation 레이어
- `FormEmailField`
  - `onResend` 콜백 옵션 추가 (기존 회원가입 화면과 backward-compatible)
  - 60초 throttle 카운트다운 (SwiftUI `.task(id:)` 기반)
  - 서버 에러를 인라인 커스텀 메시지로 표시
- `ResetPasswordView` / `ResetPasswordViewModel` 신규
  - 이메일 인증 → 새 비밀번호(8자 이상) → 확인 → 변경 완료 → 로그인 화면 복귀
  - `Loadable<Bool>` 기반 상태 관리, 완료 시 `AlertPrompt` 노출
- `LoginByIdPwView` 에 "비밀번호 찾기 | 회원가입" 진입점 추가
- `NavigationDestination.Auth.resetPassword` 라우트 + `NavigationRoutingView` 분기 추가
- `SignUpByIdPwView` / `SignUpByIdPwViewModel` `purpose: .register` 명시 + 재전송 연결

### 레거시 호환
- `MockAuthRepository`, `SignUpViewModel`, `SignUpView` Preview UseCase, `SignUpViewModelTests` Mock — 새로운 `purpose` 시그니처에 맞춰 업데이트

## 📋 추후 진행 상황

- QA: throttle 카운트다운 / 에러 메시지 케이스별 검증 (잘못된 형식·이미 가입·요청 제한)
- 디자인 QA: `ResetPasswordView` 의 안내 문구 / 완료 alert 카피 최종 확인
- 추후: 동일 패턴을 `UMCApp/` (Tuist) 쪽에도 마이그레이션 검토

## 📌 리뷰 포인트

- `AppProduct/Features/Auth/Data/Router/AuthRouter.swift` — DTO 분리 패턴 준수 (인라인 딕셔너리 없음)
- `AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift` — `mapEmailVerificationError(from:)` 의 서버 코드 → `AuthError` 매핑 정확성
- `AppProduct/Features/Auth/Presentation/Components/FormEmailField.swift` — 60초 throttle 타이머가 `verificationState` 전환에 따라 올바르게 시작/중단되는지, 재전송 버튼 노출 조건
- `AppProduct/Features/Auth/Presentation/ViewModels/ResetPasswordViewModel.swift` — `canSubmit` 검증 로직, `resetState` 전환, 에러 catch 분기
- `AppProduct/Features/Auth/Presentation/Views/ResetPasswordView.swift` — 이메일 변경 시 인증 리셋(`onEmailChanged`), 완료 alert 후 `dismiss()` 동작
- `AppProduct/Core/Navigation/NavigationRoutingView.swift` — `signUpByIdPw` 분기에 `resendEmailVerificationUseCase` 주입 누락 없는지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)