### PR TITLE
♻️ [Refactor] Activity/Domain Repository Protocol 3종 + 의존 모델 7종 이식

### DIFF
--- a/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/ParticipantAttendanceStatus.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Enums/Attendance/ParticipantAttendanceStatus.swift
@@ -1,0 +1,97 @@
+//
+//  ParticipantAttendanceStatus.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+/// 참여자(타인 관찰 시점) 출석 상태
+///
+/// 운영진이 출석 현황을 조회할 때 사용합니다. 챌린저 본인 시점의
+/// ``AttendanceStatus`` 와는 의미가 달라 별도 enum 으로 분리했습니다.
+///
+/// 서버가 케이스를 추가했을 때 디코딩 실패를 막기 위해 `.unknown` 폴백을 둡니다.
+///
+/// - SeeAlso: ``AttendanceStatus``, ``ScheduleAttendanceInfo``
+public enum ParticipantAttendanceStatus: String, Codable, Sendable, CaseIterable, Equatable, Hashable {
+
+    /// 출석 승인 대기 (체크인 완료, 운영진 승인 전)
+    case presentPending = "PRESENT_PENDING"
+    /// 지각 승인 대기
+    case latePending = "LATE_PENDING"
+    /// 사유 결석 승인 대기
+    case excusedPending = "EXCUSED_PENDING"
+    /// 출석 (정시)
+    case present = "PRESENT"
+    /// 지각
+    case late = "LATE"
+    /// 결석
+    case absent = "ABSENT"
+    /// 사유 결석 (출석으로 인정)
+    case excused = "EXCUSED"
+    /// 출석 전 (정책 시작 전)
+    case pending = "PENDING"
+    /// 알 수 없는 상태 (forward-compatible 폴백)
+    case unknown
+
+    // MARK: - Decoding
+
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = ParticipantAttendanceStatus(rawValue: raw) ?? .unknown
+    }
+
+    // MARK: - Filterable
+
+    /// 필터 UI 에 노출할 케이스
+    ///
+    /// `.unknown` 은 사용자 의도와 무관한 시스템 폴백이므로 필터 칩에서 제외합니다.
+    public static var filterableCases: [ParticipantAttendanceStatus] {
+        allCases.filter { $0 != .unknown }
+    }
+
+    // MARK: - Display
+
+    /// 배지/필터 칩에 표시할 한국어 텍스트
+    ///
+    /// 폭 제약이 있는 뱃지 UI 에는 ``badgeText`` 를 사용하세요.
+    public var displayText: String {
+        switch self {
+        case .presentPending:   return "출석 승인 대기"
+        case .latePending:      return "지각 승인 대기"
+        case .excusedPending:   return "사유 승인 대기"
+        case .present:          return "출석"
+        case .late:             return "지각"
+        case .absent:           return "결석"
+        case .excused:          return "사유 결석"
+        case .pending:          return "출석 전"
+        case .unknown:          return "상태 미지정"
+        }
+    }
+
+    /// 뱃지 컴포넌트에 렌더링할 짧은 텍스트
+    ///
+    /// `.unknown` 만 폭 제약 때문에 단축하고, 나머지는 ``displayText`` 와 동일합니다.
+    public var badgeText: String {
+        self == .unknown ? "알 수 없음" : displayText
+    }
+
+    /// 서버 쿼리 파라미터로 직렬화한 값 (`.unknown` 은 전송 차단)
+    public var serverQueryValue: String? {
+        self == .unknown ? nil : rawValue
+    }
+
+    // MARK: - Categorization
+
+    /// 승인 대기 상태 여부 (운영진 "처리 필요" 표시용)
+    public var isPending: Bool {
+        switch self {
+        case .presentPending, .latePending, .excusedPending:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/ChallengerAttendanceRepositoryProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/ChallengerAttendanceRepositoryProtocol.swift
@@ -1,0 +1,52 @@
+//
+//  ChallengerAttendanceRepositoryProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+/// 챌린저 본인 시점의 출석 액션
+///
+/// 관리자 권한 작업(일괄 결정, 위치 변경 등)은 ``OperatorAttendanceRepositoryProtocol``.
+public protocol ChallengerAttendanceRepositoryProtocol {
+
+    // MARK: - 액션
+
+    /// GPS 출석 요청
+    ///
+    /// - Parameters:
+    ///   - scheduleId: 출석할 일정 식별자
+    ///   - latitude: 체크인 위도
+    ///   - longitude: 체크인 경도
+    ///   - locationVerified: 클라이언트 측 지오펜스 검증 결과
+    func requestAttendance(
+        scheduleId: Int,
+        latitude: Double,
+        longitude: Double,
+        locationVerified: Bool
+    ) async throws -> AttendanceDecisionResult
+
+    /// 사유 결석/지각 제출
+    ///
+    /// - Parameters:
+    ///   - scheduleId: 사유 제출할 일정 식별자
+    ///   - excuseReason: 사유 내용
+    ///   - isVerified: 클라이언트 측 위치 인증 여부 (사유와 함께 보고)
+    ///   - latitude: 보고 시점 위도
+    ///   - longitude: 보고 시점 경도
+    func submitExcuse(
+        scheduleId: Int,
+        excuseReason: String,
+        isVerified: Bool,
+        latitude: Double,
+        longitude: Double
+    ) async throws -> AttendanceDecisionResult
+
+    // MARK: - 외부 도메인 의존 (별도 이슈로 추가 예정)
+    //
+    // `fetchMySchedulesForAttendance(from:to:) async throws -> [ScheduleDetailData]`
+    // 는 `ScheduleDetailData` 가 Schedule Feature 모듈에 정의될 예정이라 본 PR 에서 제외.
+    // Schedule 모듈 이식 후속 이슈에서 추가합니다.
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/ChallengerAttendanceRepositoryProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/ChallengerAttendanceRepositoryProtocol.swift
@@ -22,7 +22,7 @@ public protocol ChallengerAttendanceRepositoryProtocol {
     ///   - longitude: 체크인 경도
     ///   - locationVerified: 클라이언트 측 지오펜스 검증 결과
     func requestAttendance(
-        scheduleId: Int,
+        scheduleId: String,
         latitude: Double,
         longitude: Double,
         locationVerified: Bool
@@ -37,7 +37,7 @@ public protocol ChallengerAttendanceRepositoryProtocol {
     ///   - latitude: 보고 시점 위도
     ///   - longitude: 보고 시점 경도
     func submitExcuse(
-        scheduleId: Int,
+        scheduleId: String,
         excuseReason: String,
         isVerified: Bool,
         latitude: Double,

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/OperatorAttendanceRepositoryProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/OperatorAttendanceRepositoryProtocol.swift
@@ -1,0 +1,75 @@
+//
+//  OperatorAttendanceRepositoryProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+// MARK: - Input Model
+
+/// 출석 일괄 결정 요청 항목
+public struct AttendanceDecisionInput: Equatable, Sendable {
+    public let isApproved: Bool
+    public let participantMemberId: Int
+    public let reason: String
+
+    public init(isApproved: Bool, participantMemberId: Int, reason: String) {
+        self.isApproved = isApproved
+        self.participantMemberId = participantMemberId
+        self.reason = reason
+    }
+}
+
+// MARK: - Protocol
+
+/// 운영진 시점의 출석 관리 (조회 · 일괄 결정 · 위치 변경)
+///
+/// 챌린저 본인의 출석 요청은 ``ChallengerAttendanceRepositoryProtocol``.
+public protocol OperatorAttendanceRepositoryProtocol {
+
+    // MARK: - 조회
+
+    /// 일정 출석 현황 목록 조회 (관리자)
+    ///
+    /// `GET /api/v2/schedules/attendance` 호출. 직책별 조회 범위는 서버에서 자동 분기.
+    ///
+    /// - Parameters:
+    ///   - from: 조회 시작 시각 (`nil` 이면 서버 기본값 = 요청 시점 -1개월)
+    ///   - to: 조회 종료 시각 (`nil` 이면 서버 기본값 = 요청 시점 +24시간)
+    ///   - attendanceStatus: 필터링할 출석 상태 (`nil` 이면 모든 상태)
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> [ScheduleAttendanceInfo]
+
+    /// 단일 일정 출석 현황 조회 (관리자)
+    ///
+    /// `GET /api/v2/schedules/{scheduleId}/attendance` 호출.
+    ///
+    /// - Parameters:
+    ///   - scheduleId: 일정 식별자
+    ///   - attendanceStatus: 필터링할 출석 상태 (`nil` 이면 모든 상태)
+    func fetchAttendanceDetail(
+        scheduleId: Int,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> ScheduleAttendanceInfo
+
+    // MARK: - 액션
+
+    /// 출석 일괄 승인/반려
+    func decideAttendances(
+        scheduleId: Int,
+        decisions: [AttendanceDecisionInput]
+    ) async throws -> [AttendanceDecisionResult]
+
+    /// 세션 출석 위치 변경 (관리자)
+    func updateScheduleLocation(
+        scheduleId: Int,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    ) async throws
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/OperatorAttendanceRepositoryProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/OperatorAttendanceRepositoryProtocol.swift
@@ -12,10 +12,12 @@ import Foundation
 /// 출석 일괄 결정 요청 항목
 public struct AttendanceDecisionInput: Equatable, Sendable {
     public let isApproved: Bool
-    public let participantMemberId: Int
+
+    /// 결정 대상 참여자 멤버 ID (서버 응답)
+    public let participantMemberId: String
     public let reason: String
 
-    public init(isApproved: Bool, participantMemberId: Int, reason: String) {
+    public init(isApproved: Bool, participantMemberId: String, reason: String) {
         self.isApproved = isApproved
         self.participantMemberId = participantMemberId
         self.reason = reason
@@ -53,7 +55,7 @@ public protocol OperatorAttendanceRepositoryProtocol {
     ///   - scheduleId: 일정 식별자
     ///   - attendanceStatus: 필터링할 출석 상태 (`nil` 이면 모든 상태)
     func fetchAttendanceDetail(
-        scheduleId: Int,
+        scheduleId: String,
         attendanceStatus: ParticipantAttendanceStatus?
     ) async throws -> ScheduleAttendanceInfo
 
@@ -61,13 +63,13 @@ public protocol OperatorAttendanceRepositoryProtocol {
 
     /// 출석 일괄 승인/반려
     func decideAttendances(
-        scheduleId: Int,
+        scheduleId: String,
         decisions: [AttendanceDecisionInput]
     ) async throws -> [AttendanceDecisionResult]
 
     /// 세션 출석 위치 변경 (관리자)
     func updateScheduleLocation(
-        scheduleId: Int,
+        scheduleId: String,
         locationName: String,
         latitude: Double,
         longitude: Double

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/StudyRepositoryProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/StudyRepositoryProtocol.swift
@@ -45,47 +45,54 @@ public protocol StudyRepositoryProtocol {
     /// 단일 스터디 그룹 상세 조회
     ///
     /// `GET /api/v1/study-groups/{groupId}`
-    func fetchStudyGroupDetail(groupId: Int) async throws -> StudyGroupInfo
+    ///
+    /// - Parameter groupId: 스터디 그룹 식별자 (서버 응답)
+    func fetchStudyGroupDetail(groupId: String) async throws -> StudyGroupInfo
 
     /// 멤버 ID 로 챌린저 ID 조회
     ///
     /// - Parameters:
-    ///   - memberId: 멤버 ID
-    ///   - preferredGeneration: 우선 조회할 기수 (없으면 최신 레코드 기준)
-    /// - Returns: 조회된 챌린저 ID (없으면 `nil`)
+    ///   - memberId: 멤버 ID (서버 응답)
+    ///   - preferredGeneration: 우선 조회할 기수 (클라이언트 입력, 없으면 최신 레코드 기준)
+    /// - Returns: 조회된 챌린저 ID — 서버 응답이므로 `String?`
     func resolveChallengerId(
-        memberId: Int,
+        memberId: String,
         preferredGeneration: Int?
-    ) async throws -> Int?
+    ) async throws -> String?
 
     // MARK: - 운영진 스터디 그룹 CRUD
 
     /// 스터디 그룹 생성
+    ///
+    /// - Parameters:
+    ///   - gisuId: 기수 ID (서버 응답)
+    ///   - memberIds: 멤버 ID 목록 (서버 응답)
+    ///   - mentorIds: 멘토 ID 목록 (서버 응답)
     func createStudyGroup(
-        gisuId: Int,
+        gisuId: String,
         name: String,
         part: UMCPartType,
-        memberIds: [Int],
-        mentorIds: [Int]
+        memberIds: [String],
+        mentorIds: [String]
     ) async throws
 
     /// 스터디 그룹 정보 수정 (이름만 수정 가능)
-    func updateStudyGroup(groupId: Int, name: String) async throws
+    func updateStudyGroup(groupId: String, name: String) async throws
 
     /// 스터디 그룹 삭제
-    func deleteStudyGroup(groupId: Int) async throws
+    func deleteStudyGroup(groupId: String) async throws
 
     /// 스터디 그룹에 스터디원 추가
-    func addStudyGroupMember(groupId: Int, memberId: Int) async throws
+    func addStudyGroupMember(groupId: String, memberId: String) async throws
 
     /// 스터디 그룹에서 스터디원 제거
-    func removeStudyGroupMember(groupId: Int, memberId: Int) async throws
+    func removeStudyGroupMember(groupId: String, memberId: String) async throws
 
     /// 스터디 그룹에 담당 파트장(멘토) 추가
-    func addStudyGroupMentor(groupId: Int, mentorId: Int) async throws
+    func addStudyGroupMentor(groupId: String, mentorId: String) async throws
 
     /// 스터디 그룹에서 담당 파트장(멘토) 제거
-    func removeStudyGroupMentor(groupId: Int, mentorId: Int) async throws
+    func removeStudyGroupMentor(groupId: String, mentorId: String) async throws
 
     // MARK: - 그룹-일정 연결
 
@@ -93,10 +100,12 @@ public protocol StudyRepositoryProtocol {
     ///
     /// `POST /api/v1/study-groups/schedules` 엔드포인트의 단순 래퍼.
     /// 1단계 일정 생성은 별도 `ScheduleRepositoryProtocol.generateSchedule(...)` 사용.
+    ///
+    /// 모두 서버 응답 식별자 → `String`.
     func linkStudyGroupSchedule(
-        scheduleId: Int,
-        studyGroupId: Int,
-        weeklyCurriculumId: Int
+        scheduleId: String,
+        studyGroupId: String,
+        weeklyCurriculumId: String
     ) async throws
 
     // MARK: - 외부 도메인 의존 (별도 이슈로 추가 예정)

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/StudyRepositoryProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/StudyRepositoryProtocol.swift
@@ -1,0 +1,107 @@
+//
+//  StudyRepositoryProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 스터디 도메인 데이터 접근 Repository
+///
+/// 커리큘럼 진행률/미션 조회, 운영진 스터디 그룹 CRUD, 그룹-일정 연결 등을 담당합니다.
+public protocol StudyRepositoryProtocol {
+
+    // MARK: - 커리큘럼 / 미션
+
+    /// 커리큘럼 진행률 정보 조회
+    func fetchCurriculumProgress() async throws -> CurriculumProgressModel
+
+    /// 미션 목록 조회
+    func fetchMissions() async throws -> [MissionCardModel]
+
+    /// 주차 커리큘럼 옵션 목록 조회
+    ///
+    /// ``linkStudyGroupSchedule(scheduleId:studyGroupId:weeklyCurriculumId:)``
+    /// 의 `weeklyCurriculumId` 선택지로 사용됩니다.
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption]
+
+    // MARK: - 운영진 스터디 그룹 조회
+
+    /// 스터디 그룹 상세 목록 전체 조회
+    func fetchStudyGroupDetails() async throws -> [StudyGroupInfo]
+
+    /// 스터디 그룹 상세 목록 페이지 조회
+    ///
+    /// - Parameters:
+    ///   - cursor: 페이지 커서 (첫 페이지는 `nil`)
+    ///   - size: 페이지 크기
+    func fetchStudyGroupDetailsPage(
+        cursor: Int?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage
+
+    /// 단일 스터디 그룹 상세 조회
+    ///
+    /// `GET /api/v1/study-groups/{groupId}`
+    func fetchStudyGroupDetail(groupId: Int) async throws -> StudyGroupInfo
+
+    /// 멤버 ID 로 챌린저 ID 조회
+    ///
+    /// - Parameters:
+    ///   - memberId: 멤버 ID
+    ///   - preferredGeneration: 우선 조회할 기수 (없으면 최신 레코드 기준)
+    /// - Returns: 조회된 챌린저 ID (없으면 `nil`)
+    func resolveChallengerId(
+        memberId: Int,
+        preferredGeneration: Int?
+    ) async throws -> Int?
+
+    // MARK: - 운영진 스터디 그룹 CRUD
+
+    /// 스터디 그룹 생성
+    func createStudyGroup(
+        gisuId: Int,
+        name: String,
+        part: UMCPartType,
+        memberIds: [Int],
+        mentorIds: [Int]
+    ) async throws
+
+    /// 스터디 그룹 정보 수정 (이름만 수정 가능)
+    func updateStudyGroup(groupId: Int, name: String) async throws
+
+    /// 스터디 그룹 삭제
+    func deleteStudyGroup(groupId: Int) async throws
+
+    /// 스터디 그룹에 스터디원 추가
+    func addStudyGroupMember(groupId: Int, memberId: Int) async throws
+
+    /// 스터디 그룹에서 스터디원 제거
+    func removeStudyGroupMember(groupId: Int, memberId: Int) async throws
+
+    /// 스터디 그룹에 담당 파트장(멘토) 추가
+    func addStudyGroupMentor(groupId: Int, mentorId: Int) async throws
+
+    /// 스터디 그룹에서 담당 파트장(멘토) 제거
+    func removeStudyGroupMentor(groupId: Int, mentorId: Int) async throws
+
+    // MARK: - 그룹-일정 연결
+
+    /// 일정 생성 후 받은 `scheduleId` 를 스터디 그룹/주차 커리큘럼에 연결
+    ///
+    /// `POST /api/v1/study-groups/schedules` 엔드포인트의 단순 래퍼.
+    /// 1단계 일정 생성은 별도 `ScheduleRepositoryProtocol.generateSchedule(...)` 사용.
+    func linkStudyGroupSchedule(
+        scheduleId: Int,
+        studyGroupId: Int,
+        weeklyCurriculumId: Int
+    ) async throws
+
+    // MARK: - 외부 도메인 의존 (별도 이슈로 추가 예정)
+    //
+    // `fetchCurriculumData(weekNo:) async throws -> CurriculumData`
+    // 는 `CurriculumData` 의 정의 위치가 미확정 (별도 모듈/Feature 가능)이라 본 PR 에서 제외.
+    // 정의 위치 확정 후 후속 이슈에서 추가합니다.
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceDecisionResult.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceDecisionResult.swift
@@ -15,17 +15,17 @@ public struct AttendanceDecisionResult: Equatable, Sendable {
     // MARK: - Nested Type
 
     public struct DecisionMakerInfo: Equatable, Sendable {
-        public let memberId: Int
+        public let memberId: String
         public let name: String
         public let nickname: String
-        public let schoolId: Int
+        public let schoolId: String
         public let schoolName: String
 
         public init(
-            memberId: Int,
+            memberId: String,
             name: String,
             nickname: String,
-            schoolId: Int,
+            schoolId: String,
             schoolName: String
         ) {
             self.memberId = memberId
@@ -57,11 +57,14 @@ public struct AttendanceDecisionResult: Equatable, Sendable {
     /// 승인자 정보
     public let decisionMakerMemberInfo: DecisionMakerInfo?
 
-    /// 승인자 존재 여부
-    public let hasDecisionMakerMember: Bool
-
     /// 승인 대기 중 여부
     public let isPendingDecision: Bool
+
+    /// 승인자 존재 여부 (`decisionMakerMemberInfo` 와 1:1 연동)
+    ///
+    /// 별도 필드로 분리하면 `info = nil && hasDecisionMakerMember = true` 같은
+    /// 불일치 상태가 생성자에서 허용되므로, 단일 정보원에서 파생합니다.
+    public var hasDecisionMakerMember: Bool { decisionMakerMemberInfo != nil }
 
     public init(
         status: ParticipantAttendanceStatus,
@@ -71,7 +74,6 @@ public struct AttendanceDecisionResult: Equatable, Sendable {
         latitude: Double?,
         longitude: Double?,
         decisionMakerMemberInfo: DecisionMakerInfo?,
-        hasDecisionMakerMember: Bool,
         isPendingDecision: Bool
     ) {
         self.status = status
@@ -81,7 +83,6 @@ public struct AttendanceDecisionResult: Equatable, Sendable {
         self.latitude = latitude
         self.longitude = longitude
         self.decisionMakerMemberInfo = decisionMakerMemberInfo
-        self.hasDecisionMakerMember = hasDecisionMakerMember
         self.isPendingDecision = isPendingDecision
     }
 }

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceDecisionResult.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendanceDecisionResult.swift
@@ -1,0 +1,125 @@
+//
+//  AttendanceDecisionResult.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+/// 출석 결정 결과
+///
+/// 여러 출석 결정 액션(승인/사유/요청)의 공통 응답을 단일 모델로 표현합니다.
+public struct AttendanceDecisionResult: Equatable, Sendable {
+
+    // MARK: - Nested Type
+
+    public struct DecisionMakerInfo: Equatable, Sendable {
+        public let memberId: Int
+        public let name: String
+        public let nickname: String
+        public let schoolId: Int
+        public let schoolName: String
+
+        public init(
+            memberId: Int,
+            name: String,
+            nickname: String,
+            schoolId: Int,
+            schoolName: String
+        ) {
+            self.memberId = memberId
+            self.name = name
+            self.nickname = nickname
+            self.schoolId = schoolId
+            self.schoolName = schoolName
+        }
+    }
+
+    // MARK: - Property
+
+    /// 결정된 출석 상태 (알 수 없는 값이면 `.unknown`)
+    public let status: ParticipantAttendanceStatus
+
+    /// 결정 시각 (nil: 아직 미결정)
+    public let decidedAt: Date?
+
+    /// 결정 사유
+    public let decisionReason: String?
+
+    /// 사유 결석 내용
+    public let excuseReason: String?
+
+    public let latitude: Double?
+
+    public let longitude: Double?
+
+    /// 승인자 정보
+    public let decisionMakerMemberInfo: DecisionMakerInfo?
+
+    /// 승인자 존재 여부
+    public let hasDecisionMakerMember: Bool
+
+    /// 승인 대기 중 여부
+    public let isPendingDecision: Bool
+
+    public init(
+        status: ParticipantAttendanceStatus,
+        decidedAt: Date?,
+        decisionReason: String?,
+        excuseReason: String?,
+        latitude: Double?,
+        longitude: Double?,
+        decisionMakerMemberInfo: DecisionMakerInfo?,
+        hasDecisionMakerMember: Bool,
+        isPendingDecision: Bool
+    ) {
+        self.status = status
+        self.decidedAt = decidedAt
+        self.decisionReason = decisionReason
+        self.excuseReason = excuseReason
+        self.latitude = latitude
+        self.longitude = longitude
+        self.decisionMakerMemberInfo = decisionMakerMemberInfo
+        self.hasDecisionMakerMember = hasDecisionMakerMember
+        self.isPendingDecision = isPendingDecision
+    }
+}
+
+// MARK: - Attendance 호환 변환
+
+extension AttendanceDecisionResult {
+
+    /// 승인 결과를 기존 ``Attendance`` 로 어댑팅 (호환 어댑터)
+    ///
+    /// 도메인 규칙:
+    /// - `.excused` 는 ``Attendance`` 에서 출석으로 인정 (`.present` 로 합침)
+    /// - `*_PENDING` 계열은 모두 `.pendingApproval` 로 합침
+    /// - `excuseReason` 의 존재가 출석 유형(`.reason` vs `.gps`)을 결정
+    /// - `reason` 은 사용자가 적은 `excuseReason` 을 운영진의 `decisionReason` 보다 우선
+    public func toAttendance(sessionId: SessionID, userId: UserID) -> Attendance {
+        let attendanceStatus: AttendanceStatus = {
+            switch status {
+            case .present:          return .present
+            case .late:             return .late
+            case .absent:           return .absent
+            case .excused:          return .present
+            case .presentPending,
+                 .latePending,
+                 .excusedPending:   return .pendingApproval
+            case .pending, .unknown: return .beforeAttendance
+            }
+        }()
+
+        let attendanceType: AttendanceType = excuseReason != nil ? .reason : .gps
+
+        return Attendance(
+            sessionId: sessionId,
+            userId: userId,
+            type: attendanceType,
+            status: attendanceStatus,
+            locationVerification: nil,
+            reason: excuseReason ?? decisionReason
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/ScheduleAttendancePolicy.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/ScheduleAttendancePolicy.swift
@@ -1,0 +1,33 @@
+//
+//  ScheduleAttendancePolicy.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+/// 일정별로 다른 출석 시각 임계값
+///
+/// 체크인 가능 시각, 정시/지각 경계 등 일정마다 달라지는 동적 정책을 표현합니다.
+/// 지오펜스 반경 같은 앱 전역 상수는 ``AttendancePolicy`` 를 사용합니다.
+///
+/// > Note: UMCApp 의 ``AttendancePolicy`` (상수 enum) 와 이름 충돌을 피하기 위해
+///   `Schedule` 접두사를 부여했습니다.
+public struct ScheduleAttendancePolicy: Equatable, Sendable {
+
+    /// 출석 체크인 시작 시각 (이전엔 출석 불가)
+    public let checkInStartAt: Date
+
+    /// 정시 출석 종료 시각 (이후엔 지각)
+    public let onTimeEndAt: Date
+
+    /// 지각 종료 시각 (이후엔 결석)
+    public let lateEndAt: Date
+
+    public init(checkInStartAt: Date, onTimeEndAt: Date, lateEndAt: Date) {
+        self.checkInStartAt = checkInStartAt
+        self.onTimeEndAt = onTimeEndAt
+        self.lateEndAt = lateEndAt
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ParticipantAttendance.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ParticipantAttendance.swift
@@ -1,0 +1,68 @@
+//
+//  ParticipantAttendance.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+/// 운영진 시점에서 본 일정 참여자 출석 정보
+///
+/// 참여자 식별 정보(`name`, `nickname` 등)에 더해, 출석 상태와 GPS 인증 여부,
+/// 사유 결석 사유까지 함께 보유하므로 운영진 현황 화면 구성
+///
+/// - SeeAlso: ``ScheduleAttendanceInfo``, ``ParticipantAttendanceStatus``
+public struct ParticipantAttendance: Equatable, Sendable, Identifiable {
+
+    /// 멤버 식별자
+    public let memberId: Int
+
+    /// 본명
+    public let name: String
+
+    /// 닉네임
+    public let nickname: String
+
+    /// 프로필 이미지 URL (없으면 빈 문자열)
+    public let profileImageUrl: String
+
+    /// 학교 식별자
+    public let schoolId: Int
+
+    /// 학교명
+    public let schoolName: String
+
+    /// 출석 상태 (참여자 시점)
+    public let attendanceStatus: ParticipantAttendanceStatus
+
+    /// GPS 위치 인증 완료 여부
+    public let isLocationVerified: Bool
+
+    /// 사유 결석 사유 (없으면 `nil`)
+    public let excuseReason: String?
+
+    public var id: Int { memberId }
+
+    public init(
+        memberId: Int,
+        name: String,
+        nickname: String,
+        profileImageUrl: String,
+        schoolId: Int,
+        schoolName: String,
+        attendanceStatus: ParticipantAttendanceStatus,
+        isLocationVerified: Bool,
+        excuseReason: String?
+    ) {
+        self.memberId = memberId
+        self.name = name
+        self.nickname = nickname
+        self.profileImageUrl = profileImageUrl
+        self.schoolId = schoolId
+        self.schoolName = schoolName
+        self.attendanceStatus = attendanceStatus
+        self.isLocationVerified = isLocationVerified
+        self.excuseReason = excuseReason
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ParticipantAttendance.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ParticipantAttendance.swift
@@ -15,8 +15,8 @@ import Foundation
 /// - SeeAlso: ``ScheduleAttendanceInfo``, ``ParticipantAttendanceStatus``
 public struct ParticipantAttendance: Equatable, Sendable, Identifiable {
 
-    /// 멤버 식별자
-    public let memberId: Int
+    /// 멤버 식별자 (서버 응답)
+    public let memberId: String
 
     /// 본명
     public let name: String
@@ -27,8 +27,8 @@ public struct ParticipantAttendance: Equatable, Sendable, Identifiable {
     /// 프로필 이미지 URL (없으면 빈 문자열)
     public let profileImageUrl: String
 
-    /// 학교 식별자
-    public let schoolId: Int
+    /// 학교 식별자 (서버 응답)
+    public let schoolId: String
 
     /// 학교명
     public let schoolName: String
@@ -42,14 +42,14 @@ public struct ParticipantAttendance: Equatable, Sendable, Identifiable {
     /// 사유 결석 사유 (없으면 `nil`)
     public let excuseReason: String?
 
-    public var id: Int { memberId }
+    public var id: String { memberId }
 
     public init(
-        memberId: Int,
+        memberId: String,
         name: String,
         nickname: String,
         profileImageUrl: String,
-        schoolId: Int,
+        schoolId: String,
         schoolName: String,
         attendanceStatus: ParticipantAttendanceStatus,
         isLocationVerified: Bool,

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceInfo.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceInfo.swift
@@ -1,0 +1,106 @@
+//
+//  ScheduleAttendanceInfo.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+/// 운영진 시점의 일정 출석 현황
+///
+/// 한 일정에 참여한 멤버 전원의 출석 상태와 통계를 단일 값으로 표현합니다.
+/// 목록·단일 조회 응답 스키마가 동일하므로 단일 모델로 합쳤습니다.
+///
+/// - SeeAlso: ``ParticipantAttendance``, ``ParticipantAttendanceStatus``
+public struct ScheduleAttendanceInfo: Equatable, Sendable, Identifiable {
+
+    /// 일정 식별자
+    public let scheduleId: Int
+
+    /// 일정 제목
+    public let name: String
+
+    /// 일정 설명 (메모)
+    public let description: String
+
+    /// 시작 일시
+    public let startsAt: Date
+
+    /// 종료 일시
+    public let endsAt: Date
+
+    /// 장소 (`nil` = 비대면)
+    public let location: ScheduleLocation?
+
+    /// 비대면 일정 여부 (정상 상태에서는 `location == nil` 과 동치)
+    public let isOnline: Bool
+
+    /// 작성자 멤버 ID
+    public let authorMemberId: Int
+
+    /// 출석 정책 (`nil` = 정책 미부착)
+    public let attendancePolicy: ScheduleAttendancePolicy?
+
+    /// 카테고리 태그 (e.g., `"LEADERSHIP"`)
+    public let tags: [String]
+
+    /// 참여자별 출석 정보
+    public let participants: [ParticipantAttendance]
+
+    public var id: Int { scheduleId }
+
+    public init(
+        scheduleId: Int,
+        name: String,
+        description: String,
+        startsAt: Date,
+        endsAt: Date,
+        location: ScheduleLocation?,
+        isOnline: Bool,
+        authorMemberId: Int,
+        attendancePolicy: ScheduleAttendancePolicy?,
+        tags: [String],
+        participants: [ParticipantAttendance]
+    ) {
+        self.scheduleId = scheduleId
+        self.name = name
+        self.description = description
+        self.startsAt = startsAt
+        self.endsAt = endsAt
+        self.location = location
+        self.isOnline = isOnline
+        self.authorMemberId = authorMemberId
+        self.attendancePolicy = attendancePolicy
+        self.tags = tags
+        self.participants = participants
+    }
+
+    // MARK: - Helpers
+
+    /// 출석으로 인정되는 인원 수 (사유 결석·지각 포함)
+    public var presentCount: Int {
+        participants.filter {
+            switch $0.attendanceStatus {
+            case .present, .excused, .late:
+                return true
+            default:
+                return false
+            }
+        }.count
+    }
+
+    /// 승인 대기 인원 카운트
+    public var pendingCount: Int {
+        participants.filter(\.attendanceStatus.isPending).count
+    }
+
+    /// 전체 참여자 수
+    public var totalCount: Int { participants.count }
+
+    /// 출석률 (0.0 - 1.0)
+    public var attendanceRate: Double {
+        guard totalCount > 0 else { return 0.0 }
+        return Double(presentCount) / Double(totalCount)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceInfo.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceInfo.swift
@@ -15,8 +15,8 @@ import Foundation
 /// - SeeAlso: ``ParticipantAttendance``, ``ParticipantAttendanceStatus``
 public struct ScheduleAttendanceInfo: Equatable, Sendable, Identifiable {
 
-    /// 일정 식별자
-    public let scheduleId: Int
+    /// 일정 식별자 (서버 응답)
+    public let scheduleId: String
 
     /// 일정 제목
     public let name: String
@@ -36,8 +36,8 @@ public struct ScheduleAttendanceInfo: Equatable, Sendable, Identifiable {
     /// 비대면 일정 여부 (정상 상태에서는 `location == nil` 과 동치)
     public let isOnline: Bool
 
-    /// 작성자 멤버 ID
-    public let authorMemberId: Int
+    /// 작성자 멤버 ID (서버 응답)
+    public let authorMemberId: String
 
     /// 출석 정책 (`nil` = 정책 미부착)
     public let attendancePolicy: ScheduleAttendancePolicy?
@@ -48,17 +48,17 @@ public struct ScheduleAttendanceInfo: Equatable, Sendable, Identifiable {
     /// 참여자별 출석 정보
     public let participants: [ParticipantAttendance]
 
-    public var id: Int { scheduleId }
+    public var id: String { scheduleId }
 
     public init(
-        scheduleId: Int,
+        scheduleId: String,
         name: String,
         description: String,
         startsAt: Date,
         endsAt: Date,
         location: ScheduleLocation?,
         isOnline: Bool,
-        authorMemberId: Int,
+        authorMemberId: String,
         attendancePolicy: ScheduleAttendancePolicy?,
         tags: [String],
         participants: [ParticipantAttendance]

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Schedule/ScheduleLocation.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Schedule/ScheduleLocation.swift
@@ -1,0 +1,25 @@
+//
+//  ScheduleLocation.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+/// 일정 장소 (`nil` 컨테이너 값 = 비대면)
+///
+/// > Note: 향후 Schedule Feature 모듈이 분리되면 그쪽으로 이동 예정.
+///   현재는 ``ScheduleAttendanceInfo`` 의 의존성을 충족하기 위해 ActivityDomain 에 임시 배치.
+public struct ScheduleLocation: Equatable, Sendable {
+
+    public let latitude: Double
+    public let longitude: Double
+    public let locationName: String
+
+    public init(latitude: Double, longitude: Double, locationName: String) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.locationName = locationName
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Study/StudyGroupDetailsPage.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Study/StudyGroupDetailsPage.swift
@@ -1,0 +1,22 @@
+//
+//  StudyGroupDetailsPage.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+/// 스터디 그룹 상세 페이지 (커서 기반 페이지네이션)
+public struct StudyGroupDetailsPage: Equatable {
+
+    public let content: [StudyGroupInfo]
+    public let hasNext: Bool
+    public let nextCursor: Int?
+
+    public init(content: [StudyGroupInfo], hasNext: Bool, nextCursor: Int?) {
+        self.content = content
+        self.hasNext = hasNext
+        self.nextCursor = nextCursor
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Study/StudyGroupDetailsPage.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Study/StudyGroupDetailsPage.swift
@@ -12,9 +12,11 @@ public struct StudyGroupDetailsPage: Equatable {
 
     public let content: [StudyGroupInfo]
     public let hasNext: Bool
-    public let nextCursor: Int?
 
-    public init(content: [StudyGroupInfo], hasNext: Bool, nextCursor: Int?) {
+    /// 다음 페이지 커서 (서버 응답)
+    public let nextCursor: String?
+
+    public init(content: [StudyGroupInfo], hasNext: Bool, nextCursor: String?) {
         self.content = content
         self.hasNext = hasNext
         self.nextCursor = nextCursor

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Study/WeeklyCurriculumOption.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Study/WeeklyCurriculumOption.swift
@@ -1,0 +1,26 @@
+//
+//  WeeklyCurriculumOption.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+
+/// 주차 커리큘럼 선택 옵션
+///
+/// 스터디 그룹 일정을 주차 커리큘럼과 연결할 때 사용자가 고르는 한 줄짜리 옵션입니다.
+public struct WeeklyCurriculumOption: Hashable, Identifiable, Sendable {
+
+    public let weeklyCurriculumId: Int
+    public let weekNo: Int
+    public let title: String
+
+    public var id: Int { weeklyCurriculumId }
+
+    public init(weeklyCurriculumId: Int, weekNo: Int, title: String) {
+        self.weeklyCurriculumId = weeklyCurriculumId
+        self.weekNo = weekNo
+        self.title = title
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Study/WeeklyCurriculumOption.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Study/WeeklyCurriculumOption.swift
@@ -12,13 +12,17 @@ import Foundation
 /// 스터디 그룹 일정을 주차 커리큘럼과 연결할 때 사용자가 고르는 한 줄짜리 옵션입니다.
 public struct WeeklyCurriculumOption: Hashable, Identifiable, Sendable {
 
-    public let weeklyCurriculumId: Int
-    public let weekNo: Int
+    /// 주차 커리큘럼 식별자 (서버 응답)
+    public let weeklyCurriculumId: String
+
+    /// 주차 번호 (서버 응답)
+    public let weekNo: String
+
     public let title: String
 
-    public var id: Int { weeklyCurriculumId }
+    public var id: String { weeklyCurriculumId }
 
-    public init(weeklyCurriculumId: Int, weekNo: Int, title: String) {
+    public init(weeklyCurriculumId: String, weekNo: String, title: String) {
         self.weeklyCurriculumId = weeklyCurriculumId
         self.weekNo = weekNo
         self.title = title

--- a/UMCApp/Features/Activity/Domain/Tests/Attendance/AttendanceDecisionResultTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/Attendance/AttendanceDecisionResultTests.swift
@@ -1,0 +1,185 @@
+//
+//  AttendanceDecisionResultTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityDomain
+
+// MARK: - Helpers
+
+private let fixedSessionId = SessionID(value: "session_1")
+private let fixedUserId = UserID(value: "user_1")
+
+private func makeResult(
+    status: ParticipantAttendanceStatus,
+    excuseReason: String? = nil,
+    decisionReason: String? = nil
+) -> AttendanceDecisionResult {
+    AttendanceDecisionResult(
+        status: status,
+        decidedAt: nil,
+        decisionReason: decisionReason,
+        excuseReason: excuseReason,
+        latitude: nil,
+        longitude: nil,
+        decisionMakerMemberInfo: nil,
+        hasDecisionMakerMember: false,
+        isPendingDecision: false
+    )
+}
+
+// MARK: - Suite
+
+@Suite("AttendanceDecisionResult — Attendance 어댑팅 도메인 규칙")
+struct AttendanceDecisionResultTests {
+
+    // MARK: - status 매핑
+
+    @Test(
+        "출석/지각/결석은 V1 동일 케이스로 매핑된다",
+        arguments: [
+            (ParticipantAttendanceStatus.present, AttendanceStatus.present),
+            (.late, .late),
+            (.absent, .absent)
+        ]
+    )
+    func mapsIdenticalCases(
+        v2: ParticipantAttendanceStatus,
+        expected: AttendanceStatus
+    ) {
+        // Given
+        let result = makeResult(status: v2)
+
+        // When
+        let attendance = result.toAttendance(sessionId: fixedSessionId, userId: fixedUserId)
+
+        // Then
+        #expect(attendance.status == expected)
+    }
+
+    @Test("사유 결석(excused)은 출석(present)으로 인정 매핑된다")
+    func mapsExcusedToPresent() {
+        // Given
+        let result = makeResult(status: .excused)
+
+        // When
+        let attendance = result.toAttendance(sessionId: fixedSessionId, userId: fixedUserId)
+
+        // Then
+        #expect(attendance.status == .present)
+    }
+
+    @Test(
+        "*_PENDING 계열은 모두 pendingApproval 로 합쳐진다",
+        arguments: [
+            ParticipantAttendanceStatus.presentPending,
+            .latePending,
+            .excusedPending
+        ]
+    )
+    func mapsPendingFamilyToPendingApproval(v2: ParticipantAttendanceStatus) {
+        // Given
+        let result = makeResult(status: v2)
+
+        // When
+        let attendance = result.toAttendance(sessionId: fixedSessionId, userId: fixedUserId)
+
+        // Then
+        #expect(attendance.status == .pendingApproval)
+    }
+
+    @Test(
+        "pending / unknown 은 beforeAttendance 로 매핑된다",
+        arguments: [
+            ParticipantAttendanceStatus.pending,
+            .unknown
+        ]
+    )
+    func mapsPendingOrUnknownToBeforeAttendance(v2: ParticipantAttendanceStatus) {
+        // Given
+        let result = makeResult(status: v2)
+
+        // When
+        let attendance = result.toAttendance(sessionId: fixedSessionId, userId: fixedUserId)
+
+        // Then
+        #expect(attendance.status == .beforeAttendance)
+    }
+
+    // MARK: - type 결정
+
+    @Test("excuseReason 이 있으면 type = .reason 이다 (사유 출석)")
+    func attendanceTypeIsReasonWhenExcuseReasonPresent() {
+        // Given
+        let result = makeResult(status: .excused, excuseReason: "병원 진료")
+
+        // When
+        let attendance = result.toAttendance(sessionId: fixedSessionId, userId: fixedUserId)
+
+        // Then
+        #expect(attendance.type == .reason)
+    }
+
+    @Test("excuseReason 이 nil 이면 type = .gps 이다 (GPS 출석)")
+    func attendanceTypeIsGPSWhenExcuseReasonNil() {
+        // Given
+        let result = makeResult(status: .present, excuseReason: nil)
+
+        // When
+        let attendance = result.toAttendance(sessionId: fixedSessionId, userId: fixedUserId)
+
+        // Then
+        #expect(attendance.type == .gps)
+    }
+
+    // MARK: - reason 우선순위
+
+    @Test("reason 은 excuseReason 우선, 없으면 decisionReason 을 채택한다")
+    func reasonPrefersExcuseOverDecision() {
+        // Given
+        let withBoth = makeResult(
+            status: .excused,
+            excuseReason: "사유 텍스트",
+            decisionReason: "결정 텍스트"
+        )
+        let withoutExcuse = makeResult(
+            status: .present,
+            excuseReason: nil,
+            decisionReason: "결정 텍스트만"
+        )
+
+        // When
+        let attendanceWithBoth = withBoth.toAttendance(
+            sessionId: fixedSessionId,
+            userId: fixedUserId
+        )
+        let attendanceWithoutExcuse = withoutExcuse.toAttendance(
+            sessionId: fixedSessionId,
+            userId: fixedUserId
+        )
+
+        // Then
+        #expect(attendanceWithBoth.reason == "사유 텍스트")
+        #expect(attendanceWithoutExcuse.reason == "결정 텍스트만")
+    }
+
+    @Test("excuseReason 도 decisionReason 도 nil 이면 reason 은 nil 이다")
+    func reasonIsNilWhenBothNil() {
+        // Given
+        let result = makeResult(
+            status: .present,
+            excuseReason: nil,
+            decisionReason: nil
+        )
+
+        // When
+        let attendance = result.toAttendance(sessionId: fixedSessionId, userId: fixedUserId)
+
+        // Then
+        #expect(attendance.reason == nil)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/Attendance/AttendanceDecisionResultTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/Attendance/AttendanceDecisionResultTests.swift
@@ -27,7 +27,6 @@ private func makeResult(
         latitude: nil,
         longitude: nil,
         decisionMakerMemberInfo: nil,
-        hasDecisionMakerMember: false,
         isPendingDecision: false
     )
 }

--- a/UMCApp/Features/Activity/Domain/Tests/Attendance/ParticipantAttendanceStatusTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/Attendance/ParticipantAttendanceStatusTests.swift
@@ -1,0 +1,162 @@
+//
+//  ParticipantAttendanceStatusTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityDomain
+
+// MARK: - Helpers
+
+private func decode(rawJSON: String) throws -> ParticipantAttendanceStatus {
+    let data = Data(rawJSON.utf8)
+    return try JSONDecoder().decode(ParticipantAttendanceStatus.self, from: data)
+}
+
+// MARK: - Suite
+
+@Suite("ParticipantAttendanceStatus — 디코딩 / 필터 / 분기 도메인 규칙")
+struct ParticipantAttendanceStatusTests {
+
+    // MARK: - Decoding
+
+    @Test(
+        "서버 raw 값이 정의된 케이스이면 그 케이스로 디코딩된다",
+        arguments: [
+            ("\"PRESENT\"", ParticipantAttendanceStatus.present),
+            ("\"LATE\"", .late),
+            ("\"ABSENT\"", .absent),
+            ("\"EXCUSED\"", .excused),
+            ("\"PRESENT_PENDING\"", .presentPending),
+            ("\"LATE_PENDING\"", .latePending),
+            ("\"EXCUSED_PENDING\"", .excusedPending),
+            ("\"PENDING\"", .pending)
+        ]
+    )
+    func decodesKnownRawValues(rawJSON: String, expected: ParticipantAttendanceStatus) throws {
+        // Given
+        // (입력: rawJSON)
+
+        // When
+        let status = try decode(rawJSON: rawJSON)
+
+        // Then
+        #expect(status == expected)
+    }
+
+    @Test("서버가 미정의 raw 값을 보내면 unknown 으로 폴백 디코딩한다")
+    func decodesUnknownRawValueAsUnknown() throws {
+        // Given
+        let rawJSON = "\"BRAND_NEW_STATUS\""
+
+        // When
+        let status = try decode(rawJSON: rawJSON)
+
+        // Then
+        #expect(status == .unknown)
+    }
+
+    // MARK: - filterableCases
+
+    @Test("filterableCases 는 unknown 을 제외한 모든 케이스를 반환한다")
+    func filterableCasesExcludesUnknown() {
+        // Given
+        let allCases = ParticipantAttendanceStatus.allCases
+
+        // When
+        let filterable = ParticipantAttendanceStatus.filterableCases
+
+        // Then
+        #expect(filterable.contains(.unknown) == false)
+        #expect(filterable.count == allCases.count - 1)
+    }
+
+    // MARK: - serverQueryValue
+
+    @Test("정의된 케이스의 serverQueryValue 는 raw 값을 그대로 반환한다")
+    func serverQueryValueReturnsRawForKnownCase() {
+        // Given
+        let status = ParticipantAttendanceStatus.present
+
+        // When
+        let value = status.serverQueryValue
+
+        // Then
+        #expect(value == "PRESENT")
+    }
+
+    @Test("unknown 의 serverQueryValue 는 nil 이다 (서버 전송 차단)")
+    func serverQueryValueReturnsNilForUnknown() {
+        // Given
+        let status = ParticipantAttendanceStatus.unknown
+
+        // When
+        let value = status.serverQueryValue
+
+        // Then
+        #expect(value == nil)
+    }
+
+    // MARK: - isPending
+
+    @Test(
+        "isPending 은 *_PENDING 계열만 true 를 반환한다",
+        arguments: [
+            (ParticipantAttendanceStatus.presentPending, true),
+            (.latePending, true),
+            (.excusedPending, true),
+            (.present, false),
+            (.late, false),
+            (.absent, false),
+            (.excused, false),
+            (.pending, false),
+            (.unknown, false)
+        ]
+    )
+    func isPendingMatchesPendingFamilyOnly(
+        status: ParticipantAttendanceStatus,
+        expected: Bool
+    ) {
+        // Given
+        // (입력: status)
+
+        // When
+        let isPending = status.isPending
+
+        // Then
+        #expect(isPending == expected)
+    }
+
+    // MARK: - badgeText
+
+    @Test("unknown 의 badgeText 는 displayText 가 아닌 '알 수 없음' 단축 텍스트다")
+    func badgeTextShortensUnknown() {
+        // Given
+        let status = ParticipantAttendanceStatus.unknown
+
+        // When
+        let badge = status.badgeText
+        let display = status.displayText
+
+        // Then
+        #expect(badge == "알 수 없음")
+        #expect(display == "상태 미지정")
+        #expect(badge != display)
+    }
+
+    @Test("unknown 이 아닌 케이스의 badgeText 는 displayText 와 일치한다")
+    func badgeTextMatchesDisplayForKnownCase() {
+        // Given
+        let status = ParticipantAttendanceStatus.present
+
+        // When
+        let badge = status.badgeText
+        let display = status.displayText
+
+        // Then
+        #expect(badge == display)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/Operator/ScheduleAttendanceInfoTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/Operator/ScheduleAttendanceInfoTests.swift
@@ -12,7 +12,7 @@ import Testing
 // MARK: - Helpers
 
 private func makeParticipant(
-    memberId: Int = 1,
+    memberId: String = "1",
     status: ParticipantAttendanceStatus
 ) -> ParticipantAttendance {
     ParticipantAttendance(
@@ -20,7 +20,7 @@ private func makeParticipant(
         name: "참여자\(memberId)",
         nickname: "닉\(memberId)",
         profileImageUrl: "",
-        schoolId: 1,
+        schoolId: "1",
         schoolName: "한성대",
         attendanceStatus: status,
         isLocationVerified: false,
@@ -30,14 +30,14 @@ private func makeParticipant(
 
 private func makeInfo(participants: [ParticipantAttendance]) -> ScheduleAttendanceInfo {
     ScheduleAttendanceInfo(
-        scheduleId: 100,
+        scheduleId: "100",
         name: "정기 세션",
         description: "",
         startsAt: Date(timeIntervalSince1970: 1_736_942_400),
         endsAt: Date(timeIntervalSince1970: 1_736_949_600),
         location: nil,
         isOnline: true,
-        authorMemberId: 1,
+        authorMemberId: "1",
         attendancePolicy: nil,
         tags: [],
         participants: participants
@@ -55,12 +55,12 @@ struct ScheduleAttendanceInfoTests {
     func presentCountCountsPresentLateExcused() {
         // Given
         let info = makeInfo(participants: [
-            makeParticipant(memberId: 1, status: .present),
-            makeParticipant(memberId: 2, status: .late),
-            makeParticipant(memberId: 3, status: .excused),
-            makeParticipant(memberId: 4, status: .absent),
-            makeParticipant(memberId: 5, status: .pending),
-            makeParticipant(memberId: 6, status: .presentPending)
+            makeParticipant(memberId: "1", status: .present),
+            makeParticipant(memberId: "2", status: .late),
+            makeParticipant(memberId: "3", status: .excused),
+            makeParticipant(memberId: "4", status: .absent),
+            makeParticipant(memberId: "5", status: .pending),
+            makeParticipant(memberId: "6", status: .presentPending)
         ])
 
         // When
@@ -88,11 +88,11 @@ struct ScheduleAttendanceInfoTests {
     func pendingCountCountsPendingFamily() {
         // Given
         let info = makeInfo(participants: [
-            makeParticipant(memberId: 1, status: .presentPending),
-            makeParticipant(memberId: 2, status: .latePending),
-            makeParticipant(memberId: 3, status: .excusedPending),
-            makeParticipant(memberId: 4, status: .present),
-            makeParticipant(memberId: 5, status: .pending)
+            makeParticipant(memberId: "1", status: .presentPending),
+            makeParticipant(memberId: "2", status: .latePending),
+            makeParticipant(memberId: "3", status: .excusedPending),
+            makeParticipant(memberId: "4", status: .present),
+            makeParticipant(memberId: "5", status: .pending)
         ])
 
         // When
@@ -108,8 +108,8 @@ struct ScheduleAttendanceInfoTests {
     func totalCountMatchesParticipantsLength() {
         // Given
         let info = makeInfo(participants: [
-            makeParticipant(memberId: 1, status: .present),
-            makeParticipant(memberId: 2, status: .absent)
+            makeParticipant(memberId: "1", status: .present),
+            makeParticipant(memberId: "2", status: .absent)
         ])
 
         // When
@@ -125,10 +125,10 @@ struct ScheduleAttendanceInfoTests {
     func attendanceRateReturnsRatio() {
         // Given
         let info = makeInfo(participants: [
-            makeParticipant(memberId: 1, status: .present),
-            makeParticipant(memberId: 2, status: .late),
-            makeParticipant(memberId: 3, status: .absent),
-            makeParticipant(memberId: 4, status: .pending)
+            makeParticipant(memberId: "1", status: .present),
+            makeParticipant(memberId: "2", status: .late),
+            makeParticipant(memberId: "3", status: .absent),
+            makeParticipant(memberId: "4", status: .pending)
         ])
 
         // When
@@ -154,9 +154,9 @@ struct ScheduleAttendanceInfoTests {
     func attendanceRateIsOneWhenAllPresent() {
         // Given
         let info = makeInfo(participants: [
-            makeParticipant(memberId: 1, status: .present),
-            makeParticipant(memberId: 2, status: .excused),
-            makeParticipant(memberId: 3, status: .late)
+            makeParticipant(memberId: "1", status: .present),
+            makeParticipant(memberId: "2", status: .excused),
+            makeParticipant(memberId: "3", status: .late)
         ])
 
         // When

--- a/UMCApp/Features/Activity/Domain/Tests/Operator/ScheduleAttendanceInfoTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/Operator/ScheduleAttendanceInfoTests.swift
@@ -1,0 +1,168 @@
+//
+//  ScheduleAttendanceInfoTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/17/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityDomain
+
+// MARK: - Helpers
+
+private func makeParticipant(
+    memberId: Int = 1,
+    status: ParticipantAttendanceStatus
+) -> ParticipantAttendance {
+    ParticipantAttendance(
+        memberId: memberId,
+        name: "참여자\(memberId)",
+        nickname: "닉\(memberId)",
+        profileImageUrl: "",
+        schoolId: 1,
+        schoolName: "한성대",
+        attendanceStatus: status,
+        isLocationVerified: false,
+        excuseReason: nil
+    )
+}
+
+private func makeInfo(participants: [ParticipantAttendance]) -> ScheduleAttendanceInfo {
+    ScheduleAttendanceInfo(
+        scheduleId: 100,
+        name: "정기 세션",
+        description: "",
+        startsAt: Date(timeIntervalSince1970: 1_736_942_400),
+        endsAt: Date(timeIntervalSince1970: 1_736_949_600),
+        location: nil,
+        isOnline: true,
+        authorMemberId: 1,
+        attendancePolicy: nil,
+        tags: [],
+        participants: participants
+    )
+}
+
+// MARK: - Suite
+
+@Suite("ScheduleAttendanceInfo — 카운팅 / 출석률 도메인 규칙")
+struct ScheduleAttendanceInfoTests {
+
+    // MARK: - presentCount
+
+    @Test("presentCount 는 PRESENT / LATE / EXCUSED 인 참여자만 센다")
+    func presentCountCountsPresentLateExcused() {
+        // Given
+        let info = makeInfo(participants: [
+            makeParticipant(memberId: 1, status: .present),
+            makeParticipant(memberId: 2, status: .late),
+            makeParticipant(memberId: 3, status: .excused),
+            makeParticipant(memberId: 4, status: .absent),
+            makeParticipant(memberId: 5, status: .pending),
+            makeParticipant(memberId: 6, status: .presentPending)
+        ])
+
+        // When
+        let count = info.presentCount
+
+        // Then
+        #expect(count == 3)
+    }
+
+    @Test("참여자가 없으면 presentCount 는 0 이다")
+    func presentCountIsZeroForEmpty() {
+        // Given
+        let info = makeInfo(participants: [])
+
+        // When
+        let count = info.presentCount
+
+        // Then
+        #expect(count == 0)
+    }
+
+    // MARK: - pendingCount
+
+    @Test("pendingCount 는 *_PENDING 계열 참여자만 센다")
+    func pendingCountCountsPendingFamily() {
+        // Given
+        let info = makeInfo(participants: [
+            makeParticipant(memberId: 1, status: .presentPending),
+            makeParticipant(memberId: 2, status: .latePending),
+            makeParticipant(memberId: 3, status: .excusedPending),
+            makeParticipant(memberId: 4, status: .present),
+            makeParticipant(memberId: 5, status: .pending)
+        ])
+
+        // When
+        let count = info.pendingCount
+
+        // Then
+        #expect(count == 3)
+    }
+
+    // MARK: - totalCount
+
+    @Test("totalCount 는 participants 배열 길이와 같다")
+    func totalCountMatchesParticipantsLength() {
+        // Given
+        let info = makeInfo(participants: [
+            makeParticipant(memberId: 1, status: .present),
+            makeParticipant(memberId: 2, status: .absent)
+        ])
+
+        // When
+        let count = info.totalCount
+
+        // Then
+        #expect(count == 2)
+    }
+
+    // MARK: - attendanceRate (경계값 포함)
+
+    @Test("attendanceRate 는 presentCount / totalCount 비율을 반환한다")
+    func attendanceRateReturnsRatio() {
+        // Given
+        let info = makeInfo(participants: [
+            makeParticipant(memberId: 1, status: .present),
+            makeParticipant(memberId: 2, status: .late),
+            makeParticipant(memberId: 3, status: .absent),
+            makeParticipant(memberId: 4, status: .pending)
+        ])
+
+        // When
+        let rate = info.attendanceRate
+
+        // Then
+        #expect(rate == 0.5)
+    }
+
+    @Test("totalCount 가 0 이면 attendanceRate 는 0.0 으로 폴백한다 (0 나누기 방지)")
+    func attendanceRateIsZeroWhenTotalIsZero() {
+        // Given
+        let info = makeInfo(participants: [])
+
+        // When
+        let rate = info.attendanceRate
+
+        // Then
+        #expect(rate == 0.0)
+    }
+
+    @Test("모든 참여자가 출석으로 인정되면 attendanceRate 는 1.0 이다")
+    func attendanceRateIsOneWhenAllPresent() {
+        // Given
+        let info = makeInfo(participants: [
+            makeParticipant(memberId: 1, status: .present),
+            makeParticipant(memberId: 2, status: .excused),
+            makeParticipant(memberId: 3, status: .late)
+        ])
+
+        // When
+        let rate = info.attendanceRate
+
+        // Then
+        #expect(rate == 1.0)
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

5차 스프린트 UseCase Impl 이식([#747](https://github.com/UMC-PRODUCT/umc-product-iOS/issues/747)~[#750](https://github.com/UMC-PRODUCT/umc-product-iOS/issues/750))의 **선행 조건**.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (Domain 레이어 Protocol / 모델 이식 + GWT 단위 테스트).
<img width="1528" height="988" alt="스크린샷 2026-05-18 오후 5 05 15" src="https://github.com/user-attachments/assets/1a2aa754-7773-44f5-a373-695909419078" />

<img width="1528" height="988" alt="스크린샷 2026-05-18 오후 5 05 04" src="https://github.com/user-attachments/assets/dc7f62d5-fa27-4a6c-95e7-95d8e5ff8999" />

## 🛠️ 작업내용

### 이식 대상

| 카테고리 | 대상 |
|---|---|
| Repository Protocol (`Interfaces/`) | `ChallengerAttendanceRepositoryProtocol`, `OperatorAttendanceRepositoryProtocol`, `StudyRepositoryProtocol` |
| 의존 Enum | `ParticipantAttendanceStatus` |
| 의존 Model | `AttendanceDecisionResult`, `ScheduleAttendancePolicy`, `ParticipantAttendance`, `ScheduleAttendanceInfo`, `ScheduleLocation`, `WeeklyCurriculumOption`, `StudyGroupDetailsPage` |
| 단위 테스트 | 3 파일 / 22 cases (Phase 1 의존 모델 중 도메인 규칙 보유 3종) |

### `AttendanceDecisionResult` 의 비대칭 노출 (Anti-Corruption Layer)

이 모델은 챌린저 / 운영진 두 측면에서 노출 범위가 다릅니다:

| 측 | Repository 반환 | UseCase 반환 | UI 가 보는 것 |
|---|---|---|---|
| 챌린저 | `AttendanceDecisionResult` (9 케이스) | `Attendance` (5 케이스, `toAttendance` 어댑팅) | `Attendance` 만 |
| 운영진 | `[AttendanceDecisionResult]` | `[AttendanceDecisionResult]` (그대로) | `AttendanceDecisionResult` 직접 |

`toAttendance(sessionId:userId:)` 는 챌린저 측 Anti-Corruption Layer — 서버 응답 스키마(9 케이스 + 결정자 메타)를 챌린저 도메인의 좁은 뷰(5 케이스 + 출석 상태)로 좁히는 정책 매퍼입니다.

도메인 매핑 규칙 (`toAttendance`):
- `.excused` → `.present` (사유 결석은 출석 인정)
- `*_PENDING` 3종 → `.pendingApproval` (챌린저는 어느 종류 대기인지 구분 불필요)
- `.unknown` / `.pending` → `.beforeAttendance`
- `excuseReason` 존재 여부가 `type = .reason` vs `.gps` 결정
- `reason` 은 사용자가 적은 `excuseReason` 을 운영진의 `decisionReason` 보다 우선

## 📋 추후 진행 상황
- 5차 UseCase 이식([#747](https://github.com/UMC-PRODUCT/umc-product-iOS/issues/747)~[#750](https://github.com/UMC-PRODUCT/umc-product-iOS/issues/750))은 본 PR 머지 후 base 로 사용

## 📌 리뷰 포인트

### 1. 외부 도메인 의존 메서드 임시 제외
Protocol 3종 중 2개 메서드(`fetchMySchedulesForAttendance`, `fetchCurriculumData`)는 외부 도메인 타입 의존이라 본 PR 에서 제외하고 `// MARK: - 외부 도메인 이식 후 추가` 주석으로 TODO 표기. 5차 UseCase 이식 시 필요해지면 별도 이슈 분리 필요.

### 2. `AttendanceDecisionResult` 의 챌린저/운영진 비대칭 노출
같은 타입이 두 역할을 함:
- 챌린저 UseCase 내부에서는 **어댑터로 변환 후 폐기**되는 내부 모델
- 운영진 UseCase 에서는 **그대로 노출**되는 공개 모델

본 PR 의 Repository Protocol 2 개 분리(`Challenger` / `Operator`)는 이 비대칭을 ISP 관점에서 반영한 결과.

### 3. 빌드/테스트 결과
- `make build SCHEME=ActivityDomain` — ✅ BUILD SUCCEEDED
- `make test SCHEME=ActivityDomain` — ✅ **136 tests / 20 suites passed** (신규 22 cases / 3 suites 포함)
- ActivityDomain 커버리지 — **90.04% (633/703)** — 목표 80% 초과

| 신규 핵심 메서드 커버리지 | % |
|---|---|
| `ParticipantAttendanceStatus.init(from:)` (`unknown` 폴백 디코딩) | 100% (4/4) |
| `ParticipantAttendanceStatus.isPending` / `serverQueryValue` / `badgeText` | 100% |
| `AttendanceDecisionResult.toAttendance(sessionId:userId:)` (9→5 케이스 매핑) | 100% (25/25) |
| `ScheduleAttendanceInfo.presentCount` / `pendingCount` / `attendanceRate` | 100% |

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
