### PR TITLE
✨ [Feature] 출석 기록 보유 일정 FORCE_DELETE 플로우 지원 (SUPER_ADMIN)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Authorization/Models/ResourcePermission.swift
+++ b/AppProduct/AppProduct/Core/Common/Authorization/Models/ResourcePermission.swift
@@ -26,6 +26,8 @@ enum AuthorizationPermissionType: String, CaseIterable, Hashable {
     case edit = "EDIT"
     case write = "WRITE"
     case delete = "DELETE"
+    /// 출석 기록이 있는 일정에 대한 강제 삭제 권한 (일정 기수의 SUPER_ADMIN만 부여).
+    case forceDelete = "FORCE_DELETE"
     case approve = "APPROVE"
     case check = "CHECK"
     case manage = "MANAGE"

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/MockHomeRepository.swift
@@ -73,6 +73,10 @@ final class MockScheduleRepository: ScheduleRepositoryProtocol {
     func deleteSchedule(scheduleId: Int) async throws {
         throw DomainError.insufficientPermission(required: "인증")
     }
+
+    func forceDeleteSchedule(scheduleId: Int) async throws {
+        throw DomainError.insufficientPermission(required: "SUPER_ADMIN")
+    }
 }
 
 // MARK: - MockChallengerGenRepository

--- a/AppProduct/AppProduct/Features/Home/Data/Repository/ScheduleRepository.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Repository/ScheduleRepository.swift
@@ -138,4 +138,26 @@ final class ScheduleRepository: ScheduleRepositoryProtocol, @unchecked Sendable 
     ) async throws {
         try await deleteSchedule(scheduleId: scheduleId)
     }
+
+    /// 출석 기록이 있는 일정을 강제 삭제합니다.
+    ///
+    /// 서버 권한 정책상 일정 기수의 SUPER_ADMIN 만 호출할 수 있으며, 그 외 사용자는 403 으로 반려됩니다.
+    ///
+    /// - Parameter scheduleId: 강제 삭제할 일정 ID
+    /// - Throws: 서버 에러 또는 네트워크 에러
+    func forceDeleteSchedule(
+        scheduleId: Int
+    ) async throws {
+        let response = try await adapter.request(
+            ScheduleV2Router.forceDeleteSchedule(scheduleId: scheduleId)
+        )
+        if response.data.isEmpty {
+            return
+        }
+        let apiResponse = try decoder.decode(
+            APIResponse<EmptyResult>.self,
+            from: response.data
+        )
+        try apiResponse.validateSuccess()
+    }
 }

--- a/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleV2Router.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/Router/ScheduleV2Router.swift
@@ -26,6 +26,8 @@ enum ScheduleV2Router {
     // TODO: [#688] 백엔드 OpenAPI 어노테이션 미등록 — 추가 후 Stella 재스캔 시 unmatched에서 제외 예정
     /// 일정 삭제 (스터디 그룹 일정 2단계 실패 시 베스트 에포트 롤백 등)
     case deleteSchedule(scheduleId: Int)
+    /// 일정 강제 삭제 (출석 기록이 있는 일정 — 일정 기수의 SUPER_ADMIN 전용)
+    case forceDeleteSchedule(scheduleId: Int)
     /// 운영진용 일정 출석 현황 목록 조회 (SCHEDULE-Q004)
     ///
     /// - `from` / `to` 미지정 시 서버 기본값(요청 시점 -1개월 ~ +24시간) 적용
@@ -60,6 +62,8 @@ extension ScheduleV2Router: BaseTargetType {
             return "/api/v2/schedules/\(scheduleId)"
         case .deleteSchedule(let scheduleId):
             return "/api/v2/schedules/\(scheduleId)"
+        case .forceDeleteSchedule(let scheduleId):
+            return "/api/v2/schedules/\(scheduleId)/force"
         case .getAttendanceList:
             return "/api/v2/schedules/attendance"
         case .getAttendanceDetail(let scheduleId, _):
@@ -84,7 +88,7 @@ extension ScheduleV2Router: BaseTargetType {
             return .post
         case .patchSchedule:
             return .patch
-        case .deleteSchedule:
+        case .deleteSchedule, .forceDeleteSchedule:
             return .delete
         }
     }
@@ -93,7 +97,7 @@ extension ScheduleV2Router: BaseTargetType {
 
     var task: Moya.Task {
         switch self {
-        case .getCapabilities, .getScheduleDetail, .deleteSchedule:
+        case .getCapabilities, .getScheduleDetail, .deleteSchedule, .forceDeleteSchedule:
             return .requestPlain
         case .getMySchedules(let query):
             return .requestParameters(

--- a/AppProduct/AppProduct/Features/Home/Domain/Interface/ScheduleRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/Interface/ScheduleRepositoryProtocol.swift
@@ -53,4 +53,12 @@ protocol ScheduleRepositoryProtocol: Sendable {
     func deleteScheduleWithAttendance(
         scheduleId: Int
     ) async throws
+
+    /// 출석 기록이 있는 일정을 강제 삭제합니다 (일정 기수의 SUPER_ADMIN 전용).
+    ///
+    /// - Parameter scheduleId: 강제 삭제할 일정 ID
+    /// - Throws: 서버 에러(권한 부족 시 403) 또는 네트워크 에러
+    func forceDeleteSchedule(
+        scheduleId: Int
+    ) async throws
 }

--- a/AppProduct/AppProduct/Features/Home/Domain/UseCases/ForceDeleteScheduleUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/UseCases/ForceDeleteScheduleUseCaseProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  ForceDeleteScheduleUseCaseProtocol.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 5/18/26.
+//
+
+import Foundation
+
+/// 출석 기록이 있는 일정을 강제 삭제하는 UseCase Protocol
+///
+/// 서버 권한 정책상 일정 기수의 SUPER_ADMIN 만 사용할 수 있습니다.
+protocol ForceDeleteScheduleUseCaseProtocol {
+
+    /// 강제 삭제를 실행합니다.
+    ///
+    /// - Parameter scheduleId: 강제 삭제할 일정 ID
+    /// - Throws: 서버 에러(403 등) 또는 네트워크 에러
+    func execute(scheduleId: Int) async throws
+}

--- a/AppProduct/AppProduct/Features/Home/Domain/UseCases/Implementations/ForceDeleteScheduleUseCase.swift
+++ b/AppProduct/AppProduct/Features/Home/Domain/UseCases/Implementations/ForceDeleteScheduleUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  ForceDeleteScheduleUseCase.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 5/18/26.
+//
+
+import Foundation
+
+/// 출석 기록이 있는 일정을 강제 삭제하는 UseCase 구현체
+final class ForceDeleteScheduleUseCase: ForceDeleteScheduleUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: ScheduleRepositoryProtocol
+
+    // MARK: - Init
+
+    init(repository: ScheduleRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    func execute(scheduleId: Int) async throws {
+        try await repository.forceDeleteSchedule(scheduleId: scheduleId)
+    }
+}

--- a/AppProduct/AppProduct/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
@@ -25,6 +25,8 @@ protocol HomeUseCaseProviding {
     var updateScheduleUseCase: UpdateScheduleUseCaseProtocol { get }
     /// 일정 + 출석부 통합 삭제 UseCase
     var deleteScheduleUseCase: DeleteScheduleUseCaseProtocol { get }
+    /// 출석 기록 보유 일정 강제 삭제 UseCase (SUPER_ADMIN 전용)
+    var forceDeleteScheduleUseCase: ForceDeleteScheduleUseCaseProtocol { get }
     /// 일정 제목 기반 태그 분류 UseCase
     var classifyScheduleUseCase: ClassifyScheduleUseCase { get }
     /// 챌린저 검색 UseCase
@@ -49,6 +51,7 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
     let generateScheduleUseCase: GenerateScheduleUseCaseProtocol
     let updateScheduleUseCase: UpdateScheduleUseCaseProtocol
     let deleteScheduleUseCase: DeleteScheduleUseCaseProtocol
+    let forceDeleteScheduleUseCase: ForceDeleteScheduleUseCaseProtocol
     let classifyScheduleUseCase: ClassifyScheduleUseCase
     let searchChallengersUseCase: SearchChallengersUseCaseProtocol
     let fetchScheduleCapabilitiesUseCase: FetchScheduleCapabilitiesUseCaseProtocol
@@ -84,6 +87,9 @@ final class HomeUseCaseProvider: HomeUseCaseProviding {
             repository: scheduleRepository
         )
         self.deleteScheduleUseCase = DeleteScheduleUseCase(
+            repository: scheduleRepository
+        )
+        self.forceDeleteScheduleUseCase = ForceDeleteScheduleUseCase(
             repository: scheduleRepository
         )
         self.classifyScheduleUseCase = ClassifyScheduleUseCaseImpl(

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDetailViewModel.swift
@@ -33,6 +33,8 @@ class ScheduleDetailViewModel {
     var canEditSchedule: Bool = false
     /// 일정 삭제 가능 여부 (DELETE/MANAGE)
     var canDeleteSchedule: Bool = false
+    /// 출석 기록 보유 일정에 대한 강제 삭제 가능 여부 (FORCE_DELETE/MANAGE — 일정 기수의 SUPER_ADMIN)
+    var canForceDeleteSchedule: Bool = false
     /// 일정 삭제 진행 중 여부
     var isDeleting: Bool = false
 
@@ -109,6 +111,7 @@ class ScheduleDetailViewModel {
         if ProcessInfo.processInfo.arguments.contains("--schedule-force-permission") {
             canEditSchedule = true
             canDeleteSchedule = true
+            canForceDeleteSchedule = true
             return
         }
         #endif
@@ -120,10 +123,31 @@ class ScheduleDetailViewModel {
             )
             canEditSchedule = permission.hasAny([.edit, .write, .manage])
             canDeleteSchedule = permission.hasAny([.delete, .manage])
+            canForceDeleteSchedule = permission.hasAny([.forceDelete, .manage])
         } catch {
             canEditSchedule = false
             canDeleteSchedule = false
+            canForceDeleteSchedule = false
         }
+    }
+
+    /// 출석 기록이 있는 일정에 대한 강제 삭제 확인 Alert을 표시합니다.
+    ///
+    /// 일반 삭제가 ``DomainError/scheduleHasAttendanceRecords`` 로 거부되었을 때,
+    /// SUPER_ADMIN(FORCE_DELETE 권한 보유자)에게만 노출되는 2차 확인 다이얼로그입니다.
+    ///
+    /// - Parameter onConfirm: 강제 삭제 확정 시 실행할 액션
+    func forceDeleteAlertAction(onConfirm: @escaping () -> Void) {
+        alertPromprt = .init(
+            title: "출석 기록 포함 일정 강제 삭제",
+            message:
+                "이 일정에는 이미 출석 기록이 있습니다.\n강제 삭제하면 출석 데이터까지 함께 삭제되며, 되돌릴 수 없습니다.",
+            positiveBtnTitle: "강제 삭제",
+            positiveBtnAction: onConfirm,
+            negativeBtnTitle: "취소",
+            negativeBtnAction: {},
+            isPositiveBtnDestructive: true
+        )
     }
 
     /// 일정 상세 정보를 조회합니다.

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
@@ -195,6 +195,11 @@ struct ScheduleDetailView: View {
     }
 
     /// 일정과 출석부를 함께 삭제합니다.
+    ///
+    /// 서버가 출석 기록 존재로 인해 일반 삭제를 거부(``DomainError/scheduleHasAttendanceRecords``)하면,
+    /// FORCE_DELETE 권한 보유자(일정 기수의 SUPER_ADMIN)에게는 2차 확인 후 강제 삭제 플로우를 제공하고,
+    /// 그 외 사용자에게는 기존 에러 핸들러 경로를 그대로 사용합니다.
+    ///
     /// - Parameter scheduleId: 삭제할 일정 ID
     /// - Returns: 삭제 성공 여부
     @MainActor
@@ -209,6 +214,14 @@ struct ScheduleDetailView: View {
                 scheduleId: scheduleId
             )
             return true
+        } catch DomainError.scheduleHasAttendanceRecords where viewModel.canForceDeleteSchedule {
+            viewModel.forceDeleteAlertAction {
+                Task { @MainActor in
+                    let success = await forceDeleteSchedule(scheduleId: scheduleId)
+                    if success { dismiss() }
+                }
+            }
+            return false
         } catch {
             errorHandler.handle(error, context: ErrorContext(
                 feature: "Home",
@@ -217,6 +230,38 @@ struct ScheduleDetailView: View {
                     guard let di else { return }
                     let provider = di.resolve(HomeUseCaseProviding.self)
                     try? await provider.deleteScheduleUseCase.execute(
+                        scheduleId: scheduleId
+                    )
+                }
+            ))
+            return false
+        }
+    }
+
+    /// 출석 기록을 포함한 일정을 강제 삭제합니다 (SUPER_ADMIN 전용).
+    ///
+    /// - Parameter scheduleId: 강제 삭제할 일정 ID
+    /// - Returns: 삭제 성공 여부
+    @MainActor
+    @discardableResult
+    private func forceDeleteSchedule(scheduleId: Int) async -> Bool {
+        viewModel.isDeleting = true
+        defer { viewModel.isDeleting = false }
+
+        do {
+            let provider = di.resolve(HomeUseCaseProviding.self)
+            try await provider.forceDeleteScheduleUseCase.execute(
+                scheduleId: scheduleId
+            )
+            return true
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Home",
+                action: "forceDeleteSchedule",
+                retryAction: { [weak di] in
+                    guard let di else { return }
+                    let provider = di.resolve(HomeUseCaseProviding.self)
+                    try? await provider.forceDeleteScheduleUseCase.execute(
                         scheduleId: scheduleId
                     )
                 }


### PR DESCRIPTION
## ✨ PR 유형

- [x] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 디자인 변경 (design)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)

Schedule 도메인 권한 명세([Notion](https://uttermost-gasoline-ce6.notion.site/Schedule-364874e7a8dd80c8811ad6f5a5ec5d76))를 기준으로 클라이언트 대응 현황을 감사한 결과, **FORCE_DELETE 권한 라인이 전혀 구현되지 않은 갭**이 확인되어 이를 보완합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 자체 변경은 일정 상세 화면 삭제 플로우의 **추가 다이얼로그 1개** 입니다. 캡쳐는 SUPER_ADMIN 권한 발급 후 후속 첨부 예정. 로컬 검증은 DEBUG 플래그 `--schedule-force-permission` 으로 강제 노출하여 확인했습니다.

| 시나리오 | 노출 화면 |
|---------|----------|
| 일반 사용자 — 출석 기록 없는 일정 삭제 | (기존 동일) 1차 확인 → 정상 삭제 |
| 일반 사용자 — 출석 기록 있는 일정 삭제 | (기존 동일) 1차 확인 → "출석 기록이 있는 일정은 삭제할 수 없습니다…" 안내만 표시 |
| **SUPER_ADMIN — 출석 기록 있는 일정 삭제** | 1차 확인 → 거부 → **"출석 기록 포함 일정 강제 삭제" 2차 파괴적 확인 다이얼로그** (신규) → 확정 시 강제 삭제 호출 |

## 🛠️ 작업내용

### 1. 권한 모델 확장
- `AuthorizationPermissionType.forceDelete = "FORCE_DELETE"` 케이스 추가

### 2. 네트워크 / 데이터 레이어
- `ScheduleV2Router.forceDeleteSchedule(scheduleId:)` 신설 (DELETE `/api/v2/schedules/{id}/force`)
- `ScheduleRepositoryProtocol.forceDeleteSchedule(scheduleId:)` 추가
- `ScheduleRepository` 구현 / `MockScheduleRepository` 동기화

### 3. 도메인 / UseCase
- `ForceDeleteScheduleUseCaseProtocol` 신설
- `ForceDeleteScheduleUseCase` 구현체 신설
- `HomeUseCaseProvider` 에 `forceDeleteScheduleUseCase` 노출

### 4. Presentation
- `ScheduleDetailViewModel`
  - `canForceDeleteSchedule: Bool` 프로퍼티 추가
  - `fetchSchedulePermission` 에서 `permission.hasAny([.forceDelete, .manage])` 로 산출
  - DEBUG `--schedule-force-permission` 플래그 단축 경로 확장
  - `forceDeleteAlertAction(onConfirm:)` 메서드 추가 (파괴적 2차 확인 다이얼로그)
- `ScheduleDetailView.deleteSchedule(scheduleId:)`
  - `DomainError.scheduleHasAttendanceRecords` catch + `canForceDeleteSchedule == true` 조건에서만 2차 확인 → `forceDeleteScheduleUseCase` 호출 → 성공 시 화면 dismiss
  - 그 외 분기는 기존 `errorHandler.handle(...)` 경로 그대로 유지

### 5. 권한 매트릭스 적용 결과

| 권한 보유자 | 일정 삭제 시도 결과 |
|-------------|---------------------|
| 일반 / EDIT / DELETE | 1차 확인 → 출석 기록 있으면 안내 메시지만 표시 (기존 유지) |
| **SUPER_ADMIN (FORCE_DELETE / MANAGE)** | 1차 확인 → 거부 시 2차 파괴적 확인 → `force` 엔드포인트로 강제 삭제 |

## 📋 추후 진행 상황

스펙 감사에서 함께 도출되었으나 서버 의존성 / 정책 미확정으로 **별도 후속 PR로 분리** 합니다.

1. **응답 코드 기반 분기로 교체** — 현재 `ScheduleRepository.mapScheduleDeleteError` 는 한국어 에러 메시지 substring 매칭으로 `scheduleHasAttendanceRecords` 를 판정합니다. 서버에서 안정적인 에러 코드를 내려주면 코드 기반으로 교체해야 메시지 변경에 안전합니다 (서버팀 협의 후 별도 이슈)
2. **지부장(Chapter Leader) 권한 라인 검증** — 명세에는 지부장의 schedule 관련 권한이 명시되어 있으나 현재 서버 응답이 이를 반영하는지 미확인. 백엔드 확인 후 별도 PR

## 📌 리뷰 포인트

1. **권한 게이팅 분기 위치** — UI 노출(`canForceDeleteSchedule`) 과 실제 호출(서버 권한 검증) 의 이중 방어 구조가 의도된 것인지 확인. 서버가 최종 권한 게이트이고, 클라이언트는 UX 차원의 사전 차단입니다.
2. **에러 분기 catch 패턴** — `catch DomainError.scheduleHasAttendanceRecords where viewModel.canForceDeleteSchedule` 형태로 패턴 매칭. `where` 절을 빠뜨릴 경우 SUPER_ADMIN 외 사용자에게 강제 삭제 다이얼로그가 노출될 수 있어, 이 조합 자체가 안전 게이트입니다.
3. **AlertPrompt 연속 표시** — 1차 확인 → 실패 → 2차 확인의 흐름에서 `alertPromprt` 가 비동기로 재할당되는 패턴. SwiftUI `item:` 바인딩이 첫 다이얼로그 dismiss 직후 새 값을 받아 재표시하도록 의도. 동작 이상 시 `Task.yield()` 또는 짧은 비동기 디스패치가 필요할 수 있음.
4. **명세 외 침범 없음 확인**
   - 일정 생성 화면의 `maxParticipantCount` 강제(`ParticipantSection`) — 이미 적용된 상태라 미수정
   - 홈 일정 생성 버튼의 권한 게이팅 — 명세는 서버 API 권한만 정의하고 UI 노출 정책은 별개. 기존 정책(전체 사용자 노출) 유지
5. **Mock 동기화** — `MockScheduleRepository` 도 protocol 확장에 맞춰 `forceDeleteSchedule` 구현 추가 (프리뷰 빌드 깨짐 방지)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)