### PR TITLE
🐛 [Fix] 홈 상벌점 카드 기수 스와이프 시 도넛 차트 잘림 수정 (#837)

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift
@@ -74,10 +74,9 @@ struct PenaltyCard: View, Equatable {
                 .offset(x: dragOffset)
                 .contentShape(.rect)
                 .gesture(swipeGesture)
+                .animation(.smooth(duration: 0.3), value: currentIndex)
         })
-        .animation(.smooth(duration: 0.3), value: currentIndex)
         .padding(Constants.padding)
-        .clipped()
         .clipShape(.rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true))
         .glassEffect(.regular, in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius))
         .task {


### PR DESCRIPTION
## ✨ PR 유형

🐛 Fix — 홈 화면 상벌점 카드(`PenaltyCard`) 기수 드래그(스와이프) 시 게이지(도넛 차트)가 잘리는 버그 수정

closes #837

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 드래그(기수 스와이프) 중/직후 도넛 차트·총점·범례가 잘리지 않는 모습, 전환 중 "활동 상태" 라벨이 헤더 밖으로 튀지 않는 모습을 영상으로 첨부 권장 -->

## 🛠️ 작업내용

상벌점 카드는 `TabView`가 아닌 **수동 캐러셀**(offset + DragGesture + `.transition(.blurReplace)`)로 구현되어 있으며, 두 가지 원인으로 콘텐츠가 잘리고 라벨 아티팩트가 발생했습니다.

- **이중 클리핑 정리**: 외곽 `.clipped()` 제거
  - 직사각형 `.clipped()` 가 오프셋/전환 *이전*의 정적 레이아웃 프레임 기준으로 콘텐츠를 잘라, 드래그·`blurReplace` 전환 중 도넛 차트(120×120) 상단이 잘림
  - 둥근 모서리 클리핑은 기존 `.clipShape(.rect(corners: .concentric))` 하나로 충분하므로 `.clipped()` 만 제거
- **전환 애니메이션 범위 한정**: `.animation(.smooth, value: currentIndex)` 위치 이동
  - 기존: 외곽 `VStack`(=`GenTabBar` 포함) 전체에 적용 → 기수 전환 시 `"활동 상태"` 라벨(`GenTabBar`)이 카드 밖(헤더 영역)으로 튀는 아티팩트 발생
  - 변경: 전환 대상인 `cardContent` 체인으로 한정 → `GenTabBar`가 전환 애니메이션 영향권에서 제외됨

## 📋 추후 진행 상황

<!-- 해당 없음 -->

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Features/Home/Presentation/Components/Card/PenaltyCard.swift` (`body`)
  - `.clipped()` 제거 후에도 둥근 코너 클리핑(`.clipShape(.concentric)`)이 유지되어 카드 모서리/Glass 형태가 정상인지
  - `.animation(value: currentIndex)` 를 `cardContent` 로 옮긴 뒤 좌우 스와이프 기수 전환 애니메이션이 그대로 동작하는지 (회귀)
  - 단일 기수 / 다중 기수 모두에서 도넛 차트·총점·범례가 잘리지 않는지 (iPhone 17 Pro · iOS 26)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)