### PR TITLE
✨ [Feature] chromaticLens 시네마틱 살아있는 빛 + 로고 reveal

### DIFF
--- a/AppProduct/AppProduct/Core/Common/UIComponents/ChromaticLens/ChromaticLens.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/ChromaticLens/ChromaticLens.swift
@@ -52,6 +52,8 @@ private struct ChromaticLensModifier: ViewModifier {
     let dispersionStrength: CGFloat
     let edgeHighlight: CGFloat
     let iridescenceStrength: CGFloat
+    /// 경과 초. 0 이면 셰이더의 흐르는 빛(무지개 흐름/글림/호흡)이 비활성 — 정적 lens 는 0 고정.
+    let time: Double
 
     @State private var contentSize: CGSize = .zero
 
@@ -74,7 +76,8 @@ private struct ChromaticLensModifier: ViewModifier {
                     .float(Float(refractionStrength)),
                     .float(Float(dispersionStrength)),
                     .float(Float(edgeHighlight)),
-                    .float(Float(iridescenceStrength))
+                    .float(Float(iridescenceStrength)),
+                    .float(Float(time))
                 ),
                 maxSampleOffset: CGSize(width: radius, height: radius)
             )
@@ -137,7 +140,8 @@ private struct ChromaticLensInteractiveModifier: ViewModifier {
                     .float(Float(refractionStrength)),
                     .float(Float(dispersionStrength)),
                     .float(Float(edgeHighlight)),
-                    .float(Float(iridescenceStrength))
+                    .float(Float(iridescenceStrength)),
+                    .float(0)  // time=0 — 인터랙티브 lens 는 흐르는 빛 모션 미사용
                 ),
                 maxSampleOffset: CGSize(width: maxRadius, height: maxRadius)
             )
@@ -162,13 +166,16 @@ extension View {
     ///   - iridescenceStrength: lens 안쪽 무지개 광택 강도(0~1). 기본 0.55.
     ///     배경이 단조로워(흰색 등) chromatic dispersion 만으로는 무지개가 잘 안 드러날 때
     ///     이 값을 키워 비누거품·진주 같은 holographic 광택을 추가한다.
+    ///   - time: 경과 초. 0(기본)이면 흐르는 빛(무지개 흐름/이동 글림/미세 호흡)이 비활성.
+    ///     `RefractiveCinematic` 이 시간 클럭을 주입해 시네마틱에서 빛을 살아 움직이게 한다.
     func chromaticLens(
         center: UnitPoint = .center,
         radius: CGFloat,
         refractionStrength: CGFloat = 52,
         dispersionStrength: CGFloat = 60,
         edgeHighlight: CGFloat = 0.35,
-        iridescenceStrength: CGFloat = 0.55
+        iridescenceStrength: CGFloat = 0.55,
+        time: Double = 0
     ) -> some View {
         modifier(
             ChromaticLensModifier(
@@ -177,7 +184,8 @@ extension View {
                 refractionStrength: refractionStrength,
                 dispersionStrength: dispersionStrength,
                 edgeHighlight: edgeHighlight,
-                iridescenceStrength: iridescenceStrength
+                iridescenceStrength: iridescenceStrength,
+                time: time
             )
         )
     }

--- a/AppProduct/AppProduct/Core/Common/UIComponents/ChromaticLens/RefractiveCinematic.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/ChromaticLens/RefractiveCinematic.swift
@@ -10,6 +10,11 @@
 //  무지개(dispersion + iridescence) 강도를 기본 `chromaticLens()` 보다 강하게 잡아 시네마틱
 //  느낌을 강조한다.
 //
+//  여기에 더해 `TimelineView(.animation)` 으로 경과 시간을 셰이더에 주입해 무지개 흐름 +
+//  이동 specular glint + 광택 미세 호흡(="살아있는 빛")을 더한다. 시간 클럭은 radius keyframe
+//  과 독립적이며, 시네마틱이 끝나면 정지(`paused`)해 로그인 화면에서 GPU 비용을 0 으로
+//  되돌린다. Reduce Motion 이 켜지면 흐르는 빛은 비활성화되고 굴절 bloom/collapse 만 재생된다.
+//
 //  ## Usage
 //
 //  ```swift
@@ -17,11 +22,11 @@
 //      .refractiveCinematic(maxRadius: 280)
 //  ```
 //
-//  ## Timeline (총 1.5초)
+//  ## Timeline (총 2.3초)
 //
-//  - **preDelay** (0.0s → 0.4s): 정적 로고. 사용자가 UMC 로고와 슬로건을 인지할 시간.
-//  - **bloom**    (0.4s → 1.0s): radius 0 → maxRadius. cubic Hermite 보간으로 가속.
-//  - **collapse** (1.0s → 1.5s): radius maxRadius → 0. bloom 의 종료 속도(0이 아님)에서 자연
+//  - **preDelay** (0.0s → 0.4s): 흐릿한 워터마크 로고. 사용자가 UMC 로고를 인지할 시간.
+//  - **bloom**    (0.4s → 1.4s): radius 0 → maxRadius. 동시에 로고가 워터마크 → 선명하게 reveal.
+//  - **collapse** (1.4s → 2.3s): radius maxRadius → 0. bloom 의 종료 속도(0이 아님)에서 자연
 //    스럽게 이어받아 가운데로 모임. dwell(정지) 단계 없음.
 //
 //  `radius == 0` 상태에선 shader 가 모든 픽셀을 그대로 통과시켜 GPU 비용 0. preDelay 구간은
@@ -31,6 +36,16 @@
 //
 
 import SwiftUI
+
+/// 시네마틱 한 프레임의 애니메이션 상태.
+///
+/// `radius`(렌즈 반경)와 `logoOpacity`(reveal 투명도)를 하나의 `keyframeAnimator` 의 두
+/// `KeyframeTrack` 으로 함께 보간한다. 렌즈가 커지는 동안 로고가 흐릿한 워터마크에서 선명하게
+/// 차올라, 렌즈가 전환을 가린 채 reveal 되는 연출을 만든다.
+private struct CinematicState {
+    var radius: CGFloat
+    var logoOpacity: Double
+}
 
 /// 자동 재생 chromaticLens 시네마틱 ViewModifier.
 ///
@@ -50,6 +65,9 @@ private struct RefractiveCinematicModifier: ViewModifier {
     let preDelay: TimeInterval
     let bloomDuration: TimeInterval
     let collapseDuration: TimeInterval
+    /// reveal 시작 투명도 — preDelay 동안 로고가 흐릿한 워터마크로 보이는 정도(0~1).
+    /// bloom 동안 1.0 으로 차올라 렌즈가 덮는 사이 선명해지고, collapse 후 선명 유지.
+    let revealStartOpacity: Double
 
     /// keyframeAnimator 트리거. mount 직후 한 번만 토글되어 시퀀스를 1회 재생한다.
     ///
@@ -58,57 +76,109 @@ private struct RefractiveCinematicModifier: ViewModifier {
     /// keyframe 이 재시작되며 lens 가 두 번 bloom 하는 현상을 방지한다.
     @State private var trigger: Bool = false
     @State private var hasStarted: Bool = false
+    /// 흐르는 빛 시간 클럭의 기준점. 시네마틱 시작 시 갱신한다.
+    @State private var startDate: Date = .now
+    /// 흐르는 빛 시간 클럭 on/off. 시네마틱 동안만 true → 종료 후 TimelineView 정지(perf 0).
+    @State private var isLightActive: Bool = false
+
+    /// 접근성 — Reduce Motion 시 흐르는 빛을 비활성(굴절 bloom/collapse 는 유지)한다.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // MARK: - Body
 
     func body(content: Content) -> some View {
-        content
+        // TimelineView 가 매 프레임 경과 시간을 셰이더에 공급해 흐르는 빛을 구동한다.
+        // radius 는 keyframeAnimator 가, time 은 이 시간 클럭이 — 서로 독립적으로 흐른다.
+        // `paused: !isLightActive` 로 시네마틱 종료 후 tick 을 멈춰 GPU 비용을 0 으로 되돌린다.
+        TimelineView(.animation(paused: !isLightActive)) { timeline in
+            cinematicLens(content, now: timeline.date)
+        }
+        .task {
+            // .task 는 view re-evaluation 마다 재호출될 수 있으므로 한 번만 발동.
+            guard !hasStarted else { return }
+            hasStarted = true
+            startDate = .now
+
+            // Reduce Motion 이면 시간 클럭을 켜지 않아 흐르는 빛이 비활성(굴절 bloom 만 재생).
+            guard !reduceMotion else {
+                trigger.toggle()
+                return
+            }
+
+            isLightActive = true
+            trigger.toggle()
+
+            // 시네마틱 총 길이 후 시간 클럭 정지 → morph 된 로그인 화면에서 GPU 비용 0.
+            let total = preDelay + bloomDuration + collapseDuration
+            try? await Task.sleep(for: .seconds(total))
+            isLightActive = false
+        }
+    }
+
+    // MARK: - Function
+
+    /// 경과 시간(`now − startDate`)을 셰이더의 `time` 으로 주입한 chromaticLens 시네마틱 본체.
+    ///
+    /// `body` 의 `TimelineView` 클로저를 **단일 표현식**으로 유지하기 위해 분리한다 —
+    /// keyframeAnimator + ternary + `MainActor.assumeIsolated` 가 한 클로저에 모이면
+    /// 타입체커가 `TimelineView` 의 `Content` 제네릭을 추론하지 못한다.
+    private func cinematicLens(_ content: Content, now: Date) -> some View {
+        // 시간 클럭이 꺼져 있으면 0 → 셰이더의 흐르는 빛 정지 (정적 호출부와 동일 경로).
+        let elapsed: Double = isLightActive ? now.timeIntervalSince(startDate) : 0
+
+        return content
             .keyframeAnimator(
-                initialValue: 0.0 as CGFloat,
+                initialValue: CinematicState(radius: 0, logoOpacity: revealStartOpacity),
                 trigger: trigger,
-                content: { view, radius in
+                content: { view, state in
                     // keyframeAnimator 의 content closure 는 `@Sendable` (non-isolated) 시그니처라
                     // `@MainActor` 격리된 `chromaticLens(...)` 을 직접 호출하면 Swift 6 isolation
                     // 경고가 난다. SwiftUI body 평가는 런타임상 항상 MainActor 에서 일어나므로
                     // `MainActor.assumeIsolated` 로 안전하게 격리 경계를 표명하고 호출한다.
                     MainActor.assumeIsolated {
-                        view.chromaticLens(
-                            center: center,
-                            radius: radius,
-                            refractionStrength: refractionStrength,
-                            dispersionStrength: dispersionStrength,
-                            edgeHighlight: edgeHighlight,
-                            iridescenceStrength: iridescenceStrength
-                        )
+                        view
+                            // 워터마크 → reveal: 렌즈가 sampling 하기 전에 opacity 를 적용해
+                            // 흐릿한 로고가 그대로 굴절되고, bloom 동안 선명하게 차오른다.
+                            .opacity(state.logoOpacity)
+                            .chromaticLens(
+                                center: center,
+                                radius: state.radius,
+                                refractionStrength: refractionStrength,
+                                dispersionStrength: dispersionStrength,
+                                edgeHighlight: edgeHighlight,
+                                iridescenceStrength: iridescenceStrength,
+                                time: elapsed
+                            )
                     }
                 },
                 keyframes: { _ in
-                    // [0] PreDelay — radius 0 유지 (정적 로고 인지 구간)
-                    LinearKeyframe(0, duration: preDelay)
-                    // [1] Bloom — 0 → maxRadius (easeInOut 으로 가속/감속)
-                    //   CubicKeyframe 은 segment 간 velocity continuity 를 자동 계산하면서
-                    //   maxRadius 정점에서 overshoot 가 생겨 "정점에서 약간 부풀었다가 줄어드는
-                    //   잠시 멈춤" 으로 인지된다. SpringKeyframe(bounce: 0) 로 critically damped
-                    //   spring 을 만들어 overshoot 없이 자연스럽게 가속/감속한다.
-                    SpringKeyframe(
-                        maxRadius,
-                        duration: bloomDuration,
-                        spring: .init(duration: bloomDuration, bounce: 0)
-                    )
-                    // [2] Collapse — maxRadius → 0 (overshoot 없는 spring 으로 즉시 감속)
-                    SpringKeyframe(
-                        0,
-                        duration: collapseDuration,
-                        spring: .init(duration: collapseDuration, bounce: 0)
-                    )
+                    // radius 트랙 — 렌즈 반경. preDelay 0 유지 → bloom → collapse.
+                    KeyframeTrack(\.radius) {
+                        // [0] PreDelay — radius 0 유지 (워터마크 로고 인지 구간)
+                        LinearKeyframe(0, duration: preDelay)
+                        // [1] Bloom — 0 → maxRadius. SpringKeyframe(bounce: 0) 로 critically
+                        //   damped spring 을 만들어 정점 overshoot 없이 자연스럽게 가속/감속한다.
+                        SpringKeyframe(
+                            maxRadius,
+                            duration: bloomDuration,
+                            spring: .init(duration: bloomDuration, bounce: 0)
+                        )
+                        // [2] Collapse — maxRadius → 0 (overshoot 없는 spring 으로 즉시 감속)
+                        SpringKeyframe(
+                            0,
+                            duration: collapseDuration,
+                            spring: .init(duration: collapseDuration, bounce: 0)
+                        )
+                    }
+                    // logoOpacity 트랙 — reveal. preDelay 동안 흐릿하게 유지 → bloom 동안 1.0 으로
+                    // 차올라 렌즈가 덮는 사이 선명해지고 → collapse 후 선명 유지.
+                    KeyframeTrack(\.logoOpacity) {
+                        LinearKeyframe(revealStartOpacity, duration: preDelay)
+                        LinearKeyframe(1.0, duration: bloomDuration)
+                        LinearKeyframe(1.0, duration: collapseDuration)
+                    }
                 }
             )
-            .task {
-                // .task 는 view re-evaluation 마다 재호출될 수 있으므로 한 번만 발동.
-                guard !hasStarted else { return }
-                hasStarted = true
-                trigger.toggle()
-            }
     }
 }
 
@@ -131,9 +201,11 @@ extension View {
     ///   - edgeHighlight: 유리 rim ring 강조. 기본 0.50.
     ///   - iridescenceStrength: lens 안쪽 무지개 광택 강도(0~1). 기본 1.0 — 시네마틱에서 무지개가
     ///     뚜렷이 드러나도록 holographic 광택을 최대로.
-    ///   - preDelay: 시네마틱 시작 전 정적 로고를 보여주는 시간. 기본 0.4s — 사용자가 로고 인지.
-    ///   - bloomDuration: 0 → maxRadius 까지 부풀어 오르는 시간. 기본 0.6s.
-    ///   - collapseDuration: maxRadius → 0 으로 모이는 시간. 기본 0.5s.
+    ///   - preDelay: 시네마틱 시작 전 흐릿한 워터마크 로고를 보여주는 시간. 기본 0.4s.
+    ///   - bloomDuration: 0 → maxRadius 까지 부풀어 오르는 시간. 기본 1.0s.
+    ///   - collapseDuration: maxRadius → 0 으로 모이는 시간. 기본 0.9s.
+    ///   - revealStartOpacity: 렌즈 전 로고의 워터마크 투명도(0~1). 기본 0.18 — bloom 동안 1.0
+    ///     으로 차올라 렌즈가 덮는 사이 선명하게 reveal 된다.
     func refractiveCinematic(
         center: UnitPoint = .center,
         maxRadius: CGFloat = 280,
@@ -142,8 +214,9 @@ extension View {
         edgeHighlight: CGFloat = 0.50,
         iridescenceStrength: CGFloat = 1.0,
         preDelay: TimeInterval = 0.4,
-        bloomDuration: TimeInterval = 0.6,
-        collapseDuration: TimeInterval = 0.5
+        bloomDuration: TimeInterval = 1.0,
+        collapseDuration: TimeInterval = 0.9,
+        revealStartOpacity: Double = 0.18
     ) -> some View {
         modifier(
             RefractiveCinematicModifier(
@@ -155,7 +228,8 @@ extension View {
                 iridescenceStrength: iridescenceStrength,
                 preDelay: preDelay,
                 bloomDuration: bloomDuration,
-                collapseDuration: collapseDuration
+                collapseDuration: collapseDuration,
+                revealStartOpacity: revealStartOpacity
             )
         )
     }
@@ -164,7 +238,7 @@ extension View {
 // MARK: - Preview
 
 #if DEBUG
-#Preview("자동 시네마틱 — 가운데 bloom → collapse") {
+#Preview("자동 시네마틱 — 살아있는 빛(흐름+글림+호흡)") {
     VStack(spacing: 24) {
         Image(systemName: "sparkles")
             .font(.system(size: 96))

--- a/AppProduct/AppProduct/Core/Mock/DesignPreview/ChromaticLens.metal
+++ b/AppProduct/AppProduct/Core/Mock/DesignPreview/ChromaticLens.metal
@@ -15,6 +15,8 @@
 //     실제 유리 dispersion 처럼 blue 가 더 많이, red 가 더 적게 휜다.
 //  5. 가장자리에는 smoothstep 으로 얇은 highlight ring 을 더해 유리 rim 느낌을 추가.
 //  6. lens 안쪽에 각도+반경 기반 HSV pastel 을 합성해 진주·비누거품 같은 무지개 광택을 더한다.
+//  7. time uniform(경과 초) 으로 무지개 흐름 + 이동 specular glint + 광택 미세 호흡을 구동해
+//     "살아있는 빛" 을 더한다. time=0 이면 이 모션은 비활성 — 정적 호출부와 픽셀 단위로 동일.
 //
 
 #include <metal_stdlib>
@@ -30,7 +32,8 @@ half4 chromaticLens(
     float refractionStrength,
     float dispersionStrength,
     float edgeHighlight,
-    float iridescenceStrength
+    float iridescenceStrength,
+    float time
 ) {
     float2 toCenter = position - center;
     float dist = length(toCenter);
@@ -87,7 +90,9 @@ half4 chromaticLens(
     // 가장자리(0.92+) 는 rim highlight 영역이라 iridescence 와 겹치지 않게 분리.
     float angle = atan2(toCenter.y, toCenter.x);
     float angleNorm = (angle + 3.14159265) / 6.28318530;  // 0~1
-    float hue = fract(angleNorm + normalized * 0.6);
+    // 무지개 흐름 — time 항이 hue 를 회전시켜 색띠가 유동한다 (time=0 이면 기존과 동일).
+    const float hueFlowSpeed = 0.12;  // cycle/s
+    float hue = fract(angleNorm + normalized * 0.6 + time * hueFlowSpeed);
     float h6 = hue * 6.0;
     half3 iridescent = half3(
         clamp(abs(h6 - 3.0) - 1.0, 0.0, 1.0),
@@ -97,6 +102,11 @@ half4 chromaticLens(
     float irisMask = smoothstep(0.05, 0.30, normalized)
                    * (1.0 - smoothstep(0.75, 0.92, normalized))
                    * iridescenceStrength;
+    // 미세 호흡 — 광택 강도가 부드럽게 맥동. time>0 일 때만 적용해 정적 호출부 회귀를 막는다.
+    if (time > 0.0) {
+        const float breathSpeed = 2.2;  // rad/s
+        irisMask *= (0.85 + 0.15 * sin(time * breathSpeed));
+    }
     half3 baseRGB = half3(r, g, b);
 
     // 채도 조정 — 진주·비누거품 톤을 위해 iridescent 자체를 흰색에 살짝 mix.
@@ -106,5 +116,22 @@ half4 chromaticLens(
     half3 pastelIridescent = mix(half3(1.0), iridescent, half(0.35));
     half3 finalRGB = mix(baseRGB, pastelIridescent, half(irisMask));
 
-    return half4(finalRGB + highlight, a);
+    // ── 이동 specular glint ───────────────────────────────────────────────
+    // 대각 축을 따라 움직이는 가우시안 밝은 띠 — 유리 표면을 빛줄기가 주기적으로
+    // 가로지르는 반짝임. time>0 일 때만 (정적/인터랙티브 호출부는 glint 없이 회귀 보존).
+    // exp(-d*d) 로 띠를 만든다. pow(음수, 2.0) 이 일부 GPU 에서 NaN 을 내므로 d*d 직접 사용.
+    half3 glintHighlight = half3(0.0);
+    if (time > 0.0) {
+        const float glintSpeed = 0.45;      // sweep/s
+        const float glintWidth = 0.18;
+        const float glintIntensity = 0.6;
+        float s = dot(toCenter, normalize(float2(1.0, 1.0))) / radius;  // 대각 좌표 ≈ [-1,1]
+        float sweepPos = -1.3 + fract(time * glintSpeed) * 2.6;         // 한쪽→반대쪽 주기 이동
+        float d = (s - sweepPos) / glintWidth;
+        float glint = exp(-d * d);                                      // 밝은 띠
+        glint *= (1.0 - smoothstep(0.70, 1.0, normalized));            // rim 영역과 분리
+        glintHighlight = half3(1.0) * half(glint * glintIntensity);
+    }
+
+    return half4(finalRGB + highlight + glintHighlight, a);
 }

--- a/AppProduct/AppProduct/Features/AuthBootstrap/Presentation/Views/AuthBootstrapView.swift
+++ b/AppProduct/AppProduct/Features/AuthBootstrap/Presentation/Views/AuthBootstrapView.swift
@@ -10,11 +10,11 @@
 //
 //  ## 동작
 //
-//  - mount 직후 `refractiveCinematic` modifier 가 3-phase (정적 → bloom → collapse) 시퀀스를
-//    1.5s 동안 재생한다. dwell(정점 정지) 단계 없이 한 keyframe timeline 으로 흘러 멈춤 느낌 없음.
+//  - mount 직후 `refractiveCinematic` modifier 가 3-phase (워터마크 → bloom → collapse) 시퀀스를
+//    2.3s 동안 재생한다. dwell(정점 정지) 단계 없이 한 keyframe timeline 으로 흘러 멈춤 느낌 없음.
 //  - 동시에 `bootstrapViewModel.checkAuthStatus()` 가 background 에서 토큰/프로필/버전 검사를
 //    수행한다.
-//  - 시네마틱 최소 시간(1.8s) + 인증 완료 둘 다 만족하면 결과에 따라 분기한다.
+//  - 시네마틱 최소 시간(2.3s) + 인증 완료 둘 다 만족하면 결과에 따라 분기한다.
 //    - `.approved` / `.pendingApproval` → AppFlow 로 외부 화면 라우팅
 //    - `.notLoggedIn` → **`stage` 를 `.loginReady` 로 전환** → 같은 화면 안에서 layout 이
 //      `withAnimation` 으로 morph (로고가 위로 슬라이드, LoginActionStack 이 아래에서 등장)
@@ -57,9 +57,11 @@ struct AuthBootstrapView: View {
     private let kakaoPlusManager: KakaoPlusManager = .init()
 
     private enum Constants {
-        /// 시네마틱 종료 시점. `RefractiveCinematic` 시퀀스 총 길이와 일치.
-        /// 인증이 더 빨리 끝나도 이 시간만큼은 시네마틱을 유지하고, 그 후 morph 트리거.
-        static let cinematicTotalDuration: TimeInterval = 1.5
+        /// 시네마틱 종료 시점. `RefractiveCinematic` 시퀀스 총 길이(preDelay 0.4 + bloom 1.0 +
+        /// collapse 0.9 = 2.3s)와 일치한다. 인증이 더 빨리 끝나도 이 시간만큼은 시네마틱을
+        /// 유지하고, 그 후 morph 트리거. **이 값과 refractiveCinematic 의 duration 합은 항상
+        /// 동기화해야 한다** — 어긋나면 라우팅이 collapse 도중 끊고 들어온다.
+        static let cinematicTotalDuration: TimeInterval = 2.3
         /// 인증 최대 대기 시간. 초과 시 `.notLoggedIn` 가정 후 loginReady morph.
         static let authTimeout: TimeInterval = 3.0
         /// stage 전환 애니메이션 시간 — 로고 위로 슬라이드 + actionStack 등장 morph.


### PR DESCRIPTION
## ✨ PR 유형

Feature — 앱 진입 시네마틱(`AuthBootstrap`)의 chromaticLens 효과를 "살아있는 빛"으로 고급화하고, 로고 watermark→reveal 연출과 속도 튜닝을 더했습니다.

Closes #826

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 로컬 캡처본: /tmp/living-light-826-reveal.mp4, /tmp/reveal_1_watermark.png ~ reveal_3_solid.png -->
<!-- UI 변경이라 영상 첨부 권장 — 시뮬레이터 녹화를 드래그해 올려주세요 -->

| 렌즈 전(워터마크) | 렌즈 통과(무지개 굴절) | 렌즈 후(선명 reveal) |
|---|---|---|
| 흐릿한 회색 UMC | 무지개 dispersion + 흐르는 빛 | 선명한 검은 UMC |

## 🛠️ 작업내용

- **셰이더 `time` uniform 추가** (`ChromaticLens.metal`)
  - 무지개 흐름(hue 회전) + 이동 specular glint + iridescence 미세 호흡 → "살아있는 빛"
  - `time=0` 가드로 정적/인터랙티브 호출부는 픽셀 단위 동일(회귀 0)
- **시간 공급 & 게이팅** (`RefractiveCinematic.swift`)
  - `TimelineView(.animation(paused:))` 로 경과 시간 주입, 시네마틱 종료 후 정지 → GPU 비용 0
  - `accessibilityReduceMotion` 시 흐르는 빛 비활성(굴절 bloom/collapse 는 유지)
- **로고 watermark → reveal**
  - keyframe 에 `logoOpacity` 트랙 추가(radius 와 2-track). 렌즈 전 흐릿한 워터마크(0.18) → bloom 동안 선명하게 차올라 reveal → 이후 유지
- **시네마틱 속도 조정**
  - bloom 0.6→1.0s, collapse 0.5→0.9s (총 1.5→2.3s)
  - `AuthBootstrapView.cinematicTotalDuration` 2.3 동기화 → 라우팅이 collapse 를 끊지 않음
- `chromaticLens(...)` 에 `time: Double = 0` 파라미터 추가 (`ChromaticLens.swift`)

## 📋 추후 진행 상황

- 파라미터(`revealStartOpacity`, hue/glint/breath 속도, duration) 디자인 확정 후 미세 튜닝
- `UMCApp`(Tuist) 로 포팅 여부 검토 — 현재 chromaticLens 는 `AppProduct` 전용

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Core/Mock/DesignPreview/ChromaticLens.metal` — `time` 기반 무지개 흐름/glint/호흡, `time>0` 회귀 가드, glint 의 `exp(-d*d)`(pow NaN 회피)
- `AppProduct/AppProduct/Core/Common/UIComponents/ChromaticLens/RefractiveCinematic.swift` — `TimelineView` 게이팅, 2-track keyframeAnimator(radius+logoOpacity), `cinematicLens` 헬퍼 분리(타입체커 추론 보조)
- `AppProduct/AppProduct/Features/AuthBootstrap/Presentation/Views/AuthBootstrapView.swift` — `cinematicTotalDuration` 동기화(시퀀스 총 길이와 일치 필수)

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?