### PR TITLE
✨ [Feature] 2.0.0 업데이트 시 키체인 초기화로 강제 재로그인 (#831)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift
@@ -27,6 +27,12 @@ enum AppStorageKey {
     static let connectedSocialProviders: String = "connectedSocialProviders"
     /// 자동 로그인 허용 여부 (승인/등록 완료 사용자만 true)
     static let canAutoLogin: String = "canAutoLogin"
+    /// 2.0.0 강제 재로그인 마이그레이션 1회 실행 여부.
+    ///
+    /// iOS 키체인은 앱 업데이트·재설치로 지워지지 않으므로, 2.0.0 최초 실행 시 한 번만
+    /// 강제 로그아웃(키체인 토큰 삭제)을 수행하고 이 플래그를 set 한다.
+    /// 기기 스코프 값이므로 `sessionScopedKeys` 에 포함하지 않는다(로그아웃해도 보존).
+    static let didForceLogoutForV2: String = "didForceLogoutForV2"
 
     // MARK: - Profile (최신 기수 기준)
 

--- a/AppProduct/AppProduct/Features/AuthBootstrap/Presentation/ViewModels/AuthBootstrapViewModel.swift
+++ b/AppProduct/AppProduct/Features/AuthBootstrap/Presentation/ViewModels/AuthBootstrapViewModel.swift
@@ -148,6 +148,16 @@ final class AuthBootstrapViewModel {
     /// 토큰/프로필 기반으로 부트스트랩 인증 상태를 판정
     private func resolveAuthStatus() async -> AuthBootstrapStatus {
         let defaults = UserDefaults.standard
+
+        // 2.0.0 강제 재로그인 마이그레이션 (1회):
+        // iOS 키체인은 앱 업데이트·재설치로 지워지지 않으므로, 1.x 사용자의 잔존 토큰을
+        // 한 번만 명시적으로 비워 로그인 화면부터 다시 인증하도록 한다.
+        // (신규 설치 사용자는 저장된 토큰이 없어 logout() 이 무해하게 no-op 동작)
+        if !defaults.bool(forKey: AppStorageKey.didForceLogoutForV2) {
+            try? await networkClient.logout()
+            defaults.set(true, forKey: AppStorageKey.didForceLogoutForV2)
+        }
+
         let canAutoLogin = defaults.bool(
             forKey: AppStorageKey.canAutoLogin
         )


### PR DESCRIPTION
## ✨ PR 유형

Feature — 2.0.0 최초 실행 시 1.x 사용자의 잔존 키체인 토큰을 1회 강제 비워 재로그인 유도

Closes #831

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (부트스트랩 로직 변경). 동작은 시뮬레이터 빌드+실행으로 검증.

## 🛠️ 작업내용

- iOS 키체인은 앱 업데이트·재설치로 지워지지 않아 1.x 의 `accessToken`/`refreshToken` 이 2.0.0 에도 잔존하는 문제 해결
- `AppStorageKey` 에 기기 스코프 일회성 플래그 `didForceLogoutForV2` 추가
  - `sessionScopedKeys` 에 **미포함** → 로그아웃해도 보존되어 재실행 시 중복 동작 방지
- `AuthBootstrapViewModel.resolveAuthStatus()` 진입부에서 `isLoggedIn()` 검사 **전**, 플래그가 없으면 `networkClient.logout()`(키체인 토큰 삭제 + 세션 정리 + refresh task 취소) 호출 후 플래그 set
- 신규 설치 사용자는 저장 토큰이 없어 `logout()` 이 no-op 으로 무해하게 동작

## 📋 추후 진행 상황

- 2.0.0 배포 후 충분히 확산되면 해당 마이그레이션 코드 제거 검토

## 📌 리뷰 포인트

- \`AppProduct/AppProduct/Core/Common/Enum/AppStorageKey.swift\` - 신규 플래그가 `sessionScopedKeys` 에 들어가지 않았는지(들어가면 매 로그아웃마다 리셋되어 강제 로그아웃이 반복됨)
- \`AppProduct/AppProduct/Features/AuthBootstrap/Presentation/ViewModels/AuthBootstrapViewModel.swift\` - 삽입 위치(`isLoggedIn()` 검사 전)와 일회성 보장 로직

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)