### PR TITLE
✨ [Feature] 공지 초안 AI 요약 — 외부 텍스트 붙여넣기 → 제목/본문 자동 초안 (#842)

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+AI.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+AI.swift
@@ -30,6 +30,17 @@ extension NoticeEditorViewModel {
         }
     }
 
+    /// AI 요약 결과로 생성된 제목 + 본문 초안.
+    /// 사용자가 수락 전까지 에디터 필드에 반영되지 않습니다.
+    struct AISummaryDraft {
+        /// 요약에 사용된 원본 텍스트 (재시도 지원용)
+        let sourceText: String
+        /// 생성된 제목 후보
+        let title: String
+        /// 생성된 본문 (markdown)
+        let body: String
+    }
+
     // MARK: - AI Content Improvement
 
     /// AI 개선 요청 진입점. availability 체크 후 확인 다이얼로그를 띄운다.
@@ -190,6 +201,215 @@ extension NoticeEditorViewModel {
         } catch {
             return 0
         }
+    }
+
+    // MARK: - AI Summary (External Text → Title + Body Draft)
+
+    /// 외부 텍스트 붙여넣기 시트를 엽니다. availability를 확인한 뒤 시트를 노출합니다.
+    @MainActor
+    func openAISummaryInput() {
+        guard !isAISummaryProcessing else { return }
+
+        guard case .available = SystemLanguageModel.default.availability else {
+            alertPrompt = AlertPrompt(
+                title: "AI 기능 사용 불가",
+                message: "이 기기에서는 Apple Intelligence를 사용할 수 없습니다. 설정에서 Apple Intelligence를 활성화해주세요.",
+                positiveBtnTitle: "확인"
+            )
+            return
+        }
+
+        summarySourceText = ""
+        showAISummaryInput = true
+    }
+
+    /// 붙여넣기 시트를 취소/닫을 때 입력 버퍼를 초기화합니다.
+    @MainActor
+    func closeSummaryInput() {
+        showAISummaryInput = false
+        summarySourceText = ""
+    }
+
+    /// 붙여넣기 시트에서 "AI 요약" 버튼 탭 시 호출됩니다.
+    /// sourceText가 비어 있으면 무시합니다.
+    @MainActor
+    func requestAISummary(from sourceText: String) {
+        let trimmed = sourceText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard !isAISummaryProcessing else { return }
+
+        guard case .available = SystemLanguageModel.default.availability else {
+            alertPrompt = AlertPrompt(
+                title: "AI 기능 사용 불가",
+                message: "이 기기에서는 Apple Intelligence를 사용할 수 없습니다. 설정에서 Apple Intelligence를 활성화해주세요.",
+                positiveBtnTitle: "확인"
+            )
+            return
+        }
+
+        if let contextSize = resolveContextSize() {
+            aiTokenUsage = AITokenUsage(
+                lastRunTokens: 0,
+                cumulativeUsed: min(aiCumulativeUsedTokens, contextSize),
+                total: contextSize
+            )
+        }
+
+        showAISummaryInput = false
+        showAISummaryConfirmation = true
+        pendingSummaryDraft = AISummaryDraft(sourceText: trimmed, title: "", body: "")
+    }
+
+    /// 요약 확인 다이얼로그에서 "요약하기" 버튼 탭 시 호출됩니다.
+    @MainActor
+    func startAISummary() async {
+        guard let draft = pendingSummaryDraft else { return }
+        showAISummaryConfirmation = false
+        await summarizeWithAI(sourceText: draft.sourceText)
+    }
+
+    /// Foundation Model을 사용해 외부 텍스트에서 공지 제목과 본문 초안을 생성합니다.
+    ///
+    /// 생성된 초안은 `pendingSummaryDraft`에 저장되며, `showAISummaryDraftReview`가 true가 됩니다.
+    /// 사용자가 초안을 수락하기 전까지 title/content/richAttributedContent에 반영되지 않습니다.
+    @MainActor
+    func summarizeWithAI(sourceText: String) async {
+        guard case .available = SystemLanguageModel.default.availability else { return }
+
+        isAISummaryProcessing = true
+        aiSummaryStreamingText = ""
+        showAISummaryDraftReview = false
+
+        do {
+            let session = LanguageModelSession {
+                """
+                당신은 동아리 공지사항 작성 전문가입니다.
+                주어진 외부 텍스트(디스코드 메시지, 이메일, 메모 등)를 분석해 동아리 공지사항 초안을 작성해주세요.
+                반드시 아래 형식 그대로 출력하세요. 다른 설명이나 메타 텍스트는 절대 포함하지 마세요.
+
+                TITLE: <한 줄 제목>
+                BODY:
+                <본문 (마크다운 허용)>
+                """
+            }
+
+            let contextSize = resolveContextSize()
+            if let contextSize {
+                aiTokenUsage = AITokenUsage(
+                    lastRunTokens: 0,
+                    cumulativeUsed: min(aiCumulativeUsedTokens, contextSize),
+                    total: contextSize
+                )
+            }
+
+            let stream = session.streamResponse(to: sourceText)
+            var fullText = ""
+            var chunkIndex = 0
+            var lastRunTokens = 0
+
+            for try await partial in stream {
+                fullText = partial.content
+                aiSummaryStreamingText = fullText
+                chunkIndex += 1
+                if let contextSize, chunkIndex.isMultiple(of: 5) {
+                    lastRunTokens = await updateTokenUsage(session: session, contextSize: contextSize)
+                }
+            }
+
+            if let contextSize {
+                lastRunTokens = await updateTokenUsage(session: session, contextSize: contextSize)
+            }
+
+            let parsed = parseSummaryOutput(fullText)
+            pendingSummaryDraft = AISummaryDraft(
+                sourceText: sourceText,
+                title: parsed.title,
+                body: parsed.body
+            )
+
+            if let contextSize {
+                aiCumulativeUsedTokens = min(aiCumulativeUsedTokens + lastRunTokens, contextSize)
+                aiTokenUsage = AITokenUsage(
+                    lastRunTokens: lastRunTokens,
+                    cumulativeUsed: aiCumulativeUsedTokens,
+                    total: contextSize
+                )
+            }
+
+            persistDailyTokenUsage(lastRunTokens: lastRunTokens)
+
+            isAISummaryProcessing = false
+            showAISummaryDraftReview = true
+        } catch {
+            isAISummaryProcessing = false
+            aiSummaryStreamingText = ""
+            showAISummaryDraftReview = false
+            pendingSummaryDraft = nil
+            errorHandler?.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "summarizeWithAI"
+                )
+            )
+        }
+    }
+
+    /// 초안을 수락하고 에디터 필드에 반영합니다.
+    /// selectedCategory / subCategorySelection / allowAlert / targetInfo는 절대 자동 변경하지 않습니다.
+    @MainActor
+    func applySummaryDraft() {
+        guard let draft = pendingSummaryDraft, !draft.body.isEmpty else {
+            dismissAISummaryDraft()
+            return
+        }
+
+        title = draft.title.isEmpty ? title : draft.title
+
+        let baseFont = UIFont(name: "Pretendard-Regular", size: 16)
+            ?? UIFont.preferredFont(forTextStyle: .body)
+        richAttributedContent = MarkdownSerializer.deserialize(draft.body, baseFont: baseFont)
+        content = MarkdownSerializer.serialize(richAttributedContent)
+
+        dismissAISummaryDraft()
+    }
+
+    /// 초안을 기각하고 요약 흐름을 종료합니다.
+    @MainActor
+    func dismissAISummaryDraft() {
+        showAISummaryDraftReview = false
+        aiSummaryStreamingText = ""
+        pendingSummaryDraft = nil
+    }
+
+    // MARK: - Summary Output Parsing
+
+    /// 모델 출력에서 TITLE: / BODY: 섹션을 파싱합니다.
+    private func parseSummaryOutput(_ raw: String) -> (title: String, body: String) {
+        var title = ""
+        var body = ""
+
+        let lines = raw.components(separatedBy: "\n")
+        var isInBody = false
+        var bodyLines: [String] = []
+
+        for line in lines {
+            if !isInBody, line.hasPrefix("TITLE:") {
+                title = line.dropFirst("TITLE:".count).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("BODY:") {
+                isInBody = true
+            } else if isInBody {
+                bodyLines.append(line)
+            }
+        }
+
+        body = bodyLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if body.isEmpty {
+            body = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return (title, body)
     }
 
     // MARK: - SwiftData Persistence

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel.swift
@@ -177,6 +177,29 @@ final class NoticeEditorViewModel: MultiplePhotoPickerManageable {
     /// AI 개선 완료 후 확인 버튼 대기 중 상태 (오버레이 유지용)
     var showAICompletionSummary: Bool = false
 
+    // MARK: - AI Summary State
+
+    /// 외부 텍스트 붙여넣기 + AI 요약 시트 표시 여부
+    var showAISummaryInput: Bool = false
+
+    /// 붙여넣기 시트의 입력 텍스트 버퍼 (시트 닫힐 때 초기화)
+    var summarySourceText: String = ""
+
+    /// AI 요약 요청 전 확인 다이얼로그 표시 여부
+    var showAISummaryConfirmation: Bool = false
+
+    /// AI 요약 처리 중 여부
+    var isAISummaryProcessing: Bool = false
+
+    /// AI 요약 스트리밍 진행 중 현재까지 생성된 텍스트 (진행 상황 표시용)
+    var aiSummaryStreamingText: String = ""
+
+    /// AI 요약 완료 후 초안 검토 대기 중 상태
+    var showAISummaryDraftReview: Bool = false
+
+    /// AI 요약으로 생성된 제목 + 본문 초안 (검토 후 수락 or 기각)
+    var pendingSummaryDraft: AISummaryDraft?
+
     // MARK: - Edit Snapshot
 
     /// 수정 화면 원본 제목

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/NoticeEditorAttachmentToolbar.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/NoticeEditorAttachmentToolbar.swift
@@ -16,11 +16,13 @@ struct NoticeEditorAttachmentToolbar: View {
     @Bindable var editorToolbarViewModel: EditorToolbarViewModel
     let isEditMode: Bool
     let isAIButtonDisabled: Bool
+    let isAISummaryButtonDisabled: Bool
     @Binding var isPhotoPickerPresented: Bool
     @Binding var selectedPhotoItems: [PhotosPickerItem]
     @Binding var selectedHighlightColor: HighlightColor
     let onAddLink: () -> Void
     let onTapAI: () -> Void
+    let onTapAISummary: () -> Void
     let onShowVotingSheet: () -> Void
 
     // MARK: - Constants
@@ -66,6 +68,10 @@ struct NoticeEditorAttachmentToolbar: View {
             ToolbarIconButton(icon: "sparkles", action: onTapAI)
                 .disabled(isAIButtonDisabled)
                 .opacity(isAIButtonDisabled ? 0.4 : 1)
+
+            ToolbarIconButton(icon: "wand.and.stars", action: onTapAISummary)
+                .disabled(isAISummaryButtonDisabled)
+                .opacity(isAISummaryButtonDisabled ? 0.4 : 1)
 
             ToolbarTextFormatButton(
                 title: "B",

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorPresentations.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorPresentations.swift
@@ -31,6 +31,7 @@ struct NoticeEditorPresentations: ViewModifier {
             .sheet(item: $viewModel.activeSheetType, content: targetSheet)
             .fullScreenCover(isPresented: $viewModel.showVoting, content: votingSheet)
             .alertPrompt(item: $viewModel.alertPrompt)
+            // AI Rewrite: 확인 다이얼로그
             .overlay {
                 if viewModel.showAIConfirmation {
                     AIConfirmationOverlay(
@@ -46,6 +47,7 @@ struct NoticeEditorPresentations: ViewModifier {
                 }
             }
             .animation(.easeInOut(duration: 0.25), value: viewModel.showAIConfirmation)
+            // AI Rewrite: 로딩/완료 오버레이
             .overlay {
                 if viewModel.isAIProcessing || viewModel.showAICompletionSummary {
                     AILoadingOverlay(
@@ -58,6 +60,63 @@ struct NoticeEditorPresentations: ViewModifier {
             }
             .animation(.easeInOut(duration: 0.25), value: viewModel.isAIProcessing)
             .animation(.easeInOut(duration: 0.25), value: viewModel.showAICompletionSummary)
+            // AI Summary: 붙여넣기 입력 시트
+            .sheet(isPresented: $viewModel.showAISummaryInput, onDismiss: {
+                viewModel.summarySourceText = ""
+            }) {
+                AISummaryInputSheet(
+                    sourceText: $viewModel.summarySourceText,
+                    tokenUsage: viewModel.aiTokenUsage,
+                    onSummarize: {
+                        viewModel.requestAISummary(from: viewModel.summarySourceText)
+                    },
+                    onCancel: {
+                        viewModel.closeSummaryInput()
+                    }
+                )
+            }
+            // AI Summary: 확인 다이얼로그
+            .overlay {
+                if viewModel.showAISummaryConfirmation {
+                    AIConfirmationOverlay(
+                        tokenUsage: viewModel.aiTokenUsage,
+                        titleText: "외부 텍스트를 요약해 공지 초안을 만들어 드릴게요.\n지금 시작할까요?",
+                        confirmButtonTitle: "요약하기",
+                        onConfirm: {
+                            Task { await viewModel.startAISummary() }
+                        },
+                        onCancel: {
+                            viewModel.showAISummaryConfirmation = false
+                            viewModel.pendingSummaryDraft = nil
+                        }
+                    )
+                    .transition(.opacity.combined(with: .scale(scale: 0.94, anchor: .center)))
+                }
+            }
+            .animation(.easeInOut(duration: 0.25), value: viewModel.showAISummaryConfirmation)
+            // AI Summary: 요약 진행 중 오버레이
+            .overlay {
+                if viewModel.isAISummaryProcessing {
+                    AILoadingOverlay(
+                        phase: .processing,
+                        streamingText: viewModel.aiSummaryStreamingText
+                    )
+                    .transition(.opacity.combined(with: .scale(scale: 0.94, anchor: .center)))
+                }
+            }
+            .animation(.easeInOut(duration: 0.25), value: viewModel.isAISummaryProcessing)
+            // AI Summary: 초안 검토 오버레이
+            .overlay {
+                if viewModel.showAISummaryDraftReview, let draft = viewModel.pendingSummaryDraft {
+                    AISummaryDraftOverlay(
+                        draft: draft,
+                        onAccept: { viewModel.applySummaryDraft() },
+                        onReject: { viewModel.dismissAISummaryDraft() }
+                    )
+                    .transition(.opacity.combined(with: .scale(scale: 0.94, anchor: .center)))
+                }
+            }
+            .animation(.easeInOut(duration: 0.25), value: viewModel.showAISummaryDraftReview)
             .sheet(
                 isPresented: Binding(
                     get: { viewModel.editorToolbarViewModel.isFormatPanelVisible },

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/NoticeEditorView.swift
@@ -191,11 +191,14 @@ struct NoticeEditorView: View {
                     isEditMode: viewModel.isEditMode,
                     isAIButtonDisabled: viewModel.isAIProcessing
                         || viewModel.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                    isAISummaryButtonDisabled: viewModel.isAISummaryProcessing
+                        || viewModel.isAIProcessing,
                     isPhotoPickerPresented: $isPhotoPickerPresented,
                     selectedPhotoItems: $viewModel.selectedPhotoItems,
                     selectedHighlightColor: $selectedHighlightColor,
                     onAddLink: addLinkAttachment,
                     onTapAI: handleTapAI,
+                    onTapAISummary: handleTapAISummary,
                     onShowVotingSheet: viewModel.showVotingFormSheet
                 )
                 Spacer()
@@ -346,9 +349,14 @@ struct NoticeEditorView: View {
         viewModel.toggleSubCategory(subCategory)
     }
 
-    /// AI 도우미 버튼 탭
+    /// AI 도우미 버튼 탭 (본문 다듬기)
     private func handleTapAI() {
         viewModel.requestAIImprovement()
+    }
+
+    /// AI 요약 버튼 탭 (외부 텍스트 → 공지 초안)
+    private func handleTapAISummary() {
+        viewModel.openAISummaryInput()
     }
 
     // MARK: - Helper

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AIConfirmationOverlay.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AIConfirmationOverlay.swift
@@ -12,6 +12,8 @@ struct AIConfirmationOverlay: View {
     // MARK: - Property
 
     let tokenUsage: NoticeEditorViewModel.AITokenUsage?
+    var titleText: String = "공지 본문을 더 읽기 좋게 다듬어 드릴게요.\n지금 바로 시작할까요?"
+    var confirmButtonTitle: String = "작성하기"
     let onConfirm: () -> Void
     let onCancel: () -> Void
 
@@ -39,7 +41,7 @@ struct AIConfirmationOverlay: View {
                     .appFont(.calloutEmphasis)
                     .multilineTextAlignment(.center)
 
-                Text("공지 본문을 더 읽기 좋게 다듬어 드릴게요.\n지금 바로 시작할까요?")
+                Text(titleText)
                     .font(.app(.footnote))
                     .foregroundStyle(.grey500)
                     .multilineTextAlignment(.center)
@@ -55,7 +57,7 @@ struct AIConfirmationOverlay: View {
                 HStack(spacing: DefaultSpacing.spacing8) {
                     MainButton("취소") { onCancel() }
                         .buttonStyle(.glass)
-                    MainButton("작성하기") { onConfirm() }
+                    MainButton(confirmButtonTitle) { onConfirm() }
                         .buttonStyle(.glassProminent)
                         .disabled(tokenUsage.map { isTokenExhausted($0) } ?? false)
                 }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AISummaryDraftOverlay.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AISummaryDraftOverlay.swift
@@ -1,0 +1,111 @@
+//
+//  AISummaryDraftOverlay.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 5/31/26.
+//
+
+import SwiftUI
+
+/// AI 요약 완료 후 생성된 제목·본문 초안을 검토하고 수락 또는 기각하는 오버레이입니다.
+///
+/// 수락 시 에디터의 title/content/richAttributedContent에 반영됩니다.
+/// 카테고리·대상·알림 발송 여부는 절대 자동 변경되지 않습니다.
+struct AISummaryDraftOverlay: View {
+
+    // MARK: - Property
+
+    let draft: NoticeEditorViewModel.AISummaryDraft
+    let onAccept: () -> Void
+    let onReject: () -> Void
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let cardPadding: EdgeInsets = .init(top: 24, leading: 28, bottom: 24, trailing: 28)
+        static let cardMaxWidth: CGFloat = 360
+        static let bodyLineLimit: Int = 6
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack {
+            Color.clear
+                .contentShape(Rectangle())
+                .ignoresSafeArea()
+
+            VStack(spacing: DefaultSpacing.spacing16) {
+                headerSection
+                draftSection
+                draftNoticeLabel
+                actionSection
+            }
+            .padding(Constants.cardPadding)
+            .frame(maxWidth: Constants.cardMaxWidth)
+            .glassEffect(.regular, in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius)))
+        }
+    }
+
+    // MARK: - View Builders
+
+    private var headerSection: some View {
+        VStack(spacing: DefaultSpacing.spacing8) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: DefaultConstant.iconSize, weight: .medium))
+                .foregroundStyle(.indigo500)
+
+            Text("초안이 완성됐어요")
+                .appFont(.calloutEmphasis)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private var draftSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            if !draft.title.isEmpty {
+                VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                    Text("제목")
+                        .appFont(.caption1)
+                        .foregroundStyle(.grey500)
+                    Text(draft.title)
+                        .appFont(.calloutEmphasis)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(2)
+                }
+            }
+
+            if !draft.body.isEmpty {
+                VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                    Text("본문")
+                        .appFont(.caption1)
+                        .foregroundStyle(.grey500)
+                    Text(draft.body)
+                        .font(.app(.footnote))
+                        .foregroundStyle(.grey600)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(Constants.bodyLineLimit)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(DefaultSpacing.spacing12)
+        .glassEffect(.regular, in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius))
+    }
+
+    private var draftNoticeLabel: some View {
+        Text("초안입니다. 수락 후 직접 검토·수정해주세요.")
+            .font(.app(.caption1))
+            .foregroundStyle(.grey500)
+            .multilineTextAlignment(.center)
+    }
+
+    private var actionSection: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            MainButton("기각") { onReject() }
+                .buttonStyle(.glass)
+            MainButton("에디터에 적용") { onAccept() }
+                .buttonStyle(.glassProminent)
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AISummaryInputSheet.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AISummaryInputSheet.swift
@@ -1,0 +1,173 @@
+//
+//  AISummaryInputSheet.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 5/31/26.
+//
+
+import SwiftUI
+
+/// 외부 텍스트를 붙여넣고 AI 요약을 요청하는 시트입니다.
+///
+/// 사용자가 디스코드·이메일·메모 등 외부 텍스트를 입력 영역에 붙여넣은 뒤
+/// "AI 요약" 버튼을 탭하면 공지 초안 생성 흐름이 시작됩니다.
+/// 카테고리·대상·알림 발송 여부는 이 흐름에서 절대 변경하지 않습니다.
+struct AISummaryInputSheet: View {
+
+    // MARK: - Property
+
+    @Binding var sourceText: String
+    let tokenUsage: NoticeEditorViewModel.AITokenUsage?
+    let onSummarize: () -> Void
+    let onCancel: () -> Void
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let inputMinHeight: CGFloat = 160
+        static let cardPadding: EdgeInsets = .init(top: 24, leading: 24, bottom: 24, trailing: 24)
+        static let textEditorCornerRadius: CGFloat = 12
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+                headerSection
+                inputSection
+                if let tokenUsage {
+                    tokenSection(tokenUsage)
+                }
+                Spacer(minLength: 0)
+                actionSection
+            }
+            .padding(Constants.cardPadding)
+            .navigationTitle("붙여넣고 AI 요약")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("취소", action: onCancel)
+                        .foregroundStyle(.grey500)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    // MARK: - View Builders
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+            HStack(spacing: DefaultSpacing.spacing8) {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(.indigo500)
+                Text("Apple Intelligence")
+                    .appFont(.calloutEmphasis)
+            }
+            Text("외부 텍스트에서 공지 제목과 본문 초안을 생성합니다.\n카테고리·대상·알림 설정은 직접 지정해주세요.")
+                .font(.app(.footnote))
+                .foregroundStyle(.grey500)
+        }
+    }
+
+    private var inputSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            Text("붙여넣을 텍스트")
+                .appFont(.footnoteEmphasis)
+                .foregroundStyle(.grey600)
+
+            ZStack(alignment: .topLeading) {
+                RoundedRectangle(cornerRadius: Constants.textEditorCornerRadius)
+                    .fill(.thinMaterial)
+
+                if sourceText.isEmpty {
+                    Text("디스코드 메시지, 이메일, 메모 등을 붙여넣으세요")
+                        .font(.app(.footnote))
+                        .foregroundStyle(.grey500)
+                        .padding(.horizontal, DefaultSpacing.spacing12)
+                        .padding(.vertical, DefaultSpacing.spacing12)
+                        .allowsHitTesting(false)
+                }
+
+                TextEditor(text: $sourceText)
+                    .font(.app(.footnote))
+                    .scrollContentBackground(.hidden)
+                    .padding(.horizontal, DefaultSpacing.spacing8)
+                    .padding(.vertical, DefaultSpacing.spacing8)
+            }
+            .frame(minHeight: Constants.inputMinHeight)
+        }
+    }
+
+    @ViewBuilder
+    private func tokenSection(_ usage: NoticeEditorViewModel.AITokenUsage) -> some View {
+        if isTokenExhausted(usage) {
+            exhaustedView
+        } else {
+            tokenGaugeView(usage)
+        }
+    }
+
+    private var exhaustedView: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .foregroundStyle(.red)
+            Text("오늘 사용 가능한 토큰을 모두 사용했어요")
+                .appFont(.footnoteEmphasis)
+                .foregroundStyle(.red)
+        }
+    }
+
+    private func tokenGaugeView(_ usage: NoticeEditorViewModel.AITokenUsage) -> some View {
+        let progress = usage.progress
+        let gaugeTint = gaugeTintColor(for: progress)
+
+        return VStack(spacing: DefaultSpacing.spacing4) {
+            Gauge(
+                value: Double(usage.cumulativeUsed),
+                in: 0...Double(usage.total)
+            ) {
+                EmptyView()
+            }
+            .gaugeStyle(.linearCapacity)
+            .tint(gaugeTint)
+
+            HStack {
+                Text("사용된 토큰 \(usage.cumulativeUsed.formatted())")
+                    .appFont(.caption1)
+                    .foregroundStyle(.grey500)
+                Spacer(minLength: 0)
+                Text("남은 토큰 \(usage.remaining.formatted())")
+                    .appFont(.caption1)
+                    .foregroundStyle(.grey500)
+            }
+        }
+    }
+
+    private var actionSection: some View {
+        MainButton("AI 요약 (초안 생성)") {
+            onSummarize()
+        }
+        .buttonStyle(.glassProminent)
+        .disabled(isActionDisabled)
+    }
+
+    // MARK: - Function
+
+    private var isActionDisabled: Bool {
+        sourceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || tokenUsage.map { isTokenExhausted($0) } ?? false
+    }
+
+    private func isTokenExhausted(_ usage: NoticeEditorViewModel.AITokenUsage) -> Bool {
+        usage.remaining == 0
+    }
+
+    private func gaugeTintColor(for progress: Double) -> Color {
+        if progress >= 0.90 { return .red }
+        if progress >= 0.80 { return .orange }
+        return .indigo500
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형
- 새로운 기능 추가 (온디바이스 AI · `FoundationModels`)

## 🛠️ 작업내용
- 공지 에디터에 **외부 텍스트 붙여넣기 → AI 요약 → 제목/본문 초안** 기능 추가
- 기존 공지 AI(rewrite) 패턴 확장: `LanguageModelSession` 스트리밍·토큰 기록 재사용
- 기존 `AIConfirmationOverlay` 재사용(titleText/confirmButtonTitle 파라미터화, 기본값으로 기존 동작 유지) + 신규 `AISummaryInputSheet`/`AISummaryDraftOverlay`
- **가드레일**: 카테고리·대상(targetInfo)·알림발송(allowAlert)은 AI가 설정하지 않음, **자동 발송 없음** — "초안"까지만, 발송은 사람이 확인

### 변경 파일
- 신규: `Features/Notice/.../Overlay/AISummaryInputSheet.swift`, `Overlay/AISummaryDraftOverlay.swift`
- 수정: `NoticeEditorViewModel.swift`, `NoticeEditorViewModel+AI.swift`, `Overlay/AIConfirmationOverlay.swift`, `NoticeEditorPresentations.swift`, `AttachmentToolbar/NoticeEditorAttachmentToolbar.swift`, `NoticeEditorView.swift`

## 📋 추후 진행 상황
- 실기기에서 TITLE:/BODY: 요약 포맷 신뢰성 검증 및 프롬프트 튜닝
- rewrite ↔ summary 토큰 한도 공유 정책 확정

## 📌 리뷰 포인트
- TITLE:/BODY: 파싱 폴백(포맷 미준수 시 본문 전체로 폴백) — The Ping 오발송 방지 관점 확인
- `AIConfirmationOverlay` 기본값으로 기존 rewrite 호출부 동작 불변 확인
- iPhone 17 Pro / iOS 26.5 시뮬레이터 빌드 통과(에러 0)

Closes #842 · 관련 Epic #840

## ✅ Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
