### PR TITLE
💄 [Design] AI 시트 UI 개선 — 공지 요약 마크다운 렌더링 · 일정 AI 자동완성 시트 레이아웃

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleRegistrationView.swift
@@ -757,22 +757,27 @@ fileprivate struct AIAutofillSheet: View {
         static let buttonLabel = "AI로 정리"
         static let sheetTitle = "AI 자동완성"
         static let sheetDescription = "일정 내용을 자연어로 입력하면 AI가 폼을 자동으로 채웁니다."
+        static let headerLabel = "Apple Intelligence"
     }
 
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+                headerSection
+
                 Text(Constants.sheetDescription)
                     .appFont(.subheadline, color: .grey600)
                     .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
-                    .padding(.top, DefaultSpacing.spacing8)
 
                 inputArea
+
+                autofillButton
 
                 statusArea
 
                 Spacer()
             }
+            .padding(.top, DefaultSpacing.spacing16)
             .navigationTitle(Constants.sheetTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -799,47 +804,60 @@ fileprivate struct AIAutofillSheet: View {
 
     // MARK: - Private
 
-    private var inputArea: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
-            HStack(spacing: DefaultSpacing.spacing8) {
-                TextField(
-                    "",
-                    text: $viewModel.aiRawInput,
-                    prompt: Text(Constants.placeholder)
-                        .foregroundStyle(Color.grey400)
-                )
-                .appFont(.body, color: .black)
-                .submitLabel(.done)
-                .onSubmit {
-                    Task { @MainActor in
-                        await viewModel.requestAIAutofill()
-                    }
-                }
+    private var headerSection: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.indigo500)
 
-                autofillButton
-            }
-            .padding(DefaultSpacing.spacing12)
-            .background(Color(.systemGray6))
-            .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius))
+            Text(Constants.headerLabel)
+                .appFont(.calloutEmphasis)
+                .foregroundStyle(.grey700)
         }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    private var inputArea: some View {
+        TextField(
+            "",
+            text: $viewModel.aiRawInput,
+            prompt: Text(Constants.placeholder)
+                .foregroundStyle(Color.grey400),
+            axis: .vertical
+        )
+        .appFont(.body, color: .black)
+        .lineLimit(3...6)
+        .padding(DefaultSpacing.spacing12)
+        .background(Color.grey100)
+        .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius))
         .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
     }
 
     @ViewBuilder
     private var autofillButton: some View {
-        if case .loading = viewModel.aiAutofillState {
-            ProgressView()
-                .controlSize(.small)
-                .tint(.indigo500)
-        } else {
-            Button(Constants.buttonLabel) {
-                Task { @MainActor in
-                    await viewModel.requestAIAutofill()
+        Group {
+            if case .loading = viewModel.aiAutofillState {
+                ProgressView()
+                    .controlSize(.regular)
+                    .tint(.indigo500)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, DefaultSpacing.spacing8)
+            } else {
+                Button {
+                    Task { @MainActor in
+                        await viewModel.requestAIAutofill()
+                    }
+                } label: {
+                    Text(Constants.buttonLabel)
+                        .frame(maxWidth: .infinity)
                 }
+                .buttonStyle(.glassProminent)
+                .tint(.indigo500)
+                .controlSize(.large)
+                .disabled(viewModel.aiRawInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
-            .appFont(.footnoteEmphasis, color: .indigo500)
-            .disabled(viewModel.aiRawInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
     }
 
     @ViewBuilder

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeReadingSummarySheet.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeReadingSummarySheet.swift
@@ -123,8 +123,7 @@ struct NoticeReadingSummarySheet: View {
     }
 
     private var completedContent: some View {
-        Text(viewModel.readingSummaryStreamingText)
-            .appFont(.body)
+        MarkdownRenderedView(markdown: viewModel.readingSummaryStreamingText)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(Constants.cardPadding)
             .glassEffect(.regular, in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius)))


### PR DESCRIPTION
## ✨ PR 유형
- AI UI/UX 개선 (실기기 테스트 피드백 반영)

## 🛠️ 작업내용

**④ 공지 읽기 AI 요약 — 마크다운 렌더링**
- 요약 결과가 `**굵게**`·`*` 불릿 같은 **마크다운 기호로 날것 노출**되던 문제 수정
- 완료 시 `MarkdownRenderedView`(기존 공지 본문 렌더러)로 렌더링 → 굵게/불릿 정상 표시 (스트리밍 중엔 평문 유지 후 완료 시 렌더)

**① 일정 생성 AI 자동완성 시트 — 레이아웃 개선**
- 인라인 버튼 때문에 placeholder가 잘리던 문제 → 입력칸을 **멀티라인**(axis .vertical)으로, "AI로 정리"를 **하단 풀폭 버튼**(`.glassProminent`)으로 분리
- ✨ **Apple Intelligence 헤더** 추가로 공지 요약 시트와 톤 통일
- 입력 배경 `Color(.systemGray6)` → 디자인 토큰 **`Color.grey100`**

### 변경 파일
- `Features/Notice/.../NoticeDetail/NoticeReadingSummarySheet.swift`
- `Features/Home/.../Registration/ScheduleRegistrationView.swift`

## 📌 리뷰 포인트
- 마크다운 렌더러 재사용 (스트리밍 → 완료 전환 시 렌더)
- 멀티라인 입력 + `glassProminent` 풀폭 버튼 레이아웃

관련 Epic #840 · #850(원 구현) 후속 개선

## ✅ Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
