### PR TITLE
♻️ [Refactor] ChallengerAttendanceUseCase 신규 모듈로 이식

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ GoogleService-Info.plist
 docs/superpowers/
 # Git worktrees
 .worktrees/
+.omc/

--- a/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
@@ -81,9 +81,6 @@ public enum DomainError: Error, LocalizedError, Equatable {
     /// 출석 사유 입력 필요
     case attendanceReasonRequired
 
-    /// 일정 식별자 변환 실패 (서버 String ID → Int 변환 실패)
-    case invalidScheduleId(String)
-
     // MARK: - 워크북/과제
 
     /// 제출 기한 초과
@@ -137,8 +134,6 @@ public enum DomainError: Error, LocalizedError, Equatable {
             return "출석 시간이 지났습니다."
         case .attendanceReasonRequired:
             return "출석 사유를 입력해주세요."
-        case .invalidScheduleId(let id):
-            return "잘못된 일정 식별자입니다. (\(id))"
         case .workbookDeadlinePassed:
             return "제출 기한이 지났습니다."
         case .workbookAlreadySubmitted:

--- a/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
@@ -81,6 +81,9 @@ public enum DomainError: Error, LocalizedError, Equatable {
     /// 출석 사유 입력 필요
     case attendanceReasonRequired
 
+    /// 일정 식별자 변환 실패 (서버 String ID → Int 변환 실패)
+    case invalidScheduleId(String)
+
     // MARK: - 워크북/과제
 
     /// 제출 기한 초과
@@ -134,6 +137,8 @@ public enum DomainError: Error, LocalizedError, Equatable {
             return "출석 시간이 지났습니다."
         case .attendanceReasonRequired:
             return "출석 사유를 입력해주세요."
+        case .invalidScheduleId(let id):
+            return "잘못된 일정 식별자입니다. (\(id))"
         case .workbookDeadlinePassed:
             return "제출 기한이 지났습니다."
         case .workbookAlreadySubmitted:

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/LocationProviding.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/LocationProviding.swift
@@ -1,0 +1,56 @@
+//
+//  LocationProviding.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/20/26.
+//
+
+import Foundation
+
+/// 위치/지오펜스/지오코딩 추상화
+///
+/// 챌린저 출석 UseCase 가 `LocationManager` 싱글톤에 직접 의존하지 않도록 분리한 Protocol.
+/// Domain 레이어가 CoreLocation 에 의존하지 않게 하여 단위 테스트에서 Mock 주입을 가능하게 합니다.
+///
+/// ## 동시성 / Sendable
+///
+/// Swift 6 strict concurrency 에서 `async` 컨텍스트 cross-actor 접근 시 안전하도록 `Sendable` 채택.
+/// 실제 구현체(`LocationManager`) 는 `@MainActor` 또는 actor 격리 등 자기 isolation 정책을 선택할 수 있습니다.
+///
+/// ## 멀티 지오펜스
+///
+/// 여러 활동이 동시에 진행될 수 있으므로 지오펜스 판정은 **식별자 기반**(`isInside(geofenceId:)`)을 권장합니다.
+/// 단순 "어느 하나라도 안에 있는지"는 `isInsideAnyGeofence` 가 fallback 으로 노출됩니다 (UI 상태 표시 등).
+///
+/// - Note: 실제 구현체(`LocationManager`)는 후속 Core 모듈 이관에서 제공됩니다.
+public protocol LocationProviding: Sendable {
+
+    // MARK: - 상태
+
+    /// 시스템 위치 권한이 부여된 상태인지
+    var isAuthorized: Bool { get }
+
+    /// 추적 중인 지오펜스 중 어느 하나라도 현재 위치가 안에 있는지 (fallback / UI 상태 표시용)
+    ///
+    /// - Important: 특정 지오펜스 안인지 검증할 때는 `isInside(geofenceId:)` 를 사용하세요.
+    ///   본 프로퍼티는 멀티 지오펜스 시 어느 지오펜스인지 구분하지 않습니다.
+    var isInsideAnyGeofence: Bool { get }
+
+    /// 현재 위치 좌표 (위치 갱신 전이거나 권한이 없으면 nil)
+    var currentCoordinate: Coordinate? { get }
+
+    // MARK: - 액션
+
+    /// 특정 지오펜스 식별자 안에 현재 위치가 있는지 판정
+    ///
+    /// 멀티 지오펜스(여러 활동 동시 진행) 시나리오에서도 정확한 판정을 보장합니다.
+    /// - Parameter geofenceId: 출석/일정 등의 식별자 (스케줄 ID 와 1:1 매핑되는 운영 정책)
+    func isInside(geofenceId: String) -> Bool
+
+    /// 좌표 → 주소 역지오코딩 (도메인 모델 반환)
+    /// - throws: `LocationError.geocodingFailed` 등 위치 관련 에러
+    func reverseGeocode(coordinate: Coordinate) async throws -> Address
+
+    /// 등록된 모든 지오펜스 모니터링 중지
+    func stopAllGeofenceMonitoring() async
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/ChallengerAttendanceUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/ChallengerAttendanceUseCaseProtocol.swift
@@ -35,12 +35,11 @@ public protocol ChallengerAttendanceUseCaseProtocol {
     /// - Parameters:
     ///   - sessionId: 결과 `Attendance` 에 부착할 세션 식별자
     ///   - userId: 결과 `Attendance` 에 부착할 사용자 식별자
-    ///   - scheduleId: 일정 식별자 (서버 String ID — Repository 호출 직전 Int 로 변환)
+    ///   - scheduleId: 일정 식별자 (서버 String ID)
     /// - throws:
     ///   - `LocationError.notAuthorized`: 위치 권한 없음
     ///   - `LocationError.locationFailed`: 현재 좌표 획득 실패
     ///   - `DomainError.attendanceOutOfRange`: 지오펜스 밖
-    ///   - `DomainError.invalidScheduleId`: scheduleId Int 변환 실패
     func requestGPSAttendance(
         sessionId: SessionID,
         userId: UserID,
@@ -54,7 +53,6 @@ public protocol ChallengerAttendanceUseCaseProtocol {
     ///
     /// - throws:
     ///   - `DomainError.attendanceReasonRequired`: 빈 사유(공백 trim 결과 빈 문자열)
-    ///   - `DomainError.invalidScheduleId`: scheduleId Int 변환 실패
     func submitLateReason(
         sessionId: SessionID,
         userId: UserID,
@@ -68,7 +66,6 @@ public protocol ChallengerAttendanceUseCaseProtocol {
     ///
     /// - throws:
     ///   - `DomainError.attendanceReasonRequired`: 빈 사유(공백 trim 결과 빈 문자열)
-    ///   - `DomainError.invalidScheduleId`: scheduleId Int 변환 실패
     func submitAbsentReason(
         sessionId: SessionID,
         userId: UserID,
@@ -80,7 +77,7 @@ public protocol ChallengerAttendanceUseCaseProtocol {
 
     /// 기준 시각(`now`)이 어느 출석 시간대에 속하는지 판정 (순수 함수)
     ///
-    /// `AttendanceGeofenceConstants` 의 임계 시간을 기준으로 분기합니다.
+    /// `AttendancePolicy` 의 임계 시간을 기준으로 분기합니다.
     /// 종일 일정(`isAllDay`)은 시작-종료 시각 사이를 단일 `.onTime` 으로 처리합니다.
     ///
     /// - Parameters:

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/ChallengerAttendanceUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/ChallengerAttendanceUseCaseProtocol.swift
@@ -1,0 +1,108 @@
+//
+//  ChallengerAttendanceUseCaseProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/20/26.
+//
+
+import Foundation
+
+/// 챌린저 시점의 출석 도메인 진입점
+///
+/// GPS 스마트 출석의 핵심 UseCase. 위치 권한/지오펜스 가드, 사유 제출, 시간 윈도우 판정 등
+/// 챌린저가 출석 화면에서 수행하는 모든 액션을 단일 Protocol 로 노출합니다.
+///
+/// - 관리자 권한 작업(일괄 결정, 위치 변경 등)은 `OperatorAttendanceUseCaseProtocol` 사용.
+/// - `LocationProviding` 추상화에 의존하여 `LocationManager` 싱글톤과 분리되어 있습니다.
+public protocol ChallengerAttendanceUseCaseProtocol {
+
+    // MARK: - 상태
+
+    /// 추적 중인 지오펜스 중 어느 하나라도 현재 위치가 안에 있는지 (UI 상태 표시용 fallback)
+    ///
+    /// - Important: 특정 일정 출석 가능 여부는 `requestGPSAttendance` 내부의
+    ///   `isInside(geofenceId:)` 식별자 기반 판정을 사용합니다. 본 프로퍼티는 멀티 지오펜스
+    ///   시나리오에서 어느 지오펜스인지 구분하지 않습니다.
+    var isInsideGeofence: Bool { get }
+
+    /// 시스템 위치 권한이 부여된 상태인지
+    var isLocationAuthorized: Bool { get }
+
+    // MARK: - 출석 액션
+
+    /// GPS 기반 출석 요청
+    ///
+    /// - Parameters:
+    ///   - sessionId: 결과 `Attendance` 에 부착할 세션 식별자
+    ///   - userId: 결과 `Attendance` 에 부착할 사용자 식별자
+    ///   - scheduleId: 일정 식별자 (서버 String ID — Repository 호출 직전 Int 로 변환)
+    /// - throws:
+    ///   - `LocationError.notAuthorized`: 위치 권한 없음
+    ///   - `LocationError.locationFailed`: 현재 좌표 획득 실패
+    ///   - `DomainError.attendanceOutOfRange`: 지오펜스 밖
+    ///   - `DomainError.invalidScheduleId`: scheduleId Int 변환 실패
+    func requestGPSAttendance(
+        sessionId: SessionID,
+        userId: UserID,
+        scheduleId: String
+    ) async throws -> Attendance
+
+    /// 지각 사유 제출
+    ///
+    /// - throws:
+    ///   - `DomainError.attendanceReasonRequired`: 빈 사유(공백 trim 결과 빈 문자열)
+    ///   - `DomainError.invalidScheduleId`: scheduleId Int 변환 실패
+    func submitLateReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance
+
+    /// 불참 사유 제출
+    ///
+    /// - throws:
+    ///   - `DomainError.attendanceReasonRequired`: 빈 사유(공백 trim 결과 빈 문자열)
+    ///   - `DomainError.invalidScheduleId`: scheduleId Int 변환 실패
+    func submitAbsentReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance
+
+    // MARK: - 시간 윈도우
+
+    /// 기준 시각(`now`)이 어느 출석 시간대에 속하는지 판정 (순수 함수)
+    ///
+    /// `AttendanceGeofenceConstants` 의 임계 시간을 기준으로 분기합니다.
+    /// 종일 일정(`isAllDay`)은 시작-종료 시각 사이를 단일 `.onTime` 으로 처리합니다.
+    ///
+    /// - Parameters:
+    ///   - info: 판정할 세션 정보 (시작/종료/종일 여부)
+    ///   - now: 기준 시각. 테스트는 결정론적 epoch 를 주입하고, 프로덕션 호출은 기본 오버로드(`Date()`) 를 사용합니다.
+    func isWithinAttendanceTime(info: SessionInfo, now: Date) -> AttendanceTimeWindow
+
+    // MARK: - 위치/지오펜스
+
+    /// 현재 좌표를 주소(도메인 모델)로 역지오코딩
+    /// - throws: `LocationError.locationFailed` (좌표 없음) 등
+    func getAddressToCurrentLocation() async throws -> Address
+
+    /// 등록된 모든 지오펜스 모니터링 중지
+    func stopGeofenceMonitoring() async
+
+    // TODO: Schedule Feature 모듈 이관 후 fetchAvailableSchedules / fetchMyHistory 추가 - [25.05.22] 이재원
+    // — `ScheduleDetailData` 가 Schedule Feature 모듈에 정의 예정.
+    // — PR #797 의 `fetchMySchedulesForAttendance(from:to:)` 동결과 동일 사유.
+}
+
+// MARK: - Default Implementations
+
+extension ChallengerAttendanceUseCaseProtocol {
+
+    /// 프로덕션 편의 오버로드 — 기준 시각으로 `Date()` 를 사용
+    public func isWithinAttendanceTime(info: SessionInfo) -> AttendanceTimeWindow {
+        isWithinAttendanceTime(info: info, now: Date())
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/ChallengerAttendanceUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/ChallengerAttendanceUseCaseProtocol.swift
@@ -49,6 +49,9 @@ public protocol ChallengerAttendanceUseCaseProtocol {
 
     /// 지각 사유 제출
     ///
+    /// `submitAbsentReason` 과 의미가 다른 별도 도메인 액션입니다. 현재는 동일 서버 엔드포인트로
+    /// 수렴하지만, 호출부가 "지각/불참"을 어휘로 구분하도록 진입점을 분리해 노출합니다.
+    ///
     /// - throws:
     ///   - `DomainError.attendanceReasonRequired`: 빈 사유(공백 trim 결과 빈 문자열)
     ///   - `DomainError.invalidScheduleId`: scheduleId Int 변환 실패
@@ -60,6 +63,8 @@ public protocol ChallengerAttendanceUseCaseProtocol {
     ) async throws -> Attendance
 
     /// 불참 사유 제출
+    ///
+    /// `submitLateReason` 참고 — 별도 도메인 의미를 갖는 진입점입니다.
     ///
     /// - throws:
     ///   - `DomainError.attendanceReasonRequired`: 빈 사유(공백 trim 결과 빈 문자열)

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/ChallengerAttendanceUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/ChallengerAttendanceUseCase.swift
@@ -1,0 +1,197 @@
+//
+//  ChallengerAttendanceUseCase.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 5/20/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// `ChallengerAttendanceUseCaseProtocol` 의 기본 구현체
+///
+/// - 위치/지오펜스 의존은 `LocationProviding` Protocol 로 주입.
+/// - Repository 는 `Int` 기반 `scheduleId` 를 받지만, UseCase 시그니처는 `String` 으로 통일.
+///   (서버 ID 는 String 으로 직렬화되므로 모듈 경계에서만 변환)
+public final class ChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: ChallengerAttendanceRepositoryProtocol
+    private let locationProvider: LocationProviding
+
+    // MARK: - Computed Property
+
+    /// UI 상태 표시용 fallback — 추적 중인 지오펜스 중 어느 하나라도 안에 있는지.
+    /// 특정 출석 가드는 `requestGPSAttendance` 내부의 `isInside(geofenceId:)` 식별자 기반 판정 사용.
+    public var isInsideGeofence: Bool {
+        locationProvider.isInsideAnyGeofence
+    }
+
+    public var isLocationAuthorized: Bool {
+        locationProvider.isAuthorized
+    }
+
+    // MARK: - Init
+
+    public init(
+        repository: ChallengerAttendanceRepositoryProtocol,
+        locationProvider: LocationProviding
+    ) {
+        self.repository = repository
+        self.locationProvider = locationProvider
+    }
+
+    // MARK: - 출석 액션
+
+    /// GPS 기반 출석 요청
+    public func requestGPSAttendance(
+        sessionId: SessionID,
+        userId: UserID,
+        scheduleId: String
+    ) async throws -> Attendance {
+        guard locationProvider.isAuthorized else {
+            throw LocationError.notAuthorized
+        }
+
+        guard let coordinate = locationProvider.currentCoordinate else {
+            throw LocationError.locationFailed("현재 위치를 가져올 수 없습니다.")
+        }
+
+        guard locationProvider.isInside(geofenceId: scheduleId) else {
+            throw DomainError.attendanceOutOfRange
+        }
+
+        let intScheduleId = try Self.toIntScheduleId(scheduleId)
+
+        let result = try await repository.requestAttendance(
+            scheduleId: intScheduleId,
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude,
+            locationVerified: true
+        )
+
+        return result.toAttendance(sessionId: sessionId, userId: userId)
+    }
+
+    /// 지각 사유 제출
+    public func submitLateReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance {
+        try await submitExcuse(
+            sessionId: sessionId,
+            userId: userId,
+            reason: reason,
+            scheduleId: scheduleId
+        )
+    }
+
+    /// 불참 사유 제출
+    public func submitAbsentReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance {
+        try await submitExcuse(
+            sessionId: sessionId,
+            userId: userId,
+            reason: reason,
+            scheduleId: scheduleId
+        )
+    }
+
+    // MARK: - 시간 윈도우
+
+    /// 기준 시각(`now`)이 어느 출석 시간대에 속하는지 판정
+    public func isWithinAttendanceTime(
+        info: SessionInfo,
+        now: Date
+    ) -> AttendanceTimeWindow {
+        let onTimeThreshold = TimeInterval(
+            AttendancePolicy.onTimeThresholdMinutes * 60
+        )
+        let lateThreshold = TimeInterval(
+            AttendancePolicy.lateThresholdMinutes * 60
+        )
+        let startTime = info.startTime
+
+        if info.isAllDay {
+            if now < startTime.addingTimeInterval(-onTimeThreshold) {
+                return .tooEarly
+            }
+            if now <= info.endTime {
+                return .onTime
+            }
+            return .expired
+        }
+
+        if now < startTime.addingTimeInterval(-onTimeThreshold) {
+            return .tooEarly
+        }
+        if now <= startTime.addingTimeInterval(onTimeThreshold) {
+            return .onTime
+        }
+        if now <= startTime.addingTimeInterval(lateThreshold) {
+            return .lateWindow
+        }
+        return .expired
+    }
+
+    // MARK: - 위치/지오펜스
+
+    /// 현재 좌표 → 주소(도메인 모델) 역지오코딩
+    public func getAddressToCurrentLocation() async throws -> Address {
+        guard let coordinate = locationProvider.currentCoordinate else {
+            throw LocationError.locationFailed("주소를 찾을 수 없습니다.")
+        }
+        return try await locationProvider.reverseGeocode(coordinate: coordinate)
+    }
+
+    /// 등록된 모든 지오펜스 모니터링 중지
+    public func stopGeofenceMonitoring() async {
+        await locationProvider.stopAllGeofenceMonitoring()
+    }
+
+    // MARK: - Private
+
+    /// 사유 결석/지각 공통 제출
+    ///
+    /// 좌표 미보유 시 `isVerified = false` 로 보고 (lat/lng 0.0 폴백)
+    private func submitExcuse(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance {
+        guard !reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw DomainError.attendanceReasonRequired
+        }
+
+        let intScheduleId = try Self.toIntScheduleId(scheduleId)
+        let coordinate = locationProvider.currentCoordinate
+
+        let result = try await repository.submitExcuse(
+            scheduleId: intScheduleId,
+            excuseReason: reason,
+            isVerified: coordinate != nil,
+            latitude: coordinate?.latitude ?? 0.0,
+            longitude: coordinate?.longitude ?? 0.0
+        )
+        return result.toAttendance(sessionId: sessionId, userId: userId)
+    }
+
+    /// 서버 String 식별자 → Repository Int 시그니처 변환
+    ///
+    /// 본 모듈 경계에서만 일어나는 변환 — UseCase 외부(ViewModel/Repository)는
+    /// 서버용 String 식별자로 통일을 유지합니다.
+    private static func toIntScheduleId(_ scheduleId: String) throws -> Int {
+        guard let intValue = Int(scheduleId) else {
+            throw DomainError.invalidScheduleId(scheduleId)
+        }
+        return intValue
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/ChallengerAttendanceUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/ChallengerAttendanceUseCase.swift
@@ -11,8 +11,7 @@ import UMCFoundation
 /// `ChallengerAttendanceUseCaseProtocol` 의 기본 구현체
 ///
 /// - 위치/지오펜스 의존은 `LocationProviding` Protocol 로 주입.
-/// - Repository 는 `Int` 기반 `scheduleId` 를 받지만, UseCase 시그니처는 `String` 으로 통일.
-///   (서버 ID 는 String 으로 직렬화되므로 모듈 경계에서만 변환)
+/// - `scheduleId` 는 서버 String ID 로 전 레이어 통일 (Repository 도 String 으로 수신).
 public final class ChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProtocol {
 
     // MARK: - Property
@@ -62,10 +61,8 @@ public final class ChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProto
             throw DomainError.attendanceOutOfRange
         }
 
-        let intScheduleId = try Self.toIntScheduleId(scheduleId)
-
         let result = try await repository.requestAttendance(
-            scheduleId: intScheduleId,
+            scheduleId: scheduleId,
             latitude: coordinate.latitude,
             longitude: coordinate.longitude,
             locationVerified: true
@@ -178,29 +175,15 @@ public final class ChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProto
             throw DomainError.attendanceReasonRequired
         }
 
-        let intScheduleId = try Self.toIntScheduleId(scheduleId)
         let coordinate = locationProvider.currentCoordinate
 
         let result = try await repository.submitExcuse(
-            scheduleId: intScheduleId,
+            scheduleId: scheduleId,
             excuseReason: reason,
             isVerified: coordinate != nil,
             latitude: coordinate?.latitude ?? 0.0,
             longitude: coordinate?.longitude ?? 0.0
         )
         return result.toAttendance(sessionId: sessionId, userId: userId)
-    }
-
-    /// 서버 String 식별자 → Repository Int 시그니처 변환
-    ///
-    /// 본 모듈 경계에서만 일어나는 변환 — UseCase 외부(ViewModel/Repository)는
-    /// 서버용 String 식별자로 통일을 유지합니다.
-    ///
-    // TODO: PR #797 Repository scheduleId 를 String 으로 전환하면 본 변환 + invalidScheduleId 제거 - [26.06.06] 이재원
-    private static func toIntScheduleId(_ scheduleId: String) throws -> Int {
-        guard let intValue = Int(scheduleId) else {
-            throw DomainError.invalidScheduleId(scheduleId)
-        }
-        return intValue
     }
 }

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/ChallengerAttendanceUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/ChallengerAttendanceUseCase.swift
@@ -75,6 +75,10 @@ public final class ChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProto
     }
 
     /// 지각 사유 제출
+    ///
+    /// `submitAbsentReason` 과 함께 현재는 동일 서버 엔드포인트(`submitExcuse`)로 수렴하지만,
+    /// 호출부(ViewModel)가 "지각"과 "불참"을 도메인 어휘로 구분해 호출하도록 별도 진입점으로 유지합니다.
+    /// 사유 종류별 분기(지각=부분 출석 증빙, 불참=별도 승인 흐름 등)가 생기면 이 지점에서 갈라집니다.
     public func submitLateReason(
         sessionId: SessionID,
         userId: UserID,
@@ -90,6 +94,9 @@ public final class ChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProto
     }
 
     /// 불참 사유 제출
+    ///
+    /// `submitLateReason` 참고 — 동일 엔드포인트(`submitExcuse`)로 수렴하나
+    /// 도메인 의미가 달라 호출부 명확성을 위해 진입점을 분리합니다.
     public func submitAbsentReason(
         sessionId: SessionID,
         userId: UserID,
@@ -188,6 +195,8 @@ public final class ChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProto
     ///
     /// 본 모듈 경계에서만 일어나는 변환 — UseCase 외부(ViewModel/Repository)는
     /// 서버용 String 식별자로 통일을 유지합니다.
+    ///
+    // TODO: PR #797 Repository scheduleId 를 String 으로 전환하면 본 변환 + invalidScheduleId 제거 - [26.06.06] 이재원
     private static func toIntScheduleId(_ scheduleId: String) throws -> Int {
         guard let intValue = Int(scheduleId) else {
             throw DomainError.invalidScheduleId(scheduleId)

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
@@ -1,0 +1,538 @@
+//
+//  ChallengerAttendanceUseCaseTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 5/20/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+// MARK: - Helpers
+
+private func makeCoordinate(
+    latitude: Double = 37.5,
+    longitude: Double = 127.0
+) -> Coordinate {
+    Coordinate(latitude: latitude, longitude: longitude)
+}
+
+private func makeDecisionResult(
+    status: ParticipantAttendanceStatus = .present,
+    excuseReason: String? = nil,
+    decisionReason: String? = nil
+) -> AttendanceDecisionResult {
+    AttendanceDecisionResult(
+        status: status,
+        decidedAt: Date(timeIntervalSince1970: 1_000),
+        decisionReason: decisionReason,
+        excuseReason: excuseReason,
+        latitude: nil,
+        longitude: nil,
+        decisionMakerMemberInfo: nil,
+        hasDecisionMakerMember: false,
+        isPendingDecision: false
+    )
+}
+
+private func makeSessionInfo(
+    startTime: Date,
+    endTime: Date,
+    isAllDay: Bool = false
+) -> SessionInfo {
+    SessionInfo(
+        sessionId: SessionID(value: "S-1"),
+        iconName: "calendar.badge",
+        title: "1주차 OT",
+        week: 1,
+        startTime: startTime,
+        endTime: endTime,
+        location: Coordinate(latitude: 37.5, longitude: 127.0),
+        isAllDay: isAllDay
+    )
+}
+
+private func makeUseCase(
+    repository: MockChallengerAttendanceRepository = MockChallengerAttendanceRepository(),
+    locationProvider: MockLocationProvider = MockLocationProvider()
+) -> ChallengerAttendanceUseCase {
+    ChallengerAttendanceUseCase(
+        repository: repository,
+        locationProvider: locationProvider
+    )
+}
+
+// MARK: - Mocks
+
+private final class MockChallengerAttendanceRepository: @unchecked Sendable,
+    ChallengerAttendanceRepositoryProtocol {
+
+    // MARK: 입출력 기록
+
+    var requestAttendanceResult: AttendanceDecisionResult = makeDecisionResult()
+    var submitExcuseResult: AttendanceDecisionResult = makeDecisionResult(
+        status: .excusedPending,
+        excuseReason: "사유"
+    )
+
+    private(set) var requestAttendanceCalls: [(
+        scheduleId: Int,
+        latitude: Double,
+        longitude: Double,
+        locationVerified: Bool
+    )] = []
+
+    private(set) var submitExcuseCalls: [(
+        scheduleId: Int,
+        excuseReason: String,
+        isVerified: Bool,
+        latitude: Double,
+        longitude: Double
+    )] = []
+
+    // MARK: Protocol
+
+    func requestAttendance(
+        scheduleId: Int,
+        latitude: Double,
+        longitude: Double,
+        locationVerified: Bool
+    ) async throws -> AttendanceDecisionResult {
+        requestAttendanceCalls.append((scheduleId, latitude, longitude, locationVerified))
+        return requestAttendanceResult
+    }
+
+    func submitExcuse(
+        scheduleId: Int,
+        excuseReason: String,
+        isVerified: Bool,
+        latitude: Double,
+        longitude: Double
+    ) async throws -> AttendanceDecisionResult {
+        submitExcuseCalls.append((scheduleId, excuseReason, isVerified, latitude, longitude))
+        return submitExcuseResult
+    }
+}
+
+private final class MockLocationProvider: @unchecked Sendable, LocationProviding {
+
+    var isAuthorized: Bool = true
+    var isInsideAnyGeofence: Bool = true
+    var currentCoordinate: Coordinate? = makeCoordinate()
+    var reverseGeocodeResult: Address = Address(
+        fullAddress: "서울특별시 성북구 삼선동",
+        city: "서울특별시",
+        district: "성북구"
+    )
+    var reverseGeocodeError: Error?
+
+    /// `isInside(geofenceId:)` 의 응답을 컨트롤하는 stub
+    /// - key: geofenceId, value: 안에 있는지 여부.
+    /// - key 없는 geofenceId 는 `isInsideDefault` 반환.
+    var isInsideMap: [String: Bool] = [:]
+    var isInsideDefault: Bool = true
+
+    private(set) var stopAllGeofenceMonitoringCallCount: Int = 0
+    private(set) var isInsideQueries: [String] = []
+
+    func isInside(geofenceId: String) -> Bool {
+        isInsideQueries.append(geofenceId)
+        return isInsideMap[geofenceId] ?? isInsideDefault
+    }
+
+    func reverseGeocode(coordinate: Coordinate) async throws -> Address {
+        if let error = reverseGeocodeError {
+            throw error
+        }
+        return reverseGeocodeResult
+    }
+
+    func stopAllGeofenceMonitoring() async {
+        stopAllGeofenceMonitoringCallCount += 1
+    }
+}
+
+// MARK: - GPS 출석 요청
+
+@MainActor
+@Suite("ChallengerAttendanceUseCase — GPS 출석 요청 (도메인 규칙)")
+struct ChallengerAttendanceUseCaseGPSTests {
+
+    @Test("권한 미부여 → LocationError.notAuthorized")
+    func requestGPSAttendanceThrowsWhenNotAuthorized() async {
+        let location = MockLocationProvider()
+        location.isAuthorized = false
+        let useCase = makeUseCase(locationProvider: location)
+
+        await #expect(throws: LocationError.self) {
+            _ = try await useCase.requestGPSAttendance(
+                sessionId: SessionID(value: "S-1"),
+                userId: UserID(value: "U-1"),
+                scheduleId: "100"
+            )
+        }
+    }
+
+    @Test("현재 좌표 nil → LocationError.locationFailed")
+    func requestGPSAttendanceThrowsWhenCoordinateMissing() async {
+        let location = MockLocationProvider()
+        location.currentCoordinate = nil
+        let useCase = makeUseCase(locationProvider: location)
+
+        await #expect(throws: LocationError.self) {
+            _ = try await useCase.requestGPSAttendance(
+                sessionId: SessionID(value: "S-1"),
+                userId: UserID(value: "U-1"),
+                scheduleId: "100"
+            )
+        }
+    }
+
+    @Test("scheduleId 식별 지오펜스 밖 → DomainError.attendanceOutOfRange")
+    func requestGPSAttendanceThrowsWhenOutsideGeofence() async {
+        let location = MockLocationProvider()
+        location.isInsideMap = ["100": false]   // 본 일정 지오펜스만 false
+        location.isInsideDefault = true         // 다른 지오펜스는 true 라 해도 무관
+        let useCase = makeUseCase(locationProvider: location)
+
+        await #expect(throws: DomainError.attendanceOutOfRange) {
+            _ = try await useCase.requestGPSAttendance(
+                sessionId: SessionID(value: "S-1"),
+                userId: UserID(value: "U-1"),
+                scheduleId: "100"
+            )
+        }
+        // 정확히 scheduleId 로 질의했는지 검증 (식별자 기반)
+        #expect(location.isInsideQueries == ["100"])
+    }
+
+    @Test("scheduleId Int 변환 실패 → DomainError.invalidScheduleId")
+    func requestGPSAttendanceThrowsWhenScheduleIdInvalid() async {
+        let useCase = makeUseCase()
+
+        await #expect(throws: DomainError.invalidScheduleId("abc")) {
+            _ = try await useCase.requestGPSAttendance(
+                sessionId: SessionID(value: "S-1"),
+                userId: UserID(value: "U-1"),
+                scheduleId: "abc"
+            )
+        }
+    }
+
+    @Test("정상 — Repository 위임 + Attendance 매핑 + locationVerified=true")
+    func requestGPSAttendanceSucceeds() async throws {
+        let repository = MockChallengerAttendanceRepository()
+        repository.requestAttendanceResult = makeDecisionResult(status: .present)
+        let location = MockLocationProvider()
+        location.currentCoordinate = makeCoordinate(latitude: 37.6, longitude: 127.1)
+        location.isInsideMap = ["42": true]
+        let useCase = makeUseCase(repository: repository, locationProvider: location)
+
+        let attendance = try await useCase.requestGPSAttendance(
+            sessionId: SessionID(value: "S-7"),
+            userId: UserID(value: "U-3"),
+            scheduleId: "42"
+        )
+
+        #expect(repository.requestAttendanceCalls.count == 1)
+        let call = try #require(repository.requestAttendanceCalls.first)
+        #expect(call.scheduleId == 42)
+        #expect(call.latitude == 37.6)
+        #expect(call.longitude == 127.1)
+        #expect(call.locationVerified == true)
+
+        #expect(attendance.sessionId == SessionID(value: "S-7"))
+        #expect(attendance.userId == UserID(value: "U-3"))
+        #expect(attendance.status == .present)
+        #expect(attendance.type == .gps)
+    }
+}
+
+// MARK: - 사유 제출
+
+@MainActor
+@Suite("ChallengerAttendanceUseCase — 사유 제출 (도메인 규칙)")
+struct ChallengerAttendanceUseCaseExcuseTests {
+
+    @Test(
+        "빈 사유(공백 trim 결과 빈 문자열) → DomainError.attendanceReasonRequired",
+        arguments: ["", "   ", "\n\t  "]
+    )
+    func submitLateReasonRejectsBlank(reason: String) async {
+        let useCase = makeUseCase()
+
+        await #expect(throws: DomainError.attendanceReasonRequired) {
+            _ = try await useCase.submitLateReason(
+                sessionId: SessionID(value: "S-1"),
+                userId: UserID(value: "U-1"),
+                reason: reason,
+                scheduleId: "100"
+            )
+        }
+    }
+
+    @Test("scheduleId Int 변환 실패 → DomainError.invalidScheduleId")
+    func submitLateReasonThrowsWhenScheduleIdInvalid() async {
+        let useCase = makeUseCase()
+
+        await #expect(throws: DomainError.invalidScheduleId("x")) {
+            _ = try await useCase.submitLateReason(
+                sessionId: SessionID(value: "S-1"),
+                userId: UserID(value: "U-1"),
+                reason: "지각 사유",
+                scheduleId: "x"
+            )
+        }
+    }
+
+    @Test("지각 사유 정상 제출 → Repository 위임 + 좌표 동봉 + isVerified=true")
+    func submitLateReasonSucceedsWithCoordinate() async throws {
+        let repository = MockChallengerAttendanceRepository()
+        repository.submitExcuseResult = makeDecisionResult(
+            status: .latePending,
+            excuseReason: "지각 사유"
+        )
+        let location = MockLocationProvider()
+        location.currentCoordinate = makeCoordinate(latitude: 37.7, longitude: 127.2)
+        let useCase = makeUseCase(repository: repository, locationProvider: location)
+
+        let attendance = try await useCase.submitLateReason(
+            sessionId: SessionID(value: "S-1"),
+            userId: UserID(value: "U-1"),
+            reason: "지각 사유",
+            scheduleId: "42"
+        )
+
+        let call = try #require(repository.submitExcuseCalls.first)
+        #expect(call.scheduleId == 42)
+        #expect(call.excuseReason == "지각 사유")
+        #expect(call.isVerified == true)
+        #expect(call.latitude == 37.7)
+        #expect(call.longitude == 127.2)
+
+        #expect(attendance.status == .pendingApproval)
+        #expect(attendance.type == .reason)
+        #expect(attendance.reason == "지각 사유")
+    }
+
+    @Test("좌표 미보유 시 → isVerified=false + lat/lng 0.0 폴백")
+    func submitAbsentReasonFallsBackWhenCoordinateMissing() async throws {
+        let repository = MockChallengerAttendanceRepository()
+        repository.submitExcuseResult = makeDecisionResult(
+            status: .excusedPending,
+            excuseReason: "결석 사유"
+        )
+        let location = MockLocationProvider()
+        location.currentCoordinate = nil
+        let useCase = makeUseCase(repository: repository, locationProvider: location)
+
+        _ = try await useCase.submitAbsentReason(
+            sessionId: SessionID(value: "S-1"),
+            userId: UserID(value: "U-1"),
+            reason: "결석 사유",
+            scheduleId: "7"
+        )
+
+        let call = try #require(repository.submitExcuseCalls.first)
+        #expect(call.isVerified == false)
+        #expect(call.latitude == 0.0)
+        #expect(call.longitude == 0.0)
+    }
+
+    @Test("결석 사유 정상 제출 → Repository 위임 + Attendance.reason 일치")
+    func submitAbsentReasonSucceeds() async throws {
+        let repository = MockChallengerAttendanceRepository()
+        repository.submitExcuseResult = makeDecisionResult(
+            status: .excusedPending,
+            excuseReason: "결석 사유"
+        )
+        let useCase = makeUseCase(repository: repository)
+
+        let attendance = try await useCase.submitAbsentReason(
+            sessionId: SessionID(value: "S-1"),
+            userId: UserID(value: "U-1"),
+            reason: "결석 사유",
+            scheduleId: "5"
+        )
+
+        #expect(repository.submitExcuseCalls.count == 1)
+        #expect(attendance.reason == "결석 사유")
+        #expect(attendance.type == .reason)
+        #expect(attendance.status == .pendingApproval)
+    }
+}
+
+// MARK: - 출석 시간 윈도우
+
+@MainActor
+@Suite("ChallengerAttendanceUseCase — 출석 시간 윈도우 (도메인 규칙)")
+struct ChallengerAttendanceUseCaseTimeWindowTests {
+
+    // 결정론적 기준 시각: epoch 10_000 (1970-01-01 02:46:40 KST).
+    // 모든 케이스는 `start` 를 이 기준으로부터 상대적으로 정의하여 wall-clock 비의존.
+    private static let fixedNow = Date(timeIntervalSince1970: 10_000)
+
+    private static let onTimeSec = TimeInterval(
+        AttendancePolicy.onTimeThresholdMinutes * 60
+    )
+    private static let lateSec = TimeInterval(
+        AttendancePolicy.lateThresholdMinutes * 60
+    )
+
+    @Test("일반 — 시작 onTime 임계 이전 → tooEarly")
+    func nonAllDayBeforeOnTime() {
+        let useCase = makeUseCase()
+        let info = makeSessionInfo(
+            startTime: Self.fixedNow.addingTimeInterval(Self.onTimeSec + 60),
+            endTime: Self.fixedNow.addingTimeInterval(Self.onTimeSec + 3_600)
+        )
+        #expect(useCase.isWithinAttendanceTime(info: info, now: Self.fixedNow) == .tooEarly)
+    }
+
+    @Test("일반 — 시작 정시(now == startTime) → onTime")
+    func nonAllDayOnTimeAtStart() {
+        let useCase = makeUseCase()
+        let info = makeSessionInfo(
+            startTime: Self.fixedNow,
+            endTime: Self.fixedNow.addingTimeInterval(3_600)
+        )
+        #expect(useCase.isWithinAttendanceTime(info: info, now: Self.fixedNow) == .onTime)
+    }
+
+    @Test("일반 — onTime 경계값(now == start + onTime) → onTime (boundary 포함)")
+    func nonAllDayOnTimeUpperBoundary() {
+        let useCase = makeUseCase()
+        let info = makeSessionInfo(
+            startTime: Self.fixedNow.addingTimeInterval(-Self.onTimeSec),
+            endTime: Self.fixedNow.addingTimeInterval(3_600)
+        )
+        #expect(useCase.isWithinAttendanceTime(info: info, now: Self.fixedNow) == .onTime)
+    }
+
+    @Test("일반 — onTime 초과 ~ late 임계 → lateWindow")
+    func nonAllDayLateWindow() {
+        let useCase = makeUseCase()
+        let info = makeSessionInfo(
+            startTime: Self.fixedNow.addingTimeInterval(-(Self.onTimeSec + 60)),
+            endTime: Self.fixedNow.addingTimeInterval(3_600)
+        )
+        #expect(useCase.isWithinAttendanceTime(info: info, now: Self.fixedNow) == .lateWindow)
+    }
+
+    @Test("일반 — late 임계 초과 → expired")
+    func nonAllDayExpired() {
+        let useCase = makeUseCase()
+        let info = makeSessionInfo(
+            startTime: Self.fixedNow.addingTimeInterval(-(Self.lateSec + 60)),
+            endTime: Self.fixedNow.addingTimeInterval(3_600)
+        )
+        #expect(useCase.isWithinAttendanceTime(info: info, now: Self.fixedNow) == .expired)
+    }
+
+    @Test("종일 — 시작 onTime 임계 이전 → tooEarly")
+    func allDayBeforeOnTime() {
+        let useCase = makeUseCase()
+        let info = makeSessionInfo(
+            startTime: Self.fixedNow.addingTimeInterval(Self.onTimeSec + 60),
+            endTime: Self.fixedNow.addingTimeInterval(Self.onTimeSec + 86_400),
+            isAllDay: true
+        )
+        #expect(useCase.isWithinAttendanceTime(info: info, now: Self.fixedNow) == .tooEarly)
+    }
+
+    @Test("종일 — 시작 onTime~종료 구간 → onTime (lateWindow 미분기)")
+    func allDayWholeDayIsOnTime() {
+        let useCase = makeUseCase()
+        let info = makeSessionInfo(
+            startTime: Self.fixedNow.addingTimeInterval(-3_600),
+            endTime: Self.fixedNow.addingTimeInterval(3_600),
+            isAllDay: true
+        )
+        #expect(useCase.isWithinAttendanceTime(info: info, now: Self.fixedNow) == .onTime)
+    }
+
+    @Test("종일 — 종료 시각 지남 → expired")
+    func allDayAfterEndIsExpired() {
+        let useCase = makeUseCase()
+        let info = makeSessionInfo(
+            startTime: Self.fixedNow.addingTimeInterval(-86_400),
+            endTime: Self.fixedNow.addingTimeInterval(-60),
+            isAllDay: true
+        )
+        #expect(useCase.isWithinAttendanceTime(info: info, now: Self.fixedNow) == .expired)
+    }
+
+    @Test("프로덕션 편의 오버로드 — now 미주입 시 Date() 사용")
+    func defaultOverloadUsesCurrentDate() {
+        let useCase = makeUseCase()
+        // 시작이 지금으로부터 +1h, end +2h → tooEarly 윈도우 안에 있음 (현재 시각 기준)
+        let now = Date()
+        let info = makeSessionInfo(
+            startTime: now.addingTimeInterval(3_600),
+            endTime: now.addingTimeInterval(7_200)
+        )
+        // 결정론은 아니지만, `+1h 시작`은 onTime 임계(±10분) 밖이라
+        // 모든 wall-clock jitter 에서 tooEarly 가 보장됨 (결정론 OK).
+        #expect(useCase.isWithinAttendanceTime(info: info) == .tooEarly)
+    }
+}
+
+// MARK: - 위치/지오펜스 위임
+
+@MainActor
+@Suite("ChallengerAttendanceUseCase — 위치 위임 (도메인 규칙)")
+struct ChallengerAttendanceUseCaseLocationTests {
+
+    @Test("isInsideGeofence / isLocationAuthorized — LocationProvider 위임")
+    func computedPropertiesDelegate() {
+        let location = MockLocationProvider()
+        location.isAuthorized = false
+        location.isInsideAnyGeofence = true
+        let useCase = makeUseCase(locationProvider: location)
+
+        #expect(useCase.isLocationAuthorized == false)
+        #expect(useCase.isInsideGeofence == true)
+    }
+
+    @Test("getAddressToCurrentLocation — 좌표 nil → LocationError.locationFailed")
+    func getAddressThrowsWhenCoordinateMissing() async {
+        let location = MockLocationProvider()
+        location.currentCoordinate = nil
+        let useCase = makeUseCase(locationProvider: location)
+
+        await #expect(throws: LocationError.self) {
+            _ = try await useCase.getAddressToCurrentLocation()
+        }
+    }
+
+    @Test("getAddressToCurrentLocation — 정상 위임 결과 반환 (Address 도메인 모델)")
+    func getAddressDelegates() async throws {
+        let expected = Address(
+            fullAddress: "서울특별시 종로구 사직동",
+            city: "서울특별시",
+            district: "종로구"
+        )
+        let location = MockLocationProvider()
+        location.currentCoordinate = makeCoordinate()
+        location.reverseGeocodeResult = expected
+        let useCase = makeUseCase(locationProvider: location)
+
+        let address = try await useCase.getAddressToCurrentLocation()
+
+        #expect(address == expected)
+        #expect(address.city == "서울특별시")
+        #expect(address.district == "종로구")
+    }
+
+    @Test("stopGeofenceMonitoring — LocationProvider 위임 호출")
+    func stopGeofenceMonitoringDelegates() async {
+        let location = MockLocationProvider()
+        let useCase = makeUseCase(locationProvider: location)
+
+        await useCase.stopGeofenceMonitoring()
+
+        #expect(location.stopAllGeofenceMonitoringCallCount == 1)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
@@ -12,9 +12,6 @@ import UMCFoundation
 
 // MARK: - Helpers
 
-/// `Int()` 변환이 실패하는 비숫자 일정 식별자 fixture (invalidScheduleId 분기 검증 공용)
-private let invalidScheduleId = "invalid-id"
-
 private func makeCoordinate(
     latitude: Double = 37.5,
     longitude: Double = 127.0
@@ -35,7 +32,6 @@ private func makeDecisionResult(
         latitude: nil,
         longitude: nil,
         decisionMakerMemberInfo: nil,
-        hasDecisionMakerMember: false,
         isPendingDecision: false
     )
 }
@@ -83,14 +79,14 @@ private final class MockChallengerAttendanceRepository: @unchecked Sendable,
     )
 
     private(set) var requestAttendanceCalls: [(
-        scheduleId: Int,
+        scheduleId: String,
         latitude: Double,
         longitude: Double,
         locationVerified: Bool
     )] = []
 
     private(set) var submitExcuseCalls: [(
-        scheduleId: Int,
+        scheduleId: String,
         excuseReason: String,
         isVerified: Bool,
         latitude: Double,
@@ -100,7 +96,7 @@ private final class MockChallengerAttendanceRepository: @unchecked Sendable,
     // MARK: Protocol
 
     func requestAttendance(
-        scheduleId: Int,
+        scheduleId: String,
         latitude: Double,
         longitude: Double,
         locationVerified: Bool
@@ -110,7 +106,7 @@ private final class MockChallengerAttendanceRepository: @unchecked Sendable,
     }
 
     func submitExcuse(
-        scheduleId: Int,
+        scheduleId: String,
         excuseReason: String,
         isVerified: Bool,
         latitude: Double,
@@ -214,19 +210,6 @@ struct ChallengerAttendanceUseCaseGPSTests {
         #expect(location.isInsideQueries == ["100"])
     }
 
-    @Test("scheduleId Int 변환 실패 → DomainError.invalidScheduleId")
-    func requestGPSAttendanceThrowsWhenScheduleIdInvalid() async {
-        let useCase = makeUseCase()
-
-        await #expect(throws: DomainError.invalidScheduleId(invalidScheduleId)) {
-            _ = try await useCase.requestGPSAttendance(
-                sessionId: SessionID(value: "S-1"),
-                userId: UserID(value: "U-1"),
-                scheduleId: invalidScheduleId
-            )
-        }
-    }
-
     @Test("정상 — Repository 위임 + Attendance 매핑 + locationVerified=true")
     func requestGPSAttendanceSucceeds() async throws {
         let repository = MockChallengerAttendanceRepository()
@@ -244,7 +227,7 @@ struct ChallengerAttendanceUseCaseGPSTests {
 
         #expect(repository.requestAttendanceCalls.count == 1)
         let call = try #require(repository.requestAttendanceCalls.first)
-        #expect(call.scheduleId == 42)
+        #expect(call.scheduleId == "42")
         #expect(call.latitude == 37.6)
         #expect(call.longitude == 127.1)
         #expect(call.locationVerified == true)
@@ -278,20 +261,6 @@ struct ChallengerAttendanceUseCaseExcuseTests {
         }
     }
 
-    @Test("scheduleId Int 변환 실패 → DomainError.invalidScheduleId")
-    func submitLateReasonThrowsWhenScheduleIdInvalid() async {
-        let useCase = makeUseCase()
-
-        await #expect(throws: DomainError.invalidScheduleId(invalidScheduleId)) {
-            _ = try await useCase.submitLateReason(
-                sessionId: SessionID(value: "S-1"),
-                userId: UserID(value: "U-1"),
-                reason: "지각 사유",
-                scheduleId: invalidScheduleId
-            )
-        }
-    }
-
     @Test("지각 사유 정상 제출 → Repository 위임 + 좌표 동봉 + isVerified=true")
     func submitLateReasonSucceedsWithCoordinate() async throws {
         let repository = MockChallengerAttendanceRepository()
@@ -311,7 +280,7 @@ struct ChallengerAttendanceUseCaseExcuseTests {
         )
 
         let call = try #require(repository.submitExcuseCalls.first)
-        #expect(call.scheduleId == 42)
+        #expect(call.scheduleId == "42")
         #expect(call.excuseReason == "지각 사유")
         #expect(call.isVerified == true)
         #expect(call.latitude == 37.7)

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
@@ -12,6 +12,9 @@ import UMCFoundation
 
 // MARK: - Helpers
 
+/// `Int()` 변환이 실패하는 비숫자 일정 식별자 fixture (invalidScheduleId 분기 검증 공용)
+private let invalidScheduleId = "invalid-id"
+
 private func makeCoordinate(
     latitude: Double = 37.5,
     longitude: Double = 127.0
@@ -65,6 +68,8 @@ private func makeUseCase(
 }
 
 // MARK: - Mocks
+
+#if DEBUG
 
 private final class MockChallengerAttendanceRepository: @unchecked Sendable,
     ChallengerAttendanceRepositoryProtocol {
@@ -154,9 +159,10 @@ private final class MockLocationProvider: @unchecked Sendable, LocationProviding
     }
 }
 
+#endif
+
 // MARK: - GPS 출석 요청
 
-@MainActor
 @Suite("ChallengerAttendanceUseCase — GPS 출석 요청 (도메인 규칙)")
 struct ChallengerAttendanceUseCaseGPSTests {
 
@@ -212,11 +218,11 @@ struct ChallengerAttendanceUseCaseGPSTests {
     func requestGPSAttendanceThrowsWhenScheduleIdInvalid() async {
         let useCase = makeUseCase()
 
-        await #expect(throws: DomainError.invalidScheduleId("abc")) {
+        await #expect(throws: DomainError.invalidScheduleId(invalidScheduleId)) {
             _ = try await useCase.requestGPSAttendance(
                 sessionId: SessionID(value: "S-1"),
                 userId: UserID(value: "U-1"),
-                scheduleId: "abc"
+                scheduleId: invalidScheduleId
             )
         }
     }
@@ -252,7 +258,6 @@ struct ChallengerAttendanceUseCaseGPSTests {
 
 // MARK: - 사유 제출
 
-@MainActor
 @Suite("ChallengerAttendanceUseCase — 사유 제출 (도메인 규칙)")
 struct ChallengerAttendanceUseCaseExcuseTests {
 
@@ -277,12 +282,12 @@ struct ChallengerAttendanceUseCaseExcuseTests {
     func submitLateReasonThrowsWhenScheduleIdInvalid() async {
         let useCase = makeUseCase()
 
-        await #expect(throws: DomainError.invalidScheduleId("x")) {
+        await #expect(throws: DomainError.invalidScheduleId(invalidScheduleId)) {
             _ = try await useCase.submitLateReason(
                 sessionId: SessionID(value: "S-1"),
                 userId: UserID(value: "U-1"),
                 reason: "지각 사유",
-                scheduleId: "x"
+                scheduleId: invalidScheduleId
             )
         }
     }
@@ -366,7 +371,6 @@ struct ChallengerAttendanceUseCaseExcuseTests {
 
 // MARK: - 출석 시간 윈도우
 
-@MainActor
 @Suite("ChallengerAttendanceUseCase — 출석 시간 윈도우 (도메인 규칙)")
 struct ChallengerAttendanceUseCaseTimeWindowTests {
 
@@ -481,7 +485,6 @@ struct ChallengerAttendanceUseCaseTimeWindowTests {
 
 // MARK: - 위치/지오펜스 위임
 
-@MainActor
 @Suite("ChallengerAttendanceUseCase — 위치 위임 (도메인 규칙)")
 struct ChallengerAttendanceUseCaseLocationTests {
 


### PR DESCRIPTION
resolves #745

## ✨ PR 유형

- ♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="2032" height="1075" alt="스크린샷 2026-05-24 오후 4 29 01" src="https://github.com/user-attachments/assets/75f3d62e-4b44-4161-815f-7f6b05cc49ce" />

<img width="2032" height="1075" alt="스크린샷 2026-05-24 오후 4 28 49" src="https://github.com/user-attachments/assets/32152468-7701-4475-bc3b-8dc6c00c0259" />


## 🛠️ 작업내용

- 레거시 `ChallengerAttendanceUseCase` 를 `UMCApp/Features/Activity/Domain` 모듈로 이식 (Protocol + Impl)
- `LocationProviding` Protocol 신규 정의 — `LocationManager` 싱글톤 의존 분리, DI 기반으로 전환
- `DomainError` 에 `invalidScheduleId(String)` 케이스 추가 — 서버 String ID → Int 변환 실패 경로
- `ChallengerAttendanceUseCaseTests` 신규 (Swift Testing, 4 Suite / 17 cases)
- `.gitignore` 에 `.omc/` 추가 (개인 검증 산출물 추적 차단)

## 📋 추후 진행 상황

- `LocationProviding` 실제 구현체 (`CoreLocation` 기반) — Core 모듈 이관 후속 이슈
- `fetchAvailableSchedules` / `fetchMyHistory` UseCase 메서드 — `ScheduleDetailData` (Schedule Feature 모듈) 이관 후 추가
  - PR #797 의 `fetchMySchedulesForAttendance(from:to:)` 동결과 동일 사유로 본 PR 임시 제외
- `ChallengerAttendanceViewModel` 이관 (7차) 시 본 UseCase + DIContainer 결선

## 📌 리뷰 포인트

**레이어 / 책임 분리**
- `LocationProviding` 추상화로 Domain 레이어가 `CoreLocation` 에 직접 의존하지 않음 (Clean Architecture 준수)
- `Sendable` 채택 — Swift 6 strict concurrency, cross-actor 호출 안전성 확보
- `isInside(geofenceId:)` 식별자 기반 판정 vs `isInsideAnyGeofence` UI fallback — 멀티 지오펜스 시나리오에서 가드 분리

**서버 ID 처리 (UseCase 경계 변환)**
- UseCase 외부 시그니처는 `scheduleId: String` 통일 (서버 ID 직렬화 규약)
- Repository 호출 직전 `Int(scheduleId)` 변환, 실패 시 `DomainError.invalidScheduleId` throw
- PR #797 의 Repository 시그니처 (`scheduleId: Int`) 는 그대로 유지 — URL path interpolation 으로 wire 위에선 동일하게 String 직렬화

**테스트 결정론**
- `isWithinAttendanceTime(info:, now:)` — `now` 파라미터 주입으로 시간 의존 제거
- 프로덕션 호출은 default extension `isWithinAttendanceTime(info:)` 가 `Date()` 자동 주입

**스코프 제한 (사용자 합의)**
- `fetchAvailableSchedules` / `fetchMyHistory` 제외 — `ScheduleDetailData` 미이관, 후속 이슈
- `LocationManager` 실제 구현은 본 PR 범위 외 (10차 Core 이관)
- DIContainer 등록도 본 PR 범위 외

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
