### PR TITLE
🧹 일괄 수정 — 소셜 연동 라벨(#846) · 스터디 푸터 제거(#848) · 댓글 로딩 정렬(#849)

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/SocialType.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/SocialType.swift
@@ -97,6 +97,22 @@ enum SocialType: String, CaseIterable, Hashable {
         }
     }
 
+    /// 마이페이지 연동 섹션 등에서 사용하는 표시용 서비스 이름입니다.
+    ///
+    /// `rawValue` 는 로그인 버튼 문구("카카오로 계속하기")라 표시용으로 부적합합니다.
+    var displayName: String {
+        switch self {
+        case .kakao:
+            return "카카오"
+        case .apple:
+            return "Apple"
+        case .google:
+            return "Google"
+        case .email:
+            return "이메일"
+        }
+    }
+
     /// 서버 provider 문자열("KAKAO", "APPLE" 등)로 변환합니다.
     init?(provider: String) {
         switch provider.uppercased() {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/OperatorStudyManagementView.swift
@@ -67,7 +67,6 @@ struct OperatorStudyManagementView: View {
         static let roleChapterLeaderDescription: String = "지부 내 전체 학교의 스터디를 관리할 수 있어요"
         static let rolePresidentDescription: String = "소속 학교의 스터디 그룹을 생성·관리할 수 있어요"
         static let roleOperatorDescription: String = "담당 파트의 스터디를 조회할 수 있어요"
-        static let permissionGuideFooter: String = "권한이 필요하다면 지부장 또는 회장에게 역할 부여를 요청하세요"
     }
 
     // MARK: - Body
@@ -301,11 +300,6 @@ struct OperatorStudyManagementView: View {
                 }
                 .padding(DefaultSpacing.spacing16)
                 .background(.regularMaterial, in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius))
-
-                Text(Constants.permissionGuideFooter)
-                    .appFont(.footnote)
-                    .foregroundStyle(.grey500)
-                    .multilineTextAlignment(.center)
             }
             .padding(.top, DefaultSpacing.spacing32)
         }

--- a/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityDetailView.swift
+++ b/AppProduct/AppProduct/Features/Community/Presentation/Views/CommunityDetailView.swift
@@ -444,6 +444,7 @@ struct CommunityDetailView: View {
     /// 댓글 로딩 중 상태를 나타내는 인디케이터입니다.
     private var commentLoadingIndicator: some View {
         Progress(message: Constant.commentLoadingMessage, size: .regular)
+            .frame(maxWidth: .infinity, alignment: .center)
     }
 
     /// 댓글 전송 버튼이 포함된 입력창 하단 액션 행입니다.

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/ConnectionSocial.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/ConnectionSocial.swift
@@ -61,7 +61,7 @@ struct ConnectionSocial: View {
             onDisconnect(connection)
         } label: {
             HStack(spacing: DefaultSpacing.spacing4) {
-                Text(social.rawValue)
+                Text(social.displayName)
                 Image(systemName: disconnectingSocialType == social ? "hourglass" : "minus.circle.fill")
                     .font(.caption)
             }

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/SocialSection.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MypageSection/SocialSection.swift
@@ -51,7 +51,7 @@ struct SocialSection: View {
         Button(action: {
             onConnect(social)
         }, label: {
-            MyPageSectionRow(icon: social.imageResource, title: social.rawValue, rightText: "연동하기")
+            MyPageSectionRow(icon: social.imageResource, title: social.displayName, rightText: "연동하기")
         })
     }
 }


### PR DESCRIPTION
작은 UI/chore/bug 3건을 일괄 처리했습니다. (이슈별 커밋 분리)

## 🎨 #846 소셜 연동 섹션 라벨
- `SocialType.displayName`(카카오/Apple/Google/이메일) 추가
- 연동 섹션(`SocialSection`)·연동 태그(`ConnectionSocial`) 라벨을 `rawValue`("카카오로 계속하기") → `displayName` 으로 교체
- `rawValue`(로그인 버튼 문구)·UserDefaults 저장/복원 로직 불변

## 🧹 #848 스터디 관리 권한 안내 푸터 제거
- `OperatorStudyManagementView` 권한 안내 푸터 `Text` + 미사용 상수 `permissionGuideFooter` 제거
- (출석 섹션의 유사 문구는 범위 외 — 미변경)

## 🐛 #849 댓글 로딩 인디케이터 중앙 정렬
- `commentLoadingIndicator` 에 `.frame(maxWidth: .infinity, alignment: .center)` 적용 (로딩/완료/실패 정렬 일관)

iPhone 17 Pro / iOS 26.5 빌드 통과(에러 0).

Closes #846
Closes #848
Closes #849