### PR TITLE
✨ [Feature] 온디바이스 AI UX 개선 — 일정 AI 툴바화 · 공지 작성 AI 메뉴 통합 · 공지 읽기 요약 신규

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -26,6 +26,8 @@ struct ScheduleRegistrationView: View {
     /// 화면이 생성 모드인지 수정 모드인지 구분합니다.
     private let mode: Mode
 
+    @State private var showAISheet: Bool = false
+
     /// 일정 등록 화면의 동작 모드입니다.
     enum Mode {
         case create
@@ -61,7 +63,7 @@ struct ScheduleRegistrationView: View {
         }
         self._viewModel = .init(wrappedValue: viewModel)
     }
-    
+
     // MARK: - Body
 
     /// 일정 등록 폼과 상단 툴바를 조합한 화면 본문입니다.
@@ -89,6 +91,9 @@ struct ScheduleRegistrationView: View {
             .onChange(of: viewModel.isAllDay) {
                 viewModel.prefillAttendancePolicyIfNeeded()
             }
+            .sheet(isPresented: $showAISheet) {
+                AIAutofillSheet(viewModel: viewModel, isPresented: $showAISheet)
+            }
     }
 
     // MARK: - Private Function
@@ -97,9 +102,6 @@ struct ScheduleRegistrationView: View {
     private var formContent: some View {
         Form {
             inlineErrorSection
-            if isAIAvailable {
-                AIAutofillSection(viewModel: viewModel)
-            }
             section(.title)
             placeSection
             section(.allDay, .date)
@@ -176,6 +178,11 @@ struct ScheduleRegistrationView: View {
                 dismissOnTap: false,
             )
         } else {
+            if isAIAvailable {
+                ToolbarItem(placement: .topBarTrailing) {
+                    aiToolbarButton
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 createToolbarButton
             }
@@ -210,6 +217,16 @@ struct ScheduleRegistrationView: View {
         }
         .tint((isActionDisabled || isSubmitting) ? .grey300 : .indigo500)
         .disabled(isActionDisabled || isSubmitting)
+    }
+
+    /// 생성 모드에서 AI 자동완성 시트를 여는 툴바 버튼입니다.
+    private var aiToolbarButton: some View {
+        Button {
+            showAISheet = true
+        } label: {
+            Image(systemName: "sparkles")
+        }
+        .tint(.indigo500)
     }
 
     /// 일정 생성 또는 수정 요청이 진행 중인지 여부입니다.
@@ -723,24 +740,67 @@ fileprivate struct AttendancePolicySection: View {
     }
 }
 
-// MARK: - AI Autofill Section
+// MARK: - AI Autofill Sheet
 
-/// 자연어 입력으로 일정 폼을 자동으로 채워주는 AI 보조 섹션.
+/// 자연어 입력으로 일정 폼을 자동으로 채워주는 AI 자동완성 시트.
 ///
-/// `SystemLanguageModel.default.availability == .available` 일 때만 표시됩니다.
+/// 성공(.loaded) 상태가 되면 시트를 자동으로 닫아 사용자가 채워진 폼을 확인하게 합니다.
 /// 장소 이름만 제안하며 좌표는 생성하지 않습니다.
 /// 참여자 및 출석 정책은 AI 가 변경하지 않습니다.
-fileprivate struct AIAutofillSection: View {
+fileprivate struct AIAutofillSheet: View {
 
     @Bindable var viewModel: ScheduleRegistrationViewModel
+    @Binding var isPresented: Bool
 
     private enum Constants {
         static let placeholder = "예: 다음 주 화요일 저녁 7시 스터디 모임 강남역 근처"
         static let buttonLabel = "AI로 정리"
+        static let sheetTitle = "AI 자동완성"
+        static let sheetDescription = "일정 내용을 자연어로 입력하면 AI가 폼을 자동으로 채웁니다."
     }
 
     var body: some View {
-        Section {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+                Text(Constants.sheetDescription)
+                    .appFont(.subheadline, color: .grey600)
+                    .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+                    .padding(.top, DefaultSpacing.spacing8)
+
+                inputArea
+
+                statusArea
+
+                Spacer()
+            }
+            .navigationTitle(Constants.sheetTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        viewModel.resetAIAutofillState()
+                        isPresented = false
+                    } label: {
+                        Image(systemName: "xmark")
+                            .foregroundStyle(Color.grey500)
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+        .onChange(of: viewModel.aiAutofillState) {
+            if case .loaded = viewModel.aiAutofillState {
+                viewModel.resetAIAutofillState()
+                isPresented = false
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private var inputArea: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
             HStack(spacing: DefaultSpacing.spacing8) {
                 TextField(
                     "",
@@ -748,7 +808,7 @@ fileprivate struct AIAutofillSection: View {
                     prompt: Text(Constants.placeholder)
                         .foregroundStyle(Color.grey400)
                 )
-                .appFont(.subheadline, color: .black)
+                .appFont(.body, color: .black)
                 .submitLabel(.done)
                 .onSubmit {
                     Task { @MainActor in
@@ -758,15 +818,13 @@ fileprivate struct AIAutofillSection: View {
 
                 autofillButton
             }
-
-            autofillStatusRow
-        } header: {
-            Text("AI 자동완성")
-                .appFont(.caption1, color: .grey500)
+            .padding(DefaultSpacing.spacing12)
+            .background(Color(.systemGray6))
+            .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius))
         }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
     }
 
-    /// AI 자동완성 실행 버튼 또는 로딩 인디케이터
     @ViewBuilder
     private var autofillButton: some View {
         if case .loading = viewModel.aiAutofillState {
@@ -784,17 +842,9 @@ fileprivate struct AIAutofillSection: View {
         }
     }
 
-    /// 자동완성 성공/실패 인라인 상태 행
     @ViewBuilder
-    private var autofillStatusRow: some View {
+    private var statusArea: some View {
         switch viewModel.aiAutofillState {
-        case .loaded:
-            HStack(spacing: DefaultSpacing.spacing4) {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(Color.green)
-                Text("자동완성 적용됨. 내용을 확인하고 필요 시 수정하세요.")
-                    .appFont(.caption1, color: .grey600)
-            }
         case .failed(let error):
             HStack(spacing: DefaultSpacing.spacing4) {
                 Image(systemName: "exclamationmark.circle.fill")
@@ -802,6 +852,7 @@ fileprivate struct AIAutofillSection: View {
                 Text(error.errorDescription ?? error.userMessage)
                     .appFont(.caption1, color: .red500)
             }
+            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
         default:
             EmptyView()
         }

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+AI.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel+AI.swift
@@ -1,0 +1,150 @@
+//
+//  NoticeDetailViewModel+AI.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 5/31/26.
+//
+
+import Foundation
+import FoundationModels
+import SwiftData
+
+extension NoticeDetailViewModel {
+
+    // MARK: - Types
+
+    /// AI 읽기 요약 진행 단계
+    enum ReadingSummaryPhase: Equatable {
+        case idle
+        case streaming
+        case completed
+        case failed(String)
+    }
+
+    // MARK: - AI Reading Summary
+
+    /// 온디바이스 AI 요약 기능이 이 기기에서 사용 가능한지 여부
+    var isAIReadingSummaryAvailable: Bool {
+        if case .available = SystemLanguageModel.default.availability { return true }
+        return false
+    }
+
+    /// 공지 본문을 온디바이스 AI로 요약합니다. availability 체크 후 스트리밍을 시작합니다.
+    @MainActor
+    func requestReadingSummary(content: String, modelContext: ModelContext?) {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard readingSummaryPhase != .streaming else { return }
+
+        guard case .available = SystemLanguageModel.default.availability else {
+            readingSummaryPhase = .failed("이 기기에서는 Apple Intelligence를 사용할 수 없습니다.")
+            return
+        }
+
+        readingSummaryStreamingText = ""
+        readingSummaryPhase = .streaming
+        readingSummaryModelContext = modelContext
+
+        Task { @MainActor in
+            await performReadingSummary(content: trimmed)
+        }
+    }
+
+    /// Foundation Model을 사용해 공지 본문을 스트리밍 요약합니다.
+    @MainActor
+    private func performReadingSummary(content: String) async {
+        guard case .available = SystemLanguageModel.default.availability else {
+            readingSummaryPhase = .failed("Apple Intelligence를 사용할 수 없습니다.")
+            return
+        }
+
+        do {
+            let session = LanguageModelSession {
+                """
+                당신은 동아리 공지사항 읽기 보조 도구입니다.
+                주어진 공지 본문을 읽는 사람이 핵심 내용을 빠르게 파악할 수 있도록,
+                불필요한 서술 없이 핵심 사항만 간결하게 요약해 주세요.
+                별도의 설명이나 메타 텍스트 없이 요약된 내용만 출력하세요.
+                """
+            }
+
+            let contextSize = resolveContextSize()
+
+            let stream = session.streamResponse(to: content)
+            var fullText = ""
+            var chunkIndex = 0
+            var lastRunTokens = 0
+
+            for try await partial in stream {
+                fullText = partial.content
+                readingSummaryStreamingText = fullText
+                chunkIndex += 1
+                if let contextSize, chunkIndex.isMultiple(of: 5) {
+                    lastRunTokens = await updateTokenUsage(session: session, contextSize: contextSize)
+                }
+            }
+
+            if let contextSize {
+                lastRunTokens = await updateTokenUsage(session: session, contextSize: contextSize)
+            }
+
+            persistDailyTokenUsage(lastRunTokens: lastRunTokens)
+            readingSummaryPhase = .completed
+        } catch {
+            readingSummaryStreamingText = ""
+            readingSummaryPhase = .failed("요약 중 오류가 발생했습니다.")
+        }
+    }
+
+    /// 요약 시트가 닫힐 때 호출. 상태를 초기화합니다.
+    @MainActor
+    func dismissReadingSummary() {
+        readingSummaryPhase = .idle
+        readingSummaryStreamingText = ""
+    }
+
+    // MARK: - Token Usage
+
+    private func resolveContextSize() -> Int? {
+        guard #available(iOS 26.4, *) else { return nil }
+        return SystemLanguageModel.default.contextSize
+    }
+
+    @MainActor
+    private func updateTokenUsage(session: LanguageModelSession, contextSize: Int) async -> Int {
+        guard #available(iOS 26.4, *) else { return 0 }
+        do {
+            let used = try await SystemLanguageModel.default.tokenCount(for: session.transcript)
+            return used
+        } catch {
+            return 0
+        }
+    }
+
+    @MainActor
+    private func persistDailyTokenUsage(lastRunTokens: Int) {
+        guard let modelContext = readingSummaryModelContext, lastRunTokens > 0 else { return }
+
+        let today = Calendar.current.startOfDay(for: Date())
+        let currentMemberId = AppStorageKey.legacyMemberIdInt()
+
+        do {
+            let descriptor = FetchDescriptor<AITokenDailyUsageRecord>()
+            let records = try modelContext.fetch(descriptor)
+
+            if let record = records.first(where: { $0.memberId == currentMemberId && $0.date == today }) {
+                record.usedTokens += lastRunTokens
+            } else {
+                modelContext.insert(AITokenDailyUsageRecord(
+                    memberId: currentMemberId,
+                    date: today,
+                    usedTokens: lastRunTokens
+                ))
+            }
+
+            try modelContext.save()
+        } catch {
+            // 저장 실패해도 요약 결과에 영향 없음
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftData
 
 /// 공지사항 상세 화면 ViewModel
 ///
@@ -122,6 +123,20 @@ final class NoticeDetailViewModel {
 
     /// 선택된 필터 타입
     var selectedFilter: ReadStatusFilterType = .all
+
+    // MARK: - AI Reading Summary State
+
+    /// AI 읽기 요약 시트 표시 여부
+    var showReadingSummarySheet: Bool = false
+
+    /// AI 읽기 요약 진행 단계
+    var readingSummaryPhase: ReadingSummaryPhase = .idle
+
+    /// AI 읽기 요약 스트리밍 중 현재까지 생성된 텍스트
+    var readingSummaryStreamingText: String = ""
+
+    /// AI 읽기 요약용 ModelContext (View에서 주입)
+    var readingSummaryModelContext: ModelContext?
 
     // MARK: - Permission State
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeDetailView.swift
@@ -55,6 +55,7 @@ struct NoticeDetailView: View {
         static let collapseAnimation: Animation = .spring(response: 0.36, dampingFraction: 0.88)
         static let failedTitleText: String = "공지사항을 불러오지 못했습니다."
         static let failedIconName: String = "exclamationmark.triangle"
+        static let aiSummaryIcon: String = "sparkles"
     }
 
     // MARK: - Body
@@ -67,6 +68,7 @@ struct NoticeDetailView: View {
             .safeAreaBar(edge: .bottom, alignment: .center, content: expandedReadStatusInset)
             .safeAreaBar(edge: .bottom, alignment: .trailing, content: collapsedReadStatusInset)
             .sheet(isPresented: $viewModel.showReadStatusSheet, content: readStatusSheet)
+            .sheet(isPresented: $viewModel.showReadingSummarySheet, content: readingSummarySheet)
             .alertPrompt(item: $viewModel.alertPrompt)
             .task { await onTask() }
     }
@@ -272,6 +274,17 @@ struct NoticeDetailView: View {
     /// 수정/삭제 메뉴를 포함하는 네비게이션 툴바
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
+        if viewModel.isAIReadingSummaryAvailable, case .loaded = viewModel.noticeState {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    viewModel.showReadingSummarySheet = true
+                } label: {
+                    Image(systemName: Constants.aiSummaryIcon)
+                        .foregroundStyle(.indigo500)
+                }
+            }
+        }
+
         if currentNotice != nil, !toolbarActions.isEmpty {
             ToolBarCollection.ToolbarTrailingMenu(actions: toolbarActions)
         }
@@ -366,6 +379,14 @@ struct NoticeDetailView: View {
         NoticeReadStatusSheet(viewModel: viewModel)
             .presentationDetents(Constants.detailSheetDetents)
             .interactiveDismissDisabled()
+    }
+
+    /// AI 읽기 요약 시트를 구성합니다.
+    @ViewBuilder
+    private func readingSummarySheet() -> some View {
+        if let content = currentNotice?.content {
+            NoticeReadingSummarySheet(viewModel: viewModel, noticeContent: content)
+        }
     }
 
     // MARK: - Task

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeReadingSummarySheet.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeReadingSummarySheet.swift
@@ -1,0 +1,164 @@
+//
+//  NoticeReadingSummarySheet.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 5/31/26.
+//
+
+import SwiftUI
+import SwiftData
+
+/// AI 읽기 요약 시트
+///
+/// 공지 본문을 온디바이스 AI로 요약한 결과를 스트리밍으로 표시합니다.
+struct NoticeReadingSummarySheet: View {
+
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Bindable var viewModel: NoticeDetailViewModel
+    let noticeContent: String
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let sheetHorizontalPadding: CGFloat = DefaultConstant.defaultSafeHorizon
+        static let sheetTopPadding: CGFloat = DefaultSpacing.spacing24
+        static let headerSpacing: CGFloat = DefaultSpacing.spacing8
+        static let bodySpacing: CGFloat = DefaultSpacing.spacing16
+        static let iconSize: CGFloat = DefaultConstant.iconSize
+        static let cardPadding: EdgeInsets = .init(
+            top: DefaultSpacing.spacing16,
+            leading: DefaultConstant.defaultSafeHorizon,
+            bottom: DefaultSpacing.spacing16,
+            trailing: DefaultConstant.defaultSafeHorizon
+        )
+        static let retryButtonTitle: String = "다시 시도"
+        static let dismissButtonTitle: String = "닫기"
+        static let headerLabel: String = "Apple Intelligence"
+        static let streamingPlaceholder: String = "요약하는 중..."
+        static let failedIconName: String = "exclamationmark.circle"
+        static let sparklesIconName: String = "sparkles"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: Constants.bodySpacing) {
+                    headerSection
+                    summarySection
+                    Spacer(minLength: DefaultSpacing.spacing24)
+                }
+                .padding(.horizontal, Constants.sheetHorizontalPadding)
+                .padding(.top, Constants.sheetTopPadding)
+            }
+            .navigation(naviTitle: .noticeAISummary, displayMode: .inline)
+            .toolbar { sheetToolbar }
+        }
+        .presentationDetents([.medium, .large])
+        .onAppear {
+            if viewModel.readingSummaryPhase == .idle {
+                viewModel.requestReadingSummary(content: noticeContent, modelContext: modelContext)
+            }
+        }
+        .onDisappear {
+            viewModel.dismissReadingSummary()
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        HStack(spacing: Constants.headerSpacing) {
+            Image(systemName: Constants.sparklesIconName)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.indigo500)
+
+            Text(Constants.headerLabel)
+                .appFont(.calloutEmphasis)
+                .foregroundStyle(.grey700)
+        }
+    }
+
+    // MARK: - Summary Content
+
+    @ViewBuilder
+    private var summarySection: some View {
+        switch viewModel.readingSummaryPhase {
+        case .idle:
+            EmptyView()
+
+        case .streaming:
+            streamingContent
+
+        case .completed:
+            completedContent
+
+        case .failed(let message):
+            failedContent(message: message)
+        }
+    }
+
+    private var streamingContent: some View {
+        VStack(alignment: .leading, spacing: Constants.bodySpacing) {
+            if viewModel.readingSummaryStreamingText.isEmpty {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    ProgressView()
+                        .tint(.grey500)
+                    Text(Constants.streamingPlaceholder)
+                        .appFont(.body, color: .grey500)
+                }
+            } else {
+                Text(viewModel.readingSummaryStreamingText)
+                    .appFont(.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(Constants.cardPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassEffect(.regular, in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius)))
+    }
+
+    private var completedContent: some View {
+        Text(viewModel.readingSummaryStreamingText)
+            .appFont(.body)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Constants.cardPadding)
+            .glassEffect(.regular, in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius)))
+    }
+
+    private func failedContent(message: String) -> some View {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            Image(systemName: Constants.failedIconName)
+                .font(.system(size: Constants.iconSize, weight: .medium))
+                .foregroundStyle(.grey400)
+
+            Text(message)
+                .appFont(.footnote, color: .grey500)
+                .multilineTextAlignment(.center)
+
+            MainButton(Constants.retryButtonTitle) {
+                viewModel.requestReadingSummary(content: noticeContent, modelContext: modelContext)
+            }
+            .buttonStyle(.glassProminent)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(Constants.cardPadding)
+        .glassEffect(.regular, in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius)))
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var sheetToolbar: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Button(Constants.dismissButtonTitle) {
+                dismiss()
+            }
+            .appFont(.body, color: .grey700)
+        }
+    }
+}

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/NoticeEditorAttachmentToolbar.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/AttachmentToolbar/NoticeEditorAttachmentToolbar.swift
@@ -30,6 +30,8 @@ struct NoticeEditorAttachmentToolbar: View {
     private enum Constants {
         static let height: CGFloat = 44
         static let itemSpacing: CGFloat = 12
+        static let aiIconSize: CGFloat = 20
+        static let aiIconFrame: CGSize = .init(width: 30, height: 30)
     }
 
     // MARK: - Body
@@ -48,6 +50,37 @@ struct NoticeEditorAttachmentToolbar: View {
 
     // MARK: - Components
 
+    private var isBothAIDisabled: Bool {
+        isAIButtonDisabled && isAISummaryButtonDisabled
+    }
+
+    private var aiMenu: some View {
+        Menu {
+            Button {
+                onTapAI()
+            } label: {
+                Label("본문 다듬기", systemImage: "sparkles")
+            }
+            .disabled(isAIButtonDisabled)
+
+            Button {
+                onTapAISummary()
+            } label: {
+                Label("붙여넣고 요약", systemImage: "wand.and.stars")
+            }
+            .disabled(isAISummaryButtonDisabled)
+        } label: {
+            Image(systemName: "sparkles")
+                .font(.system(size: Constants.aiIconSize))
+                .foregroundStyle(isBothAIDisabled ? Color.black.opacity(0.4) : Color.black)
+                .frame(
+                    width: Constants.aiIconFrame.width,
+                    height: Constants.aiIconFrame.height
+                )
+                .padding(DefaultConstant.defaultBtnPadding)
+        }
+    }
+
     private var scrollableItems: some View {
         HStack(spacing: Constants.itemSpacing) {
             ToolbarIconButton(
@@ -65,13 +98,7 @@ struct NoticeEditorAttachmentToolbar: View {
             )
 
             ToolbarIconButton(icon: "link", action: onAddLink)
-            ToolbarIconButton(icon: "sparkles", action: onTapAI)
-                .disabled(isAIButtonDisabled)
-                .opacity(isAIButtonDisabled ? 0.4 : 1)
-
-            ToolbarIconButton(icon: "wand.and.stars", action: onTapAISummary)
-                .disabled(isAISummaryButtonDisabled)
-                .opacity(isAISummaryButtonDisabled ? 0.4 : 1)
+            aiMenu
 
             ToolbarTextFormatButton(
                 title: "B",

--- a/AppProduct/AppProduct/Utilities/Modifier/NavigationModifier.swift
+++ b/AppProduct/AppProduct/Utilities/Modifier/NavigationModifier.swift
@@ -42,6 +42,7 @@ struct NavigationModifier: ViewModifier {
         case partSelection = "파트 선택"
         case noticeDetail = "공지사항"
         case noticeReadStatus = "공지 열람 현황"
+        case noticeAISummary = "AI 요약"
         case detailSchedule = "일정 상세"
         case studyScheduleRegistration = "스터디 일정 등록"
         case communityPostEdit = "게시글 수정"


### PR DESCRIPTION
## ✨ PR 유형
- 온디바이스 AI UX 개선 (리팩터 + 신규 기능)

## 🛠️ 작업내용
AI 진입을 "인라인 → 툴바/메뉴"로 통일하고, 공지 **읽기용** 요약을 신규 추가했습니다.

**① 일정 생성 AI — UI 개선**
- 폼 최상단에 박혀 화면을 해치던 인라인 `AIAutofillSection` **제거**
- 우측 상단 툴바 ✨ 버튼 → `.medium` 시트(자연어 입력 + "AI로 정리"). 성공 시 시트 자동 닫힘 → 채워진 폼 확인
- AI 로직(`requestAIAutofill`/`applyDraft`) 미변경, 제목 필드 반영 유지

**③ 공지 작성 AI — 버튼 통합**
- 하단 툴바의 AI 버튼 2개(`sparkles` 본문 다듬기 + `wand.and.stars` 붙여넣고 요약) → **단일 ✨ 메뉴** [본문 다듬기] / [붙여넣고 요약]
- 두 기능 로직·props 시그니처 그대로, 진입점만 하나로 (헷갈림 해소)

**④ 공지 읽기용 AI 요약 — 신규**
- 공지 상세 우측 상단 ✨ 툴바 버튼 → 본문을 온디바이스로 요약해 시트에 **스트리밍** 표시
- 신규 `NoticeDetailViewModel+AI.swift`, `NoticeReadingSummarySheet.swift` (기존 `streamResponse`·토큰 기록 패턴 재사용)
- 모든 독자에게 노출(권한 무관), AI availability 게이팅

### 변경 파일
- 수정: `ScheduleRegistrationView`, `NoticeEditorAttachmentToolbar`, `NoticeDetailView`(+`NoticeDetailViewModel`), `NavigationModifier`(navititle case 추가)
- 신규: `NoticeDetailViewModel+AI`, `NoticeReadingSummarySheet`

## 📋 추후 진행 상황
- 실기기(Apple Intelligence) 동작 검증: 일정 한국어 날짜 파싱, 읽기 요약 품질
- 일정 시트 배경 `Color(.systemGray6)` → 디자인 토큰 교체 검토(soyeon-ui-review)

## 📌 리뷰 포인트
- AI 진입 UI 변경(인라인 제거 / 메뉴 통합)으로 기존 동작 **회귀 없는지**
- 공지 읽기 요약 스트리밍·토큰 기록, 권한 무관 노출 적절성
- iPhone 17 Pro / iOS 26.5 시뮬레이터 빌드 통과(에러 0 · 경고 0)

관련 Epic #840

## ✅ Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
