### PR TITLE
✨ [Feature] 일정 생성 AI 자동완성 — @Generable 자연어 추출·폼 프리필 (#841)

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDraft.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleDraft.swift
@@ -1,0 +1,56 @@
+//
+//  ScheduleDraft.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 5/31/26.
+//
+
+import Foundation
+import FoundationModels
+
+/// 온디바이스 LLM이 자연어 입력으로부터 추출하는 일정 초안 구조체.
+///
+/// 장소 좌표는 환각 위험이 높아 절대 포함하지 않습니다.
+/// 장소 이름만 제안하며, 실제 좌표 확정은 사용자가 장소 검색 플로우에서 수행합니다.
+/// 참여자 목록 및 출석 정책은 AI 가 건드리지 않습니다.
+///
+/// `startDateISO` / `endDateISO` 는 LLM 이 반환한 ISO 8601 문자열입니다.
+/// `applyDraft(_:)` 에서 `ISO8601DateFormatter` 로 파싱한 뒤 ViewModel 필드에 매핑합니다.
+@Generable(description: "자연어 일정 설명에서 추출한 일정 초안")
+struct ScheduleDraft {
+
+    // MARK: - Property
+
+    @Guide(description: "일정 제목. 자연어에서 핵심 이름을 추출합니다. 예: '다음주 화요일 스터디 모임' → '스터디 모임'")
+    var title: String
+
+    @Guide(description: """
+    일정 시작 시각 (ISO 8601 형식). 자연어 날짜/시간 표현을 파싱합니다.
+    예: '다음주 화요일 오후 2시' → '2026-06-09T14:00:00+09:00'
+    '내일 저녁 7시' → 내일 날짜로 계산.
+    시각이 명시되지 않으면 해당 날짜의 09:00:00+09:00 로 기본 설정합니다.
+    """)
+    var startDateISO: String
+
+    @Guide(description: """
+    일정 종료 시각 (ISO 8601 형식). 명시되지 않은 경우 startDateISO + 1시간으로 추정합니다.
+    """)
+    var endDateISO: String
+
+    @Guide(description: "하루 종일 일정 여부. '하루종일', '종일', '전일' 같은 표현이 있거나 시각이 명시되지 않으면 true.")
+    var isAllDay: Bool
+
+    @Guide(description: """
+    일정 카테고리. 다음 rawValue 중 하나를 정확히 반환하세요:
+    LEADERSHIP, DUES, MEETING, NETWORKING, HACKATHON, PROJECT,
+    PRESENTATION, WORKSHOP, RETROSPECTIVE, AFTER_PARTY, ORIENTATION, GENERAL.
+    입력에 가장 잘 맞는 카테고리를 선택하세요.
+    """)
+    var tag: String
+
+    @Guide(description: "일정에 대한 추가 메모나 설명. 자연어 입력에서 부가 내용을 추출합니다. 없으면 빈 문자열.")
+    var memo: String
+
+    @Guide(description: "장소 이름만 추출합니다. 좌표나 주소는 절대 포함하지 않습니다. 장소 언급이 없으면 빈 문자열.")
+    var placeName: String
+}

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel+AI.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel+AI.swift
@@ -1,0 +1,155 @@
+//
+//  ScheduleRegistrationViewModel+AI.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 5/31/26.
+//
+
+import Foundation
+import FoundationModels
+import SwiftData
+
+extension ScheduleRegistrationViewModel {
+
+    // MARK: - Function
+
+    /// 온디바이스 AI로 자연어 일정 설명을 분석해 폼 필드를 자동으로 채웁니다.
+    ///
+    /// - 장소 좌표는 절대 AI로 채우지 않습니다. `placeName` 만 제안 텍스트로 반영하며,
+    ///   실제 좌표 확정은 기존 장소 검색 플로우에서 사용자가 수행합니다.
+    /// - 참여자(`participatn`) 및 출석 정책은 건드리지 않습니다.
+    /// - AI 미지원 기기에서는 상태를 `.failed` 로 설정하고 조기 반환합니다.
+    @MainActor
+    func requestAIAutofill() async {
+        let rawText = aiRawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawText.isEmpty else { return }
+        if case .loading = aiAutofillState { return }
+
+        guard case .available = SystemLanguageModel.default.availability else {
+            aiAutofillState = .failed(
+                .unknown(message: "이 기기에서는 Apple Intelligence를 사용할 수 없습니다.")
+            )
+            return
+        }
+
+        aiAutofillState = .loading
+
+        do {
+            let session = LanguageModelSession {
+                """
+                당신은 한국 대학 동아리 일정 등록을 돕는 보조 시스템입니다.
+                사용자가 입력한 자연어 일정 설명에서 필요한 정보를 추출하세요.
+                날짜/시간이 명확하지 않으면 합리적인 기본값을 사용하세요.
+                장소는 이름만 추출하고 좌표나 주소는 절대 생성하지 마세요.
+                오늘 날짜는 현재 시스템 날짜를 기준으로 합니다.
+                """
+            }
+
+            let response = try await session.respond(to: rawText, generating: ScheduleDraft.self)
+            applyDraft(response.content)
+            await persistDailyTokenUsage(session: session)
+            aiAutofillState = .loaded(true)
+        } catch {
+            aiAutofillState = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    /// AI 자동완성 상태를 초기로 되돌립니다.
+    @MainActor
+    func resetAIAutofillState() {
+        aiAutofillState = .idle
+    }
+
+    // MARK: - Private Function
+
+    /// `ScheduleDraft` 결과를 ViewModel 폼 필드에 반영합니다.
+    ///
+    /// - ISO 8601 날짜 파싱에 실패하면 해당 필드는 기존 값을 유지합니다.
+    /// - placeName 이 비어있지 않으면 place 이름만 덮어쓰고 좌표는 0,0 으로 유지합니다.
+    ///   사용자가 이후 장소 검색 플로우를 통해 좌표를 확정해야 합니다.
+    @MainActor
+    private func applyDraft(_ draft: ScheduleDraft) {
+        if !draft.title.isEmpty {
+            title = draft.title
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let formatterNoFraction = ISO8601DateFormatter()
+        formatterNoFraction.formatOptions = [.withInternetDateTime]
+
+        func parseISO(_ string: String) -> Date? {
+            formatter.date(from: string) ?? formatterNoFraction.date(from: string)
+        }
+
+        if let start = parseISO(draft.startDateISO) {
+            let end: Date
+            if let parsedEnd = parseISO(draft.endDateISO), parsedEnd > start {
+                end = parsedEnd
+            } else {
+                end = start.addingTimeInterval(3600)
+            }
+            dataRange = DateRange(startDate: start, endDate: end)
+        }
+
+        isAllDay = draft.isAllDay
+
+        if let category = ScheduleIconCategory(rawValue: draft.tag), !category.isDeprecated {
+            tag = [category]
+            isTagManuallyOverridden = true
+        }
+
+        if !draft.memo.isEmpty {
+            memo = draft.memo
+        }
+
+        if !draft.placeName.isEmpty {
+            place = PlaceSearchInfo(
+                name: draft.placeName,
+                address: "",
+                coordinate: Coordinate(latitude: 0.0, longitude: 0.0)
+            )
+        }
+    }
+
+    /// AI 실행 후 당일 토큰 사용량을 SwiftData 에 기록합니다.
+    ///
+    /// SwiftData 컨텍스트가 없거나 저장에 실패해도 AI 결과에는 영향이 없습니다.
+    @MainActor
+    private func persistDailyTokenUsage(session: LanguageModelSession) async {
+        guard let modelContext else { return }
+        guard #available(iOS 26.4, *) else { return }
+
+        let used: Int
+        do {
+            used = try await SystemLanguageModel.default.tokenCount(for: session.transcript)
+        } catch {
+            return
+        }
+        guard used > 0 else { return }
+
+        let today = Calendar.current.startOfDay(for: Date())
+        let currentMemberId = AppStorageKey.legacyMemberIdInt()
+
+        do {
+            let descriptor = FetchDescriptor<AITokenDailyUsageRecord>()
+            let records = try modelContext.fetch(descriptor)
+
+            if let record = records.first(where: {
+                $0.memberId == currentMemberId && $0.date == today
+            }) {
+                record.usedTokens += used
+            } else {
+                modelContext.insert(AITokenDailyUsageRecord(
+                    memberId: currentMemberId,
+                    date: today,
+                    usedTokens: used
+                ))
+            }
+
+            try modelContext.save()
+        } catch {
+            // 저장 실패해도 AI 실행 결과에 영향 없음
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/ViewModels/ScheduleRegistrationViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftData
 
 /// 일정 등록 화면의 비즈니스 로직을 담당하는 뷰 모델입니다.
 ///
@@ -135,9 +136,20 @@ class ScheduleRegistrationViewModel {
     /// 수정 모드 초기값 스냅샷
     private var initialEditSnapshot: EditFormSnapshot?
     /// 사용자가 태그를 직접 조정했는지 여부
-    private var isTagManuallyOverridden: Bool = false
+    var isTagManuallyOverridden: Bool = false
     /// 수정 모드 프리필 시 서버에서 받은 참여자 멤버 ID 목록
     private var prefillMemberIds: Set<Int> = []
+
+    // MARK: - AI Autofill Property
+
+    /// SwiftData ModelContext (토큰 사용량 기록용). 뷰에서 주입합니다.
+    var modelContext: ModelContext?
+
+    /// AI 자동완성 자연어 입력 텍스트
+    var aiRawInput: String = ""
+
+    /// AI 자동완성 진행 상태
+    var aiAutofillState: Loadable<Bool> = .idle
 
     // MARK: - Init
 

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -6,6 +6,8 @@
 //
 
 import SwiftUI
+import FoundationModels
+import SwiftData
 
 /// 일정 생성 화면
 ///
@@ -19,6 +21,7 @@ struct ScheduleRegistrationView: View {
     @State var viewModel: ScheduleRegistrationViewModel
 
     @Environment(\.dismiss) var dismiss
+    @Environment(\.modelContext) private var modelContext
 
     /// 화면이 생성 모드인지 수정 모드인지 구분합니다.
     private let mode: Mode
@@ -74,6 +77,7 @@ struct ScheduleRegistrationView: View {
                 }
             }
             .task {
+                viewModel.modelContext = modelContext
                 if mode == .edit {
                     await viewModel.fetchPrefillParticipants()
                 }
@@ -93,6 +97,9 @@ struct ScheduleRegistrationView: View {
     private var formContent: some View {
         Form {
             inlineErrorSection
+            if isAIAvailable {
+                AIAutofillSection(viewModel: viewModel)
+            }
             section(.title)
             placeSection
             section(.allDay, .date)
@@ -102,6 +109,14 @@ struct ScheduleRegistrationView: View {
             section(.memo)
         }
         .alertPrompt(item: $viewModel.alertPrompt)
+    }
+
+    /// 현재 기기에서 온디바이스 AI 가 사용 가능한지 여부입니다.
+    private var isAIAvailable: Bool {
+        if case .available = SystemLanguageModel.default.availability {
+            return true
+        }
+        return false
     }
 
     /// 대면/비대면 토글과 장소 선택을 묶은 섹션입니다.
@@ -705,6 +720,91 @@ fileprivate struct AttendancePolicySection: View {
                 viewModel.attendanceToggleChanged(to: newValue)
             }
         )
+    }
+}
+
+// MARK: - AI Autofill Section
+
+/// 자연어 입력으로 일정 폼을 자동으로 채워주는 AI 보조 섹션.
+///
+/// `SystemLanguageModel.default.availability == .available` 일 때만 표시됩니다.
+/// 장소 이름만 제안하며 좌표는 생성하지 않습니다.
+/// 참여자 및 출석 정책은 AI 가 변경하지 않습니다.
+fileprivate struct AIAutofillSection: View {
+
+    @Bindable var viewModel: ScheduleRegistrationViewModel
+
+    private enum Constants {
+        static let placeholder = "예: 다음 주 화요일 저녁 7시 스터디 모임 강남역 근처"
+        static let buttonLabel = "AI로 정리"
+    }
+
+    var body: some View {
+        Section {
+            HStack(spacing: DefaultSpacing.spacing8) {
+                TextField(
+                    "",
+                    text: $viewModel.aiRawInput,
+                    prompt: Text(Constants.placeholder)
+                        .foregroundStyle(Color.grey400)
+                )
+                .appFont(.subheadline, color: .black)
+                .submitLabel(.done)
+                .onSubmit {
+                    Task { @MainActor in
+                        await viewModel.requestAIAutofill()
+                    }
+                }
+
+                autofillButton
+            }
+
+            autofillStatusRow
+        } header: {
+            Text("AI 자동완성")
+                .appFont(.caption1, color: .grey500)
+        }
+    }
+
+    /// AI 자동완성 실행 버튼 또는 로딩 인디케이터
+    @ViewBuilder
+    private var autofillButton: some View {
+        if case .loading = viewModel.aiAutofillState {
+            ProgressView()
+                .controlSize(.small)
+                .tint(.indigo500)
+        } else {
+            Button(Constants.buttonLabel) {
+                Task { @MainActor in
+                    await viewModel.requestAIAutofill()
+                }
+            }
+            .appFont(.footnoteEmphasis, color: .indigo500)
+            .disabled(viewModel.aiRawInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    /// 자동완성 성공/실패 인라인 상태 행
+    @ViewBuilder
+    private var autofillStatusRow: some View {
+        switch viewModel.aiAutofillState {
+        case .loaded:
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(Color.green)
+                Text("자동완성 적용됨. 내용을 확인하고 필요 시 수정하세요.")
+                    .appFont(.caption1, color: .grey600)
+            }
+        case .failed(let error):
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(Color.red500)
+                Text(error.errorDescription ?? error.userMessage)
+                    .appFont(.caption1, color: .red500)
+            }
+        default:
+            EmptyView()
+        }
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형
- 새로운 기능 추가 (온디바이스 AI · `FoundationModels`)

## 🛠️ 작업내용
- 일정 생성 화면에 **온디바이스 AI 자동완성** 추가
- 자연어 입력("다음주 화요일 7시 강남역 OT") → `@Generable ScheduleDraft` 로 제목/일시/하루종일/태그/메모/장소이름 구조화 추출 → 폼 프리필
- 이 코드베이스 **최초 `@Generable` + `@Guide` 도입** (`Date` 미지원 → ISO8601 String 우회)
- 기존 AI 인프라 재사용: `SystemLanguageModel.availability` 체크, `LanguageModelSession`, 일일 토큰 사용량(`AITokenDailyUsageRecord`)
- **환각 가드레일**: 장소 **좌표**·참여자·출석정책은 AI가 설정하지 않음 (좌표는 기존 장소검색으로 사용자가 확정)

### 변경 파일
- 신규: `Features/Home/Presentation/ViewModels/ScheduleDraft.swift`, `ScheduleRegistrationViewModel+AI.swift`
- 수정: `ScheduleRegistrationViewModel.swift`, `Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift`

## 📋 추후 진행 상황
- 실기기(Apple Intelligence)에서 한국어 자연어 날짜 파싱 정확도 검증
- `ScheduleClassifierUseCase`(기존 태그 분류기)와 AI tag 추출 역할 분담 정리

## 📌 리뷰 포인트
- `@Generable` 패턴 최초 도입 — `docs/claude/ios26-frameworks/FoundationModels-Using-on-device-LLM-in-your-app.md` 참고
- ISO8601 두 포맷 파싱 폴백, AI 미지원 기기 시 진입 버튼 숨김 처리
- iPhone 17 Pro / iOS 26.5 시뮬레이터 빌드 통과(에러 0)

Closes #841 · 관련 Epic #840

## ✅ Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
