### PR TITLE
💄 [Design] ID/PW 로그인 버튼 Liquid Glass 적용 (#829)

### DIFF
--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginByIdPwViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginByIdPwViewModel.swift
@@ -36,6 +36,15 @@ final class LoginByIdPwViewModel {
     /// 자동로그인 활성화 여부
     var isAutoLoginEnabled: Bool = false
 
+    /// 로그인 버튼 활성화 조건.
+    ///
+    /// 이메일(공백 제거 후)과 비밀번호가 모두 입력되어야 `true`. `loginWithEmail()`의
+    /// 빈 입력 검증과 동일한 기준이라, 비활성 상태와 실제 제출 가능 여부가 항상 일치합니다.
+    var canSubmit: Bool {
+        !emailInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !passwordInput.isEmpty
+    }
+
     // MARK: - Init
 
     init(

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginByIdPwView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginByIdPwView.swift
@@ -178,8 +178,8 @@ struct LoginByIdPwView: View {
             Task { await viewModel.loginWithEmail() }
         }
         .loading(.constant(viewModel.loginByEmailState.isLoading))
-        .disabled(viewModel.loginByEmailState.isLoading)
-        .buttonStyle(.gradientCapsule)
+        .disabled(!viewModel.canSubmit)
+        .buttonStyle(.glassProminent)
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

- 💄 Design (UI 스타일 개선)
- Resolves #829

## 📷 스크린샷 or 영상(UI 변경 시)

| 비활성 (입력 검증 실패) |
|---|
| ID/PW 로그인 버튼이 기존 인디고 그라데이션 캡슐(`.gradientCapsule`) → **Liquid Glass 캡슐(`.glassProminent`)** 로 전환됨. 이메일·비밀번호 미입력 상태에서 흐릿한 Glass 로 비활성 표현 (AX 계층 `enabled: false` 확인). |

> 활성/로딩 상태는 형제 화면 `SignUpByIdPwView` 의 가입 버튼과 동일한 `.glassProminent` + `.tint(.indigo500)` 표현입니다. (시뮬레이터 입력 자동화 권한 거부로 활성 상태 캡처는 생략 — 동일 패턴 재사용으로 동작 보장)

## 🛠️ 작업내용

- `LoginByIdPwView.loginButton` 의 `.buttonStyle(.gradientCapsule)` → `.buttonStyle(.glassProminent)` 로 전환하여 인증 플로우 전반의 Liquid Glass 디자인 언어와 시각적 통일성 확보
- `LoginByIdPwViewModel` 에 `canSubmit` 검증 프로퍼티 추가 (이메일 trim 후 + 비밀번호가 모두 입력되어야 `true`) — `loginWithEmail()` 의 빈 입력 검증과 동일 기준
- 버튼 비활성 조건을 `.disabled(viewModel.loginByEmailState.isLoading)` → `.disabled(!viewModel.canSubmit)` 로 변경하여 **입력 미완성 시 비활성** 처리 (SignUpByIdPwView 와 동일 패턴)
- 로딩 상태 비활성/스피너는 기존 `MainButton.loading()` 내부 처리로 그대로 커버

## 📋 추후 진행 상황

- `ResetPasswordView` 도 아직 `.gradientCapsule` 사용 중 — #829 범위 밖이라 미포함. 별도 이슈로 Liquid Glass 전환 검토 가능

## 📌 리뷰 포인트

- **상호작용 변경 확인**: 버튼이 입력 미완성 시 비활성화됨. 단, 비밀번호 필드 `onSubmit`(키보드 '완료')은 버튼과 별개로 `loginWithEmail()` 을 직접 호출하므로, 빈 입력 가이드 메시지("이메일을 입력해 주세요" 등) 로직은 키보드 제출 경로에서 여전히 동작합니다(죽은 코드 아님).
- 접근성: 터치 타겟 58pt(≥44pt), VoiceOver 라벨 "로그인" 유지, Dynamic Type 은 `MainButton` 컴포넌트 재사용으로 보존
- 빌드 검증 완료: AppProduct 스킴 시뮬레이터 빌드 성공 (경고·에러 0건)

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
