### PR TITLE
✨ [Feature] Firebase RemoteConfig 기반 원격 점검(킬스위치) 모드 — 구버전 앱 진입 차단 (#839)

### DIFF
--- a/AppProduct/AppProduct.xcodeproj/project.pbxproj
+++ b/AppProduct/AppProduct.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0EEC14D52F0B92FA00345AD8 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0EEC14D42F0B92FA00345AD8 /* Kingfisher */; };
 		1F3173D62F127A5000601344 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 1F3173D52F127A5000601344 /* FirebaseCore */; };
 		1F3173D82F127A5000601344 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 1F3173D72F127A5000601344 /* FirebaseMessaging */; };
+		1F3173E22F127A5000601344 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 1F3173E12F127A5000601344 /* FirebaseRemoteConfig */; };
 		1F9189A52FCC480E008F6668 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 1F9189A42FCC480E008F6668 /* GoogleSignIn */; };
 		1F9189A72FCC480E008F6668 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1F9189A62FCC480E008F6668 /* GoogleSignInSwift */; };
 		1F953CD92F31D2BB0067FE73 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 1F953CD82F31D2BB0067FE73 /* AppIcon.icon */; };
@@ -88,6 +89,7 @@
 				0EEC14C52F0B92CD00345AD8 /* CombineMoya in Frameworks */,
 				0EEC14CE2F0B92EF00345AD8 /* KakaoSDKCert in Frameworks */,
 				1F3173D82F127A5000601344 /* FirebaseMessaging in Frameworks */,
+				1F3173E22F127A5000601344 /* FirebaseRemoteConfig in Frameworks */,
 				0EEC14CC2F0B92EF00345AD8 /* KakaoSDKAuth in Frameworks */,
 			);
 		};
@@ -149,6 +151,7 @@
 				0EEC14D42F0B92FA00345AD8 /* Kingfisher */,
 				1F3173D52F127A5000601344 /* FirebaseCore */,
 				1F3173D72F127A5000601344 /* FirebaseMessaging */,
+				1F3173E12F127A5000601344 /* FirebaseRemoteConfig */,
 				1F9189A42FCC480E008F6668 /* GoogleSignIn */,
 				1F9189A62FCC480E008F6668 /* GoogleSignInSwift */,
 			);
@@ -683,6 +686,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1F3173D42F127A5000601344 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
+		};
+		1F3173E12F127A5000601344 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1F3173D42F127A5000601344 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
 		};
 		1F9189A42FCC480E008F6668 /* GoogleSignIn */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/AppProduct/AppProduct/App/AppProductApp.swift
+++ b/AppProduct/AppProduct/App/AppProductApp.swift
@@ -23,10 +23,13 @@ struct AppProductApp: App {
     // MARK: - Property
 
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    @Environment(\.scenePhase) private var scenePhase
     @State private var container: DIContainer
     @State private var didConfigureAppDelegate: Bool = false
     @State private var errorHandler: ErrorHandler = .init()
     @State private var appState: AppState = .bootstrap
+    /// 원격 점검(킬스위치) 상태를 관리하는 앱 전역 ViewModel
+    @State private var maintenanceViewModel: MaintenanceViewModel
     private let sharedModelContainer: ModelContainer
 
     // MARK: - AppState
@@ -53,9 +56,17 @@ struct AppProductApp: App {
     init() {
         sharedModelContainer = Self.makeModelContainer()
         KakaoSDK.initSDK(appKey: Config.kakaoAppKey)
-        _container = State(
-            initialValue: DIContainer.configured(
-                modelContext: sharedModelContainer.mainContext
+        let container = DIContainer.configured(
+            modelContext: sharedModelContainer.mainContext
+        )
+        _container = State(initialValue: container)
+        // RemoteConfig 접근은 lazy 이므로 여기서 ViewModel 을 만들어도
+        // FirebaseApp.configure() 이전에 RemoteConfig 가 생성되지 않는다.
+        _maintenanceViewModel = State(
+            initialValue: MaintenanceViewModel(
+                checkMaintenanceUseCase: container.resolve(
+                    CheckMaintenanceUseCaseProtocol.self
+                )
             )
         )
         try? Tips.configure()
@@ -72,6 +83,18 @@ struct AppProductApp: App {
                 .environment(\.appFlow, appFlow)
                 .modelContainer(sharedModelContainer)
                 .alertPrompt(item: errorAlertBinding)
+                .fullScreenCover(isPresented: maintenanceBinding) {
+                    if let info = maintenanceViewModel.maintenanceInfo {
+                        MaintenanceView(info: info)
+                    }
+                }
+                .task {
+                    await maintenanceViewModel.check()
+                }
+                .onChange(of: scenePhase) { _, newPhase in
+                    guard newPhase == .active else { return }
+                    Task { await maintenanceViewModel.check() }
+                }
                 .onAppear(perform: configureAppDelegateIfNeeded)
                 .onReceive(
                     NotificationCenter.default.publisher(for: .authSessionExpired)
@@ -185,6 +208,17 @@ extension AppProductApp {
                     errorHandler.clearError()
                 }
             }
+        )
+    }
+
+    /// 점검 상태를 fullScreenCover 표시 바인딩으로 변환합니다.
+    ///
+    /// 사용자가 직접 닫을 수 없도록 setter 는 무시합니다. 점검 해제는
+    /// 포그라운드 재확인 시 `maintenanceInfo` 가 `nil` 로 갱신되며 자동 dismiss 됩니다.
+    private var maintenanceBinding: Binding<Bool> {
+        Binding(
+            get: { maintenanceViewModel.isUnderMaintenance },
+            set: { _ in }
         )
     }
 

--- a/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
+++ b/AppProduct/AppProduct/Core/DIContainer/DIContainer.swift
@@ -379,6 +379,16 @@ extension DIContainer {
             )
         }
 
+        // MARK: - Maintenance (Remote Kill Switch)
+        container.register(RemoteConfigServiceProtocol.self) {
+            DefaultRemoteConfigService()
+        }
+        container.register(CheckMaintenanceUseCaseProtocol.self) {
+            CheckMaintenanceUseCase(
+                service: container.resolve(RemoteConfigServiceProtocol.self)
+            )
+        }
+
         return container
     }
 

--- a/AppProduct/AppProduct/Features/Maintenance/Data/RemoteConfigService.swift
+++ b/AppProduct/AppProduct/Features/Maintenance/Data/RemoteConfigService.swift
@@ -1,0 +1,133 @@
+//
+//  RemoteConfigService.swift
+//  AppProduct
+//
+//  Firebase RemoteConfig 를 래핑하여 원격 점검 상태를 제공하는 서비스.
+//
+
+import Foundation
+import FirebaseRemoteConfig
+
+/// 원격 점검 상태를 가져오는 서비스.
+protocol RemoteConfigServiceProtocol {
+
+    /// 원격 구성을 갱신한 뒤 현재 점검 상태를 반환합니다.
+    ///
+    /// 갱신 실패·네트워크 없음·타임아웃이어도 예외를 던지지 않고,
+    /// 마지막으로 활성화된 값(없으면 인앱 기본값 `enabled=false`)을 기준으로 판단합니다.
+    /// 따라서 점검 중이 아니면 `nil` 을 반환해 진입을 허용합니다(fail-open).
+    func fetchMaintenanceStatus() async -> MaintenanceInfo?
+}
+
+/// Firebase RemoteConfig 기반 구현.
+///
+/// - Important: `RemoteConfig.remoteConfig()` 는 `FirebaseApp.configure()` 이후에만
+///   유효하므로, 실제 인스턴스 생성을 `remoteConfig` lazy 프로퍼티로 지연시켜
+///   최초 fetch 시점(앱 부팅 이후)에 생성합니다.
+final class DefaultRemoteConfigService: RemoteConfigServiceProtocol {
+
+    // MARK: - Key
+
+    /// Firebase 콘솔의 RemoteConfig 파라미터 키와 글자까지 일치해야 합니다.
+    private enum Key {
+        static let enabled = "maintenance_enabled"
+        static let title = "maintenance_title"
+        static let message = "maintenance_message"
+    }
+
+    // MARK: - Default Value
+
+    /// 콘솔 값을 읽지 못했을 때 사용하는 인앱 기본값.
+    private enum DefaultValue {
+        static let title = "서비스 점검 안내"
+        static let message = "보다 나은 서비스 제공을 위해 점검 중입니다.\n잠시 후 다시 이용해 주세요."
+    }
+
+    // MARK: - Property
+
+    /// fetch 네트워크 최대 대기 시간(초). 초과 시 진입을 차단하지 않습니다.
+    private let fetchTimeout: TimeInterval
+
+    /// 최초 접근 시 Firebase 구성 이후에 생성됩니다.
+    private lazy var remoteConfig: RemoteConfig = makeRemoteConfig()
+
+    // MARK: - Init
+
+    init(fetchTimeout: TimeInterval = 4) {
+        self.fetchTimeout = fetchTimeout
+    }
+
+    // MARK: - RemoteConfigServiceProtocol
+
+    func fetchMaintenanceStatus() async -> MaintenanceInfo? {
+        await refreshIfPossible()
+        return currentMaintenanceInfo()
+    }
+
+    // MARK: - Private Function
+
+    private func makeRemoteConfig() -> RemoteConfig {
+        let config = RemoteConfig.remoteConfig()
+
+        let settings = RemoteConfigSettings()
+        #if DEBUG
+        // 디버그에서는 캐시 없이 즉시 최신 값을 받아 점검 토글을 빠르게 검증한다.
+        settings.minimumFetchInterval = 0
+        #else
+        // 킬스위치 반응성과 Firebase 쓰로틀링의 균형 (10분).
+        settings.minimumFetchInterval = 600
+        #endif
+        settings.fetchTimeout = fetchTimeout
+        config.configSettings = settings
+
+        config.setDefaults([
+            Key.enabled: NSNumber(value: false),
+            Key.title: DefaultValue.title as NSString,
+            Key.message: DefaultValue.message as NSString
+        ])
+        return config
+    }
+
+    /// 원격 값을 best-effort 로 갱신합니다. 실패는 무시합니다(fail-open).
+    ///
+    /// 네트워크 대기 시간은 `configSettings.fetchTimeout` 으로 제한됩니다.
+    private func refreshIfPossible() async {
+        _ = try? await remoteConfig.fetchAndActivate()
+    }
+
+    /// 현재 활성화된 원격 값으로 점검 상태를 해석합니다.
+    ///
+    /// 점검 플래그가 꺼져 있으면 `nil` 을 반환합니다.
+    private func currentMaintenanceInfo() -> MaintenanceInfo? {
+        guard remoteConfig[Key.enabled].boolValue else { return nil }
+
+        let title = remoteConfig[Key.title].stringValue
+        let message = remoteConfig[Key.message].stringValue
+
+        return MaintenanceInfo(
+            isActive: true,
+            title: title.isEmpty ? DefaultValue.title : title,
+            message: message.isEmpty ? DefaultValue.message : message
+        )
+    }
+}
+
+#if DEBUG
+
+/// 프리뷰/로컬 디버깅용 Mock 서비스.
+///
+/// 네트워크 없이 점검 화면을 독립적으로 띄워볼 때 사용합니다.
+final class MockRemoteConfigService: RemoteConfigServiceProtocol {
+
+    var stubbedInfo: MaintenanceInfo?
+
+    init(stubbedInfo: MaintenanceInfo? = nil) {
+        self.stubbedInfo = stubbedInfo
+    }
+
+    func fetchMaintenanceStatus() async -> MaintenanceInfo? {
+        stubbedInfo
+    }
+}
+
+#endif

--- a/AppProduct/AppProduct/Features/Maintenance/Domain/CheckMaintenanceUseCase.swift
+++ b/AppProduct/AppProduct/Features/Maintenance/Domain/CheckMaintenanceUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  CheckMaintenanceUseCase.swift
+//  AppProduct
+//
+//  원격 점검 상태를 조회하는 UseCase.
+//
+
+import Foundation
+
+/// 원격 점검 상태 조회 UseCase.
+protocol CheckMaintenanceUseCaseProtocol {
+
+    /// 현재 점검 상태를 조회합니다.
+    ///
+    /// - Returns: 점검 중이면 `MaintenanceInfo`, 점검 중이 아니거나
+    ///   상태 확인에 실패하면 `nil` (fail-open).
+    func execute() async -> MaintenanceInfo?
+}
+
+/// `RemoteConfigService` 에 조회를 위임하는 기본 구현.
+final class CheckMaintenanceUseCase: CheckMaintenanceUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let service: RemoteConfigServiceProtocol
+
+    // MARK: - Init
+
+    init(service: RemoteConfigServiceProtocol) {
+        self.service = service
+    }
+
+    // MARK: - Function
+
+    func execute() async -> MaintenanceInfo? {
+        await service.fetchMaintenanceStatus()
+    }
+}

--- a/AppProduct/AppProduct/Features/Maintenance/Domain/MaintenanceInfo.swift
+++ b/AppProduct/AppProduct/Features/Maintenance/Domain/MaintenanceInfo.swift
@@ -1,0 +1,30 @@
+//
+//  MaintenanceInfo.swift
+//  AppProduct
+//
+//  원격 점검(킬스위치) 상태를 표현하는 도메인 모델.
+//
+
+import Foundation
+
+/// 원격 점검 상태.
+///
+/// `RemoteConfig` 의 점검 플래그/문구를 앱 레이어에서 사용하기 위한 모델입니다.
+/// `isActive` 가 `true` 일 때만 점검 화면으로 진입을 차단합니다.
+struct MaintenanceInfo: Equatable {
+
+    /// 점검 모드 활성화 여부.
+    let isActive: Bool
+
+    /// 점검 안내 제목.
+    let title: String
+
+    /// 점검 안내 본문.
+    let message: String
+
+    init(isActive: Bool, title: String, message: String) {
+        self.isActive = isActive
+        self.title = title
+        self.message = message
+    }
+}

--- a/AppProduct/AppProduct/Features/Maintenance/Presentation/ViewModels/MaintenanceViewModel.swift
+++ b/AppProduct/AppProduct/Features/Maintenance/Presentation/ViewModels/MaintenanceViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  MaintenanceViewModel.swift
+//  AppProduct
+//
+//  원격 점검 상태를 보유하고, 앱 진입/포그라운드 시 갱신하는 ViewModel.
+//
+
+import Foundation
+
+/// 원격 점검(킬스위치) 상태를 관리하는 ViewModel.
+///
+/// 앱 루트에서 소유하며, `maintenanceInfo` 가 채워지면 전체화면 점검 안내로
+/// 진입을 차단합니다. 서버가 점검을 해제하면 재확인 시 자동으로 차단이 풀립니다.
+@MainActor
+@Observable
+final class MaintenanceViewModel {
+
+    // MARK: - Property
+
+    /// 현재 점검 정보. `nil` 이면 정상(차단 안 함).
+    private(set) var maintenanceInfo: MaintenanceInfo?
+
+    /// 점검으로 진입을 차단해야 하는지 여부.
+    var isUnderMaintenance: Bool {
+        maintenanceInfo?.isActive == true
+    }
+
+    private let checkMaintenanceUseCase: CheckMaintenanceUseCaseProtocol
+
+    /// 중복 호출 가드 (앱 시작 `.task` 와 포그라운드 복귀가 겹칠 때).
+    private var isChecking = false
+
+    // MARK: - Init
+
+    init(checkMaintenanceUseCase: CheckMaintenanceUseCaseProtocol) {
+        self.checkMaintenanceUseCase = checkMaintenanceUseCase
+    }
+
+    // MARK: - Function
+
+    /// 원격 점검 상태를 확인하고 차단 여부를 갱신합니다.
+    ///
+    /// 점검 중이 아니거나 확인에 실패하면 `maintenanceInfo` 를 `nil` 로 두어
+    /// 진입을 허용합니다(fail-open).
+    func check() async {
+        guard !isChecking else { return }
+        isChecking = true
+        defer { isChecking = false }
+
+        maintenanceInfo = await checkMaintenanceUseCase.execute()
+    }
+}

--- a/AppProduct/AppProduct/Features/Maintenance/Presentation/Views/MaintenanceView.swift
+++ b/AppProduct/AppProduct/Features/Maintenance/Presentation/Views/MaintenanceView.swift
@@ -1,0 +1,68 @@
+//
+//  MaintenanceView.swift
+//  AppProduct
+//
+//  원격 점검 중일 때 앱 전체를 덮는 전체화면 안내. 닫을 수 없습니다.
+//
+
+import SwiftUI
+
+/// 점검 중 전체화면 안내.
+///
+/// 닫기 버튼/제스처가 없는 순수 킬스위치 화면입니다. 서버가 점검을 해제하면
+/// 앱 루트의 ViewModel 이 재확인 후 자동으로 dismiss 합니다.
+struct MaintenanceView: View {
+
+    // MARK: - Property
+
+    let info: MaintenanceInfo
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let iconName = "wrench.and.screwdriver.fill"
+        static let iconSize: CGFloat = 56
+        static let maxContentWidth: CGFloat = 360
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack {
+            Color.grey000
+                .ignoresSafeArea()
+
+            VStack(spacing: DefaultSpacing.spacing24) {
+                Image(systemName: Constants.iconName)
+                    .font(.system(size: Constants.iconSize, weight: .semibold))
+                    .foregroundStyle(Color.orange500)
+                    .padding(.bottom, DefaultSpacing.spacing8)
+
+                Text(info.title)
+                    .appFont(.title2Emphasis, color: .grey900)
+                    .multilineTextAlignment(.center)
+
+                Text(info.message)
+                    .appFont(.body, color: .grey600)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: Constants.maxContentWidth)
+            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        }
+        // 스와이프/제스처로 빠져나갈 수 없도록 차단.
+        .interactiveDismissDisabled(true)
+    }
+}
+
+#if DEBUG
+#Preview {
+    MaintenanceView(
+        info: MaintenanceInfo(
+            isActive: true,
+            title: "서비스 점검 안내",
+            message: "보다 나은 서비스 제공을 위해 점검 중입니다.\n잠시 후 다시 이용해 주세요."
+        )
+    )
+}
+#endif

--- a/AppProduct/AppProductTests/MaintenanceTest/MaintenanceViewModelTests.swift
+++ b/AppProduct/AppProductTests/MaintenanceTest/MaintenanceViewModelTests.swift
@@ -1,0 +1,75 @@
+//
+//  MaintenanceViewModelTests.swift
+//  AppProductTests
+//
+//  원격 점검 ViewModel 의 차단/해제/fail-open 동작 검증.
+//
+
+@testable import AppProduct
+import Testing
+
+@MainActor
+struct MaintenanceViewModelTests {
+
+    @Test("점검이 활성화되면 점검 정보가 노출되고 진입이 차단된다")
+    func showsMaintenanceWhenActive() async {
+        let info = MaintenanceInfo(
+            isActive: true,
+            title: "서비스 점검 안내",
+            message: "잠시 후 다시 이용해 주세요."
+        )
+        let viewModel = MaintenanceViewModel(
+            checkMaintenanceUseCase: StubCheckMaintenanceUseCase(result: info)
+        )
+
+        await viewModel.check()
+
+        #expect(viewModel.isUnderMaintenance == true)
+        #expect(viewModel.maintenanceInfo == info)
+    }
+
+    @Test("점검이 비활성이면 차단하지 않는다")
+    func noBlockWhenInactive() async {
+        let viewModel = MaintenanceViewModel(
+            checkMaintenanceUseCase: StubCheckMaintenanceUseCase(result: nil)
+        )
+
+        await viewModel.check()
+
+        #expect(viewModel.isUnderMaintenance == false)
+        #expect(viewModel.maintenanceInfo == nil)
+    }
+
+    @Test("서버가 점검을 해제하면 재확인 시 차단이 풀린다")
+    func clearsWhenServerDisables() async {
+        let stub = StubCheckMaintenanceUseCase(
+            result: MaintenanceInfo(
+                isActive: true,
+                title: "점검",
+                message: "점검 중"
+            )
+        )
+        let viewModel = MaintenanceViewModel(checkMaintenanceUseCase: stub)
+
+        await viewModel.check()
+        #expect(viewModel.isUnderMaintenance == true)
+
+        stub.result = nil
+        await viewModel.check()
+        #expect(viewModel.isUnderMaintenance == false)
+    }
+}
+
+// MARK: - Stub
+
+private final class StubCheckMaintenanceUseCase: CheckMaintenanceUseCaseProtocol {
+    var result: MaintenanceInfo?
+
+    init(result: MaintenanceInfo?) {
+        self.result = result
+    }
+
+    func execute() async -> MaintenanceInfo? {
+        result
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형
- 새로운 기능 (Firebase RemoteConfig 기반 원격 점검 / 킬스위치)

## 🛠️ 작업내용
- Firebase RemoteConfig 기반 **원격 점검(킬스위치) 모드** 추가 — 점검 중이거나 강제 업데이트 대상(구버전)일 때 앱 진입 차단
- Clean Architecture 구성:
  - `Data/RemoteConfigService` — RemoteConfig fetch/접근 (FirebaseApp.configure 이후 lazy 접근)
  - `Domain/CheckMaintenanceUseCase` + `MaintenanceInfo`
  - `Presentation/MaintenanceViewModel` + `MaintenanceView`
- `AppProductApp`에 앱 전역 `@State MaintenanceViewModel` + `.fullScreenCover`로 점검 화면 표시(사용자가 닫을 수 없음), 진입/foreground 시 `check()`
- `DIContainer`에 UseCase 등록
- 유닛 테스트 `MaintenanceViewModelTests` 추가

### 변경 파일
- 신규: `Features/Maintenance/{Data,Domain,Presentation}`, `AppProductTests/MaintenanceTest`
- 수정: `App/AppProductApp.swift`, `Core/DIContainer/DIContainer.swift`, `project.pbxproj`

## 📋 추후 진행 상황
- RemoteConfig 키/조건을 Firebase 콘솔에서 운영 설정 확인

## 📌 리뷰 포인트
- 점검 화면 강제 표시(닫기 불가) 바인딩 로직
- RemoteConfig fetch 타이밍 (FirebaseApp.configure 이후 lazy 접근)
- 진입/foreground 재진입 시 `check()` 호출

Closes #839

## ✅ Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
