### PR TITLE
🎨 [Design] 운영진 스터디 관리 카드 Liquid Glass 가이드 반영 (#818)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Study/StudyGroupCard.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Study/StudyGroupCard.swift
@@ -17,6 +17,20 @@ struct StudyGroupCard: View, Equatable {
     // MARK: - Property
 
     @State private var deleteAlertPrompt: AlertPrompt?
+    /// 멘토/스터디원 섹션 펼침 상태
+    ///
+    /// 멘토가 N명 가능 + 멤버 많을수록 카드 길이가 빠르게 늘어남.
+    /// 기본 collapsed → 헤더만으로 빠른 스캔, 관심 카드만 펼침.
+    @State private var isExpanded: Bool = false
+
+    /// 펼침 콘텐츠(멘토+멤버 섹션)의 자연 높이.
+    ///
+    /// `fixedSize`로 클램프와 무관하게 측정한 natural height를 보관한다. `frame(height:)`를
+    /// 이 값↔0 으로 애니메이션해 콘텐츠를 카드 안에 가둔 채(clip) 펼침/접힘을 표현한다.
+    /// `if + .transition` 방식은 제거되는 뷰가 축소된 부모 밖으로 잔류 렌더되며 clip을 벗어나
+    /// 잔상이 생기는데(이번 이슈 영상 검증), 이 방식은 콘텐츠가 항상 클램프 프레임 안에 있어
+    /// 헤더 아래로 넘치지 않는다.
+    @State private var expandedSectionsHeight: CGFloat = 0
 
     private let detail: StudyGroupInfo
     private var onEdit: (() -> Void)?
@@ -64,32 +78,124 @@ struct StudyGroupCard: View, Equatable {
         lhs.detail == rhs.detail
     }
 
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        /// 카드 외곽 라운드 — Apple 가이드 권장 `.glassEffect(_:in:)` 패턴에서 사용
+        ///
+        /// `ConcentricRectangle`은 superview corner 상속에 의존하는데,
+        /// `GlassEffectContainer` 내부에서는 그 상속이 끊겨 의도와 다른 거대 round로
+        /// morphing되는 문제가 있어 명시 corner radius로 고정한다.
+        static let cardCornerRadius: CGFloat = 24
+        /// 좌측 파트 컬러 strip 너비
+        static let accentStripWidth: CGFloat = 4
+        /// strip 모서리 둥글기
+        static let accentStripCornerRadius: CGFloat = 2
+        /// sub-section(멘토/멤버) 내부 패딩
+        static let subSectionPadding: CGFloat = 12
+        /// sub-section Material 배경 라운드
+        static let subSectionCornerRadius: CGFloat = 14
+        /// HIG 권장 최소 터치 타겟
+        static let minTouchTarget: CGFloat = 44
+        /// metadataRow 배경 라운드
+        static let metadataRowCornerRadius: CGFloat = 10
+    }
+
     // MARK: - Body
 
     var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            accentStrip
+
+            VStack(alignment: .leading, spacing: 0) {
+                headerSection
+
+                // 펼침 콘텐츠는 항상 트리에 존재하고 `fixedSize`로 자연 높이를 측정한다.
+                // 표시 높이는 `frame(height:)`로 0↔측정값을 애니메이션하고 `clipped()`로 잘라,
+                // 콘텐츠가 헤더 아래로 빠져나오는 잔상 없이 카드 안에서만 열리고 닫힌다.
+                expandableSections
+                    .fixedSize(horizontal: false, vertical: true)
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.size.height
+                    } action: { newHeight in
+                        expandedSectionsHeight = newHeight
+                    }
+                    .frame(
+                        height: isExpanded ? expandedSectionsHeight : 0,
+                        alignment: .top
+                    )
+                    .opacity(isExpanded ? 1 : 0)
+                    .clipped()
+            }
+            .padding(DefaultConstant.defaultCardPadding)
+        }
+        // Apple 가이드 권장 패턴: View 자체에 `.glassEffect(_:in:)` 적용
+        // → GlassEffectContainer 내부 morphing/blending이 정상 동작
+        .glassEffect(
+            .regular,
+            in: .rect(cornerRadius: Constants.cardCornerRadius)
+        )
+        // 카드 외곽 라운드로 콘텐츠를 한 번 더 clip — 내부 섹션 clip과 더불어 어떤 자식도
+        // 카드 모서리를 넘지 않도록 보장한다.
+        .clipShape(.rect(cornerRadius: Constants.cardCornerRadius))
+        // 카드 전체를 펼침/접힘 탭 영역으로 만든다. 내부 Button/Menu(일정 등록·설정·추가)는
+        // 자체적으로 탭을 소비하므로 토글되지 않고, 빈 영역·타이틀·메타·파트장/멤버 행을
+        // 탭하면 펼침/접힘이 토글된다.
+        .contentShape(.rect(cornerRadius: Constants.cardCornerRadius))
+        .onTapGesture { toggleExpansion() }
+        .alertPrompt(item: $deleteAlertPrompt)
+    }
+
+    /// 펼침/접힘 토글 — `metadataRow`의 chevron과 카드 전체 탭이 공유하는 단일 진입점.
+    private func toggleExpansion() {
+        withAnimation(.smooth(duration: 0.3)) {
+            isExpanded.toggle()
+        }
+    }
+
+    /// 펼침 시 노출되는 멘토/멤버 섹션 묶음.
+    ///
+    /// 헤더와의 간격(spacing16)을 이 블록 상단 패딩으로 흡수해, 접힘 시 `frame(height: 0)`로
+    /// 갭까지 함께 사라지게 한다(외곽 VStack spacing은 0).
+    private var expandableSections: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
-            headerSection
             mentorSection
             membersSection
         }
-        .padding(DefaultConstant.defaultCardPadding)
-        .background(
-            ConcentricRectangle(
-                corners: .concentric(minimum: DefaultConstant.concentricRadius)
-            )
-            .glassEffect(.regular)
-        )
-        .alertPrompt(item: $deleteAlertPrompt)
+        .padding(.top, DefaultSpacing.spacing16)
     }
 
     // MARK: - View Components
 
+    /// 카드 좌측 파트 컬러 accent strip
+    ///
+    /// `maxHeight: .infinity`로 카드 content 영역 전체 높이를 채워 파트 정체성을 강한 시각 단서로
+    /// 표현한다. 좌측만 leading 패딩을 두고, 카드 패딩과의 어색한 갭이 생기지 않도록 한다.
+    private var accentStrip: some View {
+        RoundedRectangle(cornerRadius: Constants.accentStripCornerRadius)
+            .fill(detail.part.color)
+            .frame(width: Constants.accentStripWidth)
+            .frame(maxHeight: .infinity)
+            .padding(.vertical, DefaultConstant.defaultCardPadding.top)
+            .padding(.leading, DefaultSpacing.spacing8)
+            .accessibilityHidden(true)
+    }
+
+    /// 헤더 — 2-row 구조로 식별/액션을 분리한다.
+    ///
+    /// Row 1 (Identity): 그룹명·파트 뱃지·오늘 미팅 — primary attention.
+    /// Row 2 (Meta + Actions): 멤버 수·생성일·펼침 토글 + 일정 등록·설정 — secondary.
+    ///
+    /// 그룹명에 `lineLimit(2) + fixedSize(vertical)`를 부여해 긴 이름이 truncate 되는 대신 줄바꿈된다.
     @ViewBuilder
     private var headerSection: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
-            HStack(spacing: DefaultSpacing.spacing8) {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            // Row 1: 식별 정보 (primary)
+            HStack(alignment: .firstTextBaseline, spacing: DefaultSpacing.spacing8) {
                 Text(detail.name)
                     .appFont(.calloutEmphasis)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 InfoBadge(
                     detail.part.name,
@@ -97,16 +203,30 @@ struct StudyGroupCard: View, Equatable {
                     tintColor: detail.part.color
                 )
 
-                Spacer()
+                // "오늘 미팅" active 상태 뱃지 — UI hook만 준비, 산정 로직은 별도 이슈
+                // .tint(part.color)는 prominence 신호 보존을 위해 이 active 뱃지에만 한정한다.
+                if isMeetingToday {
+                    todayMeetingBadge
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            // Row 2: 메타/펼침 토글 + 액션 버튼
+            HStack(spacing: DefaultSpacing.spacing8) {
+                metadataRow
+
+                Spacer(minLength: DefaultSpacing.spacing8)
 
                 scheduleActionButton
                 settingsMenu
             }
-
-            metadataRow
         }
     }
 
+    /// 그룹 편집·삭제 메뉴 — HIG 44×44 터치 타겟 보장.
+    ///
+    /// 인접한 expand 토글(`metadataRow`) 영역과 오탭을 피하기 위해 명시 frame을 사용한다.
     private var settingsMenu: some View {
         Menu {
             Button("그룹 편집", systemImage: "pencil") {
@@ -130,32 +250,110 @@ struct StudyGroupCard: View, Equatable {
         } label: {
             Image(systemName: "gearshape")
                 .font(.app(.title3))
-                .padding(DefaultConstant.iconPadding)
+                .frame(
+                    width: Constants.minTouchTarget,
+                    height: Constants.minTouchTarget
+                )
+                .contentShape(Rectangle())
                 .glassEffect(.regular.interactive())
         }
         .accessibilityLabel("그룹 설정")
     }
 
+    /// 일정 등록 — collapsed에서는 quiet 아이콘 chip, expanded에서 tinted prominent capsule.
+    ///
+    /// soyeon-ui-review CRITICAL: 카드 N개에 prominent CTA가 반복 배치되면 화면 전체에서
+    /// "primary CTA가 N개" 패턴이 되어 그룹명의 primary attention을 침범한다. collapsed는
+    /// 정보 스캔 우선 → 액션 강조 약화, expanded는 운영 작업 우선 → 강조 회복.
+    ///
+    /// **잔상 방지를 위한 단일 persistent view 패턴**: 이전엔 collapsed(원형)와 expanded(캡슐)를
+    /// 서로 다른 뷰로 두고 `glassEffectID`로 morphing했는데, 전환 중 두 상태가 cross-fade되며
+    /// 캘린더 아이콘이 두 개로 겹쳐 보이는 잔상이 생겼다(영상 검증). 아이콘 하나가 항상 존재하는
+    /// 단일 HStack으로 만들고, 배경은 항상 `.capsule`(44×44면 원으로 보임)로 두어 **너비·틴트·
+    /// 글자만 연속 변화**시킨다. 뷰 identity가 유지되므로 아이콘이 중복 렌더되지 않는다.
+    ///
+    /// 높이는 인접한 `settingsMenu`(고정 44×44)와 baseline 정렬을 위해 `minHeight: 44`.
     private var scheduleActionButton: some View {
         Button {
             onSchedule?()
         } label: {
-            HStack(spacing: DefaultSpacing.spacing4) {
+            HStack(spacing: isExpanded ? DefaultSpacing.spacing4 : 0) {
                 Image(systemName: "calendar.badge.plus")
-                Text("일정 등록")
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
+                    .font(.app(.title3))
+                    .foregroundStyle(isExpanded ? Color.white : Color.indigo600)
+
+                if isExpanded {
+                    Text("일정 등록")
+                        .appFont(.footnoteEmphasis, color: .white)
+                        .lineLimit(1)
+                        .fixedSize()
+                }
             }
-            .appFont(.footnoteEmphasis, color: .indigo600)
-            .padding(.horizontal, DefaultSpacing.spacing4)
-            .padding(.vertical, DefaultSpacing.spacing4)
+            .padding(.horizontal, isExpanded ? DefaultSpacing.spacing12 : 0)
+            .frame(
+                minWidth: Constants.minTouchTarget,
+                minHeight: Constants.minTouchTarget
+            )
+            .contentShape(.capsule)
+            // 배경을 항상 `.capsule`로 두면 collapsed(44×44)는 원, expanded는 알약으로 같은
+            // shape 프리미티브 안에서 너비만 변해 shape swap 잔상이 없다. tint opacity는
+            // collapsed에서 0(plain glass) → expanded에서 1(indigo)로 연속 전환된다.
+            .glassEffect(
+                .regular
+                    .tint(.indigo600.opacity(isExpanded ? 1 : 0))
+                    .interactive(),
+                in: .capsule
+            )
         }
-        .buttonStyle(.glass)
+        .accessibilityLabel("일정 등록")
     }
 
+    /// "오늘 미팅" active 상태 뱃지 (UI hook)
+    /// 산정 로직은 별도 이슈에서 추가하고, 여기서는 `isMeetingToday` false 고정으로 hidden 상태.
+    private var todayMeetingBadge: some View {
+        InfoBadge(
+            "오늘 미팅",
+            textColor: detail.part.color,
+            tintColor: detail.part.color,
+            glassVariant: .regular
+        )
+        .tint(detail.part.color)
+    }
+
+    /// 오늘 미팅 여부 — 산정 로직은 후속 이슈에서 도입. 현 시점에서는 hidden.
+    private var isMeetingToday: Bool { false }
+
+    /// 메타 + 펼침 토글 — collapsed 시각 단서를 강화한 secondary 액션.
+    ///
+    /// 멘토/멤버 수만 표시해 좁은 디바이스에서도 절대 잘리지 않도록 한다.
+    /// 생성일은 부가정보로 prominence가 낮아 collapsed에서는 생략, 필요 시 expanded 내부
+    /// 메타 카드에서 노출 가능하다(향후 도입). 배경에 thinMaterial을 깔아 탭 가능 영역을
+    /// 시각화하고, 우측 chevron 회전으로 상태를 표현한다. `minHeight: 44`로 HIG 터치 타겟 보장.
     private var metadataRow: some View {
-        Text("생성일: \(detail.formattedCreatedDate) | 멤버 \(detail.memberCount)명")
-            .appFont(.footnote, color: .grey500)
+        Button {
+            toggleExpansion()
+        } label: {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Text("멘토 \(detail.mentors.count)명 · 멤버 \(detail.members.count)명")
+                    .appFont(.caption1Emphasis, color: .grey600)
+                    .lineLimit(1)
+
+                Image(systemName: "chevron.down")
+                    .font(.app(.caption1))
+                    .foregroundStyle(.grey500)
+                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
+            }
+            .padding(.horizontal, DefaultSpacing.spacing8)
+            .frame(minHeight: Constants.minTouchTarget)
+            .background(
+                .thinMaterial,
+                in: .rect(cornerRadius: Constants.metadataRowCornerRadius)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isExpanded ? "스터디 그룹 상세 접기" : "스터디 그룹 상세 펼치기")
+        .accessibilityHint("멘토와 스터디원 목록 보기")
     }
 
     @ViewBuilder
@@ -182,6 +380,11 @@ struct StudyGroupCard: View, Equatable {
                 }
             }
         }
+        .padding(Constants.subSectionPadding)
+        .background(
+            .regularMaterial,
+            in: .rect(cornerRadius: Constants.subSectionCornerRadius)
+        )
     }
 
     @ViewBuilder
@@ -210,6 +413,11 @@ struct StudyGroupCard: View, Equatable {
                 }
             }
         }
+        .padding(Constants.subSectionPadding)
+        .background(
+            .regularMaterial,
+            in: .rect(cornerRadius: Constants.subSectionCornerRadius)
+        )
     }
 
     private var topBestWorkbookMemberServerIDs: Set<String> {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Study/StudyGroupLeaderRow.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Study/StudyGroupLeaderRow.swift
@@ -18,10 +18,13 @@ struct StudyGroupLeaderRow: View, Equatable {
 
     fileprivate enum Constants {
         static let avatarSize: CGFloat = 48
-        static let rowPadding: CGFloat = 8
+        static let rowPadding: CGFloat = 12
         static let surfaceShadowRadius: CGFloat = 10
         static let surfaceHighlightRadius: CGFloat = 4
         static let surfaceShadowYOffset: CGFloat = 6
+        /// 표면 라운드 — Nested Material/Glass 환경에서 ConcentricRectangle inheritance가
+        /// 끊기는 문제가 있어 명시 cornerRadius로 곡률을 직접 보장한다.
+        static let surfaceCornerRadius: CGFloat = 16
     }
 
     // MARK: - Property
@@ -53,13 +56,21 @@ struct StudyGroupLeaderRow: View, Equatable {
     // MARK: - Body
 
     var body: some View {
-        HStack(spacing: DefaultSpacing.spacing16) {
+        HStack(spacing: DefaultSpacing.spacing8) {
             avatarView
 
+            // displayName = "{nickname}/{name}" 또는 "{name}". "운영이/김운영" 같은 단일 식별자가
+            // 좁은 폭에서 임의로 줄바꿈되지 않도록 lineLimit(1) + minimumScaleFactor로 한 줄을
+            // 강제하고, 그래도 부족하면 자동 축소 후 마지막에 ellipsis로 잘린다.
             Text(leader.displayName)
                 .appFont(.calloutEmphasis, color: .black)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .truncationMode(.tail)
+                .layoutPriority(1)
 
             InfoBadge(leader.university)
+                .layoutPriority(-1)
 
             InfoBadge(leader.role.rawValue)
         }
@@ -83,34 +94,39 @@ struct StudyGroupLeaderRow: View, Equatable {
         .clipShape(Circle())
     }
 
+    /// 표면 배경 — 파트 컬러 그라데이션 + 미묘한 highlight/shadow.
+    ///
+    /// 카드 외부가 이미 `.glassEffect(.regular)`이고 상위 `mentorSection`은 `.regularMaterial`이다.
+    /// 추가 Glass를 중첩하면 Glass-on-Glass-on-Material 삼중 블러가 발생해 가독성·성능 모두 손해다.
+    /// 따라서 Glass 없이 LinearGradient + shadow만 사용한다.
+    ///
+    /// 곡률은 `RoundedRectangle(cornerRadius:)`로 직접 보장한다. `ConcentricRectangle`은 nested
+    /// Material 컨테이너에서 corner inheritance가 끊겨 곡률이 무너지는 문제가 있다.
     private var surfaceBackground: some View {
-        ConcentricRectangle(
-            corners: .concentric(minimum: DefaultConstant.concentricRadius)
-        )
-        .fill(
-            LinearGradient(
-                colors: [
-                    .white,
-                    partTintColor.opacity(0.22),
-                    partTintColor.opacity(0.10)
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
+        RoundedRectangle(cornerRadius: Constants.surfaceCornerRadius)
+            .fill(
+                LinearGradient(
+                    colors: [
+                        .white.opacity(0.85),
+                        partTintColor.opacity(0.20),
+                        partTintColor.opacity(0.08)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
             )
-        )
-        .glass()
-        .shadow(
-            color: .black.opacity(0.08),
-            radius: Constants.surfaceShadowRadius,
-            x: 0,
-            y: Constants.surfaceShadowYOffset
-        )
-        .shadow(
-            color: .white.opacity(0.7),
-            radius: Constants.surfaceHighlightRadius,
-            x: -2,
-            y: -2
-        )
+            .shadow(
+                color: .black.opacity(0.08),
+                radius: Constants.surfaceShadowRadius,
+                x: 0,
+                y: Constants.surfaceShadowYOffset
+            )
+            .shadow(
+                color: .white.opacity(0.7),
+                radius: Constants.surfaceHighlightRadius,
+                x: -2,
+                y: -2
+            )
     }
 }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Study/StudyGroupMemberChip.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Study/StudyGroupMemberChip.swift
@@ -18,7 +18,9 @@ struct StudyGroupMemberChip: View, Equatable {
         static let avatarPlaceholderImageName: String = "person.fill"
         static let bestBorderWidth: CGFloat = 1
         static let bestPointThreshold: Int = 0
-        static let chipCornerMinimum: Edge.Corner.Style = 16
+        /// 칩 corner radius — Nested Material/Glass 환경에서 ConcentricRectangle inheritance가
+        /// 끊기는 문제가 있어 명시 cornerRadius로 곡률을 직접 보장한다.
+        static let chipCornerRadius: CGFloat = 16
         static let chipHeight: CGFloat = 68
         static let chipHorizontalPadding: CGFloat = 6
         static let chipVerticalPadding: CGFloat = 6
@@ -67,7 +69,9 @@ struct StudyGroupMemberChip: View, Equatable {
     var body: some View {
         VStack(spacing: DefaultSpacing.spacing4) {
             avatarView
-            Text(member.name)
+            // 칩에는 닉네임만 노출(없으면 본명). LeaderRow의 "닉네임/이름" 풀 표기와 다르게,
+            // 좁은 폭의 칩에서는 한 글자라도 더 보여야 가독성이 높다는 디자인 결정.
+            Text(member.nickname ?? member.name)
                 .appFont(.caption1)
                 .lineLimit(Constants.nameLineLimit)
                 .minimumScaleFactor(Constants.nameMinimumScaleFactor)
@@ -75,12 +79,14 @@ struct StudyGroupMemberChip: View, Equatable {
         .padding(.horizontal, Constants.chipHorizontalPadding)
         .padding(.vertical, Constants.chipVerticalPadding)
         .frame(width: Constants.chipWidth, height: Constants.chipHeight)
+        // 명시 cornerRadius로 칩 곡률 보장 — ConcentricRectangle은 nested Material/Glass에서
+        // corner inheritance가 끊겨 곡률이 무너진다(이번 이슈 캡처 검증).
         .glassEffect(
             .regular.tint(.gray.opacity(Constants.baseTintOpacity)),
-            in: .rect(corners: .concentric(minimum: Constants.chipCornerMinimum))
+            in: .rect(cornerRadius: Constants.chipCornerRadius)
         )
         .overlay {
-            ConcentricRectangle(corners: .concentric(minimum: Constants.chipCornerMinimum))
+            RoundedRectangle(cornerRadius: Constants.chipCornerRadius)
                 .stroke(
                     hasBestWorkbookPoint
                         ? .orange.opacity(Constants.bestBorderOpacity)

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -166,72 +166,76 @@ struct OperatorStudyManagementView: View {
 
     private func groupManagementListView(groups: [StudyGroupInfo]) -> some View {
         ScrollView {
-            LazyVStack(spacing: DefaultSpacing.spacing16) {
-                ForEach(groups) { group in
-                    StudyGroupCard(
-                        detail: group,
-                        onEdit: {
-                            viewModel.showEditSheet(for: group)
-                        },
-                        onDelete: {
-                            viewModel.deleteGroup(group)
-                        },
-                        onAddMember: {
-                            viewModel.showAddMemberSheet(
-                                for: group
-                            )
-                        },
-                        onAddMentor: {
-                            viewModel.showAddMentorSheet(for: group)
-                        },
-                        onSchedule: {
-                            let isMentor = group.mentors.contains { mentor in
-                                mentor.challengerID == currentChallengerId
-                            }
-                            guard isMentor else {
-                                viewModel.alertPrompt = AlertPrompt(
-                                    title: "권한 없음",
-                                    message: "담당 파트장(멘토)만 일정을 등록할 수 있습니다.",
-                                    positiveBtnTitle: "확인"
+            // Apple iOS 26 가이드: 같은 화면에 Liquid Glass가 여러 개 있을 때
+            // GlassEffectContainer 로 묶어 카드 사이 morphing/blending + 렌더링 성능 ↑
+            GlassEffectContainer(spacing: DefaultSpacing.spacing16) {
+                LazyVStack(spacing: DefaultSpacing.spacing16) {
+                    ForEach(groups) { group in
+                        StudyGroupCard(
+                            detail: group,
+                            onEdit: {
+                                viewModel.showEditSheet(for: group)
+                            },
+                            onDelete: {
+                                viewModel.deleteGroup(group)
+                            },
+                            onAddMember: {
+                                viewModel.showAddMemberSheet(
+                                    for: group
                                 )
-                                return
-                            }
-                            guard let studyGroupId = Int(group.serverID) else {
-                                return
-                            }
-                            pathStore.activityPath.append(
-                                .activity(
-                                    .studyScheduleRegistration(
-                                        studyName: group.name,
-                                        studyGroupId: studyGroupId
+                            },
+                            onAddMentor: {
+                                viewModel.showAddMentorSheet(for: group)
+                            },
+                            onSchedule: {
+                                let isMentor = group.mentors.contains { mentor in
+                                    mentor.challengerID == currentChallengerId
+                                }
+                                guard isMentor else {
+                                    viewModel.alertPrompt = AlertPrompt(
+                                        title: "권한 없음",
+                                        message: "담당 파트장(멘토)만 일정을 등록할 수 있습니다.",
+                                        positiveBtnTitle: "확인"
+                                    )
+                                    return
+                                }
+                                guard let studyGroupId = Int(group.serverID) else {
+                                    return
+                                }
+                                pathStore.activityPath.append(
+                                    .activity(
+                                        .studyScheduleRegistration(
+                                            studyName: group.name,
+                                            studyGroupId: studyGroupId
+                                        )
                                     )
                                 )
-                            )
-                        },
-                        onRemoveMember: { member in
-                            Task {
-                                await viewModel.removeMember(member, from: group)
+                            },
+                            onRemoveMember: { member in
+                                Task {
+                                    await viewModel.removeMember(member, from: group)
+                                }
+                            },
+                            onRemoveMentor: { mentor in
+                                Task {
+                                    await viewModel.removeMentor(mentor, from: group)
+                                }
                             }
-                        },
-                        onRemoveMentor: { mentor in
-                            Task {
-                                await viewModel.removeMentor(mentor, from: group)
-                            }
-                        }
-                    )
-                    .equatable()
-                    .task {
-                        await viewModel.loadMoreGroupManagementDataIfNeeded(
-                            currentGroupID: group.id
                         )
+                        .equatable()
+                        .task {
+                            await viewModel.loadMoreGroupManagementDataIfNeeded(
+                                currentGroupID: group.id
+                            )
+                        }
                     }
-                }
 
-                if viewModel.isLoadingMoreStudyGroupDetails {
-                    ProgressView()
-                        .tint(.grey500)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, DefaultSpacing.spacing8)
+                    if viewModel.isLoadingMoreStudyGroupDetails {
+                        ProgressView()
+                            .tint(.grey500)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, DefaultSpacing.spacing8)
+                    }
                 }
             }
             .safeAreaPadding(


### PR DESCRIPTION
## ✨ PR 유형

🎨 Design — 운영진 스터디 관리 카드 Liquid Glass 가이드 반영 (#818)

## 📷 스크린샷 or 영상(UI 변경 시)

> 시뮬레이터 검증 화면 (펼침/접힘, 버튼 정렬, 닉네임 표기)

| Collapsed | Expanded |
|-----------|----------|
| 일정 등록·설정 버튼 동일 44×44 정사각 chip | 인디고 캡슐 + "일정 등록" 텍스트, 설정과 동일 높이 |

- 펼침/접힘 애니메이션 잔상 제거를 60fps 녹화 → 프레임 추출로 검증 (collapse/expand 중간 프레임에서 콘텐츠 오버행·버튼 더블아이콘 없음 확인)

## 🛠️ 작업내용

Apple iOS 26 Liquid Glass 가이드에 맞춰 `StudyGroupCard`(운영진 스터디 관리)를 리팩터링했습니다.

**디자인 토큰 / 곡률**
- `ConcentricRectangle` 곡률 상속이 nested Material/Glass(`GlassEffectContainer`) 안에서 끊겨 모서리가 무너지는 문제 확인 → 명시 `RoundedRectangle`/`cornerRadius`로 곡률 고정 (LeaderRow·MemberChip·카드 외곽)
- 같은 화면 다중 Glass를 `GlassEffectContainer`로 묶어 morphing/렌더링 최적화

**일정 등록 버튼**
- collapsed: 캘린더 아이콘 chip / expanded: 인디고 캡슐 + "일정 등록" 텍스트
- 인접 설정 메뉴(고정 44×44)와 baseline 정렬 — `buttonStyle(.glass)`가 내부 padding을 자체 결정해 높이가 어긋나는 문제로, 명시 `frame` + `glassEffect(in: .capsule)` 패턴으로 통일 (UI hierarchy로 44pt 일치 확인)

**텍스트 표기**
- LeaderRow: `displayName`(닉네임/이름)을 `lineLimit(1)` + `minimumScaleFactor`로 한 줄 강제, 대학 배지 `layoutPriority` 조정으로 줄바꿈 방지
- MemberChip: 닉네임 우선 표시(`nickname ?? name`)

**펼침/접힘 잔상 제거 (핵심)**
- 기존 `if + .transition(.opacity/.move)`는 제거되는 뷰가 축소된 부모 밖(헤더 아래)에 잔류 렌더되어 `clipShape`로도 clip을 벗어나는 잔상 발생
- → 콘텐츠를 항상 트리에 두고 `fixedSize`로 자연 높이 측정 후 `frame(height: 0↔측정값)` + `clipped()` 아코디언 방식으로 변경 → 콘텐츠가 항상 카드 안에 갇혀 넘치지 않음
- 일정 등록 버튼 모핑 잔상(아이콘 더블 렌더): `glassEffectID` 두-뷰 cross-fade 제거 → 아이콘 1개가 항상 존재하는 단일 persistent view로 너비·틴트만 연속 변화

**인터랙션**
- 카드 전체 탭으로 펼침/접힘 토글 (내부 버튼/메뉴는 자체적으로 탭 소비하므로 토글되지 않음, chevron 버튼과 동일 토글 함수 공유 → 접근성 유지)

## 📋 추후 진행 상황

- 오늘 미팅 active 상태(`isMeetingToday`) 산정 로직은 별도 이슈에서 연결 (현재 UI hook만)
- 커리큘럼 과제 제출란(#587), 스터디 제출 현황(#586)은 API 미완성으로 UI 비활성 유지

## 📌 리뷰 포인트

- **이슈 범위 확장 명시**: 당초 범위는 `StudyGroupCard` + `OperatorStudyManagementView`였으나, 곡률/표기 수정으로 `StudyGroupLeaderRow`·`StudyGroupMemberChip`까지 4개 파일로 확장했습니다.
- 펼침/접힘 잔상 해결의 `fixedSize` 측정 → `frame(height:)` 클램프 + `clipped()` 패턴 (`StudyGroupCard.body`)
- `ConcentricRectangle` 대신 명시 cornerRadius를 쓴 이유(상속 단절)는 각 파일 주석에 기록
- 검증용 자동 토글/디버그 호스트는 커밋에 포함되지 않았습니다 (소스/트리 클린 확인 완료)

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
