### PR TITLE
♻️ [Refactor] NoticeViewModel 이식 (목록)

### DIFF
--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Context.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Context.swift
@@ -1,0 +1,243 @@
+//
+//  NoticeViewModel+Context.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/26/26.
+//
+
+import Foundation
+import UMCFoundation
+import NoticeDomain
+
+extension NoticeViewModel {
+
+    private enum GenerationFilterDefaults {
+        static let mainFilter: NoticeMainFilterType = .central
+    }
+
+    // MARK: - Context & Filter
+
+    /// 공지 탭 메뉴에 쓰이는 사용자 컨텍스트를 반영합니다.
+    ///
+    /// - Parameters:
+    ///   - schoolName: 사용자 학교명
+    ///   - chapterName: 사용자 지부명
+    ///   - responsiblePart: 사용자 파트 API 값
+    ///   - organizationTypeRawValue: 사용자 조직 타입 raw value
+    ///   - chapterId: 사용자 지부 ID
+    ///   - schoolId: 사용자 학교 ID
+    ///   - memberRoleRawValue: 사용자 역할 raw value
+    func applyUserContext(
+        schoolName: String,
+        chapterName: String,
+        responsiblePart: String,
+        organizationTypeRawValue: String,
+        chapterId: String,
+        schoolId: String,
+        memberRoleRawValue: String,
+        generationOrganizationsJSON: String
+    ) {
+        self.userContext = NoticeUserContext(
+            schoolName: schoolName,
+            chapterName: chapterName,
+            responsiblePart: responsiblePart
+        )
+        self.organizationType = OrganizationType(rawValue: organizationTypeRawValue)
+        self.memberRole = ManagementTeam(rawValue: memberRoleRawValue)
+        self.chapterId = chapterId
+        self.schoolId = schoolId
+        self.generationOrganizations = decodeGenerationOrganizations(from: generationOrganizationsJSON)
+
+        let validMainFilters = mainFilterItems
+        let isCurrentPartSelectionValid: Bool = {
+            if case .part = selectedMainFilter {
+                return canSelectPartFilter
+            }
+            return validMainFilters.contains(selectedMainFilter)
+        }()
+
+        if !isCurrentPartSelectionValid {
+            var state = currentState
+            state.mainFilter = validMainFilters.first ?? .all
+            currentState = state
+        }
+    }
+
+    private func decodeGenerationOrganizations(from json: String) -> [String: GenerationOrganizationContext] {
+        guard let data = json.data(using: .utf8),
+              let contexts = try? JSONDecoder().decode([GenerationOrganizationContext].self, from: data) else {
+            return [:]
+        }
+
+        return Dictionary(uniqueKeysWithValues: contexts.map { ($0.gen, $0) })
+    }
+
+    /// 기수 목록 조회
+    func fetchGisuList() {
+        guard !isFetchingGisuList else { return }
+        isFetchingGisuList = true
+        defer { isFetchingGisuList = false }
+
+        do {
+            let fetchedPairs = try genRepository.fetchGenGisuIdPairs()
+            gisuPairs = fetchedPairs.filter { !$0.gisuId.isEmpty && $0.gisuId != "0" }
+            isGisuListLoaded = !gisuPairs.isEmpty
+
+            generations = gisuPairs.map { Generation(value: $0.gen) }
+
+            if let latestGen = generations.max(by: { (Int($0.value) ?? 0) < (Int($1.value) ?? 0) }) {
+                let hasValidSelectedGeneration = generations.contains {
+                    $0.value == selectedGeneration.value
+                }
+                let targetGeneration = hasValidSelectedGeneration ? selectedGeneration : latestGen
+                selectedGeneration = targetGeneration
+
+                if generationStates[targetGeneration.value] == nil {
+                    generationStates[targetGeneration.value] = GenerationFilterState(
+                        mainFilter: GenerationFilterDefaults.mainFilter
+                    )
+                }
+
+                Task { @MainActor in
+                    await refreshSelectedGenerationContext(
+                        resetFilters: !hasValidSelectedGeneration
+                    )
+                }
+            } else {
+                isGisuListLoaded = false
+                noticeItems = .failed(.domain(.custom(message: "기수 정보를 불러오지 못했습니다.")))
+                errorHandler.handle(
+                    DomainError.custom(message: "기수 정보를 불러오지 못했습니다."),
+                    context: .init(
+                        feature: "Notice",
+                        action: "fetchGisuList"
+                    )
+                )
+            }
+        } catch {
+            gisuPairs = []
+            isGisuListLoaded = false
+            generations = []
+            noticeItems = .failed(.domain(.custom(message: "기수 정보를 불러오지 못했습니다.")))
+            errorHandler.handle(
+                error,
+                context: .init(
+                    feature: "Notice",
+                    action: "fetchGisuList"
+                )
+            )
+        }
+    }
+
+    /// 기수 선택
+    /// - Parameter generation: 선택된 기수
+    func selectGeneration(_ generation: Generation) {
+        guard gisuPairs.contains(where: {
+              $0.gen == generation.value && !$0.gisuId.isEmpty && $0.gisuId != "0"
+          }) else { return }
+        selectedGeneration = generation
+        Task { @MainActor in
+            await refreshSelectedGenerationContext(resetFilters: true)
+        }
+    }
+
+    /// 메인필터 선택
+    /// - Parameter filter: 선택된 메인 필터
+    func selectMainFilter(_ filter: NoticeMainFilterType) {
+        var state = currentState
+        state.mainFilter = filter
+        currentState = state
+        isSearchMode = false
+        searchQuery = ""
+        Task {
+            await fetchNotices()
+        }
+    }
+
+    /// 서브필터 선택
+    /// - Parameter subFilter: 선택된 서브 필터
+    func selectSubFilter(_ subFilter: NoticeSubFilterType) {
+        let key = MainFilterKey(from: selectedMainFilter)
+        var mainState = currentState.state(for: key)
+        mainState.subFilter = subFilter
+
+        var state = currentState
+        state.updateState(for: key, state: mainState)
+        currentState = state
+        Task {
+            await fetchNotices()
+        }
+    }
+
+    /// 파트 선택
+    /// - Parameter part: 선택 파트. `nil`이면 파트 전체 의미
+    func selectPart(_ part: NoticePart?) {
+        let key = MainFilterKey(from: selectedMainFilter)
+        var mainState = currentState.state(for: key)
+        mainState.selectedPart = part
+
+        var state = currentState
+        state.updateState(for: key, state: mainState)
+        currentState = state
+        Task {
+            await fetchNotices()
+        }
+    }
+
+    // MARK: - Internal Helper
+
+    /// 현재 선택된 gen에 매핑된 gisuId를 반환
+    func currentSelectedGisuId() -> String? {
+        guard isGisuListLoaded else { return nil }
+        return gisuPairs.first(where: {
+            $0.gen == selectedGeneration.value && !$0.gisuId.isEmpty && $0.gisuId != "0"
+        })?.gisuId
+    }
+
+    /// 선택 기수 기준으로 필터 옵션을 다시 불러오고 목록을 재조회합니다.
+    @MainActor
+    func refreshSelectedGenerationContext(resetFilters: Bool) async {
+        if resetFilters {
+            resetSelectionStateForCurrentGeneration()
+        } else if generationStates[selectedGeneration.value] == nil {
+            generationStates[selectedGeneration.value] = GenerationFilterState(
+                mainFilter: GenerationFilterDefaults.mainFilter
+            )
+        }
+
+        await loadTargetStateForCurrentGeneration()
+        await fetchNotices()
+    }
+
+    /// 기수 전환 시 필터 선택 상태를 기본값으로 되돌립니다.
+    @MainActor
+    func resetSelectionStateForCurrentGeneration() {
+        generationStates[selectedGeneration.value] = GenerationFilterState(
+            mainFilter: GenerationFilterDefaults.mainFilter
+        )
+        pagingState.reset()
+        isSearchMode = false
+        searchQuery = ""
+    }
+
+    /// 현재 선택 기수의 지부/학교 필터 옵션을 조회합니다.
+    @MainActor
+    func loadTargetStateForCurrentGeneration() async {
+        guard let gisuId = currentSelectedGisuId(), !gisuId.isEmpty else {
+            generationTargetStates[selectedGeneration.value] = NoticeGenerationTargetState()
+            return
+        }
+
+        async let branchesTask = try? noticeEditorTargetUseCase.fetchBranches(gisuId: gisuId)
+        async let schoolsTask = try? noticeEditorTargetUseCase.fetchSchools(gisuId: gisuId)
+
+        let branches = await branchesTask ?? []
+        let schools = await schoolsTask ?? []
+
+        branches.forEach { chapterNameCache[$0.id] = $0.name }
+        generationTargetStates[selectedGeneration.value] = NoticeGenerationTargetState(
+            branches: branches,
+            schools: schools
+        )
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -1,0 +1,354 @@
+//
+//  NoticeViewModel+Fetch.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/26/26.
+//
+
+import Foundation
+import UMCFoundation
+import NoticeDomain
+
+extension NoticeViewModel {
+
+    // MARK: - Fetch
+
+    /// 공지사항 목록 조회
+    /// - Parameter page: 조회할 페이지 인덱스
+    @MainActor
+    func fetchNotices(page: Int = 0) async {
+        await performPagedFetch(page: page) { request in
+            try await self.noticeUseCase.getAllNotices(request: request)
+        }
+    }
+
+    /// 공지사항 검색
+    ///
+    /// - Parameters:
+    ///   - keyword: 검색어
+    ///   - page: 조회할 페이지 인덱스
+    @MainActor
+    func searchNotices(keyword: String, page: Int = 0) async {
+        guard !keyword.trimmingCharacters(in: .whitespaces).isEmpty else {
+            isSearchMode = false
+            await fetchNotices()
+            return
+        }
+
+        isSearchMode = true
+        searchQuery = keyword
+        await performPagedFetch(page: page) { request in
+            try await self.noticeUseCase.searchNotice(keyword: keyword, request: request)
+        }
+    }
+
+    /// 검색 모드 해제 (일반 목록으로 복귀)
+    @MainActor
+    func clearSearch() async {
+        searchQuery = ""
+        isSearchMode = false
+        await fetchNotices()
+    }
+
+    /// 현재 상태 기준으로 공지 조회를 재시도합니다.
+    /// - Note: 기수 매핑이 비어 있으면 기수 목록부터 다시 로드합니다.
+    @MainActor
+    func retryCurrentRequest() async {
+        if gisuPairs.isEmpty {
+            fetchGisuList()
+            return
+        }
+
+        if isSearchMode, !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            await searchNotices(keyword: searchQuery)
+        } else {
+            await fetchNotices()
+        }
+    }
+
+    /// 리스트 마지막 셀 진입 시 다음 페이지 로드
+    /// - Parameter currentItem: 화면에 노출된 현재 항목
+    @MainActor
+    func loadNextPageIfNeeded(currentItem: NoticeItemModel) async {
+        guard case .loaded(let items) = noticeItems,
+              let last = items.last,
+              currentItem.id == last.id,
+              pagingState.hasNextPage,
+              !pagingState.isLoadingMore else {
+            return
+        }
+
+        let nextPage = pagingState.nextPage
+        if isSearchMode {
+            await searchNotices(keyword: searchQuery, page: nextPage)
+        } else {
+            await fetchNotices(page: nextPage)
+        }
+    }
+
+    // MARK: - Private Function
+
+    /// 페이징 조회 공통 로직 (기수 검증 → 요청 → 응답 반영)
+    @MainActor
+    private func performPagedFetch(
+        page: Int,
+        requestAction: (NoticeListRequest) async throws -> NoticePage
+    ) async {
+        if page == 0 {
+            guard !isFetchingFirstPage else { return }
+            isFetchingFirstPage = true
+        }
+        defer {
+            if page == 0 {
+                isFetchingFirstPage = false
+            }
+        }
+
+        let previousState = noticeItems
+        guard let gisuId = preparePagingAndResolveGisuId(page: page) else { return }
+
+        do {
+            let request = buildNoticeListRequest(gisuId: gisuId, page: page)
+            let response = try await requestAction(request)
+            applyPagedResponse(response, page: page)
+        } catch is CancellationError {
+            handleCancelledFetch(page: page, previousState: previousState)
+        } catch let error as NSError where isRequestCancellation(error) {
+            handleCancelledFetch(page: page, previousState: previousState)
+        } catch let error as RepositoryError {
+            handleFetchError(.repository(error), page: page, action: "fetchNotices", failure: error)
+        } catch let error as DomainError {
+            handleFetchError(.domain(error), page: page, action: "fetchNotices", failure: error)
+        } catch let error as NetworkError {
+            handleFetchError(.network(error), page: page, action: "fetchNotices", failure: error)
+        } catch {
+            handleFetchError(
+                .unknown(message: error.localizedDescription),
+                page: page,
+                action: "fetchNotices",
+                failure: error
+            )
+        }
+    }
+
+    /// 페이지 상태를 준비하고 현재 선택된 기수의 gisuId를 반환합니다.
+    /// - Parameter page: 요청 페이지
+    /// - Returns: 조회 가능한 gisuId. 없으면 `nil`
+    @MainActor
+    private func preparePagingAndResolveGisuId(page: Int) -> String? {
+        if page == 0, noticeItems.value == nil {
+            noticeItems = .loading
+        }
+
+        guard isGisuListLoaded, !gisuPairs.isEmpty else {
+            if !isFetchingGisuList {
+                fetchGisuList()
+            }
+            return nil
+        }
+
+        guard pagingState.begin(page: page) else { return nil }
+
+        guard let gisuId = resolveCurrentGisuIdWithFallback() else {
+            handleFetchError(
+                .domain(.custom(message: "기수 정보를 불러오지 못했습니다.")),
+                page: page,
+                action: "fetchNotices",
+                failure: DomainError.custom(message: "기수 정보를 불러오지 못했습니다.")
+            )
+            return nil
+        }
+        return gisuId
+    }
+
+    /// 현재 선택 기수의 gisuId를 우선 사용하고, 없으면 최신 기수로 보정합니다.
+    @MainActor
+    private func resolveCurrentGisuIdWithFallback() -> String? {
+        if let gisuId = currentSelectedGisuId(), !gisuId.isEmpty {
+            return gisuId
+        }
+
+        guard let fallback = gisuPairs
+            .filter({ !$0.gisuId.isEmpty && $0.gisuId != "0" })
+            .max(by: { (Int($0.gen) ?? 0) < (Int($1.gen) ?? 0) }) else {
+            return nil
+        }
+
+        selectedGeneration = Generation(value: fallback.gen)
+        if generationStates[fallback.gen] == nil {
+            generationStates[fallback.gen] = GenerationFilterState(mainFilter: .central)
+        }
+        return fallback.gisuId
+    }
+
+    /// 페이지 응답을 목록 상태에 반영합니다.
+    /// - Parameters:
+    ///   - response: 공지 페이징 응답 DTO
+    ///   - page: 조회한 페이지 인덱스
+    @MainActor
+    private func applyPagedResponse(_ response: NoticePage, page: Int) {
+        #if DEBUG
+        print(
+            "[NoticeViewModel] applyPagedResponse " +
+            "page=\(page) " +
+            "contentCount=\(response.items.count) " +
+            "totalElements=\(response.totalElements) " +
+            "hasNext=\(response.hasNext)"
+        )
+        #endif
+
+        if page == 0,
+           response.items.isEmpty,
+           (Int(response.totalElements) ?? 0) > 0 {
+            let decodeError = RepositoryError.decodingError(
+                detail: "공지 목록 응답 불일치: totalElements=\(response.totalElements), content=0"
+            )
+
+            handleFetchError(
+                .repository(decodeError),
+                page: page,
+                action: "fetchNotices",
+                failure: decodeError
+            )
+            return
+        }
+
+        let readNoticeIDs = resolvedReadNoticeIDs()
+        let mappedItems = response.items.map { item -> NoticeItemModel in
+
+            guard readNoticeIDs.contains(item.noticeId) else {
+                return item
+            }
+
+            return NoticeItemModel(
+                noticeId: item.noticeId,
+                generation: item.generation,
+                scope: item.scope,
+                category: item.category,
+                mustRead: item.mustRead,
+                isAlert: item.isAlert,
+                date: item.date,
+                title: item.title,
+                content: item.content,
+                writer: item.writer,
+                authorNickname: item.authorNickname,
+                authorName: item.authorName,
+                links: item.links,
+                images: item.images,
+                vote: item.vote,
+                viewCount: item.viewCount,
+                scopeDisplayName: item.scopeDisplayName,
+                targetsAllGenerations: item.targetsAllGenerations,
+                parts: item.parts,
+                isRead: true
+            )
+        }
+        pagingState.applySuccess(page: page, hasNextPage: response.hasNext)
+
+        /// 현재 선택된 조회 필터에 맞지 않는 공지를 클라이언트 측에서 정리합니다.
+        ///
+        /// iOS-01은 서버-01, 서버-03만 노출하도록 후처리합니다.
+        let items: [NoticeItemModel]
+        if case .central = selectedMainFilter {
+            items = mappedItems.filter { $0.scope == .central && $0.category == .general }
+        } else {
+            items = mappedItems
+        }
+        
+        if page == 0 {
+            noticeItems = .loaded(items)
+        } else {
+            let mergedItems = (noticeItems.value ?? []) + items
+            noticeItems = .loaded(mergedItems)
+        }
+    }
+
+    private func resolvedReadNoticeIDs() -> Set<String> {
+        guard currentMemberId > 0 else { return [] }
+        return (try? noticeReadRepository.fetchReadNoticeIDs(memberId: String(currentMemberId))) ?? []
+    }
+
+    /// 조회 실패 상태를 반영합니다.
+    /// - Parameters:
+    ///   - error: 화면에 표시할 앱 에러
+    ///   - page: 실패한 페이지 인덱스
+    ///   - action: 에러 컨텍스트의 action 식별자
+    ///   - failure: ErrorHandler에 전달할 원본 에러
+    ///
+    /// DomainError는 화면 인라인 에러(Loadable.failed)로만 표시해 Alert 중복을 방지합니다.
+    /// 그 외 에러는 ErrorHandler를 통해 Alert 및 특수 케이스(자동 로그아웃 등) 흐름을 유지합니다.
+    @MainActor
+    private func handleFetchError(_ error: AppError, page: Int, action: String, failure: Error) {
+        if page == 0 {
+            noticeItems = .failed(error)
+        }
+        pagingState.applyFailure()
+
+        if case .domain = error {
+            return
+        }
+
+        errorHandler.handle(
+            failure,
+            context: ErrorContext(
+                feature: "Notice",
+                action: action
+            )
+        )
+    }
+
+    @MainActor
+    private func handleCancelledFetch(page: Int, previousState: Loadable<[NoticeItemModel]>) {
+        if page == 0 {
+            noticeItems = previousState
+        }
+        pagingState.applyFailure()
+    }
+
+    private func isRequestCancellation(_ error: NSError) -> Bool {
+        error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled
+    }
+
+    /// NoticeListRequestDTO 생성
+    private func buildNoticeListRequest(gisuId: String, page: Int) -> NoticeListRequest {
+        let myChapterId: String? = chapterId.isEmpty || chapterId == "0"
+        ? nil : chapterId
+        let mySchoolId: String? = schoolId.isEmpty || schoolId == "0"
+        ? nil : schoolId
+        
+        let requestChapterId: String?
+        let requestSchoolId: String?
+        let requestPart: UMCPartType?
+        switch selectedMainFilter {
+        case .all, .central:
+            // iOS-01 (UMC 공지): gisuId only
+            requestChapterId = nil
+            requestSchoolId = nil
+            requestPart = nil
+        case .branch:
+            // iOS-03 (지부 필터): gisuId + chapterId
+            requestChapterId = myChapterId
+            requestSchoolId = nil
+            requestPart = nil
+        case .school:
+            // iOS-02 (학교 필터): gisuId + schoolId
+            requestChapterId = nil
+            requestSchoolId = mySchoolId
+            requestPart = nil
+        case .part(let filterPart):
+            // iOS-04 (파트 필터): gisuId + part
+            requestChapterId = nil
+            requestSchoolId = nil
+            requestPart = filterPart.umcPartType
+        }
+        return NoticeListRequest (
+            gisuId: gisuId,
+            chapterId: requestChapterId,
+            schoolId: requestSchoolId,
+            part: requestPart,
+            page: page,
+            size: pageSize,
+            sort: sort
+        )
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel.swift
@@ -1,0 +1,219 @@
+//
+//  NoticeViewModel.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/26/26.
+//
+
+import Foundation
+import UMCFoundation
+import CoreDI
+import NoticeDomain
+
+/// 공지사항 리스트 탭 화면 ViewModel
+@Observable
+final class NoticeViewModel {
+
+    // MARK: - Property
+
+    /// DI Container
+    private let container: DIContainer
+
+    /// UseCase
+    var noticeUseCase: NoticeUseCaseProtocol {
+        container.resolve(NoticeUseCaseProtocol.self)
+    }
+
+    /// 기수 Repository
+    var genRepository: ChallengerGenRepositoryProtocol {
+        container.resolve(ChallengerGenRepositoryProtocol.self)
+    }
+
+    var noticeReadRepository: NoticeReadRepositoryProtocol {
+        container.resolve(NoticeReadRepositoryProtocol.self)
+    }
+
+    /// 공지 타겟(지부/학교) 조회 UseCase
+    var noticeEditorTargetUseCase: NoticeEditorTargetUseCaseProtocol {
+        container.resolve(NoticeEditorTargetUseCaseProtocol.self)
+    }
+
+    /// ViewModel 기능을 extension 파일로 분리해 관리하므로,
+    /// 동일 타입 extension에서도 상태 변경이 가능하도록 내부 공개합니다.
+    var organizationType: OrganizationType?
+    /// 사용자 역할 (역할별 필터/메뉴 가시성 제어에 사용)
+    var memberRole: ManagementTeam?
+    var chapterId: String = ""
+    var schoolId: String = ""
+    var generationOrganizations: [String: GenerationOrganizationContext] = [:]
+
+    /// 기수-기수ID 쌍 목록
+    var gisuPairs: [(gen: String, gisuId: String)] = []
+    /// 지부명 캐시 (chapterId -> chapterName)
+    var chapterNameCache: [String: String] = [:]
+    /// 기수 매핑 로딩 완료 여부
+    var isGisuListLoaded: Bool = false
+    /// 기수 매핑 로딩 진행 여부
+    var isFetchingGisuList: Bool = false
+
+    var pagingState = NoticePagingState()
+    var userContext: NoticeUserContext = .empty
+
+    /// 기수별 필터 상태 저장소
+    var generationStates: [String: GenerationFilterState] = [:]
+    /// 기수별 지부/학교 필터 옵션 저장소
+    var generationTargetStates: [String: NoticeGenerationTargetState] = [:]
+
+    /// 기수 목록
+    var generations: [Generation] = []
+
+    /// 선택된 기수
+    var selectedGeneration: Generation = Generation(value: "9")
+
+    /// 공지 생성 진입 시 사용할 현재 선택 기수 ID
+    var selectedGisuIdForEditor: String? {
+        currentSelectedGisuId()
+    }
+
+    /// 공지 데이터 (Loadable)
+    var noticeItems: Loadable<[NoticeItemModel]> = .idle
+    /// 첫 페이지 목록/검색 조회 중복 방지 플래그
+    var isFetchingFirstPage: Bool = false
+
+    /// Error Handler
+    let errorHandler: ErrorHandler
+
+    /// 페이징 진행 상태 (무한 스크롤 인디케이터 노출용)
+    var isLoadingMore: Bool {
+        pagingState.isLoadingMore
+    }
+
+    /// 검색 관련
+    var searchQuery: String = ""
+    var isSearchMode: Bool = false
+
+    private enum Pagination {
+        static let pageSize: Int = 20
+        static let sort: [String] = ["createdAt,DESC"]
+    }
+
+    // MARK: - Lifecycle
+
+    /// 의존성을 주입받아 공지 탭 상태를 초기화합니다.
+    init(container: DIContainer, errorHandler: ErrorHandler) {
+        self.container = container
+        self.errorHandler = errorHandler
+    }
+
+    // MARK: - Helper
+
+    /// 현재 기수의 필터 상태
+    var currentState: GenerationFilterState {
+        get { generationStates[selectedGeneration.value] ?? GenerationFilterState() }
+        set { generationStates[selectedGeneration.value] = newValue }
+    }
+
+    /// 현재 선택된 메인필터
+    var selectedMainFilter: NoticeMainFilterType {
+        currentState.mainFilter
+    }
+
+    /// 현재 메인필터의 서브필터 상태
+    var currentMainFilterState: MainFilterState {
+        currentState.state(for: MainFilterKey(from: selectedMainFilter))
+    }
+
+    /// 현재 선택된 서브필터
+    var selectedSubFilter: NoticeSubFilterType {
+        currentMainFilterState.subFilter
+    }
+
+    /// 현재 선택된 파트
+    var selectedPart: NoticePart? {
+        currentMainFilterState.selectedPart
+    }
+
+    /// 현재 선택 기수에 매핑된 지부/학교 타겟 옵션
+    var currentTargetState: NoticeGenerationTargetState {
+        generationTargetStates[selectedGeneration.value] ?? NoticeGenerationTargetState()
+    }
+
+    /// 역할(memberRole) 기반으로 노출할 메인필터 항목 목록을 반환합니다.
+    ///
+    /// 권한과 무관하게 상위 조직 필터는 UMC 공지/본인 지부/본인 학교를 노출합니다.
+    /// 파트 필터는 별도 Nested Menu에서 제공합니다.
+    var mainFilterItems: [NoticeMainFilterType] {
+        [.central, .branch(currentBranchFilterTitle), .school(currentSchoolFilterTitle)]
+    }
+
+    /// 상단 메인 메뉴에 표시할 기본 조직 필터 목록(파트 제외)
+    var baseMainFilterItems: [NoticeMainFilterType] {
+        mainFilterItems.filter {
+            if case .part = $0 { return false }
+            return true
+        }
+    }
+
+    /// 파트 Nested Menu 노출 여부
+    var canSelectPartFilter: Bool {
+        memberRole != .superAdmin
+    }
+
+    /// 파트 Nested Menu 항목
+    var partFilterItems: [NoticePart] {
+        canSelectPartFilter ? NoticePart.allCases : []
+    }
+
+    /// 현재 메인필터에 따라 노출할 하단 서브필터 칩 목록을 반환합니다.
+    ///
+    /// - 전체/파트: 칩 없음
+    /// - 중앙/지부: 전체 + 파트
+    /// - 학교: 학교 + 파트
+    var subFilterChips: [NoticeListSubFilterChip] {
+        // iOS 공지 필터는 2계층(기수 + 조직/파트)만 사용합니다.
+        []
+    }
+
+    /// 서브필터 표시 여부 (중앙/지부/학교만)
+    var showSubFilter: Bool {
+        false
+    }
+
+    var pageSize: Int {
+        Pagination.pageSize
+    }
+
+    var sort: [String] {
+        Pagination.sort
+    }
+
+    private var currentBranchFilterTitle: String {
+        let resolvedChapterId = selectedGenerationOrganization?.chapterId ?? ""
+        return currentTargetState.branches
+            .first(where: { $0.id == resolvedChapterId })?
+            .name ?? selectedGenerationOrganization?.chapterName ?? NoticeUserContext.empty.branchName
+    }
+
+    private var currentSchoolFilterTitle: String {
+        let resolvedSchoolId = selectedGenerationOrganization?.schoolId ?? ""
+        return currentTargetState.schools
+            .first(where: { $0.id == resolvedSchoolId })?
+            .name ?? selectedGenerationOrganization?.schoolName ?? NoticeUserContext.empty.schoolName
+    }
+
+    var selectedGenerationOrganization: GenerationOrganizationContext? {
+        generationOrganizations[selectedGeneration.value]
+    }
+
+    var selectedGenerationChapterId: String {
+        selectedGenerationOrganization?.chapterId ?? ""
+    }
+
+    var selectedGenerationSchoolId: String {
+        selectedGenerationOrganization?.schoolId ?? ""
+    }
+
+    var currentMemberId: Int {
+        AppStorageKey.legacyMemberIdInt()
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

리팩토링 — AppProduct 모놀리식 구조에서 UMCApp Tuist 모듈 구조로 NoticeViewModel 이식

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 여기에 추가해주세요 -->

## 🛠️ 작업내용

- `NoticeViewModel.swift` — 상태 프로퍼티, 액션 메서드, DIContainer 기반 의존성 주입 구조
- `NoticeViewModel+Fetch.swift` — 공지 목록 조회, 페이징, 필터 적용, 기수 로딩 로직
- `NoticeViewModel+Context.swift` — 선택된 기수/조직 컨텍스트 관리 및 필터 상태 처리

> **base**: `refactor/805` (Notice 모듈 이식 준비 PR) 머지 후 develop으로 재타겟 예정

## 📋 추후 진행 상황

<!-- 수동 입력 필요 -->

## 📌 리뷰 포인트

- `NoticeViewModel+Fetch.swift` — `applyPagedResponse` 페이징/필터 로직, `.central` 필터 처리
- `NoticeViewModel+Context.swift` — 기수/조직 컨텍스트 상태 전이 로직
- `NoticeViewModel.swift` — `@Observable` 패턴 및 DIContainer 의존성 주입 구조

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)