### PR TITLE
✨ [Feature] 비밀번호 변경 (PATCH /api/v1/auth/password) — 마이페이지 회원 관리 (#832)

### DIFF
--- a/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationDestination.swift
@@ -57,6 +57,8 @@ enum NavigationDestination: Hashable {
         case signUpByIdPw
         /// 비밀번호 찾기 화면
         case resetPassword
+        /// 비밀번호 변경 화면
+        case changePassword
     }
 
     /// 홈(Home) 관련 화면 목적지

--- a/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
+++ b/AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift
@@ -84,6 +84,10 @@ private extension NavigationRoutingView {
                 verifyEmailCodeUseCase: authProvider.verifyEmailCodeUseCase,
                 resetPasswordUseCase: authProvider.resetPasswordUseCase
             )
+        case .changePassword:
+            ChangePasswordView(
+                changePasswordUseCase: di.resolve(AuthUseCaseProviding.self).changePasswordUseCase
+            )
         }
     }
 

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/ChangePasswordRequestDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/ChangePasswordRequestDTO.swift
@@ -1,0 +1,11 @@
+//
+//  ChangePasswordRequestDTO.swift
+//  AppProduct
+//
+
+import Foundation
+
+struct ChangePasswordRequestDTO: Encodable {
+    let currentPassword: String
+    let newPassword: String
+}

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -408,6 +408,34 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         return try apiResponse.unwrap().schools.map { $0.toDomain() }
     }
 
+    /// 비밀번호를 변경합니다.
+    ///
+    /// - Parameters:
+    ///   - currentPassword: 현재 비밀번호 (평문)
+    ///   - newPassword: 새 비밀번호 (평문)
+    func changePassword(
+        currentPassword: String,
+        newPassword: String
+    ) async throws {
+        do {
+            let response = try await adapter.request(
+                AuthRouter.changePassword(
+                    body: ChangePasswordRequestDTO(
+                        currentPassword: currentPassword,
+                        newPassword: newPassword
+                    )
+                )
+            )
+            let apiResponse = try decoder.decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let error as NetworkError {
+            throw Self.parseServerError(from: error) ?? error
+        }
+    }
+
     /// OAuth 회원 비밀번호를 추가 등록합니다.
     ///
     /// - Parameter rawPassword: 평문 비밀번호

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
@@ -160,6 +160,20 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         try await Task.sleep(for: .milliseconds(500))
     }
 
+    func changePassword(
+        currentPassword: String,
+        newPassword: String
+    ) async throws {
+        try await Task.sleep(for: .milliseconds(500))
+
+        guard currentPassword == "umc12345!" else {
+            throw RepositoryError.serverError(
+                code: "AUTHENTICATION-0022",
+                message: "현재 비밀번호가 올바르지 않습니다."
+            )
+        }
+    }
+
     func verifyEmailCode(
         emailVerificationId: String,
         verificationCode: String

--- a/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Router/AuthRouter.swift
@@ -54,6 +54,8 @@ enum AuthRouter: BaseTargetType {
     case getTerms(termsType: String)
     /// OAuth 회원 비밀번호 추가 등록
     case registerCredential(body: RegisterCredentialRequestDTO)
+    /// 비밀번호 변경
+    case changePassword(body: ChangePasswordRequestDTO)
 
     // MARK: - Path
 
@@ -95,6 +97,8 @@ enum AuthRouter: BaseTargetType {
             return "/api/v1/terms/type/\(termsType)"
         case .registerCredential:
             return "/api/v1/auth/credentials"
+        case .changePassword:
+            return "/api/v1/auth/password"
         }
     }
 
@@ -115,7 +119,7 @@ enum AuthRouter: BaseTargetType {
             return .get
         case .registerCredential:
             return .post
-        case .resetPassword:
+        case .resetPassword, .changePassword:
             return .patch
         }
     }
@@ -175,6 +179,8 @@ enum AuthRouter: BaseTargetType {
         case .getSchools, .getTerms:
             return .requestPlain
         case .registerCredential(let body):
+            return .requestJSONEncodable(body)
+        case .changePassword(let body):
             return .requestJSONEncodable(body)
         }
     }

--- a/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
@@ -144,4 +144,13 @@ protocol AuthRepositoryProtocol: Sendable {
     /// OAuth 회원 비밀번호 추가 등록
     /// - Parameter rawPassword: 평문 비밀번호
     func registerCredential(rawPassword: String) async throws
+
+    /// 비밀번호 변경
+    /// - Parameters:
+    ///   - currentPassword: 현재 비밀번호 (평문)
+    ///   - newPassword: 새 비밀번호 (평문)
+    func changePassword(
+        currentPassword: String,
+        newPassword: String
+    ) async throws
 }

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/ChangePasswordUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/ChangePasswordUseCaseProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  ChangePasswordUseCaseProtocol.swift
+//  AppProduct
+//
+
+import Foundation
+
+/// 비밀번호 변경 UseCase Protocol
+protocol ChangePasswordUseCaseProtocol {
+    /// 비밀번호 변경 실행
+    /// - Parameters:
+    ///   - currentPassword: 현재 비밀번호 (평문)
+    ///   - newPassword: 새 비밀번호 (평문)
+    func execute(
+        currentPassword: String,
+        newPassword: String
+    ) async throws
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/ChangePasswordUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/ChangePasswordUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  ChangePasswordUseCase.swift
+//  AppProduct
+//
+
+import Foundation
+
+final class ChangePasswordUseCase: ChangePasswordUseCaseProtocol {
+
+    private let repository: AuthRepositoryProtocol
+
+    init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(
+        currentPassword: String,
+        newPassword: String
+    ) async throws {
+        try await repository.changePassword(
+            currentPassword: currentPassword,
+            newPassword: newPassword
+        )
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
@@ -39,6 +39,8 @@ protocol AuthUseCaseProviding {
     var fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol { get }
     /// OAuth 회원 비밀번호 추가 등록 UseCase
     var registerCredentialUseCase: RegisterCredentialUseCaseProtocol { get }
+    /// 비밀번호 변경 UseCase
+    var changePasswordUseCase: ChangePasswordUseCaseProtocol { get }
 }
 
 /// Auth UseCase Provider 구현
@@ -63,6 +65,7 @@ final class AuthUseCaseProvider: AuthUseCaseProviding {
     let registerExistingChallengerUseCase: RegisterExistingChallengerUseCaseProtocol
     let fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
     let registerCredentialUseCase: RegisterCredentialUseCaseProtocol
+    let changePasswordUseCase: ChangePasswordUseCaseProtocol
 
     // MARK: - Init
 
@@ -118,6 +121,9 @@ final class AuthUseCaseProvider: AuthUseCaseProviding {
             repository: repository
         )
         self.registerCredentialUseCase = RegisterCredentialUseCase(
+            repository: repository
+        )
+        self.changePasswordUseCase = ChangePasswordUseCase(
             repository: repository
         )
     }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/ChangePasswordViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/ChangePasswordViewModel.swift
@@ -1,0 +1,64 @@
+//
+//  ChangePasswordViewModel.swift
+//  AppProduct
+//
+
+import Foundation
+
+@Observable
+@MainActor
+final class ChangePasswordViewModel {
+
+    // MARK: - Property
+
+    private let changePasswordUseCase: ChangePasswordUseCaseProtocol
+
+    var currentPasswordInput: String = ""
+    var newPasswordInput: String = ""
+
+    private(set) var changePasswordState: Loadable<Bool> = .idle
+
+    // MARK: - Init
+
+    init(changePasswordUseCase: ChangePasswordUseCaseProtocol) {
+        self.changePasswordUseCase = changePasswordUseCase
+    }
+
+    // MARK: - Validation
+
+    var isNewPasswordValid: Bool {
+        newPasswordInput.count >= 8
+    }
+
+    var canSubmit: Bool {
+        !currentPasswordInput.isEmpty &&
+        isNewPasswordValid &&
+        newPasswordInput != currentPasswordInput
+    }
+
+    // MARK: - Function
+
+    func changePassword() async {
+        guard canSubmit else { return }
+        changePasswordState = .loading
+        do {
+            try await changePasswordUseCase.execute(
+                currentPassword: currentPasswordInput,
+                newPassword: newPasswordInput
+            )
+            changePasswordState = .loaded(true)
+        } catch let error as AppError {
+            changePasswordState = .failed(error)
+        } catch let error as AuthError {
+            changePasswordState = .failed(.auth(error))
+        } catch let error as RepositoryError {
+            changePasswordState = .failed(.repository(error))
+        } catch let error as NetworkError {
+            changePasswordState = .failed(.network(error))
+        } catch {
+            changePasswordState = .failed(
+                .unknown(message: error.localizedDescription)
+            )
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/ChangePasswordView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/ChangePasswordView.swift
@@ -1,0 +1,112 @@
+//
+//  ChangePasswordView.swift
+//  AppProduct
+//
+
+import SwiftUI
+
+/// 비밀번호 변경 화면
+struct ChangePasswordView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: ChangePasswordViewModel
+    @State private var alertPrompt: AlertPrompt?
+    @FocusState private var currentPasswordFocused: Bool
+    @FocusState private var newPasswordFocused: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Init
+
+    init(changePasswordUseCase: ChangePasswordUseCaseProtocol) {
+        self._viewModel = .init(
+            wrappedValue: ChangePasswordViewModel(
+                changePasswordUseCase: changePasswordUseCase
+            )
+        )
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
+                UnderlineTextField(
+                    label: "현재 비밀번호",
+                    placeholder: "현재 비밀번호를 입력해주세요",
+                    text: $viewModel.currentPasswordInput,
+                    isSecure: true,
+                    submitLabel: .next,
+                    onSubmit: { newPasswordFocused = true },
+                    focusBinding: $currentPasswordFocused
+                )
+
+                VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                    UnderlineTextField(
+                        label: "새 비밀번호",
+                        placeholder: "8자 이상 입력해주세요",
+                        text: $viewModel.newPasswordInput,
+                        isSecure: true,
+                        submitLabel: .done,
+                        onSubmit: {
+                            newPasswordFocused = false
+                            Task { await viewModel.changePassword() }
+                        },
+                        focusBinding: $newPasswordFocused,
+                        guideMessage: viewModel.isNewPasswordValid || viewModel.newPasswordInput.isEmpty
+                            ? nil
+                            : "8자 이상 입력해주세요"
+                    )
+
+                    if case .failed(let error) = viewModel.changePasswordState {
+                        Text(error.userMessage)
+                            .appFont(.footnote, color: .red500)
+                    }
+                }
+            }
+            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+            .padding(.top, DefaultConstant.defaultSafeTop)
+            .padding(.bottom, DefaultConstant.defaultSafeBottom)
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .navigationTitle(Constants.navTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .safeAreaInset(edge: .bottom) {
+            submitButton
+        }
+        .alertPrompt(item: $alertPrompt)
+        .onChange(of: viewModel.changePasswordState) { _, newValue in
+            if case .loaded = newValue {
+                alertPrompt = AlertPrompt(
+                    title: "비밀번호 변경 완료",
+                    message: "비밀번호가 변경되었습니다.",
+                    positiveBtnTitle: "확인",
+                    positiveBtnAction: { dismiss() },
+                    negativeBtnTitle: nil
+                )
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var submitButton: some View {
+        MainButton(Constants.submitTitle) {
+            currentPasswordFocused = false
+            newPasswordFocused = false
+            Task { await viewModel.changePassword() }
+        }
+        .loading(.constant(viewModel.changePasswordState.isLoading))
+        .disabled(!viewModel.canSubmit || viewModel.changePasswordState.isLoading)
+        .buttonStyle(.gradientCapsule)
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .padding(.bottom, DefaultConstant.defaultSafeBottom)
+    }
+}
+
+// MARK: - Constants
+
+fileprivate enum Constants {
+    static let navTitle: String = "비밀번호 변경"
+    static let submitTitle: String = "변경하기"
+}

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/AuthSection.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/AuthSection.swift
@@ -19,6 +19,10 @@ struct AuthSection: View {
     @Environment(\.appFlow) private var appFlow
     @Environment(ErrorHandler.self) private var errorHandler
 
+    private var pathStore: PathStore {
+        di.resolve(PathStore.self)
+    }
+
     // MARK: - Body
 
     var body: some View {
@@ -48,9 +52,11 @@ struct AuthSection: View {
 
     /// 인증 타입에 따른 액션을 처리하고 AlertPrompt를 표시
     ///
-    /// - Parameter auth: 처리할 인증 타입 (로그아웃 또는 회원탈퇴)
+    /// - Parameter auth: 처리할 인증 타입 (비밀번호 변경, 로그아웃 또는 회원탈퇴)
     private func typeAction(_ auth: AuthType) {
         switch auth {
+        case .changePassword:
+            pathStore.mypagePath.append(.auth(.changePassword))
         case .logout:
             alertPrompt = .init(
                 title: "로그아웃",

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Enum/AuthType.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Enum/AuthType.swift
@@ -10,8 +10,10 @@ import SwiftUI
 
 /// 마이페이지 인증 관련 액션 타입
 ///
-/// 사용자 인증과 관련된 작업(로그아웃, 회원탈퇴)을 정의합니다.
+/// 사용자 인증과 관련된 작업(비밀번호 변경, 로그아웃, 회원탈퇴)을 정의합니다.
 enum AuthType: String, CaseIterable {
+    /// 비밀번호 변경
+    case changePassword = "비밀번호 변경"
     /// 로그아웃
     case logout = "로그아웃"
     /// 회원 탈퇴
@@ -20,6 +22,8 @@ enum AuthType: String, CaseIterable {
     /// 인증 타입별 SF Symbol 아이콘 이름
     var icon: String {
         switch self {
+        case .changePassword:
+            return "lock.rotation"
         case .logout:
             return "rectangle.portrait.and.arrow.right"
         case .accountDelete:
@@ -30,6 +34,8 @@ enum AuthType: String, CaseIterable {
     /// 인증 타입별 아이콘 배경 색상
     var color: Color {
         switch self {
+        case .changePassword:
+            return .primary
         case .logout:
             return .primary
         case .accountDelete:


### PR DESCRIPTION
## ✨ PR 유형

Feature — 로그인 상태에서 현재 비밀번호 검증 후 새 비밀번호로 교체. 기존 `resetPassword` 플로우를 이메일 인증 단계 없이 미러링하여 마이페이지 "회원 관리"에 진입점 추가

Closes #832

## 📷 스크린샷 or 영상(UI 변경 시)

> ⚠️ UI 변경 있음 — **비밀번호 변경 화면 신규 추가**. 스크린샷/영상 첨부 필요.
> (현재 XcodeBuildMCP UI 자동화 도구 비활성으로 캡처 미첨부. 빌드+실행+DI 해석은 검증 완료)

## 🛠️ 작업내용

**Data**
- `ChangePasswordRequestDTO`(Encodable, currentPassword/newPassword) 신규
- `AuthRouter.changePassword(body:)` — `PATCH /api/v1/auth/password`, `.requestJSONEncodable`
- `AuthRepository.changePassword` — 인증 필요(`adapter.request`) + `APIResponse<EmptyResult>` + `validateSuccess()` + `parseServerError` 매핑
- `MockAuthRepository.changePassword` — 현재 비밀번호 검증 stub

**Domain**
- `AuthRepositoryProtocol.changePassword` 시그니처 추가
- `ChangePasswordUseCaseProtocol` / `ChangePasswordUseCase` 신규 (repository 위임)

**DI**
- `AuthUseCaseProviding.changePasswordUseCase` 추가 + `AuthUseCaseProvider` init 주입

**Presentation**
- `ChangePasswordViewModel`(@Observable @MainActor, `Loadable<Bool>`) 신규 — 검증: 현재 비번 비어있지 않음 / 새 비번 8자 이상 / 새 비번 ≠ 현재 비번
- `ChangePasswordView` 신규 — 현재·새 비밀번호 secure 입력, 성공 시 `AlertPrompt` 후 dismiss, 실패 시 인라인 에러

**진입점 / 네비게이션**
- `AuthType.changePassword`("비밀번호 변경", icon `lock.rotation`) — 회원 관리 항상 노출
- `AuthSection.typeAction` → `mypagePath.append(.auth(.changePassword))`
- `NavigationDestination.Auth.changePassword` + `NavigationRoutingView` 라우팅

## 📋 추후 진행 상황

- OAuth 전용 회원 대상 노출 정책 정밀화 (현재는 항상 노출 + 서버 에러 처리. 서버에 자격증명 보유 필드가 생기면 조건부 노출로 전환 검토)
- 비밀번호 형식 정책이 강화되면 검증 규칙(`count >= 8`) 공용 헬퍼화 검토

## 📌 리뷰 포인트

- \`AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift\` - 인증 필요 API 라 `requestWithoutAuth` 아닌 `adapter.request` 사용 + 바디 없는 200 처리
- \`AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/ChangePasswordViewModel.swift\` - `@Observable`/`Loadable` 패턴, 검증 로직(현재≠새, 8자) 위치
- \`AppProduct/AppProduct/Features/Auth/Presentation/Views/ChangePasswordView.swift\` - 성공 AlertPrompt+dismiss / 실패 인라인 에러
- \`AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/AuthSection.swift\` - 노출 정책(항상 노출) 및 `mypagePath` push
- \`AppProduct/AppProduct/Core/Navigation/NavigationRoutingView.swift\` - `.changePassword` 라우팅 + UseCase 주입
- **노출 정책 확정 필요**: ID/PW 자격증명 여부를 클라이언트가 안정적으로 판별 불가하여 항상 노출 + 서버 에러 처리 방식 채택 (이슈 논의 반영)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)