### PR TITLE
💄 [Design] 공지 AI 요약 시트 기본 .large + 렌더 뷰 fixedSize — 요약 글 잘림 방지

### DIFF
--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeReadingSummarySheet.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeDetail/NoticeReadingSummarySheet.swift
@@ -20,6 +20,9 @@ struct NoticeReadingSummarySheet: View {
     @Bindable var viewModel: NoticeDetailViewModel
     let noticeContent: String
 
+    /// 시트 높이. 요약 글이 잘리지 않도록 기본을 `.large` 로 연다.
+    @State private var selectedDetent: PresentationDetent = .large
+
     // MARK: - Constants
 
     fileprivate enum Constants {
@@ -58,7 +61,7 @@ struct NoticeReadingSummarySheet: View {
             .navigation(naviTitle: .noticeAISummary, displayMode: .inline)
             .toolbar { sheetToolbar }
         }
-        .presentationDetents([.medium, .large])
+        .presentationDetents([.medium, .large], selection: $selectedDetent)
         .onAppear {
             if viewModel.readingSummaryPhase == .idle {
                 viewModel.requestReadingSummary(content: noticeContent, modelContext: modelContext)
@@ -124,6 +127,7 @@ struct NoticeReadingSummarySheet: View {
 
     private var completedContent: some View {
         MarkdownRenderedView(markdown: viewModel.readingSummaryStreamingText)
+            .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(Constants.cardPadding)
             .glassEffect(.regular, in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius)))


### PR DESCRIPTION
## 🛠️ 작업내용
- 공지 상세 **AI 요약 시트**에서 요약 카드가 작아 글이 잘리던 문제 수정
- 시트 기본 높이를 **`.large`** 로 열도록(`presentationDetents(selection:)`) → 요약 공간 확대 (medium으로 끌어내리기도 가능)
- 마크다운 렌더 뷰에 **`.fixedSize(vertical:)`** → 카드가 텍스트 전체 높이를 차지해 잘림 방지

#852 후속 개선 · 관련 Epic #840

## ✅ Checklist
- [x] 커밋 메시지 컨벤션
- [x] iPhone 17 Pro / iOS 26.5 빌드 통과(에러 0)