### PR TITLE
♻️ [Refactor] NoticePresentation 이식 (NoticeDetailViewModel, Stubs)

### DIFF
--- a/UMCApp/Core/DesignSystem/Sources/Utilities/DefaultBackgroundModifier.swift
+++ b/UMCApp/Core/DesignSystem/Sources/Utilities/DefaultBackgroundModifier.swift
@@ -1,0 +1,20 @@
+//
+//  DefaultBackgroundModifier.swift
+//  CoreDesignSystem
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+
+public struct DefaultBackgroundModifier: ViewModifier {
+    public func body(content: Content) -> some View {
+        content.background(Color.grey100.opacity(0.55))
+    }
+}
+
+extension View {
+    public func umcDefaultBackground() -> some View {
+        modifier(DefaultBackgroundModifier())
+    }
+}

--- a/UMCApp/Core/DesignSystem/Sources/Utilities/ShadowReuse.swift
+++ b/UMCApp/Core/DesignSystem/Sources/Utilities/ShadowReuse.swift
@@ -1,0 +1,49 @@
+//
+//  ShadowReuse.swift
+//  CoreDesignSystem
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation
+import SwiftUI
+
+/// shadow1 modifier
+public struct Shadow1: ViewModifier {
+    public func body(content: Content) -> some View {
+        content
+            .shadow(color: .grey900.opacity(0.03), radius: 4, x: 0, y: 8)
+            .shadow(color: .grey900.opacity(0.03), radius: 2, x: 1, y: 3)
+            .shadow(color: .grey900.opacity(0.03), radius: 3, x: 0, y: 2)
+    }
+}
+
+/// glass modifier
+public struct Glass: ViewModifier {
+    public func body(content: Content) -> some View {
+        content
+            .shadow(color: .black.opacity(0.03), radius: 4, x: 0, y: 8)
+            .shadow(color: .black.opacity(0.03), radius: 2, x: 1, y: 3)
+    }
+}
+
+public struct BlurShadow: ViewModifier {
+    public func body(content: Content) -> some View {
+        content
+            .shadow(color: Color(red: 0.56, green: 0.56, blue: 0.58).opacity(0.05), radius: 4, x: 0, y: -14)
+    }
+}
+
+extension View {
+    public func shadow1() -> some View {
+        self.modifier(Shadow1())
+    }
+    
+    public func glass() -> some View {
+        self.modifier(Glass())
+    }
+    
+    public func blurShadow() -> some View {
+        self.modifier(BlurShadow())
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Extensions/DateFormatter.swift
+++ b/UMCApp/Core/Foundation/Sources/Extensions/DateFormatter.swift
@@ -1,0 +1,96 @@
+//
+//  DateFormatter.swift
+//  UMCFoundation
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation
+
+extension Date {
+    // MARK: - Function
+
+    /// "yyyy.MM.dd" 형식으로 변환 (예: "2026.01.17")
+    public func toYearMonthDay() -> String {
+        formatted(.dateTime.year().month(.twoDigits).day(.twoDigits))
+            .replacingOccurrences(of: "/", with: ".")
+    }
+    
+    /// "MM.dd" 형식으로 변환 (예: "01.17")
+    public func toMonthDay() -> String {
+        formatted(.dateTime.month(.twoDigits).day(.twoDigits))
+            .replacingOccurrences(of: "/", with: ".")
+    }
+    
+    /// "HH:mm" 24시간제 형식으로 변환 (예: "14:30")
+    public func toHourMinutes() -> String {
+        Date.hourMinuteFormatter.string(from: self)
+    }
+    
+    /// 현재 시간 기준 상대적 시간 표현 (예: "3시간 전", "2일 전")
+    public var timeAgoText: String {
+        let now = Date()
+        let interval = now.timeIntervalSince(self)
+        
+        let minutes = Int(interval / 60)
+        let hours = Int(interval / 3600)
+        let days = Int(interval / 86400)
+        let weeks = Int(interval / 604800)
+        let month = Int(interval / 2592000)
+        
+        if minutes < 1 {
+            return "방금 전"
+        } else if minutes < 60 {
+            return "\(minutes)분 전"
+        } else if hours < 24 {
+            return "\(hours)시간 전"
+        } else if days < 7 {
+            return "\(days)일 전"
+        } else if weeks < 4 {
+            return "\(weeks)주 전"
+        } else {
+            return "\(month)개월 전"
+        }
+    }
+    
+    /// "HH:mm - HH:mm" 시간 범위 형식 (예: "14:00 - 18:00")
+    public func timeRange(to endTime: Date) -> String {
+        "\(self.toHourMinutes()) - \(endTime.toHourMinutes())"
+    }
+    
+    /// "MM.dd - MM.dd" 날짜 범위 형식 (예: "01.17 - 01.20")
+    public func dateRange(to endDate: Date) -> String {
+        "\(self.toMonthDay()) - \(endDate.toMonthDay())"
+    }
+
+    /// "yyyy.MM.dd (E)" 형식으로 변환 (예: "2026.01.01 (토)")
+    public func toYearMonthDayWithWeekday() -> String {
+        formatted(.dateTime.year().month(.twoDigits).day(.twoDigits).weekday(.abbreviated))
+            .replacingOccurrences(of: "/", with: ".")
+    }
+    
+    /// "MM.dd (E)" 형식으로 변환 (예: "01.01 (토)")
+    public func toMonthDayWithWeekDay() -> String {
+        formatted(.dateTime.month(.twoDigits).day(.twoDigits).weekday(.abbreviated))
+            .replacingOccurrences(of: "/", with: ".")
+    }
+    
+    /// "MM.dd (E) HH:mm" 형식으로 변환 (예: "01.01 (토) 19:00")
+    public func toMonthDayWeekDayWithTime() -> String {
+        "\(self.toMonthDayWithWeekDay()) \(self.toHourMinutes())"
+    }
+
+    // MARK: - Helper
+}
+
+private extension Date {
+    // MARK: - Property
+
+    static let hourMinuteFormatter: Foundation.DateFormatter = {
+        let formatter = Foundation.DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+}

--- a/UMCApp/Core/Foundation/Sources/Extensions/NotificationName+App.swift
+++ b/UMCApp/Core/Foundation/Sources/Extensions/NotificationName+App.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationName+App.swift
+//  UMCFoundation
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation
+
+public extension Notification.Name {
+    static let generationMappingsUpdated = Notification.Name("generationMappingsUpdated")
+}

--- a/UMCApp/Core/Foundation/Sources/Extensions/ToolBarCollection.swift
+++ b/UMCApp/Core/Foundation/Sources/Extensions/ToolBarCollection.swift
@@ -1,0 +1,820 @@
+//
+//  ToolBarCollection.swift
+//  UMCFoundation
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation
+import SwiftUI
+import CoreDesignSystem
+
+/// 앱 전체에서 사용되는 재사용 가능한 Toolbar 컴포넌트 모음
+///
+/// 취소/확인/추가 등 공통 액션 버튼과 필터 메뉴를 제공합니다.
+public struct ToolBarCollection {
+
+    // MARK: - Primary Action Buttons
+    
+    /// 기본 시스템 뒤로 가기 동작과 추가 후처리를 함께 수행하는 툴바 버튼입니다.
+    public struct BackBtn: ToolbarContent {
+        @Environment(\.dismiss) var dismiss
+        public var action: () -> Void
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(role: .cancel, action: {
+                    action()
+                    dismiss()
+                })
+            }
+        }
+    }
+    
+    
+    /// 시트나 편집 화면에서 취소 동작을 제공하는 툴바 버튼입니다.
+    public struct CancelBtn: ToolbarContent {
+        @Environment(\.dismiss) var dismiss
+        public var action: () -> Void
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(role: .cancel, action: {
+                    action()
+                    dismiss()
+                })
+            }
+        }
+    }
+    
+    /// 저장, 완료 같은 확인 액션에 사용하는 공용 툴바 버튼입니다.
+    ///
+    /// `isLoading`이 `true`이면 체크 아이콘 대신 `ProgressView`를 노출하고,
+    /// 탭 입력도 함께 막아 중복 제출을 방지합니다.
+    public struct ConfirmBtn: ToolbarContent {
+        @Environment(\.dismiss) var dismiss
+        public let action: () -> Void
+        public let disable: Bool
+        public let isLoading: Bool
+        public let dismissOnTap: Bool
+        public let tintColor: Color
+        
+        public init(
+            action: @escaping () -> Void,
+            disable: Bool = false,
+            isLoading: Bool = false,
+            dismissOnTap: Bool = true,
+            tintColor: Color = .indigo500
+        ) {
+            self.action = action
+            self.disable = disable
+            self.isLoading = isLoading
+            self.dismissOnTap = dismissOnTap
+            self.tintColor = tintColor
+        }
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .confirmationAction) {
+                Button(role: .confirm, action: {
+                    guard !isLoading, !disable else { return }
+                    action()
+                    if dismissOnTap {
+                        dismiss()
+                    }
+                }, label: {
+                    ZStack {
+                        Image(systemName: "checkmark")
+                            .opacity(isLoading ? 0 : 1)
+
+                        if isLoading {
+                            ProgressView()
+                                .controlSize(.small)
+                                .tint(.blue)
+                        }
+                    }
+                })
+                .tint((disable || isLoading) ? .grey300 : tintColor)
+                .disabled(disable || isLoading)
+            }
+        }
+    }
+    
+    /// 파괴적이거나 취소 성격이 강한 좌측 상단 액션에 사용하는 버튼입니다.
+    public struct RejectBtn: ToolbarContent {
+        @Environment(\.dismiss) var dismiss
+        public let action: () -> Void
+        public let disable: Bool
+        
+        public init(action: @escaping () -> Void, disable: Bool = false) {
+            self.action = action
+            self.disable = disable
+        }
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarLeading) {
+                Button(role: .destructive, action: {
+                    action()
+                    dismiss()
+                }) {
+                    Image(systemName: "xmark")
+                }
+                .tint(.red)
+                .disabled(disable)
+            }
+        }
+    }
+    
+    /// 생성, 추가 같은 우측 상단 액션에 사용하는 공용 버튼입니다.
+    ///
+    /// 타이틀 없이 사용하면 시스템 아이콘 버튼으로, `title`을 전달하면 텍스트 버튼으로 동작합니다.
+    public struct AddBtn: ToolbarContent {
+        @Environment(\.dismiss) private var dismiss
+        public let action: () -> Void
+        public let disable: Bool
+        public let isLoading: Bool
+        public let dismissOnTap: Bool
+        public let title: String?
+        public let imageSystemName: String
+        public let tintColor: Color
+        
+        public init(
+            title: String? = nil,
+            imageSystemName: String = "plus",
+            action: @escaping () -> Void,
+            disable: Bool = false,
+            isLoading: Bool = false,
+            dismissOnTap: Bool = false,
+            tintColor: Color = .indigo500
+        ) {
+            self.title = title
+            self.imageSystemName = imageSystemName
+            self.action = action
+            self.disable = disable
+            self.isLoading = isLoading
+            self.dismissOnTap = dismissOnTap
+            self.tintColor = tintColor
+        }
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarTrailing) {
+                baseButton
+            }
+        }
+
+        private var baseButton: some View {
+            Button(action: {
+                guard !disable, !isLoading else { return }
+                action()
+                if dismissOnTap {
+                    dismiss()
+                }
+            }, label: {
+                ZStack {
+                    if let title {
+                        Text(title)
+                            .opacity(isLoading ? 0 : 1)
+                    } else {
+                        Image(systemName: imageSystemName)
+                            .opacity(isLoading ? 0 : 1)
+                    }
+
+                    if isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                            .tint(.indigo500)
+                    }
+                }
+            })
+            .tint((disable || isLoading) ? .grey300 : tintColor)
+            .disabled(disable || isLoading)
+        }
+    }
+
+    // MARK: - Icon Buttons
+    
+    /// 좌측 상단에 임의의 SF Symbol 액션을 배치하는 버튼입니다.
+    public struct LeadingButton: ToolbarContent {
+        public let image: String
+        public let action: () -> Void
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarLeading) {
+                Button(action: {
+                    action()
+                }, label: {
+                    Image(systemName: image)
+                })
+            }
+        }
+    }
+    
+    /// 알림함 진입 버튼입니다.
+    ///
+    /// `recentPush`가 `true`이면 배지 포함 심볼을 사용해 새 알림 존재를 표현합니다.
+    public struct BellBtn: ToolbarContent {
+        public let action: () -> Void
+        public var tintColor: Color = .grey900
+        public let recentPush: Bool = false
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: { action() }, label: {
+                    Image(systemName: recentPush ? "bell.badge" : "bell")
+                })
+                .tint(tintColor)
+            }
+        }
+    }
+    
+    /// 앱 브랜딩용 로고를 상단 좌측에 배치하는 툴바입니다.
+    public struct Logo: ToolbarContent {
+        public let image: ImageResource
+        @Namespace var namespace
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarLeading) {
+                Image(image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 80, height: 40)
+                    .padding(EdgeInsets(top: 8, leading: 6, bottom: 8, trailing: 6))
+                    .disabled(true)
+            }
+            .sharedBackgroundVisibility(.hidden)
+            .matchedTransitionSource(id: "logo", in: namespace)
+        }
+    }
+
+    // MARK: - Filters
+    
+    /// 기수 선택 메뉴를 상단 좌측에 배치하는 필터 툴바입니다.
+    public struct GenerationFilter: ToolbarContent {
+        public let title: String
+        public let generations: [Generation]
+        @Binding public var selection: Generation
+        
+        public init(title: String, generations: [Generation], selection: Binding<Generation>) {
+            self.title = title
+            self.generations = generations
+            self._selection = selection
+        }
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    generationPicker
+                } label: {
+                    menuLabel
+                }
+            }
+        }
+        
+        /// 등록된 기수 목록을 inline 스타일로 보여주는 Picker입니다.
+        private var generationPicker: some View {
+            Picker("기수 선택", selection: $selection) {
+                ForEach(generations) { generation in
+                    Text(generation.title).tag(generation)
+                }
+            }
+            .pickerStyle(.inline)
+        }
+        
+        /// 현재 필터 타이틀을 표시하는 메뉴 라벨입니다.
+        private var menuLabel: some View {
+            Text(title)
+                .font(.callout)
+                .fontWeight(.semibold)
+        }
+    }
+    
+    /// 커뮤니티 화면에서 주차를 선택하는 필터 툴바입니다.
+    public struct CommunityWeekFilter: ToolbarContent {
+        public let weeks: [Int]
+        @Binding var selection: Int
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    weekPicker
+                } label: {
+                    Text("\(selection)주차")
+                        .appFont(.subheadline, weight: .medium)
+                }
+            }
+        }
+        
+        /// 주차 값을 선택하는 inline Picker입니다.
+        private var weekPicker: some View {
+            Picker("주차 선택", selection: $selection) {
+                ForEach(weeks, id: \.self) { week in
+                    Text("\(week)주차")
+                        .tag(week)
+                }
+            }
+            .pickerStyle(.inline)
+        }
+    }
+    
+    /// 커뮤니티 목록을 학교 기준으로 좁혀보는 필터 툴바입니다.
+    public struct CommunityUnivFilter: ToolbarContent {
+        @Binding var selectedUniversity: String
+        public let universities: [String]
+
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    universityPicker
+                } label: {
+                    Image(systemName: "graduationcap.fill")
+                        .appFont(.subheadline)
+                }
+            }
+        }
+
+        /// 학교 목록을 선택 가능한 메뉴 형태로 구성한 Picker입니다.
+        private var universityPicker: some View {
+            Picker("학교 선택", selection: $selectedUniversity) {
+                Text("전체")
+                    .tag("전체")
+
+                ForEach(universities.filter { $0 != "전체" }, id: \.self) { university in
+                    Text(university)
+                        .tag(university)
+                }
+            }
+            .pickerStyle(.inline)
+        }
+    }
+
+    /// 커뮤니티 목록을 파트 기준으로 좁혀보는 필터 툴바입니다.
+    public struct CommunityPartFilter: ToolbarContent {
+        @Binding var selectedPart: UMCPartType?
+        public let parts: [UMCPartType]
+
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    partPicker
+                } label: {
+                    Image(systemName: "building.columns.fill")
+                        .appFont(.subheadline)
+                }
+            }
+        }
+
+        /// 파트 목록을 inline 메뉴로 렌더링하는 Picker입니다.
+        private var partPicker: some View {
+            Picker("파트 선택", selection: $selectedPart) {
+                Label("전체", systemImage: "person.2.fill")
+                    .tag(nil as UMCPartType?)
+
+                ForEach(parts, id: \.self) { part in
+                    Label(part.name, systemImage: part.icon)
+                        .tag(part)
+                }
+            }
+            .pickerStyle(.inline)
+        }
+    }
+
+    /// 커뮤니티 명예의 전당에서 학교/파트 필터를 하나의 메뉴로 통합한 툴바입니다.
+    public struct CommunityFameFilter: ToolbarContent {
+        @Binding var selectedUniversity: String
+        public let universities: [String]
+        @Binding var selectedPart: UMCPartType?
+        public let parts: [UMCPartType]
+
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Menu {
+                        Picker("학교 선택", selection: $selectedUniversity) {
+                            Text("전체")
+                                .tag("전체")
+
+                            ForEach(universities.filter { $0 != "전체" }, id: \.self) { university in
+                                Text(university)
+                                    .tag(university)
+                            }
+                        }
+                        .pickerStyle(.inline)
+                    } label: {
+                        Label("\(selectedUniversity)", systemImage: "graduationcap.fill")
+                    }
+
+                    Menu {
+                        Picker("파트 선택", selection: $selectedPart) {
+                            Label("전체", systemImage: "person.2.fill")
+                                .tag(nil as UMCPartType?)
+
+                            ForEach(parts, id: \.self) { part in
+                                Label(part.name, systemImage: part.icon)
+                                    .tag(part)
+                            }
+                        }
+                        .pickerStyle(.inline)
+                    } label: {
+                        Label("\(selectedPart?.name ?? "전체")", systemImage: "building.columns.fill")
+                    }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle.fill")
+                        .appFont(.subheadline)
+                }
+            }
+        }
+    }
+
+    // MARK: - Menus
+    
+    /// 상단 중앙 섹션 메뉴 툴바 (시스템 ToolbarTitleMenu 기반)
+    ///
+    /// - Note: 타이틀 텍스트는 각 화면에서 `.navigationTitle(...)`로 지정해야 합니다.
+    public struct ToolBarCenterMenu<Item: Identifiable & Hashable>: ToolbarContent {
+
+        // MARK: - Property
+        public let items: [Item]
+        @Binding var selection: Item
+        public let itemLabel: (Item) -> String
+        public let itemIcon: ((Item) -> String)?
+        public let onSelect: ((Item) -> Void)?
+        
+        // MARK: - Initializer
+        public init(
+            items: [Item],
+            selection: Binding<Item>,
+            itemLabel: @escaping (Item) -> String,
+            itemIcon: ((Item) -> String)? = nil,
+            onSelect: ((Item) -> Void)? = nil
+        ) {
+            self.items = items
+            self._selection = selection
+            self.itemLabel = itemLabel
+            self.itemIcon = itemIcon
+            self.onSelect = onSelect
+        }
+        
+        // MARK: - Body
+        public var body: some ToolbarContent {
+            ToolbarTitleMenu {
+                ForEach(items) { item in
+                    Button {
+                        selection = item
+                        onSelect?(item)
+                    } label: {
+                        if let itemIcon = itemIcon {
+                            Label(itemLabel(item), systemImage: itemIcon(item))
+                                .imageScale(.small)
+                                .font(.subheadline)
+                        } else {
+                            Text(itemLabel(item))
+                                .font(.subheadline)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    /// 우측 상단의 `ellipsis` 메뉴를 공통 액션 목록으로 렌더링합니다.
+    public struct ToolbarTrailingMenu: ToolbarContent {
+        public let actions: [ActionItem]
+        
+        /// `ToolbarTrailingMenu`가 노출할 단일 메뉴 액션 모델입니다.
+        public struct ActionItem: Identifiable {
+            public let id = UUID()
+            public let title: String
+            public let icon: String
+            public let role: ButtonRole?
+            public let action: () -> Void
+            
+            public init(title: String,
+                 icon: String,
+                 role: ButtonRole? = nil,
+                 action: @escaping () -> Void
+            ) {
+                self.title = title
+                self.icon = icon
+                self.role = role
+                self.action = action
+            }
+        }
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    ForEach(actions) { item in
+                        Button(role: item.role) {
+                            item.action()
+                        } label: {
+                            Label(item.title, systemImage: item.icon)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                }
+            }
+        }
+    }
+    
+    /// 운영진 출석 승인 메뉴 (선택 모드 토글 지원)
+    ///
+    /// - 일반 모드: "선택" 버튼 표시
+    /// - 선택 모드: ellipsis 메뉴 + X 버튼 표시
+    public struct OperationApprovalMenu: ToolbarContent {
+        @Binding var isSelecting: Bool
+        public let selectedCount: Int
+        public var onApproveSelected: () -> Void
+        public var onRejectSelected: () -> Void
+        public var onApproveAll: () -> Void
+        public var onRejectAll: () -> Void
+        
+        private var hasSelection: Bool {
+            selectedCount > 0
+        }
+        
+        public var body: some ToolbarContent {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                if isSelecting {
+                    approvalMenu
+                    closeButton
+                } else {
+                    selectButton
+                }
+            }
+        }
+        
+        // MARK: - View Components
+        
+        /// 선택 모드에서 승인/거절 관련 액션을 묶어 보여주는 메뉴입니다.
+        private var approvalMenu: some View {
+            Menu {
+                Section {
+                    Button(role: .destructive, action: onRejectSelected) {
+                        Label("선택 거절 (\(selectedCount))", systemImage: "xmark.circle")
+                    }
+                    .disabled(!hasSelection)
+                    
+                    Button(action: onApproveSelected) {
+                        Label("선택 승인 (\(selectedCount))", systemImage: "checkmark.circle")
+                    }
+                    .disabled(!hasSelection)
+                }
+                
+                Section {
+                    Button(role: .destructive, action: onRejectAll) {
+                        Label("전체 거절", systemImage: "xmark.circle.fill")
+                    }
+                    Button(action: onApproveAll) {
+                        Label("전체 승인", systemImage: "checkmark.circle.fill")
+                    }
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 16))
+                    .foregroundStyle(.black)
+            }
+        }
+        
+        /// 선택 모드를 종료하고 기본 표시 상태로 복귀시키는 버튼입니다.
+        private var closeButton: some View {
+            Button {
+                withAnimation(.snappy(duration: DefaultConstant.animationTime)) {
+                    isSelecting = false
+                }
+            } label: {
+                Image(systemName: "arrow.uturn.backward")
+                    .font(.system(size: 16))
+                    .foregroundStyle(.black)
+            }
+        }
+        
+        /// 일반 모드에서 선택 모드로 진입시키는 버튼입니다.
+        private var selectButton: some View {
+            Button {
+                withAnimation(.snappy(duration: DefaultConstant.animationTime)) {
+                    isSelecting = true
+                }
+            } label: {
+                Image(systemName: "checklist")
+                    .font(.system(size: 16))
+                    .foregroundStyle(.black)
+            }
+        }
+    }
+    
+    // MARK: - Study Management Filters
+    
+    /// 스터디 관리 화면의 주차 선택 메뉴입니다.
+    public struct StudyWeekFilter: ToolbarContent {
+        public let weeks: [Int]
+        @Binding var selection: Int
+        public let onChange: (Int) -> Void
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    weekPicker
+                } label: {
+                    Text("\(selection)주차")
+                        .appFont(.callout)
+                }
+            }
+        }
+        
+        /// 주차 변경 시 외부 `onChange`까지 연결하는 Picker입니다.
+        private var weekPicker: some View {
+            Picker("주차", selection: $selection) {
+                ForEach(weeks, id: \.self) { week in
+                    Text("\(week)주차")
+                        .tag(week)
+                }
+            }
+            .onChange(of: selection) { _, newValue in
+                onChange(newValue)
+            }
+        }
+    }
+    
+//    /// 스터디 그룹별 세부 목록을 전환하는 우측 상단 필터입니다.
+//    public struct StudyGroupFilter: ToolbarContent {
+//        public let studyGroups: [StudyGroupItem]
+//        @Binding var selection: StudyGroupItem
+//        public let onChange: (StudyGroupItem) -> Void
+//        
+//        public var body: some ToolbarContent {
+//            ToolbarItem(placement: .topBarTrailing) {
+//                Menu {
+//                    groupPicker
+//                } label: {
+//                    Image(
+//                        systemName: selection == .all
+//                        ? "line.3.horizontal.decrease"
+//                        : selection.iconName
+//                    )
+//                }
+//            }
+//        }
+//        
+//        /// 스터디 그룹 선택과 변경 이벤트 전달을 담당하는 Picker입니다.
+//        private var groupPicker: some View {
+//            Picker("스터디 그룹", selection: $selection) {
+//                ForEach(studyGroups, id: \.self) { group in
+//                    Label(group.name, systemImage: group.iconName)
+//                        .tag(group)
+//                }
+//            }
+//            .onChange(of: selection) { _, newValue in
+//                onChange(newValue)
+//            }
+//        }
+//    }
+    
+    /// 공지 열람 현황 화면의 학교/지부 필터 메뉴입니다.
+    public struct ReadStatusFilter<Item: Identifiable & Hashable>: ToolbarContent {
+        public let items: [Item]
+        @Binding var selection: Item
+        public let itemLabel: (Item) -> String
+        public let itemIcon: ((Item) -> String)?
+        
+        public init(
+            items: [Item],
+            selection: Binding<Item>,
+            itemLabel: @escaping (Item) -> String,
+            itemIcon: ((Item) -> String)? = nil
+        ) {
+            self.items = items
+            self._selection = selection
+            self.itemLabel = itemLabel
+            self.itemIcon = itemIcon
+        }
+        
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Picker("열람 현황 필터", selection: $selection) {
+                        ForEach(items) { item in
+                            if let itemIcon {
+                                Label(itemLabel(item), systemImage: itemIcon(item))
+                                    .tag(item)
+                            } else {
+                                Text(itemLabel(item))
+                                    .tag(item)
+                            }
+                        }
+                    }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease")
+                }
+            }
+        }
+    }
+
+    // MARK: - Specialized Bottom Toolbar
+
+    /// 챌린저 인증 실패 화면 전용 하단 툴바입니다.
+    ///
+    /// 홈페이지 이동, 문의하기, 계정 관련 액션을 하단 바에 고정된 형태로 제공합니다.
+    public struct FailedVerificationBottomToolbar: ToolbarContent {
+        @State private var isAccountDialogPresented: Bool = false
+
+        public let isSubmitting: Bool
+        public let isDeletingAccount: Bool
+        public let isLoggingOut: Bool
+        public let onHome: () -> Void
+        public let onInquiry: () -> Void
+        public let onLogout: () -> Void
+        public let onDeleteAccount: () -> Void
+
+        private enum Constants {
+            static let iconSize: CGFloat = 18
+        }
+
+        public var body: some ToolbarContent {
+            ToolbarItem(placement: .bottomBar) {
+                actionButton(
+                    icon: "house.fill",
+                    title: "홈페이지",
+                    color: .indigo,
+                    disabled: isDeletingAccount,
+                    action: onHome
+                )
+            }
+
+            ToolbarItem(placement: .bottomBar) {
+                actionButton(
+                    icon: "message.fill",
+                    title: "문의하기",
+                    color: .yellow,
+                    disabled: isDeletingAccount,
+                    action: onInquiry
+                )
+            }
+
+            ToolbarItem(placement: .bottomBar) {
+                Button(action: onAccountAction) {
+                    actionLabel(
+                        icon: "person.crop.circle.badge.xmark",
+                        title: "계정",
+                        color: .red
+                    )
+                }
+                .confirmationDialog(
+                    "계정 관리",
+                    isPresented: $isAccountDialogPresented,
+                    titleVisibility: .hidden
+                ) {
+                    Button("로그아웃", action: onLogout)
+                    Button("탈퇴하기", role: .destructive, action: onDeleteAccount)
+                }
+                .disabled(isSubmitting || isDeletingAccount || isLoggingOut)
+            }
+        }
+
+        private func onAccountAction() {
+            isAccountDialogPresented = true
+        }
+
+        /// 단일 하단 바 액션 버튼을 렌더링합니다.
+        private func actionButton(
+            icon: String,
+            title: String,
+            color: Color,
+            disabled: Bool,
+            action: @escaping () -> Void
+        ) -> some View {
+            Button(action: action) {
+                VStack(spacing: DefaultSpacing.spacing4) {
+                    Image(systemName: icon)
+                        .font(.system(size: Constants.iconSize, weight: .semibold))
+                        .foregroundStyle(color)
+
+                    Text(title)
+                        .appFont(.caption2, weight: .medium, color: .black)
+                        .lineLimit(1)
+                }
+                .padding()
+                .frame(maxWidth: .infinity)
+            }
+            .disabled(disabled)
+        }
+
+        /// 계정 메뉴의 커스텀 라벨을 구성합니다.
+        private func actionLabel(
+            icon: String,
+            title: String,
+            color: Color
+        ) -> some View {
+            VStack(spacing: DefaultSpacing.spacing4) {
+                Image(systemName: icon)
+                    .font(.system(size: Constants.iconSize, weight: .semibold))
+                    .foregroundStyle(color)
+
+                Text(title)
+                    .appFont(.caption2, weight: .medium, color: .black)
+                    .lineLimit(1)
+            }
+            .padding()
+            .frame(maxWidth: .infinity)
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Model/Generation.swift
+++ b/UMCApp/Core/Foundation/Sources/Model/Generation.swift
@@ -1,0 +1,20 @@
+//
+//  Generation.swift
+//  UMCFoundation
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation
+
+// MARK: - Generation
+/// 기수 모델
+public struct Generation: Identifiable, Equatable, Hashable {
+    public let value: String
+    public var id: String { value }
+    public var title: String { "\(value)기" }
+    
+    public init(value: String) {
+        self.value = value
+    }
+}

--- a/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButton.swift
+++ b/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButton.swift
@@ -1,0 +1,214 @@
+//
+//  ChipButton.swift
+//  UMCApp
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+
+// MARK: - ChipButton
+
+/// 선택 상태를 표시하는 칩 형태의 버튼 컴포넌트
+///
+/// 필터링, 카테고리 선택, 태그 표시 등에 사용합니다.
+/// `action`이 nil이면 인터랙션 없는 읽기 전용 태그로 동작합니다.
+///
+/// ## 사용 예시
+///
+/// **기본 사용 (인터랙티브 버튼)**
+/// ```swift
+/// ChipButton("iOS", isSelected: selected) {
+///     selected.toggle()
+/// }
+/// .buttonSize(.medium)
+/// .buttonStyle(.filter)
+/// ```
+///
+/// **아이콘 포함**
+/// ```swift
+/// // Leading 아이콘 (SF Symbol)
+/// ChipButton("링크", isSelected: true, leadingIcon: "link") { }
+///
+/// // Trailing chevron (드롭다운 표시용)
+/// ChipButton("전체", isSelected: false, trailingIcon: true) { }
+/// ```
+///
+/// **읽기 전용 태그 (action 생략)**
+/// ```swift
+/// ChipButton("Week 1", isSelected: false)
+/// ```
+///
+/// ## 사이즈 옵션 (`buttonSize`)
+///
+/// | Size | Font | Padding | 용도 |
+/// |------|------|---------|------|
+/// | `.small` | footnote | 8pt | 컴팩트한 태그, 뱃지 |
+/// | `.medium` | subheadline | 16pt | 일반 필터, 선택 버튼 |
+/// | `.large` | callout | 16pt | 강조 버튼 |
+///
+/// ## 스타일 옵션 (`buttonStyle`)
+///
+/// | Style | 선택 시 | 미선택 시 | 용도 |
+/// |-------|--------|----------|------|
+/// | `.filter` | indigo500/grey000 | grey200/grey600 | 공지 리스트 필터 |
+/// | `.board` | indigo500/grey000 | grey300/grey000 | 게시판 분류 선택 |
+/// | `.fame` | yellow500/white | white/grey600 | 명예의전당 주차 선택 |
+///
+/// - Important: `buttonSize()`와 `buttonStyle()`은 반드시 ChipButton에 직접 적용해야 합니다.
+///   다른 컨테이너 뷰에 적용하면 Environment 전파가 되지 않습니다.
+///
+/// - Note: Liquid Glass 효과가 자동 적용됩니다.
+///   인터랙티브 버튼은 `.interactive()`, 읽기 전용은 `.identity` 사용.
+public struct ChipButton: View {
+
+    // MARK: - Properties
+
+    /// 버튼에 표시될 텍스트
+    private let title: String
+
+    /// 선택 상태 여부 (선택 시 스타일 변경)
+    private let isSelected: Bool
+    private let leadingIcon: String?
+    private let trailingIcon: Bool?
+    private let action: (() -> Void)?
+
+    /// Environment로 주입되는 버튼 크기 스타일
+    @Environment(\.chipButtonSize) private var size
+
+    /// Environment로 주입되는 버튼 컬러 스타일
+    @Environment(\.chipButtonStyle) private var style
+
+    // MARK: - Initializer
+
+    /// ChipButton 생성자
+    ///
+    /// - Parameters:
+    ///   - title: 버튼 텍스트
+    ///   - isSelected: 선택 상태
+    ///   - trailingIcon: 트레일링 아이콘 표시 여부
+    ///   - action: 탭 액션 (nil이면 읽기 전용 태그로 동작)
+    public init(
+        _ title: String,
+        isSelected: Bool,
+        leadingIcon: String? = nil,
+        trailingIcon: Bool? = nil,
+        action: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.isSelected = isSelected
+        self.leadingIcon = leadingIcon
+        self.trailingIcon = trailingIcon
+        self.action = action
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        if let action = action {
+            Button(action: action) {
+                ChipButtonContent(
+                    title: title,
+                    size: size,
+                    style: style,
+                    isSelected: isSelected,
+                    leadingIcon: leadingIcon,
+                    trailingIcon: trailingIcon,
+                    isInteractive: true
+                )
+                .equatable()
+            }
+        } else {
+            ChipButtonContent(
+                title: title,
+                size: size,
+                style: style,
+                isSelected: isSelected,
+                leadingIcon: leadingIcon,
+                trailingIcon: trailingIcon,
+                isInteractive: false
+            )
+            .equatable()
+        }
+    }
+}
+
+// MARK: - ChipButtonContent (Presenter)
+
+/// ChipButton의 Presenter 컴포넌트
+///
+/// Container-Presenter 패턴을 적용하여 렌더링 성능을 최적화합니다.
+/// Equatable 구현으로 불필요한 재렌더링을 방지합니다.
+private struct ChipButtonContent: View, Equatable {
+
+    // MARK: - Property
+
+    /// 버튼 텍스트
+    let title: String
+
+    /// 버튼 크기 스타일
+    let size: ChipButtonSize
+
+    /// 버튼 컬러 스타일
+    let style: ChipButtonStyle
+
+    /// 선택 상태 여부
+    let isSelected: Bool
+    let leadingIcon: String?
+    let trailingIcon: Bool?
+    let isInteractive: Bool
+    
+    // MARK: - Constant
+
+    fileprivate enum Constants {
+        /// chevron 아이콘 크기
+        static let chevronSize: CGFloat = 10
+
+        /// 버튼 상하 패딩
+        static let btnVerticalPadding: CGFloat = 8
+    }
+
+    // MARK: - Equatable
+
+    /// Equatable 비교 구현
+    ///
+    /// trailingIcon은 클로저가 아니므로 비교에 포함됩니다.
+    static func == (lhs: ChipButtonContent, rhs: ChipButtonContent) -> Bool {
+        lhs.title == rhs.title &&
+        lhs.size == rhs.size &&
+        lhs.style == rhs.style &&
+        lhs.isSelected == rhs.isSelected &&
+        lhs.leadingIcon == rhs.leadingIcon &&
+        lhs.trailingIcon == rhs.trailingIcon &&
+        lhs.isInteractive == rhs.isInteractive
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing4) {
+            Text(title)
+            if trailingIcon == true {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: Constants.chevronSize))
+            }
+        }
+        .foregroundStyle(style.textColor(isSelected: isSelected))
+        .font(size.font)
+        .padding(.horizontal, size.horizonPadding)
+        .padding(.vertical, Constants.btnVerticalPadding)
+        .background(
+            Capsule()
+                .fill(style.bgColor(isSelected: isSelected))
+        )
+        .glassEffect(
+            isInteractive ? .clear.interactive() : .identity,
+            in: Capsule()
+        )
+    }
+}
+
+// MARK: - ChipButton + AnyChipButton
+
+extension ChipButton: AnyChipButton {}

--- a/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButtonEnvironment.swift
+++ b/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButtonEnvironment.swift
@@ -1,0 +1,34 @@
+//
+//  ChipButtonEnvironment.swift
+//  UMCApp
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+
+// MARK: - Environment Keys
+
+public struct ChipButtonSizeKey: EnvironmentKey {
+    public static let defaultValue: ChipButtonSize = .medium
+}
+
+public struct ChipButtonStyleKey: EnvironmentKey {
+    public static let defaultValue: ChipButtonStyle = .filter
+}
+
+// MARK: - EnvironmentValues Extension
+
+extension EnvironmentValues {
+    public var chipButtonSize: ChipButtonSize {
+        get { self[ChipButtonSizeKey.self] }
+        set { self[ChipButtonSizeKey.self] = newValue }
+    }
+}
+
+extension EnvironmentValues {
+    public var chipButtonStyle: ChipButtonStyle {
+        get { self[ChipButtonStyleKey.self] }
+        set { self[ChipButtonStyleKey.self] = newValue }
+    }
+}

--- a/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButtonModifiers.swift
+++ b/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButtonModifiers.swift
@@ -1,0 +1,47 @@
+//
+//  ChipButtonModifiers.swift
+//  UMCApp
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+
+// MARK: - AnyChipButton Protocol
+
+/// ChipButton 전용 프로토콜
+public protocol AnyChipButton: View {}
+
+// MARK: - ViewModifiers
+
+public struct ChipButtonSizeModifier: ViewModifier {
+    public let size: ChipButtonSize
+
+    public func body(content: Content) -> some View {
+        content.environment(\.chipButtonSize, size)
+    }
+}
+
+public struct ChipButtonStyleModifier: ViewModifier {
+    public let style: ChipButtonStyle
+
+    public func body(content: Content) -> some View {
+        content.environment(\.chipButtonStyle, style)
+    }
+}
+
+// MARK: - AnyChipButton Extension
+
+extension AnyChipButton {
+    /// ChipButton 사이즈 설정
+    /// - Parameter size: small, medium, large
+    public func buttonSize(_ size: ChipButtonSize) -> some View {
+        modifier(ChipButtonSizeModifier(size: size))
+    }
+
+    /// 버튼 색상 설정
+    /// - Parameter style: filter, board, fame
+    public func buttonStyle(_ style: ChipButtonStyle) -> some View {
+        modifier(ChipButtonStyleModifier(style: style))
+    }
+}

--- a/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButtonSize.swift
+++ b/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButtonSize.swift
@@ -1,0 +1,40 @@
+//
+//  ChipButtonSize.swift
+//  UMCApp
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+
+// MARK: - ChipButtonSize
+
+/// ChipButton 사이즈 유형
+public enum ChipButtonSize {
+    case small
+    case medium
+    case large
+    
+    public var horizonPadding: CGFloat {
+        switch self {
+        case .small:
+            return 8
+        case .medium:
+            return 16
+        case .large:
+            return 16
+        }
+    }
+    
+    public var font: Font {
+        switch self {
+        case .small:
+            return .app(.footnote, weight: .semibold)
+        case .medium:
+            return .app(.subheadline, weight: .semibold)
+        case .large:
+            return .app(.callout, weight: .semibold)
+        }
+    }
+}

--- a/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButtonStyle.swift
+++ b/UMCApp/Core/UIComponents/Sources/ChipButton/ChipButtonStyle.swift
@@ -1,0 +1,45 @@
+//
+//  ChipButtonStyle.swift
+//  UMCApp
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - ChipButtonStyle
+
+/// ChipButton 사이즈 유형
+public enum ChipButtonStyle {
+    // 공지 리스트 필터(전체, 중앙운영사무국, 지부, 학교)
+    case filter
+
+    // 공지 작성: 게시판 분류(전체, 운영진 공지, 파트, 학교)
+    case board
+
+    // 커뮤니티: 명예의 전당 (주차)
+    case fame
+
+    public func textColor(isSelected: Bool) -> Color {
+        switch self {
+        case .filter:
+            return isSelected ? .grey000 : .grey600
+        case .board:
+            return .grey000
+        case .fame:
+            return isSelected ? .white : .grey600
+        }
+    }
+
+    public func bgColor(isSelected: Bool) -> Color {
+        switch self {
+        case .filter:
+            return isSelected ? .indigo500 : .grey200
+        case .board:
+            return isSelected ? .indigo500 : .grey300
+        case .fame:
+            return isSelected ? .yellow500 : .white
+        }
+    }
+}

--- a/UMCApp/Core/UIComponents/Sources/Progress/Progress.swift
+++ b/UMCApp/Core/UIComponents/Sources/Progress/Progress.swift
@@ -1,0 +1,59 @@
+//
+//  Progress.swift
+//  UMCApp
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+
+public struct Progress: View {
+    
+    // MARK: - Property
+    public let progressColor: Color
+    public let message: String?
+    public let messageColor: Color
+    public var size: ProgressSize
+    
+    // MARK: - Initializer
+    public init(progressColor: Color = .indigo500,
+         message: String? = nil,
+         messageColor: Color = .grey900,
+         size: ProgressSize = .large) {
+        self.progressColor = progressColor
+        self.message = message
+        self.messageColor = messageColor
+        self.size = size
+    }
+    
+    // MARK: - Constant
+    fileprivate enum Constants {
+        static let vstackSpacing: CGFloat = 10
+    }
+    
+    // MARK: - Body
+    public var body: some View {
+        VStack(spacing: Constants.vstackSpacing, content: {
+            ProgressView()
+                .controlSize(size.controlSize)
+                .tint(progressColor)
+            if let message = message {
+                Text(message)
+                    .foregroundStyle(messageColor)
+                    .appFont(size.messageSize)
+            }
+        })
+    }
+}
+
+// MARK: - Preview
+#Preview(traits: .sizeThatFitsLayout) {
+    VStack(spacing: 100) {
+        Progress(message: "로딩중!", size: .small)
+        
+        Progress(message: "공지를 불러오고 있어요!", size: .regular)
+        
+        Progress(message: "잠시만 기다려주세요!", size: .large)
+    }
+}

--- a/UMCApp/Core/UIComponents/Sources/Progress/ProgressSize.swift
+++ b/UMCApp/Core/UIComponents/Sources/Progress/ProgressSize.swift
@@ -1,0 +1,38 @@
+//
+//  ProgressSize.swift
+//  UMCApp
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation
+import SwiftUI
+import CoreDesignSystem
+
+public enum ProgressSize {
+    case small
+    case regular
+    case large
+
+    public var controlSize: ControlSize {
+        switch self {
+        case .small:
+            return .small
+        case .regular:
+            return .regular
+        case .large:
+            return .large
+        }
+    }
+    
+    public var messageSize: AppFont {
+        switch self {
+        case .small:
+            return .caption1
+        case .regular:
+            return .subheadline
+        case .large:
+            return .body
+        }
+    }
+}

--- a/UMCApp/Core/UIComponents/Sources/State/RetryContentUnavailableView.swift
+++ b/UMCApp/Core/UIComponents/Sources/State/RetryContentUnavailableView.swift
@@ -1,0 +1,78 @@
+//
+//  RetryContentUnavailableView.swift
+//  CoreUIComponents
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+
+/// 로딩 실패 시 재시도 액션을 함께 제공하는 공통 Unavailable View입니다.
+public struct RetryContentUnavailableView: View {
+
+    // MARK: - Property
+    public let title: String
+    public let systemImage: String
+    public let description: String
+    public let retryTitle: String
+    public let isRetrying: Bool
+    public let minRetryButtonWidth: CGFloat
+    public let minRetryButtonHeight: CGFloat
+    public let topPadding: CGFloat
+    public let retryAction: () async -> Void
+
+    // MARK: - Initializer
+    public init(
+        title: String,
+        systemImage: String,
+        description: String,
+        retryTitle: String = "다시 시도",
+        isRetrying: Bool,
+        minRetryButtonWidth: CGFloat = 72,
+        minRetryButtonHeight: CGFloat = 20,
+        topPadding: CGFloat = .zero,
+        retryAction: @escaping () async -> Void
+    ) {
+        self.title = title
+        self.systemImage = systemImage
+        self.description = description
+        self.retryTitle = retryTitle
+        self.isRetrying = isRetrying
+        self.minRetryButtonWidth = minRetryButtonWidth
+        self.minRetryButtonHeight = minRetryButtonHeight
+        self.topPadding = topPadding
+        self.retryAction = retryAction
+    }
+
+    // MARK: - Body
+    public var body: some View {
+        ContentUnavailableView {
+            Label(title, systemImage: systemImage)
+        } description: {
+            Text(description)
+                .multilineTextAlignment(.center)
+        } actions: {
+            Button {
+                Task {
+                    await retryAction()
+                }
+            } label: {
+                ZStack {
+                    Text(retryTitle)
+                        .opacity(isRetrying ? 0 : 1)
+                    if isRetrying {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+                .frame(
+                    minWidth: minRetryButtonWidth,
+                    minHeight: minRetryButtonHeight
+                )
+            }
+            .buttonStyle(.glassProminent)
+            .disabled(isRetrying)
+        }
+        .padding(.top, topPadding)
+    }
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeDetail.swift
@@ -368,6 +368,12 @@ public struct NoticeReadStatus: Equatable {
     public var bottomMessage: String {
         "이미 \(confirmedCount)명이 공지를 확인했습니다."
     }
+    
+    public init(noticeId: String, confirmedUsers: [ReadStatusUser], unconfirmedUsers: [ReadStatusUser]) {
+        self.noticeId = noticeId
+        self.confirmedUsers = confirmedUsers
+        self.unconfirmedUsers = unconfirmedUsers
+    }
 }
 
 

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeModel.swift
@@ -8,18 +8,6 @@
 import Foundation
 import UMCFoundation
 
-// MARK: - Generation
-/// 기수 모델
-public struct Generation: Identifiable, Equatable, Hashable {
-    public let value: String
-    public var id: String { value }
-    public var title: String { "\(value)기" }
-    
-    public init(value: String) {
-        self.value = value
-    }
-}
-
 // MARK: - NoticeScope
 /// 공지 출처 (어디서 온 공지인지)
 public enum NoticeScope: Equatable, Hashable {

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeChip.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeChip.swift
@@ -1,0 +1,48 @@
+//
+//  NoticeChip.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+import NoticeDomain
+
+// MARK: - NoticeChip
+/// 공지 화면: 공지 상세화면 공지 구분 칩
+public struct NoticeChip: View {
+    
+    // MARK: - Property
+    public let noticeType: NoticeType
+    
+    // MARK: - Constants
+    fileprivate enum NoticeChipConstants {
+        static let horizonPadding: CGFloat = 12
+        static let verticalPadding: CGFloat = 6
+        static let radius: CGFloat = 8
+    }
+    
+    // MARK: - Body
+    public var body: some View {
+        Text(noticeType.rawValue)
+            .font(.app(.caption1, weight: .regular))
+            .foregroundStyle(noticeType.textColor)
+            .padding(.horizontal, NoticeChipConstants.horizonPadding)
+            .padding(.vertical, NoticeChipConstants.verticalPadding)
+            .background {
+                RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius)
+                    .foregroundStyle(noticeType.backgroundColor)
+            }
+    }
+}
+
+// MARK: - Preview
+#Preview(traits: .sizeThatFitsLayout) {
+    HStack {
+        NoticeChip(noticeType: .core)
+        NoticeChip(noticeType: .branch)
+        NoticeChip(noticeType: .campus)
+        NoticeChip(noticeType: .part)
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeList/NoticeItem.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeList/NoticeItem.swift
@@ -1,0 +1,200 @@
+//
+//  NoticeItem.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+import NoticeDomain
+
+// MARK: - Constant
+
+private enum Constant {
+    static let mainVSpacing: CGFloat = 12
+    static let mainBoxHeight: CGFloat = 128
+    static let mainPadding: EdgeInsets = .init(top: 12, leading: 24, bottom: 12, trailing: 24)
+    static let mainBoxRadius: CGFloat = 24
+    // top
+    static let topHSpacing: CGFloat = 4
+    static let tagPadding: EdgeInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
+    // content
+    static let contentSpacing: CGFloat = 4
+    // bottom
+    static let bottomIconSize: CGFloat = 12
+    static let unreadDotSize: CGFloat = 8
+}
+
+// MARK: - NoticeItem
+
+/// 공지 탭 - 리스트
+
+public struct NoticeItem: View {
+    // MARK: - Properties
+
+    private let model: NoticeItemModel
+    private let action: () -> Void
+
+    // MARK: - Init
+
+    public init(model: NoticeItemModel, action: @escaping () -> Void) {
+        self.model = model
+        self.action = action
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Button(action: action) {
+            NoticeItemPresenter(model: model)
+                .equatable()
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Presenter
+
+private struct NoticeItemPresenter: View, Equatable {
+    let model: NoticeItemModel
+
+    static func == (lhs: NoticeItemPresenter, rhs: NoticeItemPresenter) -> Bool {
+        lhs.model == rhs.model
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Constant.mainVSpacing) {
+            TopSection(model: model)
+            ContentSection(model: model)
+            BottomSection(model: model)
+        }
+        .frame(height: Constant.mainBoxHeight)
+        .padding(Constant.mainPadding)
+        .background {
+            ConcentricRectangle(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
+                .fill(.white)
+                .glass()
+        }
+    }
+}
+
+/// 태그 + 알림 + 날짜
+private struct TopSection: View, Equatable {
+    let model: NoticeItemModel
+
+    var body: some View {
+        HStack(spacing: Constant.topHSpacing) {
+            ForEach(Array(model.tags.enumerated()), id: \.offset) { _, tagItem in
+                tag(tagItem.text, color: tagItem.backColor)
+            }
+
+            Spacer()
+        }
+    }
+    
+    private func tag(_ text: String, color: Color) -> some View {
+        Text(text)
+            .appFont(.caption1, weight: .semibold, color: .grey000)
+            .padding(Constant.tagPadding)
+            .background {
+                RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius)
+                    .fill(color)
+            }
+            .glassEffect(.clear, in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius))
+    }
+}
+
+/// 제목 + 내용
+private struct ContentSection: View, Equatable {
+    let model: NoticeItemModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+            Text(model.title)
+                .appFont(.body, weight: .semibold, color: .grey900)
+                .lineLimit(1)
+
+            Text(MarkdownSerializer.plainText(from: model.content))
+                .appFont(.subheadline, color: .grey600)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+        }
+    }
+}
+
+/// 작성자 + 링크/투표 여부 + 조회수
+private struct BottomSection: View, Equatable {
+    let model: NoticeItemModel
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(model.displayWriter)
+
+            Spacer()
+
+            if model.hasLink {
+                Image(systemName: "link")
+                    .font(.system(size: Constant.bottomIconSize))
+            }
+
+            if model.hasVote {
+                Image(systemName: "chart.bar.fill")
+                    .font(.system(size: Constant.bottomIconSize))
+            }
+
+            if model.isAlert {
+                Image(systemName: "bell.fill")
+                    .font(.system(size: Constant.bottomIconSize))
+            }
+
+            if !model.isRead {
+                Circle()
+                    .fill(.red)
+                    .glassEffect(.clear.tint(.red), in: .circle)
+                    .frame(width: Constant.unreadDotSize, height: Constant.unreadDotSize)
+            }
+
+            Text(model.date.toYearMonthDay())
+
+            Text("조회 \(model.viewCount)")
+        }
+        .appFont(.footnote, color: .gray)
+    }
+}
+
+#Preview(traits: .sizeThatFitsLayout) {
+    VStack(spacing: 16) {
+        NoticeItem(model: NoticeItemModel(
+            generation: "9",
+            scope: .central,
+            category: .general,
+            mustRead: true,
+            isAlert: true,
+            date: Date(),
+            title: "[투표] 12기 중앙 해커톤 회식 메뉴 선정 안내",
+            content: "이번 해커톤 종료 후 진행될 회식 메뉴를 결정하고자 합니다. 가장 많은 표를 받은 메뉴로 진행됩니다!",
+            writer: "쳇쳇/전채운",
+            links: [],
+            images: [],
+            vote: NoticeVote(
+                id: "vote1",
+                question: "회식 메뉴를 선택해주세요",
+                options: [
+                    VoteOption(id: "1", title: "삼겹살", voteCount: "45"),
+                    VoteOption(id: "2", title: "치킨", voteCount: "23"),
+                    VoteOption(id: "3", title: "피자", voteCount: "18"),
+                    VoteOption(id: "4", title: "떡볶이", voteCount: "34")
+                ],
+                startDate: Date(timeIntervalSinceNow: -86400),
+                endDate: Date(timeIntervalSinceNow: 86400 * 7),
+                allowMultipleChoices: false,
+                isAnonymous: true,
+                userVotedOptionIds: []
+            ),
+            viewCount: "32"
+        )) {
+            print("oo")
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeSubFilter.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeSubFilter.swift
@@ -1,0 +1,189 @@
+//
+//  NoticeSubFilter.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+import CoreUIComponents
+import NoticeDomain
+
+// MARK: - NoticeSubFilter
+/// 서브필터 영역 (전체, 운영진 공지 칩 + 파트 메뉴)
+public struct NoticeSubFilter: View, Equatable {
+
+    @Bindable var viewModel: NoticeViewModel
+
+    public static func == (lhs: NoticeSubFilter, rhs: NoticeSubFilter) -> Bool {
+        lhs.viewModel.selectedSubFilter == rhs.viewModel.selectedSubFilter &&
+        lhs.viewModel.selectedPart == rhs.viewModel.selectedPart &&
+        lhs.viewModel.selectedMainFilter == rhs.viewModel.selectedMainFilter &&
+        lhs.viewModel.subFilterChips == rhs.viewModel.subFilterChips
+    }
+
+    private enum Constants {
+        static let hstackSpacing: CGFloat = 8
+    }
+
+    public var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Constants.hstackSpacing) {
+                ForEach(viewModel.subFilterChips) { chip in
+                    chipView(for: chip)
+                }
+            }
+            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        }
+    }
+
+    /// 칩 타입에 따라 ChipButton 또는 PartFilterMenu를 반환합니다.
+    @ViewBuilder
+    private func chipView(for chip: NoticeListSubFilterChip) -> some View {
+        switch chip {
+        case .part:
+            PartFilterMenu(viewModel: viewModel)
+                .equatable()
+        case .all, .branch, .school:
+            ChipButton(chipDisplayTitle(chip), isSelected: isChipSelected(chip)) {
+                handleChipTap(chip)
+            }
+            .buttonSize(.medium)
+        }
+    }
+
+    /// 칩의 선택 상태를 판단합니다.
+    ///
+    /// - all: 파트가 미선택이면 선택 상태
+    /// - branch: 현재 메인필터가 지부이면 선택 상태
+    /// - school: 현재 메인필터가 학교이고 파트 미선택이면 선택 상태
+    /// - part: 파트가 선택되었으면 선택 상태
+    private func isChipSelected(_ chip: NoticeListSubFilterChip) -> Bool {
+        switch chip {
+        case .all:
+            return viewModel.selectedPart == nil
+        case .branch:
+            if case .branch = viewModel.selectedMainFilter { return true }
+            return false
+        case .school:
+            if case .school = viewModel.selectedMainFilter {
+                return viewModel.selectedPart == nil
+            }
+            return false
+        case .part:
+            return viewModel.selectedPart != nil
+        }
+    }
+
+    /// 칩 탭 시 메인필터 전환 또는 파트 초기화를 수행합니다.
+    private func handleChipTap(_ chip: NoticeListSubFilterChip) {
+        switch chip {
+        case .all:
+            viewModel.selectPart(nil)
+        case .branch:
+            let branchFilter = viewModel.mainFilterItems.first {
+                if case .branch = $0 { return true }
+                return false
+            }
+            if let branchFilter {
+                viewModel.selectMainFilter(branchFilter)
+            }
+        case .school:
+            // 학교 메인 탭에서는 "전체(학교 전체)" 칩으로 동작합니다.
+            if case .school = viewModel.selectedMainFilter {
+                viewModel.selectPart(nil)
+                return
+            }
+            let schoolFilter = viewModel.mainFilterItems.first {
+                if case .school = $0 { return true }
+                return false
+            }
+            if let schoolFilter {
+                viewModel.selectMainFilter(schoolFilter)
+            }
+        case .part:
+            return
+        }
+    }
+
+    /// 칩 라벨 텍스트를 반환합니다. 학교 메인탭에서는 "전체"로 표시합니다.
+    private func chipDisplayTitle(_ chip: NoticeListSubFilterChip) -> String {
+        switch chip {
+        case .school:
+            if case .school = viewModel.selectedMainFilter {
+                return "전체"
+            }
+            return chip.labelText
+        default:
+            return chip.labelText
+        }
+    }
+}
+
+// MARK: - PartFilterMenu
+/// 파트 선택 메뉴
+private struct PartFilterMenu: View, Equatable {
+
+    @Bindable var viewModel: NoticeViewModel
+
+    static func == (lhs: PartFilterMenu, rhs: PartFilterMenu) -> Bool {
+        lhs.viewModel.selectedPart == rhs.viewModel.selectedPart
+    }
+
+    private enum Constants {
+        static let hstackSpacing: CGFloat = 4
+        static let chevronSize: CGFloat = 10
+        static let chipPadding: EdgeInsets = .init(top: 8, leading: 16, bottom: 8, trailing: 16)
+    }
+
+    private var partBinding: Binding<NoticePart?> {
+        Binding(
+            get: { viewModel.selectedPart },
+            set: { viewModel.selectPart($0) }
+        )
+    }
+
+    var body: some View {
+        Menu {
+            partPicker
+        } label: {
+            menuLabel
+        }
+    }
+
+    private var partPicker: some View {
+        Picker("파트 선택", selection: partBinding) {
+            Label("파트", systemImage: "person.2.fill")
+                .tag(nil as NoticePart?)
+            ForEach(NoticePart.allCases) { part in
+                Label(part.displayName, systemImage: part.iconName)
+                    .tag(Optional(part))
+            }
+        }
+        .pickerStyle(.inline)
+    }
+
+    private var isPartSelected: Bool {
+        viewModel.selectedPart != nil
+    }
+
+    private var menuLabel: some View {
+        HStack(spacing: Constants.hstackSpacing) {
+            Image(systemName: viewModel.selectedPart?.iconName ?? "person.2.fill")
+                .appFont(.subheadline)
+            Text(viewModel.selectedPart?.displayName ?? "파트")
+                .appFont(.subheadline, weight: .semibold)
+            Image(systemName: "chevron.down")
+                .font(.system(size: Constants.chevronSize))
+        }
+        .foregroundStyle(isPartSelected ? Color.grey000 : Color.grey600)
+        .padding(Constants.chipPadding)
+        .clipShape(Capsule())
+        .background {
+            Capsule()
+                .fill(isPartSelected ? Color.indigo500 : Color.grey200)
+        }
+        .glassEffect(.clear.interactive(), in: Capsule())
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Navigation/NoticeNavigation.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Navigation/NoticeNavigation.swift
@@ -1,0 +1,36 @@
+//
+//  NoticeNavigation.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import SwiftUI
+import NoticeDomain
+
+// TODO: PathStore / NavigationDestination 교체
+@Observable
+public final class PathStore {
+    public var noticePath: [NavigationDestination] = []
+    public init() {}
+}
+
+public enum NavigationDestination: Hashable {
+    case notice(NoticeDestination)
+}
+
+public enum NoticeDestination: Hashable {
+    case detail(detailItem: NoticeDetail)
+    case staffNotice
+}
+
+public struct NavigationRoutingView: View {
+    private let destination: NavigationDestination
+    public init(destination: NavigationDestination) {
+        self.destination = destination
+    }
+    public var body: some View {
+        // TODO: Route to actual destination views
+        Text("Navigation destination: \(String(describing: destination))")
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Stubs/AuthorizationStubs.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Stubs/AuthorizationStubs.swift
@@ -6,3 +6,22 @@
 //
 
 import Foundation
+  
+// TODO: Auth 모듈 이식 후 교체
+public enum AuthorizationResourceType { case notice }
+
+public enum PermissionType { case write, edit, delete, manage }
+  
+public struct ResourcePermission {
+    let permissions: Set<PermissionType>
+    func hasAny(_ types: [PermissionType]) -> Bool {
+        types.contains(where: { permissions.contains($0) })
+    }
+}
+  
+public protocol AuthorizationUseCaseProtocol {
+    func getResourcePermission(
+        resourceType: AuthorizationResourceType,
+        resourceId: Int
+    ) async throws -> ResourcePermission
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Stubs/AuthorizationStubs.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Stubs/AuthorizationStubs.swift
@@ -1,0 +1,8 @@
+//
+//  AuthorizationStubs.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation

--- a/UMCApp/Features/Notice/Presentation/Sources/Stubs/MemberProfileSummary.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Stubs/MemberProfileSummary.swift
@@ -6,3 +6,14 @@
 //
 
 import Foundation
+
+// TODO: MyPage/Home 도메인 모델로 교체
+public struct MemberProfileSummary {
+    public let memberId: String
+    public let name: String
+    public let nickname: String
+    public let generation: String
+    public let organizationName: String?
+    public let roleName: String
+    public let profileImageURL: String?
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Stubs/MemberProfileSummary.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Stubs/MemberProfileSummary.swift
@@ -1,0 +1,8 @@
+//
+//  MemberProfileSummary.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation

--- a/UMCApp/Features/Notice/Presentation/Sources/Stubs/MyPageRepositoryStub.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Stubs/MyPageRepositoryStub.swift
@@ -1,0 +1,8 @@
+//
+//  MyPageRepositoryStub.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation

--- a/UMCApp/Features/Notice/Presentation/Sources/Stubs/MyPageRepositoryStub.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Stubs/MyPageRepositoryStub.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+// TODO: MyPage 모듈 이식 후 교체
+public protocol MyPageRepositoryProtocol {
+    func fetchMemberProfile(memberId: Int) async throws -> MemberProfileSummary
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Stubs/UserSessionManager.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Stubs/UserSessionManager.swift
@@ -1,0 +1,8 @@
+//
+//  UserSessionManager.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation

--- a/UMCApp/Features/Notice/Presentation/Sources/Stubs/UserSessionManager.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Stubs/UserSessionManager.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+import UMCFoundation
+
+// TODO: 앱 타겟 공통 매니저로 교체
+@Observable
+public final class UserSessionManager {
+    public private(set) var currentRole: ManagementTeam = .challenger
+    public init() {}
+    public func updateRole(_ role: ManagementTeam) { currentRole = role }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -1,0 +1,8 @@
+//
+//  NoticeDetailViewModel+NoticeActions.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel+NoticeActions.swift
@@ -6,3 +6,828 @@
 //
 
 import Foundation
+import UMCFoundation
+import NoticeDomain
+
+extension NoticeDetailViewModel {
+
+    // MARK: - Notice Actions
+
+    /// 공지사항 상세 조회 (최신 데이터 fetch)
+    @MainActor
+    public func fetchNoticeDetail() async {
+        if noticeState.isIdle {
+            noticeState = .loading
+        }
+        defer { isVoteLoading = false }
+
+        do {
+            let noticeDetail = try await noticeUseCase.getDetailNotice(noticeId: noticeID)
+            let mergedDetail = Self.mergeFetchedNoticeDetail(
+                fetched: noticeDetail,
+                fallback: noticeState.value
+            )
+            let normalizedDetail = normalizeTargetGenerationIfNeeded(in: mergedDetail)
+            noticeState = .loaded(normalizedDetail)
+            refreshAuthorDisplayName(for: normalizedDetail)
+            await fetchAuthorProfileIfNeeded(for: normalizedDetail)
+            isDetailPreparedForEdit = true
+        } catch let error as RepositoryError {
+            noticeState = .failed(.repository(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "fetchNoticeDetail",
+                    retryAction: { [weak self] in
+                        Task { await self?.fetchNoticeDetail() }
+                    }
+                )
+            )
+
+        } catch let error as DomainError {
+            noticeState = .failed(.domain(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "fetchNoticeDetail",
+                    retryAction: { [weak self] in
+                        Task { await self?.fetchNoticeDetail() }
+                    }
+                )
+            )
+        } catch let error as NetworkError {
+            noticeState = .failed(.network(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "fetchNoticeDetail",
+                    retryAction: { [weak self] in
+                        Task { await self?.fetchNoticeDetail() }
+                    }
+                )
+            )
+        } catch {
+            noticeState = .failed(.unknown(message: error.localizedDescription))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "fetchNoticeDetail",
+                    retryAction: { [weak self] in
+                        Task { await self?.fetchNoticeDetail() }
+                    }
+                )
+            )
+        }
+    }
+
+    /// 공지 작성자의 멤버 프로필을 조회해 이름/닉네임/기수/역할 표시용 상태를 갱신합니다.
+    @MainActor
+    public func fetchAuthorProfileIfNeeded(for detail: NoticeDetail) async {
+        hasResolvedAuthorProfile = false
+
+        guard let rawMemberId = detail.authorMemberId,
+              let memberId = Int(rawMemberId) else {
+            isAuthorProfileLoading = false
+            authorProfileSummary = nil
+            hasResolvedAuthorProfile = true
+            return
+        }
+
+        isAuthorProfileLoading = true
+        defer {
+            isAuthorProfileLoading = false
+            hasResolvedAuthorProfile = true
+        }
+
+        do {
+            authorProfileSummary = try await container
+                .resolve(MyPageRepositoryProtocol.self)
+                .fetchMemberProfile(memberId: memberId)
+        } catch {
+            authorProfileSummary = nil
+        }
+    }
+
+    public static func mergeFetchedNoticeDetail(
+        fetched: NoticeDetail,
+        fallback: NoticeDetail?
+    ) -> NoticeDetail {
+        guard let fallback else { return fetched }
+
+        let resolvedGeneration = (!fetched.generation.isEmpty && fetched.generation != "0") ? fetched.generation : fallback.generation
+        let resolvedTargetAudience = resolvedTargetAudience(
+            primary: fetched.targetAudience,
+            fallback: fallback.targetAudience
+        )
+        let resolvedNickname = resolvedAuthorField(
+            primary: fetched.authorNickname,
+            fallback: fallback.authorNickname
+        )
+        let resolvedName = resolvedAuthorField(
+            primary: fetched.authorName,
+            fallback: fallback.authorName
+        ) ?? ""
+
+        return NoticeDetail(
+            id: fetched.id,
+            generation: resolvedGeneration,
+            scope: fetched.scope,
+            category: fetched.category,
+            isMustRead: fetched.isMustRead,
+            title: fetched.title,
+            content: fetched.content,
+            authorID: fetched.authorID,
+            authorMemberId: fetched.authorMemberId,
+            authorNickname: resolvedNickname,
+            authorName: resolvedName,
+            authorImageURL: fetched.authorImageURL,
+            createdAt: fetched.createdAt,
+            updatedAt: fetched.updatedAt,
+            targetAudience: resolvedTargetAudience,
+            hasPermission: fetched.hasPermission,
+            images: fetched.images,
+            imageItems: fetched.imageItems,
+            links: fetched.links,
+            vote: fetched.vote
+        )
+    }
+
+    private static func resolvedTargetAudience(
+        primary: TargetAudience,
+        fallback: TargetAudience
+    ) -> TargetAudience {
+        let resolvedGeneration = (!primary.generation.isEmpty && primary.generation != "0") ? primary.generation : fallback.generation
+
+        return TargetAudience(
+            generation: resolvedGeneration,
+            scope: primary.scope,
+            parts: primary.parts,
+            chapterId: primary.chapterId,
+            schoolId: primary.schoolId,
+            branches: primary.branches,
+            schools: primary.schools
+        )
+    }
+
+    private static func resolvedAuthorField(primary: String?, fallback: String?) -> String? {
+        let trimmedPrimary = primary?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedPrimary.isEmpty, trimmedPrimary != "알 수 없음" {
+            return trimmedPrimary
+        }
+
+        let trimmedFallback = fallback?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedFallback.isEmpty ? nil : trimmedFallback
+    }
+
+    /// 공지 리소스 권한 조회
+    @MainActor
+    public func fetchNoticePermission() async {
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("--notice-force-permission") {
+            canEditNotice = true
+            canDeleteNotice = true
+            return
+        }
+        #endif
+
+        do {
+            let permission = try await authorizationUseCase.getResourcePermission(
+                resourceType: .notice,
+                resourceId: Int(noticeID) ?? 0
+            )
+            canEditNotice = permission.hasAny([.write, .edit, .manage])
+            canDeleteNotice = permission.hasAny([.delete, .manage])
+        } catch let error as RepositoryError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchNoticePermission")
+            )
+            let fallback = noticeState.value?.hasPermission ?? false
+            canEditNotice = fallback
+            canDeleteNotice = fallback
+        } catch let error as DomainError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchNoticePermission")
+            )
+            let fallback = noticeState.value?.hasPermission ?? false
+            canEditNotice = fallback
+            canDeleteNotice = fallback
+        } catch let error as NetworkError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchNoticePermission")
+            )
+            let fallback = noticeState.value?.hasPermission ?? false
+            canEditNotice = fallback
+            canDeleteNotice = fallback
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchNoticePermission")
+            )
+            let fallback = noticeState.value?.hasPermission ?? false
+            canEditNotice = fallback
+            canDeleteNotice = fallback
+        }
+    }
+
+    /// 삭제 확인 다이얼로그 표시
+    ///
+    /// 확인 버튼 탭 시 화면은 즉시 닫고, 삭제 API는 백그라운드로 전송합니다.
+    public func showDeleteConfirmation(onDeleteRequested: @escaping () -> Void) {
+        alertPrompt = AlertPrompt(
+            id: .init(),
+            title: "공지 삭제",
+            message: "정말 삭제하시겠습니까?",
+            positiveBtnTitle: "삭제",
+            positiveBtnAction: { [weak self] in
+                onDeleteRequested()
+                Task {
+                    await self?.deleteNotice()
+                }
+            },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    /// 공지 상세 진입 시 1회 읽음 처리
+    @MainActor
+    public func markAsReadIfNeeded() async -> Bool {
+        guard !hasMarkedAsRead else { return false }
+        guard !noticeID.isEmpty && noticeID != "0" else { return false }
+
+        do {
+            try await noticeUseCase.readNotice(noticeId: noticeID)
+            persistReadStateIfPossible()
+            hasMarkedAsRead = true
+            return true
+        } catch let error as RepositoryError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "markAsReadIfNeeded"
+                )
+            )
+            // 읽음 처리 실패는 상세 진입을 막지 않습니다.
+            return false
+        } catch let error as DomainError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "markAsReadIfNeeded"
+                )
+            )
+            // 읽음 처리 실패는 상세 진입을 막지 않습니다.
+            return false
+        } catch let error as NetworkError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "markAsReadIfNeeded"
+                )
+            )
+            // 읽음 처리 실패는 상세 진입을 막지 않습니다.
+            return false
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "markAsReadIfNeeded"
+                )
+            )
+            // 읽음 처리 실패는 상세 진입을 막지 않습니다.
+            return false
+        }
+    }
+
+    private func persistReadStateIfPossible() {
+        guard currentMemberId > 0 else { return }
+
+        do {
+            try noticeReadRepository.markAsRead(
+                noticeId: String(noticeID),
+                memberId: String(currentMemberId)
+            )
+        } catch {
+            // 로컬 읽음 상태 저장 실패는 화면 흐름을 막지 않습니다.
+        }
+    }
+
+    /// 리마인더 발송
+    @MainActor
+    public func sendReminder(targetIds: [String]) async {
+        do {
+            #if DEBUG
+            print("[NoticeReminder] request targetIds: \(targetIds)")
+            #endif
+
+            try await noticeUseCase.sendReminder(
+                noticeId: noticeID,
+                targetIds: targetIds
+            )
+
+            let successMessage: String
+            if targetIds.count == 1, let singleTargetId = targetIds.first {
+                successMessage = "1명에게 리마인더를 발송했습니다. (ID: \(singleTargetId))"
+            } else {
+                successMessage = "\(targetIds.count)명에게 리마인더를 발송했습니다."
+            }
+
+            alertPrompt = AlertPrompt(
+                id: .init(),
+                title: "리마인더 발송 완료",
+                message: successMessage,
+                positiveBtnTitle: "확인"
+            )
+
+        } catch let error as DomainError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "sendReminder",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.sendReminder(targetIds: targetIds)
+                        }
+                    }
+                )
+            )
+        } catch let error as RepositoryError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "sendReminder",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.sendReminder(targetIds: targetIds)
+                        }
+                    }
+                )
+            )
+        } catch let error as NetworkError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "sendReminder",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.sendReminder(targetIds: targetIds)
+                        }
+                    }
+                )
+            )
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "sendReminder",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.sendReminder(targetIds: targetIds)
+                        }
+                    }
+                )
+            )
+        }
+    }
+
+    /// 미확인 사용자 전체에게 리마인더를 발송합니다.
+    ///
+    /// 커서 기반 페이징으로 전체 미확인 사용자를 수집한 뒤 일괄 발송합니다.
+    @MainActor
+    public func sendReminderToAllUnreadUsers() async {
+        do {
+            var cursor = 0
+            var hasNext = true
+            var targetIds: Set<String> = []
+
+            // 커서 기반으로 모든 미확인 사용자 ID를 수집
+            while hasNext {
+                let response = try await fetchReadStatusPage(
+                    cursorId: cursor,
+                    status: .unconfirmed
+                )
+
+                response.users.forEach {
+                    targetIds.insert($0.id)
+                }
+                hasNext = response.hasNext
+                cursor = parseCursor(response.nextCursor) ?? 0
+
+                // 서버가 빈 커서를 반환하면 무한 루프 방지
+                if hasNext && response.nextCursor.isEmpty {
+                    break
+                }
+            }
+
+            await sendReminder(targetIds: Array(targetIds))
+        } catch let error as DomainError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "sendReminderToAllUnreadUsers")
+            )
+        } catch let error as RepositoryError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "sendReminderToAllUnreadUsers")
+            )
+        } catch let error as NetworkError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "sendReminderToAllUnreadUsers")
+            )
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "sendReminderToAllUnreadUsers")
+            )
+        }
+    }
+
+    // MARK: - Update Actions
+
+    /// 공지사항 수정 완료 (제목, 본문)
+    @MainActor
+    public func updateNoticeContent(title: String, content: String) async {
+        noticeState = .loading
+
+        do {
+            let updatedNotice = try await noticeUseCase.updateNotice(
+                noticeId: noticeID,
+                title: title,
+                content: content
+            )
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: updatedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
+
+        } catch let error as DomainError {
+            noticeState = .failed(.domain(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "updateNoticeContent")
+            )
+        } catch let error as RepositoryError {
+            noticeState = .failed(.repository(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "updateNoticeContent")
+            )
+        } catch let error as NetworkError {
+            noticeState = .failed(.network(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "updateNoticeContent")
+            )
+        } catch {
+            noticeState = .failed(.unknown(message: error.localizedDescription))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "updateNoticeContent")
+            )
+        }
+    }
+
+    /// 공지사항 링크 수정
+    @MainActor
+    public func updateNoticeLinks(links: [String]) async {
+        do {
+            let updatedNotice = try await noticeUseCase.updateLinks(
+                noticeId: noticeID,
+                links: links
+            )
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: updatedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
+        } catch let error as RepositoryError {
+            noticeState = .failed(.repository(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "updateLinks",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.updateNoticeLinks(links: links)
+                        }
+                    }
+                )
+            )
+
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "updateLinks",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.updateNoticeLinks(links: links)
+                        }
+                    }
+                )
+            )
+        }
+    }
+
+    /// 공지사항 이미지 수정
+    @MainActor
+    public func updateNoticeImages(imageIds: [String]) async {
+        do {
+            let updatedNotice = try await noticeUseCase.updateImages(
+                noticeId: noticeID,
+                imageIds: imageIds
+            )
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: updatedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
+        } catch let error as RepositoryError {
+            noticeState = .failed(.repository(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "updateImages",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.updateNoticeImages(imageIds: imageIds)
+                        }
+                    }
+                )
+            )
+
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "updateImages",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.updateNoticeImages(imageIds: imageIds)
+                        }
+                    }
+                )
+            )
+        }
+    }
+
+    /// 투표 응답 처리
+    ///
+    /// 선택 옵션을 서버로 전송한 뒤 공지 상세를 재조회하여 최신 투표 상태를 반영합니다.
+    @MainActor
+    public func handleVote(optionIds: [String]) async {
+        guard case .loaded = noticeState else {
+            return
+        }
+        guard !isSubmittingVote else { return }
+
+        do {
+            isSubmittingVote = true
+            defer { isSubmittingVote = false }
+
+            guard !optionIds.isEmpty else {
+                throw DomainError.custom(message: "유효한 투표 항목이 없습니다.")
+            }
+
+            try await noticeUseCase.submitVoteResponse(
+                noticeId: noticeID,
+                optionIds: optionIds
+            )
+
+            // 서버 반영 결과(득표수/내 선택 상태)를 최신값으로 반영
+            let refreshedNotice = try await noticeUseCase.getDetailNotice(noticeId: noticeID)
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: refreshedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
+        } catch let error as DomainError {
+            isSubmittingVote = false
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "handleVote",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.handleVote(optionIds: optionIds)
+                        }
+                    }
+                )
+            )
+        } catch let error as RepositoryError {
+            isSubmittingVote = false
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "handleVote",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.handleVote(optionIds: optionIds)
+                        }
+                    }
+                )
+            )
+        } catch let error as NetworkError {
+            isSubmittingVote = false
+            if case .requestFailed(_, let data) = error,
+               let data,
+               let parsed = try? JSONDecoder().decode(
+                     VoteErrorResponse.self, from: data
+               ) {
+                alertPrompt = AlertPrompt(
+                    id: .init(),
+                    title: "투표 실패",
+                    message: parsed.message ?? error.userMessage,
+                    positiveBtnTitle: "확인"
+                )
+            } else {
+                errorHandler.handle(
+                    error,
+                    context: ErrorContext(
+                        feature: "Notice",
+                        action: "handleVote",
+                        retryAction: { [weak self] in
+                            guard let self = self else { return }
+                            Task {
+                                await self.handleVote(optionIds: optionIds)
+                            }
+                        }
+                    )
+                )
+            }
+        } catch {
+            isSubmittingVote = false
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "handleVote",
+                    retryAction: { [weak self] in
+                        guard let self = self else { return }
+                        Task {
+                            await self.handleVote(optionIds: optionIds)
+                        }
+                    }
+                )
+            )
+        }
+    }
+
+    /// 투표 응답 수정 처리
+    ///
+    /// 기존 투표를 수정(PUT)한 뒤 공지 상세를 재조회하여 최신 투표 상태를 반영합니다.
+    /// 빈 배열 전송 시 기존 응답이 취소(삭제)됩니다.
+    @MainActor
+    public func handleUpdateVote(optionIds: [String]) async {
+        guard case .loaded = noticeState else { return }
+        guard !isSubmittingVote else { return }
+
+        do {
+            isSubmittingVote = true
+            defer { isSubmittingVote = false }
+
+            try await noticeUseCase.updateVoteResponse(
+                noticeId: noticeID,
+                optionIds: optionIds
+            )
+
+            let refreshedNotice = try await noticeUseCase.getDetailNotice(noticeId: noticeID)
+            let normalizedNotice = normalizeTargetGenerationIfNeeded(in: refreshedNotice)
+            noticeState = .loaded(normalizedNotice)
+            refreshAuthorDisplayName(for: normalizedNotice)
+        } catch let error as DomainError {
+            isSubmittingVote = false
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "handleUpdateVote",
+                    retryAction: { [weak self] in
+                        guard let self else { return }
+                        Task { await self.handleUpdateVote(optionIds: optionIds) }
+                    }
+                )
+            )
+        } catch let error as RepositoryError {
+            isSubmittingVote = false
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "handleUpdateVote",
+                    retryAction: { [weak self] in
+                        guard let self else { return }
+                        Task { await self.handleUpdateVote(optionIds: optionIds) }
+                    }
+                )
+            )
+        } catch let error as NetworkError {
+            isSubmittingVote = false
+            if case .requestFailed(_, let data) = error,
+               let data,
+               let parsed = try? JSONDecoder().decode(
+                     VoteErrorResponse.self, from: data
+               ) {
+                alertPrompt = AlertPrompt(
+                    id: .init(),
+                    title: "투표 실패",
+                    message: parsed.message ?? error.userMessage,
+                    positiveBtnTitle: "확인"
+                )
+            } else {
+                errorHandler.handle(
+                    error,
+                    context: ErrorContext(
+                        feature: "Notice",
+                        action: "handleUpdateVote",
+                        retryAction: { [weak self] in
+                            guard let self else { return }
+                            Task {
+                                await self.handleUpdateVote(optionIds: optionIds)
+                            }
+                        }
+                    )
+                )
+            }
+        } catch {
+            isSubmittingVote = false
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "handleUpdateVote",
+                    retryAction: { [weak self] in
+                        guard let self else { return }
+                        Task {
+                            await self.handleUpdateVote(optionIds: optionIds)
+                        }
+                    }
+                )
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    /// 공지 삭제
+    @MainActor
+    private func deleteNotice() async {
+        do {
+            try await noticeUseCase.deleteNotice(noticeId: noticeID)
+        } catch let error as RepositoryError {
+            handleDeleteError(error)
+        } catch let error as DomainError {
+            handleDeleteError(error)
+        } catch let error as NetworkError {
+            handleDeleteError(error)
+        } catch {
+            handleDeleteError(error)
+        }
+    }
+
+    /// 삭제 실패 시 ErrorHandler로 에러를 전달하고 재시도 액션을 바인딩합니다.
+    private func handleDeleteError(_ error: Error) {
+        errorHandler.handle(
+            error,
+            context: ErrorContext(
+                feature: "Notice",
+                action: "deleteNotice",
+                retryAction: { [weak self] in
+                    guard let self = self else { return }
+                    Task {
+                        await self.deleteNotice()
+                    }
+                }
+            )
+        )
+    }
+    
+    private struct VoteErrorResponse: Decodable {
+        let message: String?
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift
@@ -6,3 +6,277 @@
 //
 
 import Foundation
+import UMCFoundation
+import NoticeDomain
+
+extension NoticeDetailViewModel {
+
+    // MARK: - Read Status Actions
+
+    /// 공지 열람 현황 Sheet 표시
+    @MainActor
+    public func openReadStatusSheet() {
+        guard canViewReadStatus else { return }
+        showReadStatusSheet = true
+        if readStatusState.isIdle {
+            Task { await fetchReadStatus() }
+        }
+    }
+
+    /// 공지 상세 진입 시 통계(read-statics)만 선조회합니다.
+    ///
+    /// 하단 수신 확인 카드의 숫자/비율을 먼저 안정적으로 노출하고,
+    /// 상세 목록(read-status)은 시트 진입 시점에만 로드합니다.
+    @MainActor
+    public func prefetchReadStaticsIfNeeded(forceReload: Bool = false) async {
+        guard canViewReadStatus else { return }
+        guard forceReload || !hasPrefetchedReadStatics else { return }
+        guard !noticeID.isEmpty && noticeID != "0" else { return }
+        if forceReload == false, readStatics != nil { return }
+
+        isReadStaticsLoading = true
+        defer { isReadStaticsLoading = false }
+        do {
+            readStatics = try await noticeUseCase.getReadStatics(noticeId: noticeID)
+            hasPrefetchedReadStatics = true
+        } catch let error as RepositoryError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "prefetchReadStaticsIfNeeded"
+                )
+            )
+            // 통계 선조회 실패는 상세 진입을 막지 않으며, 시트 진입 시 재시도할 수 있습니다.
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Notice",
+                    action: "prefetchReadStaticsIfNeeded"
+                )
+            )
+            // 통계 선조회 실패는 상세 진입을 막지 않으며, 시트 진입 시 재시도할 수 있습니다.
+        }
+    }
+
+    /// 읽음 처리 직후 UI를 즉시 반영하기 위해 통계를 낙관적으로 갱신합니다.
+    public func applyOptimisticReadStatics() {
+        guard let current = readStatics else { return }
+
+        let readCount = Int(current.readCount) ?? 0
+        let unreadCount = Int(current.unreadCount) ?? 0
+        let totalCount = Int(current.totalCount) ?? max(readCount + unreadCount, 0)
+
+        guard totalCount > 0 else { return }
+        guard unreadCount > 0 else { return }
+        guard readCount < totalCount else { return }
+
+        let nextReadCount = readCount + 1
+        let nextUnreadCount = max(unreadCount - 1, 0)
+        let nextReadRate = Double(nextReadCount) / Double(totalCount)
+
+        readStatics = NoticeReadStatics(
+            totalCount: String(totalCount),
+            readCount: String(nextReadCount),
+            unreadCount: String(nextUnreadCount),
+            readRate: String(nextReadRate)
+        )
+    }
+
+    /// 공지 열람 현황 데이터 로드 (통계 + 상세)
+    @MainActor
+    public func fetchReadStatus(showLoadingState: Bool = true) async {
+        guard canViewReadStatus else { return }
+        if showLoadingState {
+            readStatusState = .loading
+        }
+
+        do {
+            resetReadStatusPagination()
+            if readStatics == nil {
+                isReadStaticsLoading = true
+                readStatics = try await noticeUseCase.getReadStatics(noticeId: noticeID)
+                hasPrefetchedReadStatics = true
+                isReadStaticsLoading = false
+            }
+
+            let confirmedResponse = try await fetchReadStatusPage(cursorId: 0, status: .confirmed)
+            let unconfirmedResponse = try await fetchReadStatusPage(cursorId: 0, status: .unconfirmed)
+
+            let confirmedUsers = confirmedResponse.users
+            let unconfirmedUsers = unconfirmedResponse.users
+            
+            readNextCursor = parseCursor(confirmedResponse.nextCursor)
+            unreadNextCursor = parseCursor(unconfirmedResponse.nextCursor)
+            hasNextReadPage = confirmedResponse.hasNext
+            hasNextUnreadPage = unconfirmedResponse.hasNext
+
+            readStatusState = .loaded(
+                NoticeReadStatus(
+                    noticeId: noticeID,
+                    confirmedUsers: confirmedUsers,
+                    unconfirmedUsers: unconfirmedUsers
+                )
+            )
+
+        } catch let error as RepositoryError {
+            isReadStaticsLoading = false
+            readStatics = nil
+            readStatusState = .failed(.repository(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchReadStatus")
+            )
+        } catch let error as DomainError {
+            isReadStaticsLoading = false
+            readStatics = nil
+            readStatusState = .failed(.domain(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchReadStatus")
+            )
+        } catch let error as NetworkError {
+            isReadStaticsLoading = false
+            readStatics = nil
+            readStatusState = .failed(.network(error))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchReadStatus")
+            )
+        } catch {
+            isReadStaticsLoading = false
+            readStatics = nil
+            readStatusState = .failed(.unknown(message: error.localizedDescription))
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "fetchReadStatus")
+            )
+        }
+    }
+
+    /// 실패 화면에서 재시도 버튼을 눌렀을 때 호출됩니다.
+    @MainActor
+    public func retryFetchReadStatus() async {
+        guard !isRetryingReadStatus else { return }
+        isRetryingReadStatus = true
+        defer { isRetryingReadStatus = false }
+        await fetchReadStatus(showLoadingState: false)
+    }
+
+    /// 현재 선택된 탭 목록에서 특정 아이템이 하단에 도달했는지 확인하고 다음 페이지를 로드합니다.
+    ///
+    /// 무한 스크롤 방식으로 리스트 끝 근처 아이템이 표시될 때 자동 호출됩니다.
+    @MainActor
+    public func loadMoreReadStatusIfNeeded(currentItem: ReadStatusUser) async {
+        guard var current = readStatusState.value else { return }
+        guard !isLoadingMoreReadStatus else { return }
+
+        let currentUsers = selectedReadTab == .confirmed
+            ? current.confirmedUsers
+            : current.unconfirmedUsers
+        guard shouldLoadMore(currentItem: currentItem, in: currentUsers) else { return }
+
+        // 탭별 다음 페이지 존재 여부 및 커서 유효성 확인
+        switch selectedReadTab {
+        case .confirmed:
+            guard hasNextReadPage else { return }
+            guard readNextCursor != nil else { return }
+        case .unconfirmed:
+            guard hasNextUnreadPage else { return }
+            guard unreadNextCursor != nil else { return }
+        }
+
+        isLoadingMoreReadStatus = true
+        defer { isLoadingMoreReadStatus = false }
+
+        do {
+            let response = try await fetchReadStatusPage(
+                cursorId: selectedReadTab == .confirmed ? (readNextCursor ?? 0) : (unreadNextCursor ?? 0),
+                status: selectedReadTab
+            )
+
+            let appendedUsers = response.users
+
+            switch selectedReadTab {
+            case .confirmed:
+                let merged = current.confirmedUsers + appendedUsers
+                current = NoticeReadStatus(
+                    noticeId: current.noticeId,
+                    confirmedUsers: merged,
+                    unconfirmedUsers: current.unconfirmedUsers
+                )
+                readNextCursor = parseCursor(response.nextCursor)
+                hasNextReadPage = response.hasNext
+            case .unconfirmed:
+                let merged = current.unconfirmedUsers + appendedUsers
+                current = NoticeReadStatus(
+                    noticeId: current.noticeId,
+                    confirmedUsers: current.confirmedUsers,
+                    unconfirmedUsers: merged
+                )
+                unreadNextCursor = parseCursor(response.nextCursor)
+                hasNextUnreadPage = response.hasNext
+            }
+
+            readStatusState = .loaded(current)
+        } catch let error as RepositoryError {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "loadMoreReadStatusIfNeeded")
+            )
+            // 페이징 실패는 기존 데이터를 유지합니다.
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "Notice", action: "loadMoreReadStatusIfNeeded")
+            )
+            // 페이징 실패는 기존 데이터를 유지합니다.
+        }
+    }
+
+    /// 탭 전환
+    public func switchReadTab(to tab: ReadStatusTab) {
+        selectedReadTab = tab
+    }
+
+    // MARK: - Read Status Helper
+
+    /// 읽음/안읽음 상세 목록 페이지를 조회합니다.
+    public func fetchReadStatusPage(
+        cursorId: Int,
+        status: ReadStatusTab
+    ) async throws -> NoticeReadStatusPage {
+        try await noticeUseCase.getReadStatusList(
+            noticeId: noticeID,
+            cursorId: String(cursorId),
+            filterType: "ALL",
+            organizationIds: [],
+            status: status == .confirmed ? "READ" : "UNREAD"
+        )
+    }
+
+    /// 커서 페이지네이션 상태를 초기화합니다.
+    public func resetReadStatusPagination() {
+        readNextCursor = nil
+        unreadNextCursor = nil
+        hasNextReadPage = false
+        hasNextUnreadPage = false
+        isLoadingMoreReadStatus = false
+    }
+
+    /// 무한 스크롤 트리거 여부를 판단합니다.
+    public func shouldLoadMore(currentItem: ReadStatusUser, in users: [ReadStatusUser]) -> Bool {
+        guard let currentIndex = users.firstIndex(where: { $0.id == currentItem.id }) else {
+            return false
+        }
+        let thresholdIndex = max(users.count - 3, 0)
+        return currentIndex >= thresholdIndex
+    }
+
+    /// 문자열 커서를 Int로 변환합니다.
+    public func parseCursor(_ value: String) -> Int? {
+        guard !value.isEmpty else { return nil }
+        return Int(value)
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel+ReadStatus.swift
@@ -1,0 +1,8 @@
+//
+//  NoticeDetailViewModel+ReadStatus.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  NoticeDetailViewModel.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel.swift
@@ -5,4 +5,413 @@
 //  Created by 이예지 on 5/30/26.
 //
 
-import Foundation
+import SwiftUI
+import UMCFoundation
+import CoreDI
+import NoticeDomain
+
+/// 공지사항 상세 화면 ViewModel
+///
+/// 공지 조회/수정/삭제, 투표 처리, 열람 현황(The Ping) 관리를 담당합니다.
+@Observable
+public final class NoticeDetailViewModel {
+
+    // MARK: - Dependency
+
+    /// DI Container
+    public let container: DIContainer
+
+    /// UseCase
+    public var noticeUseCase: NoticeUseCaseProtocol {
+        container.resolve(NoticeUseCaseProtocol.self)
+    }
+
+    public var authorizationUseCase: AuthorizationUseCaseProtocol {
+        container.resolve(AuthorizationUseCaseProtocol.self)
+    }
+
+    public var genRepository: ChallengerGenRepositoryProtocol {
+        container.resolve(ChallengerGenRepositoryProtocol.self)
+    }
+
+    public var noticeReadRepository: NoticeReadRepositoryProtocol {
+        container.resolve(NoticeReadRepositoryProtocol.self)
+    }
+
+    public var userSessionManager: UserSessionManager {
+        container.resolve(UserSessionManager.self)
+    }
+
+    public var currentMemberId: Int {
+        AppStorageKey.legacyMemberIdInt()
+    }
+
+    // MARK: - Core State
+
+    /// 공지 상세 상태
+    public var noticeState: Loadable<NoticeDetail>
+
+    /// 작성자 표시 텍스트 (닉네임/이름-기수TH UMC 직책)
+    public var authorDisplayName: String = ""
+    /// 작성자 상세 프로필 요약 정보
+    public var authorProfileSummary: MemberProfileSummary?
+    /// 작성자 프로필 추가 조회 진행 상태
+    public var isAuthorProfileLoading: Bool = false
+    /// 작성자 프로필 추가 조회 완료 여부
+    public var hasResolvedAuthorProfile: Bool = false
+
+    /// 액션 메뉴 표시 여부
+    public var showingActionMenu: Bool = false
+
+    /// Alert 프롬프트
+    public var alertPrompt: AlertPrompt?
+
+    /// 투표 응답 전송 진행 상태
+    public var isSubmittingVote: Bool = false
+
+    /// 공지 상세 초기 fetch 완료 전까지 투표 영역 로딩 표시 여부
+    public var isVoteLoading: Bool = true
+
+    /// 공지 ID
+    public let noticeID: String
+
+    /// 읽음 처리 완료 여부(중복 호출 방지)
+    public var hasMarkedAsRead: Bool = false
+
+    /// Error Handler
+    public var errorHandler: ErrorHandler
+
+    /// Navigation 콜백
+    public var onEditNotice: ((Int) -> Void)?
+    public var onDeleteSuccess: (() -> Void)?
+
+    // MARK: - Read Status State
+
+    /// 공지 열람 현황 Sheet 표시 여부
+    public var showReadStatusSheet: Bool = false
+
+    /// 공지 열람 현황 데이터 상태
+    public var readStatusState: Loadable<NoticeReadStatus> = .idle
+
+    /// 공지 열람 통계 API 원본 값
+    public var readStatics: NoticeReadStatics?
+
+    /// 공지 열람 통계(read-statics) 로딩 상태
+    public var isReadStaticsLoading: Bool = false
+
+    /// 공지 열람 통계 선조회 여부
+    public var hasPrefetchedReadStatics: Bool = false
+
+    /// 읽음 사용자 페이지 커서
+    public var readNextCursor: Int?
+
+    /// 안읽음 사용자 페이지 커서
+    public var unreadNextCursor: Int?
+
+    /// 읽음 사용자 다음 페이지 존재 여부
+    public var hasNextReadPage: Bool = false
+
+    /// 안읽음 사용자 다음 페이지 존재 여부
+    public var hasNextUnreadPage: Bool = false
+
+    /// 페이지네이션 진행 상태
+    public var isLoadingMoreReadStatus: Bool = false
+
+    /// 열람 현황 재시도 진행 상태 (실패 화면의 버튼 내부 로딩 표시용)
+    public var isRetryingReadStatus: Bool = false
+
+    /// 선택된 탭 (확인/미확인)
+    public var selectedReadTab: ReadStatusTab = .confirmed
+
+    /// 선택된 필터 타입
+    public var selectedFilter: ReadStatusFilterType = .all
+
+    // MARK: - Permission State
+
+    /// 공지 수정 가능 여부 (WRITE/MANAGE)
+    public var canEditNotice: Bool = false
+
+    /// 공지 삭제 가능 여부 (DELETE/MANAGE)
+    public var canDeleteNotice: Bool = false
+
+    /// 수정 화면 진입에 필요한 상세 데이터 준비 완료 여부
+    public var isDetailPreparedForEdit: Bool = false
+
+    /// 수신 확인 현황 접근 가능 여부
+    public var canViewReadStatus: Bool {
+        guard let detail = noticeState.value else { return false }
+        return NoticeReadStatusPermissionEvaluator.canViewReadStatus(
+            roles: resolvedMemberRoles,
+            userChapterId: resolvedChapterId,
+            userSchoolId: resolvedSchoolId,
+            targetAudience: detail.targetAudience
+        )
+    }
+
+    // MARK: - Read Status Computed
+
+    /// 현재 선택된 탭에 따른 필터링된 사용자 목록
+    public var filteredReadStatusUsers: [ReadStatusUser] {
+        guard let readStatus = readStatusState.value else { return [] }
+        return selectedReadTab == .confirmed ? readStatus.confirmedUsers : readStatus.unconfirmedUsers
+    }
+
+    /// 하단 메시지 표시 여부 (확인 탭에서만)
+    public var shouldShowBottomMessage: Bool {
+        selectedReadTab == .confirmed && readStatusState.value != nil
+    }
+
+    /// 하단 메시지 텍스트
+    public var bottomMessage: String {
+        readStatusState.value?.bottomMessage ?? ""
+    }
+
+    /// 확인한 인원 수 (버튼용)
+    public var confirmedCount: String {
+        if let readStatics { return readStatics.readCount }
+        return readStatusState.value?.confirmedCount ?? "0"
+    }
+
+    /// 확인하지 않은 인원 수 (버튼용)
+    public var unconfirmedCount: String {
+        if let readStatics { return readStatics.unreadCount }
+        return readStatusState.value?.unconfirmedCount ?? "0"
+    }
+
+    /// 전체 인원 수 (버튼용)
+    public var totalCount: Int {
+        if let readStatics { return Int(readStatics.totalCount) ?? 0 }
+        let confirmed = Int(confirmedCount) ?? 0
+        let unconfirmed = Int(unconfirmedCount) ?? 0
+        return confirmed + unconfirmed
+    }
+
+    /// 읽음 비율(0.0 ~ 1.0)
+    public var readRate: Double {
+        if let readStatics {
+            return Self.normalizedReadRate(from: readStatics.readRate)
+        }
+        guard totalCount > 0 else { return 0 }
+        return Double(Int(confirmedCount) ?? 0) / Double(totalCount)
+    }
+
+    /// 지부별로 그룹화된 사용자
+    public var groupedUsersByBranch: [String: [ReadStatusUser]] {
+        Dictionary(grouping: filteredReadStatusUsers, by: { $0.branch })
+            .sorted { $0.key < $1.key }
+            .reduce(into: [:]) { $0[$1.key] = $1.value }
+    }
+
+    /// 학교별로 그룹화된 사용자
+    public var groupedUsersBySchool: [String: [ReadStatusUser]] {
+        Dictionary(grouping: filteredReadStatusUsers, by: { $0.campus })
+            .sorted { $0.key < $1.key }
+            .reduce(into: [:]) { $0[$1.key] = $1.value }
+    }
+
+    // MARK: - Initialization
+
+    public init(
+        container: DIContainer,
+        errorHandler: ErrorHandler,
+        model: NoticeDetail
+    ) {
+        self.container = container
+        self.noticeID = model.id
+        self.errorHandler = errorHandler
+        self.noticeState = .loaded(model)
+        let normalizedModel = normalizeTargetGenerationIfNeeded(in: model)
+        noticeState = .loaded(normalizedModel)
+        authorDisplayName = normalizedModel.defaultAuthorDisplayName
+    }
+
+    // MARK: - Function
+
+    /// ErrorHandler 업데이트
+    public func updateErrorHandler(_ handler: ErrorHandler) {
+        errorHandler = handler
+    }
+
+    /// 액션 메뉴 표시
+    public func showActionMenu() {
+        showingActionMenu = true
+    }
+
+    // MARK: - Author Profile
+
+    /// 공지 작성자 표기명을 목록/상세 응답에 포함된 닉네임/이름 값으로 갱신합니다.
+    @MainActor
+    public func refreshAuthorDisplayName(for detail: NoticeDetail) {
+        authorDisplayName = detail.defaultAuthorDisplayName
+    }
+
+    /// 화면에 즉시 노출할 작성자명을 반환합니다.
+    public func displayedAuthorName(for detail: NoticeDetail) -> String {
+        authorDisplayName.isEmpty ? detail.defaultAuthorDisplayName : authorDisplayName
+    }
+
+    /// 화면에 노출할 작성자 이름/닉네임 텍스트를 반환합니다.
+    public func displayedAuthorIdentity(for detail: NoticeDetail) -> String {
+        if let authorProfileSummary {
+            let name = authorProfileSummary.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let nickname = authorProfileSummary.nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if !name.isEmpty && !nickname.isEmpty {
+                return "\(nickname)/\(name)"
+            }
+            return !nickname.isEmpty ? nickname : name
+        }
+
+        let fallbackName = detail.authorName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallbackNickname = detail.authorNickname?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if !fallbackName.isEmpty && !fallbackNickname.isEmpty {
+            return "\(fallbackNickname)/\(fallbackName)"
+        }
+        return displayedAuthorName(for: detail)
+    }
+
+    /// 화면에 노출할 작성자 프로필 한 줄 텍스트를 반환합니다.
+    public func displayedAuthorProfileLine(for detail: NoticeDetail) -> String {
+        let identity = displayedAuthorIdentity(for: detail)
+        let generation: String
+        let roleName: String
+
+        if let authorProfileSummary {
+            generation = String(authorProfileSummary.generation)
+            roleName = authorProfileSummary.roleName.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            generation = detail.generation
+            roleName = ""
+        }
+
+        var components: [String] = []
+        if let genInt = Int(generation), genInt > 0 {
+            components.append("\(generation)\(ordinalSuffix(for: genInt))")
+        }
+        if !roleName.isEmpty && roleName != ManagementTeam.challenger.korean {
+            components.append(roleName)
+        }
+        components.append(identity)
+
+        return components.joined(separator: " ")
+    }
+
+    /// 화면에 노출할 작성자 프로필 이미지 URL을 반환합니다.
+    public func displayedAuthorImageURL(for detail: NoticeDetail) -> String? {
+        authorProfileSummary?.profileImageURL ?? detail.authorImageURL
+    }
+
+    private func ordinalSuffix(for generation: Int) -> String {
+        let suffixBase = generation % 100
+        if (11...13).contains(suffixBase) {
+            return "th"
+        }
+
+        switch generation % 10 {
+        case 1:
+            return "st"
+        case 2:
+            return "nd"
+        case 3:
+            return "rd"
+        default:
+            return "th"
+        }
+    }
+
+    // MARK: - Generation Helper
+
+    /// targetAudience.generation 값이 gisu PK인 경우 로컬 매핑으로 실제 기수(gen)로 보정합니다.
+    ///
+    /// 서버가 `targetGisu`를 내려주면 DTO 매퍼에서 우선 적용되고,
+    /// 해당 값이 없거나 `targetGisuId`만 존재할 때만 이 보정 로직이 동작합니다.
+    public func normalizeTargetGenerationIfNeeded(in detail: NoticeDetail) -> NoticeDetail {
+        let originalGeneration = detail.targetAudience.generation
+        let resolvedGeneration = resolveGeneration(from: originalGeneration)
+
+        guard resolvedGeneration != originalGeneration else {
+            return detail
+        }
+
+        let normalizedAudience = TargetAudience(
+            generation: resolvedGeneration,
+            scope: detail.targetAudience.scope,
+            parts: detail.targetAudience.parts,
+            chapterId: detail.targetAudience.chapterId,
+            schoolId: detail.targetAudience.schoolId,
+            branches: detail.targetAudience.branches,
+            schools: detail.targetAudience.schools
+        )
+
+        return NoticeDetail(
+            id: detail.id,
+            generation: resolvedGeneration,
+            scope: detail.scope,
+            category: detail.category,
+            isMustRead: detail.isMustRead,
+            title: detail.title,
+            content: detail.content,
+            authorID: detail.authorID,
+            authorMemberId: detail.authorMemberId,
+            authorNickname: detail.authorNickname,
+            authorName: detail.authorName,
+            authorImageURL: detail.authorImageURL,
+            createdAt: detail.createdAt,
+            updatedAt: detail.updatedAt,
+            targetAudience: normalizedAudience,
+            hasPermission: detail.hasPermission,
+            images: detail.images,
+            imageItems: detail.imageItems,
+            links: detail.links,
+            vote: detail.vote
+        )
+    }
+
+    /// 현재 값이 gisuId인지 판별하여 실제 기수(gen)를 반환합니다.
+    private func resolveGeneration(from value: String) -> String {
+        guard !value.isEmpty else { return value }
+        do {
+            let pairs = try genRepository.fetchGenGisuIdPairs()
+            if let matchedGen = pairs.first(where: { $0.gisuId == value })?.gen {
+                return matchedGen
+            }
+            return value
+        } catch {
+            return value
+        }
+    }
+
+    private var resolvedMemberRoles: [ManagementTeam] {
+        let storedRoles = (UserDefaults.standard.array(forKey: AppStorageKey.memberRoles) as? [String] ?? [])
+            .compactMap(ManagementTeam.init(rawValue:))
+        let storedHighestRole = UserDefaults.standard.string(forKey: AppStorageKey.memberRole)
+            .flatMap(ManagementTeam.init(rawValue:))
+        let combinedRoles = storedRoles + [userSessionManager.currentRole] + [storedHighestRole].compactMap { $0 }
+
+        return Array(Set(combinedRoles))
+    }
+
+    private var resolvedChapterId: String? {
+        let str = UserDefaults.standard.string(forKey: AppStorageKey.chapterId) ?? ""
+        return str.isEmpty || str == "0" ? nil : str
+    }
+
+    private var resolvedSchoolId: String? {
+        let str = UserDefaults.standard.string(forKey: AppStorageKey.schoolId) ?? ""
+        return str.isEmpty || str == "0" ? nil : str
+    }
+
+}
+
+private extension NoticeDetailViewModel {
+    static func normalizedReadRate(from rawValue: String) -> Double {
+        let parsedRate = Double(rawValue) ?? 0
+
+        if parsedRate > 1 {
+            return min(max(parsedRate / 100, 0), 1)
+        }
+
+        return min(max(parsedRate, 0), 1)
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeReadStatusPermissionEvaluator.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeReadStatusPermissionEvaluator.swift
@@ -6,3 +6,60 @@
 //
 
 import Foundation
+import UMCFoundation
+import NoticeDomain
+
+/// 공지 대상과 사용자 역할을 기준으로 수신 확인 현황 접근 가능 여부를 계산합니다.
+public struct NoticeReadStatusPermissionEvaluator {
+
+    // MARK: - Role Sets
+
+    private static let executiveRoles: Set<ManagementTeam> = [
+        .superAdmin,
+        .centralPresident,
+        .centralVicePresident
+    ]
+
+    private static let centralOperationRoles: Set<ManagementTeam> = [
+        .centralOperatingTeamMember,
+        .centralEducationTeamMember
+    ]
+
+    private static let schoolAdminRoles: Set<ManagementTeam> = [
+        .schoolPresident,
+        .schoolVicePresident,
+        .schoolPartLeader,
+        .schoolEtcAdmin
+    ]
+
+    // MARK: - Function
+
+    public static func canViewReadStatus(
+        roles: [ManagementTeam],
+        userChapterId: String?,
+        userSchoolId: String?,
+        targetAudience: TargetAudience
+    ) -> Bool {
+        let roleSet = Set(roles)
+
+        if !roleSet.isDisjoint(with: executiveRoles) {
+            return true
+        }
+
+        if let targetChapterId = targetAudience.chapterId {
+            guard let userChapterId, !userChapterId.isEmpty else { return false }
+            return roleSet.contains(.chapterPresident) && userChapterId == targetChapterId
+        }
+
+        if let targetSchoolId = targetAudience.schoolId {
+            guard let userSchoolId, !userSchoolId.isEmpty else { return false }
+            return !roleSet.isDisjoint(with: schoolAdminRoles) && userSchoolId == targetSchoolId
+        }
+
+        guard !targetAudience.generation.isEmpty && targetAudience.generation != "0" else {
+            return false
+        }
+
+        return !roleSet.isDisjoint(with: centralOperationRoles)
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeReadStatusPermissionEvaluator.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeReadStatusPermissionEvaluator.swift
@@ -1,0 +1,8 @@
+//
+//  NoticeReadStatusPermissionEvaluator.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarTypes.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeEditor/EditorToolbar/EditorToolbarTypes.swift
@@ -1,0 +1,61 @@
+//
+//  EditorToolbarTypes.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation
+
+
+/// 공지 에디터 툴바의 표시 상태를 정의합니다.
+enum EditorToolbarMode {
+    case `default`
+    case textSelected
+    case tableCell
+}
+
+/// 공지 에디터 단락 스타일 프리셋을 정의합니다.
+enum EditorParagraphStyle: String, CaseIterable {
+    case title
+    case heading
+    case subheading
+    case body
+    case mono
+}
+
+/// 공지 에디터 목록 스타일을 정의합니다.
+enum EditorListStyle {
+    case bullet
+    case dash
+    case number
+}
+
+/// 공지 에디터 전역 상수입니다.
+enum EditorConstants {
+    /// 블록 인용문에 적용되는 들여쓰기(pt) 값입니다. 에디터와 역직렬화에서 공통 사용합니다.
+    static let blockquoteIndent: CGFloat = 14
+}
+
+extension NSAttributedString.Key {
+
+    /// 블록 인용문 적용 여부를 저장하는 키입니다.
+    static let editorBlockquote = NSAttributedString.Key("EditorToolbarBlockquote")
+
+    /// 블록 인용문 테두리 색상을 저장하는 키입니다.
+    static let editorBlockquoteBorderColor = NSAttributedString.Key("EditorToolbarBlockquoteBorderColor")
+
+    /// 블록 인용문 이전의 headIndent 값을 저장하는 키입니다.
+    static let editorBlockquoteBaseHeadIndent = NSAttributedString.Key("EditorToolbarBlockquoteBaseHeadIndent")
+
+    /// 블록 인용문 이전의 firstLineHeadIndent 값을 저장하는 키입니다.
+    static let editorBlockquoteBaseFirstLineHeadIndent = NSAttributedString.Key("EditorToolbarBlockquoteBaseFirstLineHeadIndent")
+
+    /// 현재 목록 스타일 식별자를 저장하는 키입니다.
+    static let editorListStyle = NSAttributedString.Key("EditorToolbarListStyle")
+
+    /// Pretendard oblique italic 상태를 저장하는 키입니다.
+    /// UIKit이 커서 이동 시 typingAttributes의 oblique matrix를 버리므로
+    /// 이 키로 italic 활성 상태를 별도 추적합니다.
+    static let editorItalic = NSAttributedString.Key("EditorToolbarItalic")
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Context.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Context.swift
@@ -1,0 +1,243 @@
+//
+//  NoticeViewModel+Context.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/26/26.
+//
+
+import Foundation
+import UMCFoundation
+import NoticeDomain
+
+extension NoticeViewModel {
+
+    private enum GenerationFilterDefaults {
+        static let mainFilter: NoticeMainFilterType = .central
+    }
+
+    // MARK: - Context & Filter
+
+    /// 공지 탭 메뉴에 쓰이는 사용자 컨텍스트를 반영합니다.
+    ///
+    /// - Parameters:
+    ///   - schoolName: 사용자 학교명
+    ///   - chapterName: 사용자 지부명
+    ///   - responsiblePart: 사용자 파트 API 값
+    ///   - organizationTypeRawValue: 사용자 조직 타입 raw value
+    ///   - chapterId: 사용자 지부 ID
+    ///   - schoolId: 사용자 학교 ID
+    ///   - memberRoleRawValue: 사용자 역할 raw value
+    func applyUserContext(
+        schoolName: String,
+        chapterName: String,
+        responsiblePart: String,
+        organizationTypeRawValue: String,
+        chapterId: String,
+        schoolId: String,
+        memberRoleRawValue: String,
+        generationOrganizationsJSON: String
+    ) {
+        self.userContext = NoticeUserContext(
+            schoolName: schoolName,
+            chapterName: chapterName,
+            responsiblePart: responsiblePart
+        )
+        self.organizationType = OrganizationType(rawValue: organizationTypeRawValue)
+        self.memberRole = ManagementTeam(rawValue: memberRoleRawValue)
+        self.chapterId = chapterId
+        self.schoolId = schoolId
+        self.generationOrganizations = decodeGenerationOrganizations(from: generationOrganizationsJSON)
+
+        let validMainFilters = mainFilterItems
+        let isCurrentPartSelectionValid: Bool = {
+            if case .part = selectedMainFilter {
+                return canSelectPartFilter
+            }
+            return validMainFilters.contains(selectedMainFilter)
+        }()
+
+        if !isCurrentPartSelectionValid {
+            var state = currentState
+            state.mainFilter = validMainFilters.first ?? .all
+            currentState = state
+        }
+    }
+
+    private func decodeGenerationOrganizations(from json: String) -> [String: GenerationOrganizationContext] {
+        guard let data = json.data(using: .utf8),
+              let contexts = try? JSONDecoder().decode([GenerationOrganizationContext].self, from: data) else {
+            return [:]
+        }
+
+        return Dictionary(uniqueKeysWithValues: contexts.map { ($0.gen, $0) })
+    }
+
+    /// 기수 목록 조회
+    func fetchGisuList() {
+        guard !isFetchingGisuList else { return }
+        isFetchingGisuList = true
+        defer { isFetchingGisuList = false }
+
+        do {
+            let fetchedPairs = try genRepository.fetchGenGisuIdPairs()
+            gisuPairs = fetchedPairs.filter { !$0.gisuId.isEmpty && $0.gisuId != "0" }
+            isGisuListLoaded = !gisuPairs.isEmpty
+
+            generations = gisuPairs.map { Generation(value: $0.gen) }
+
+            if let latestGen = generations.max(by: { (Int($0.value) ?? 0) < (Int($1.value) ?? 0) }) {
+                let hasValidSelectedGeneration = generations.contains {
+                    $0.value == selectedGeneration.value
+                }
+                let targetGeneration = hasValidSelectedGeneration ? selectedGeneration : latestGen
+                selectedGeneration = targetGeneration
+
+                if generationStates[targetGeneration.value] == nil {
+                    generationStates[targetGeneration.value] = GenerationFilterState(
+                        mainFilter: GenerationFilterDefaults.mainFilter
+                    )
+                }
+
+                Task { @MainActor in
+                    await refreshSelectedGenerationContext(
+                        resetFilters: !hasValidSelectedGeneration
+                    )
+                }
+            } else {
+                isGisuListLoaded = false
+                noticeItems = .failed(.domain(.custom(message: "기수 정보를 불러오지 못했습니다.")))
+                errorHandler.handle(
+                    DomainError.custom(message: "기수 정보를 불러오지 못했습니다."),
+                    context: .init(
+                        feature: "Notice",
+                        action: "fetchGisuList"
+                    )
+                )
+            }
+        } catch {
+            gisuPairs = []
+            isGisuListLoaded = false
+            generations = []
+            noticeItems = .failed(.domain(.custom(message: "기수 정보를 불러오지 못했습니다.")))
+            errorHandler.handle(
+                error,
+                context: .init(
+                    feature: "Notice",
+                    action: "fetchGisuList"
+                )
+            )
+        }
+    }
+
+    /// 기수 선택
+    /// - Parameter generation: 선택된 기수
+    func selectGeneration(_ generation: Generation) {
+        guard gisuPairs.contains(where: {
+              $0.gen == generation.value && !$0.gisuId.isEmpty && $0.gisuId != "0"
+          }) else { return }
+        selectedGeneration = generation
+        Task { @MainActor in
+            await refreshSelectedGenerationContext(resetFilters: true)
+        }
+    }
+
+    /// 메인필터 선택
+    /// - Parameter filter: 선택된 메인 필터
+    func selectMainFilter(_ filter: NoticeMainFilterType) {
+        var state = currentState
+        state.mainFilter = filter
+        currentState = state
+        isSearchMode = false
+        searchQuery = ""
+        Task {
+            await fetchNotices()
+        }
+    }
+
+    /// 서브필터 선택
+    /// - Parameter subFilter: 선택된 서브 필터
+    func selectSubFilter(_ subFilter: NoticeSubFilterType) {
+        let key = MainFilterKey(from: selectedMainFilter)
+        var mainState = currentState.state(for: key)
+        mainState.subFilter = subFilter
+
+        var state = currentState
+        state.updateState(for: key, state: mainState)
+        currentState = state
+        Task {
+            await fetchNotices()
+        }
+    }
+
+    /// 파트 선택
+    /// - Parameter part: 선택 파트. `nil`이면 파트 전체 의미
+    func selectPart(_ part: NoticePart?) {
+        let key = MainFilterKey(from: selectedMainFilter)
+        var mainState = currentState.state(for: key)
+        mainState.selectedPart = part
+
+        var state = currentState
+        state.updateState(for: key, state: mainState)
+        currentState = state
+        Task {
+            await fetchNotices()
+        }
+    }
+
+    // MARK: - Internal Helper
+
+    /// 현재 선택된 gen에 매핑된 gisuId를 반환
+    func currentSelectedGisuId() -> String? {
+        guard isGisuListLoaded else { return nil }
+        return gisuPairs.first(where: {
+            $0.gen == selectedGeneration.value && !$0.gisuId.isEmpty && $0.gisuId != "0"
+        })?.gisuId
+    }
+
+    /// 선택 기수 기준으로 필터 옵션을 다시 불러오고 목록을 재조회합니다.
+    @MainActor
+    func refreshSelectedGenerationContext(resetFilters: Bool) async {
+        if resetFilters {
+            resetSelectionStateForCurrentGeneration()
+        } else if generationStates[selectedGeneration.value] == nil {
+            generationStates[selectedGeneration.value] = GenerationFilterState(
+                mainFilter: GenerationFilterDefaults.mainFilter
+            )
+        }
+
+        await loadTargetStateForCurrentGeneration()
+        await fetchNotices()
+    }
+
+    /// 기수 전환 시 필터 선택 상태를 기본값으로 되돌립니다.
+    @MainActor
+    func resetSelectionStateForCurrentGeneration() {
+        generationStates[selectedGeneration.value] = GenerationFilterState(
+            mainFilter: GenerationFilterDefaults.mainFilter
+        )
+        pagingState.reset()
+        isSearchMode = false
+        searchQuery = ""
+    }
+
+    /// 현재 선택 기수의 지부/학교 필터 옵션을 조회합니다.
+    @MainActor
+    func loadTargetStateForCurrentGeneration() async {
+        guard let gisuId = currentSelectedGisuId(), !gisuId.isEmpty else {
+            generationTargetStates[selectedGeneration.value] = NoticeGenerationTargetState()
+            return
+        }
+
+        async let branchesTask = try? noticeEditorTargetUseCase.fetchBranches(gisuId: gisuId)
+        async let schoolsTask = try? noticeEditorTargetUseCase.fetchSchools(gisuId: gisuId)
+
+        let branches = await branchesTask ?? []
+        let schools = await schoolsTask ?? []
+
+        branches.forEach { chapterNameCache[$0.id] = $0.name }
+        generationTargetStates[selectedGeneration.value] = NoticeGenerationTargetState(
+            branches: branches,
+            schools: schools
+        )
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -1,0 +1,354 @@
+//
+//  NoticeViewModel+Fetch.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/26/26.
+//
+
+import Foundation
+import UMCFoundation
+import NoticeDomain
+
+extension NoticeViewModel {
+
+    // MARK: - Fetch
+
+    /// 공지사항 목록 조회
+    /// - Parameter page: 조회할 페이지 인덱스
+    @MainActor
+    func fetchNotices(page: Int = 0) async {
+        await performPagedFetch(page: page) { request in
+            try await self.noticeUseCase.getAllNotices(request: request)
+        }
+    }
+
+    /// 공지사항 검색
+    ///
+    /// - Parameters:
+    ///   - keyword: 검색어
+    ///   - page: 조회할 페이지 인덱스
+    @MainActor
+    func searchNotices(keyword: String, page: Int = 0) async {
+        guard !keyword.trimmingCharacters(in: .whitespaces).isEmpty else {
+            isSearchMode = false
+            await fetchNotices()
+            return
+        }
+
+        isSearchMode = true
+        searchQuery = keyword
+        await performPagedFetch(page: page) { request in
+            try await self.noticeUseCase.searchNotice(keyword: keyword, request: request)
+        }
+    }
+
+    /// 검색 모드 해제 (일반 목록으로 복귀)
+    @MainActor
+    func clearSearch() async {
+        searchQuery = ""
+        isSearchMode = false
+        await fetchNotices()
+    }
+
+    /// 현재 상태 기준으로 공지 조회를 재시도합니다.
+    /// - Note: 기수 매핑이 비어 있으면 기수 목록부터 다시 로드합니다.
+    @MainActor
+    func retryCurrentRequest() async {
+        if gisuPairs.isEmpty {
+            fetchGisuList()
+            return
+        }
+
+        if isSearchMode, !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            await searchNotices(keyword: searchQuery)
+        } else {
+            await fetchNotices()
+        }
+    }
+
+    /// 리스트 마지막 셀 진입 시 다음 페이지 로드
+    /// - Parameter currentItem: 화면에 노출된 현재 항목
+    @MainActor
+    func loadNextPageIfNeeded(currentItem: NoticeItemModel) async {
+        guard case .loaded(let items) = noticeItems,
+              let last = items.last,
+              currentItem.id == last.id,
+              pagingState.hasNextPage,
+              !pagingState.isLoadingMore else {
+            return
+        }
+
+        let nextPage = pagingState.nextPage
+        if isSearchMode {
+            await searchNotices(keyword: searchQuery, page: nextPage)
+        } else {
+            await fetchNotices(page: nextPage)
+        }
+    }
+
+    // MARK: - Private Function
+
+    /// 페이징 조회 공통 로직 (기수 검증 → 요청 → 응답 반영)
+    @MainActor
+    private func performPagedFetch(
+        page: Int,
+        requestAction: (NoticeListRequest) async throws -> NoticePage
+    ) async {
+        if page == 0 {
+            guard !isFetchingFirstPage else { return }
+            isFetchingFirstPage = true
+        }
+        defer {
+            if page == 0 {
+                isFetchingFirstPage = false
+            }
+        }
+
+        let previousState = noticeItems
+        guard let gisuId = preparePagingAndResolveGisuId(page: page) else { return }
+
+        do {
+            let request = buildNoticeListRequest(gisuId: gisuId, page: page)
+            let response = try await requestAction(request)
+            applyPagedResponse(response, page: page)
+        } catch is CancellationError {
+            handleCancelledFetch(page: page, previousState: previousState)
+        } catch let error as NSError where isRequestCancellation(error) {
+            handleCancelledFetch(page: page, previousState: previousState)
+        } catch let error as RepositoryError {
+            handleFetchError(.repository(error), page: page, action: "fetchNotices", failure: error)
+        } catch let error as DomainError {
+            handleFetchError(.domain(error), page: page, action: "fetchNotices", failure: error)
+        } catch let error as NetworkError {
+            handleFetchError(.network(error), page: page, action: "fetchNotices", failure: error)
+        } catch {
+            handleFetchError(
+                .unknown(message: error.localizedDescription),
+                page: page,
+                action: "fetchNotices",
+                failure: error
+            )
+        }
+    }
+
+    /// 페이지 상태를 준비하고 현재 선택된 기수의 gisuId를 반환합니다.
+    /// - Parameter page: 요청 페이지
+    /// - Returns: 조회 가능한 gisuId. 없으면 `nil`
+    @MainActor
+    private func preparePagingAndResolveGisuId(page: Int) -> String? {
+        if page == 0, noticeItems.value == nil {
+            noticeItems = .loading
+        }
+
+        guard isGisuListLoaded, !gisuPairs.isEmpty else {
+            if !isFetchingGisuList {
+                fetchGisuList()
+            }
+            return nil
+        }
+
+        guard pagingState.begin(page: page) else { return nil }
+
+        guard let gisuId = resolveCurrentGisuIdWithFallback() else {
+            handleFetchError(
+                .domain(.custom(message: "기수 정보를 불러오지 못했습니다.")),
+                page: page,
+                action: "fetchNotices",
+                failure: DomainError.custom(message: "기수 정보를 불러오지 못했습니다.")
+            )
+            return nil
+        }
+        return gisuId
+    }
+
+    /// 현재 선택 기수의 gisuId를 우선 사용하고, 없으면 최신 기수로 보정합니다.
+    @MainActor
+    private func resolveCurrentGisuIdWithFallback() -> String? {
+        if let gisuId = currentSelectedGisuId(), !gisuId.isEmpty {
+            return gisuId
+        }
+
+        guard let fallback = gisuPairs
+            .filter({ !$0.gisuId.isEmpty && $0.gisuId != "0" })
+            .max(by: { (Int($0.gen) ?? 0) < (Int($1.gen) ?? 0) }) else {
+            return nil
+        }
+
+        selectedGeneration = Generation(value: fallback.gen)
+        if generationStates[fallback.gen] == nil {
+            generationStates[fallback.gen] = GenerationFilterState(mainFilter: .central)
+        }
+        return fallback.gisuId
+    }
+
+    /// 페이지 응답을 목록 상태에 반영합니다.
+    /// - Parameters:
+    ///   - response: 공지 페이징 응답 DTO
+    ///   - page: 조회한 페이지 인덱스
+    @MainActor
+    private func applyPagedResponse(_ response: NoticePage, page: Int) {
+        #if DEBUG
+        print(
+            "[NoticeViewModel] applyPagedResponse " +
+            "page=\(page) " +
+            "contentCount=\(response.items.count) " +
+            "totalElements=\(response.totalElements) " +
+            "hasNext=\(response.hasNext)"
+        )
+        #endif
+
+        if page == 0,
+           response.items.isEmpty,
+           (Int(response.totalElements) ?? 0) > 0 {
+            let decodeError = RepositoryError.decodingError(
+                detail: "공지 목록 응답 불일치: totalElements=\(response.totalElements), content=0"
+            )
+
+            handleFetchError(
+                .repository(decodeError),
+                page: page,
+                action: "fetchNotices",
+                failure: decodeError
+            )
+            return
+        }
+
+        let readNoticeIDs = resolvedReadNoticeIDs()
+        let mappedItems = response.items.map { item -> NoticeItemModel in
+
+            guard readNoticeIDs.contains(item.noticeId) else {
+                return item
+            }
+
+            return NoticeItemModel(
+                noticeId: item.noticeId,
+                generation: item.generation,
+                scope: item.scope,
+                category: item.category,
+                mustRead: item.mustRead,
+                isAlert: item.isAlert,
+                date: item.date,
+                title: item.title,
+                content: item.content,
+                writer: item.writer,
+                authorNickname: item.authorNickname,
+                authorName: item.authorName,
+                links: item.links,
+                images: item.images,
+                vote: item.vote,
+                viewCount: item.viewCount,
+                scopeDisplayName: item.scopeDisplayName,
+                targetsAllGenerations: item.targetsAllGenerations,
+                parts: item.parts,
+                isRead: true
+            )
+        }
+        pagingState.applySuccess(page: page, hasNextPage: response.hasNext)
+
+        /// 현재 선택된 조회 필터에 맞지 않는 공지를 클라이언트 측에서 정리합니다.
+        ///
+        /// iOS-01은 서버-01, 서버-03만 노출하도록 후처리합니다.
+        let items: [NoticeItemModel]
+        if case .central = selectedMainFilter {
+            items = mappedItems.filter { $0.scope == .central && $0.category == .general }
+        } else {
+            items = mappedItems
+        }
+        
+        if page == 0 {
+            noticeItems = .loaded(items)
+        } else {
+            let mergedItems = (noticeItems.value ?? []) + items
+            noticeItems = .loaded(mergedItems)
+        }
+    }
+
+    private func resolvedReadNoticeIDs() -> Set<String> {
+        guard currentMemberId > 0 else { return [] }
+        return (try? noticeReadRepository.fetchReadNoticeIDs(memberId: String(currentMemberId))) ?? []
+    }
+
+    /// 조회 실패 상태를 반영합니다.
+    /// - Parameters:
+    ///   - error: 화면에 표시할 앱 에러
+    ///   - page: 실패한 페이지 인덱스
+    ///   - action: 에러 컨텍스트의 action 식별자
+    ///   - failure: ErrorHandler에 전달할 원본 에러
+    ///
+    /// DomainError는 화면 인라인 에러(Loadable.failed)로만 표시해 Alert 중복을 방지합니다.
+    /// 그 외 에러는 ErrorHandler를 통해 Alert 및 특수 케이스(자동 로그아웃 등) 흐름을 유지합니다.
+    @MainActor
+    private func handleFetchError(_ error: AppError, page: Int, action: String, failure: Error) {
+        if page == 0 {
+            noticeItems = .failed(error)
+        }
+        pagingState.applyFailure()
+
+        if case .domain = error {
+            return
+        }
+
+        errorHandler.handle(
+            failure,
+            context: ErrorContext(
+                feature: "Notice",
+                action: action
+            )
+        )
+    }
+
+    @MainActor
+    private func handleCancelledFetch(page: Int, previousState: Loadable<[NoticeItemModel]>) {
+        if page == 0 {
+            noticeItems = previousState
+        }
+        pagingState.applyFailure()
+    }
+
+    private func isRequestCancellation(_ error: NSError) -> Bool {
+        error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled
+    }
+
+    /// NoticeListRequestDTO 생성
+    private func buildNoticeListRequest(gisuId: String, page: Int) -> NoticeListRequest {
+        let myChapterId: String? = chapterId.isEmpty || chapterId == "0"
+        ? nil : chapterId
+        let mySchoolId: String? = schoolId.isEmpty || schoolId == "0"
+        ? nil : schoolId
+        
+        let requestChapterId: String?
+        let requestSchoolId: String?
+        let requestPart: UMCPartType?
+        switch selectedMainFilter {
+        case .all, .central:
+            // iOS-01 (UMC 공지): gisuId only
+            requestChapterId = nil
+            requestSchoolId = nil
+            requestPart = nil
+        case .branch:
+            // iOS-03 (지부 필터): gisuId + chapterId
+            requestChapterId = myChapterId
+            requestSchoolId = nil
+            requestPart = nil
+        case .school:
+            // iOS-02 (학교 필터): gisuId + schoolId
+            requestChapterId = nil
+            requestSchoolId = mySchoolId
+            requestPart = nil
+        case .part(let filterPart):
+            // iOS-04 (파트 필터): gisuId + part
+            requestChapterId = nil
+            requestSchoolId = nil
+            requestPart = filterPart.umcPartType
+        }
+        return NoticeListRequest (
+            gisuId: gisuId,
+            chapterId: requestChapterId,
+            schoolId: requestSchoolId,
+            part: requestPart,
+            page: page,
+            size: pageSize,
+            sort: sort
+        )
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel.swift
@@ -1,0 +1,219 @@
+//
+//  NoticeViewModel.swift
+//  NoticeData
+//
+//  Created by 이예지 on 5/26/26.
+//
+
+import Foundation
+import UMCFoundation
+import CoreDI
+import NoticeDomain
+
+/// 공지사항 리스트 탭 화면 ViewModel
+@Observable
+final class NoticeViewModel {
+
+    // MARK: - Property
+
+    /// DI Container
+    private let container: DIContainer
+
+    /// UseCase
+    var noticeUseCase: NoticeUseCaseProtocol {
+        container.resolve(NoticeUseCaseProtocol.self)
+    }
+
+    /// 기수 Repository
+    var genRepository: ChallengerGenRepositoryProtocol {
+        container.resolve(ChallengerGenRepositoryProtocol.self)
+    }
+
+    var noticeReadRepository: NoticeReadRepositoryProtocol {
+        container.resolve(NoticeReadRepositoryProtocol.self)
+    }
+
+    /// 공지 타겟(지부/학교) 조회 UseCase
+    var noticeEditorTargetUseCase: NoticeEditorTargetUseCaseProtocol {
+        container.resolve(NoticeEditorTargetUseCaseProtocol.self)
+    }
+
+    /// ViewModel 기능을 extension 파일로 분리해 관리하므로,
+    /// 동일 타입 extension에서도 상태 변경이 가능하도록 내부 공개합니다.
+    var organizationType: OrganizationType?
+    /// 사용자 역할 (역할별 필터/메뉴 가시성 제어에 사용)
+    var memberRole: ManagementTeam?
+    var chapterId: String = ""
+    var schoolId: String = ""
+    var generationOrganizations: [String: GenerationOrganizationContext] = [:]
+
+    /// 기수-기수ID 쌍 목록
+    var gisuPairs: [(gen: String, gisuId: String)] = []
+    /// 지부명 캐시 (chapterId -> chapterName)
+    var chapterNameCache: [String: String] = [:]
+    /// 기수 매핑 로딩 완료 여부
+    var isGisuListLoaded: Bool = false
+    /// 기수 매핑 로딩 진행 여부
+    var isFetchingGisuList: Bool = false
+
+    var pagingState = NoticePagingState()
+    var userContext: NoticeUserContext = .empty
+
+    /// 기수별 필터 상태 저장소
+    var generationStates: [String: GenerationFilterState] = [:]
+    /// 기수별 지부/학교 필터 옵션 저장소
+    var generationTargetStates: [String: NoticeGenerationTargetState] = [:]
+
+    /// 기수 목록
+    var generations: [Generation] = []
+
+    /// 선택된 기수
+    var selectedGeneration: Generation = Generation(value: "9")
+
+    /// 공지 생성 진입 시 사용할 현재 선택 기수 ID
+    var selectedGisuIdForEditor: String? {
+        currentSelectedGisuId()
+    }
+
+    /// 공지 데이터 (Loadable)
+    var noticeItems: Loadable<[NoticeItemModel]> = .idle
+    /// 첫 페이지 목록/검색 조회 중복 방지 플래그
+    var isFetchingFirstPage: Bool = false
+
+    /// Error Handler
+    let errorHandler: ErrorHandler
+
+    /// 페이징 진행 상태 (무한 스크롤 인디케이터 노출용)
+    var isLoadingMore: Bool {
+        pagingState.isLoadingMore
+    }
+
+    /// 검색 관련
+    var searchQuery: String = ""
+    var isSearchMode: Bool = false
+
+    private enum Pagination {
+        static let pageSize: Int = 20
+        static let sort: [String] = ["createdAt,DESC"]
+    }
+
+    // MARK: - Lifecycle
+
+    /// 의존성을 주입받아 공지 탭 상태를 초기화합니다.
+    init(container: DIContainer, errorHandler: ErrorHandler) {
+        self.container = container
+        self.errorHandler = errorHandler
+    }
+
+    // MARK: - Helper
+
+    /// 현재 기수의 필터 상태
+    var currentState: GenerationFilterState {
+        get { generationStates[selectedGeneration.value] ?? GenerationFilterState() }
+        set { generationStates[selectedGeneration.value] = newValue }
+    }
+
+    /// 현재 선택된 메인필터
+    var selectedMainFilter: NoticeMainFilterType {
+        currentState.mainFilter
+    }
+
+    /// 현재 메인필터의 서브필터 상태
+    var currentMainFilterState: MainFilterState {
+        currentState.state(for: MainFilterKey(from: selectedMainFilter))
+    }
+
+    /// 현재 선택된 서브필터
+    var selectedSubFilter: NoticeSubFilterType {
+        currentMainFilterState.subFilter
+    }
+
+    /// 현재 선택된 파트
+    var selectedPart: NoticePart? {
+        currentMainFilterState.selectedPart
+    }
+
+    /// 현재 선택 기수에 매핑된 지부/학교 타겟 옵션
+    var currentTargetState: NoticeGenerationTargetState {
+        generationTargetStates[selectedGeneration.value] ?? NoticeGenerationTargetState()
+    }
+
+    /// 역할(memberRole) 기반으로 노출할 메인필터 항목 목록을 반환합니다.
+    ///
+    /// 권한과 무관하게 상위 조직 필터는 UMC 공지/본인 지부/본인 학교를 노출합니다.
+    /// 파트 필터는 별도 Nested Menu에서 제공합니다.
+    var mainFilterItems: [NoticeMainFilterType] {
+        [.central, .branch(currentBranchFilterTitle), .school(currentSchoolFilterTitle)]
+    }
+
+    /// 상단 메인 메뉴에 표시할 기본 조직 필터 목록(파트 제외)
+    var baseMainFilterItems: [NoticeMainFilterType] {
+        mainFilterItems.filter {
+            if case .part = $0 { return false }
+            return true
+        }
+    }
+
+    /// 파트 Nested Menu 노출 여부
+    var canSelectPartFilter: Bool {
+        memberRole != .superAdmin
+    }
+
+    /// 파트 Nested Menu 항목
+    var partFilterItems: [NoticePart] {
+        canSelectPartFilter ? NoticePart.allCases : []
+    }
+
+    /// 현재 메인필터에 따라 노출할 하단 서브필터 칩 목록을 반환합니다.
+    ///
+    /// - 전체/파트: 칩 없음
+    /// - 중앙/지부: 전체 + 파트
+    /// - 학교: 학교 + 파트
+    var subFilterChips: [NoticeListSubFilterChip] {
+        // iOS 공지 필터는 2계층(기수 + 조직/파트)만 사용합니다.
+        []
+    }
+
+    /// 서브필터 표시 여부 (중앙/지부/학교만)
+    var showSubFilter: Bool {
+        false
+    }
+
+    var pageSize: Int {
+        Pagination.pageSize
+    }
+
+    var sort: [String] {
+        Pagination.sort
+    }
+
+    private var currentBranchFilterTitle: String {
+        let resolvedChapterId = selectedGenerationOrganization?.chapterId ?? ""
+        return currentTargetState.branches
+            .first(where: { $0.id == resolvedChapterId })?
+            .name ?? selectedGenerationOrganization?.chapterName ?? NoticeUserContext.empty.branchName
+    }
+
+    private var currentSchoolFilterTitle: String {
+        let resolvedSchoolId = selectedGenerationOrganization?.schoolId ?? ""
+        return currentTargetState.schools
+            .first(where: { $0.id == resolvedSchoolId })?
+            .name ?? selectedGenerationOrganization?.schoolName ?? NoticeUserContext.empty.schoolName
+    }
+
+    var selectedGenerationOrganization: GenerationOrganizationContext? {
+        generationOrganizations[selectedGeneration.value]
+    }
+
+    var selectedGenerationChapterId: String {
+        selectedGenerationOrganization?.chapterId ?? ""
+    }
+
+    var selectedGenerationSchoolId: String {
+        selectedGenerationOrganization?.schoolId ?? ""
+    }
+
+    var currentMemberId: Int {
+        AppStorageKey.legacyMemberIdInt()
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Views/MarkdownSerializer.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Views/MarkdownSerializer.swift
@@ -1,0 +1,13 @@
+//
+//  MarkdownSerializer.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 5/30/26.
+//
+
+import Foundation
+
+// TODO: 교체 - MarkdownSerializer 본체로 대체 예정
+public enum MarkdownSerializer {
+    public static func plainText(from markdown: String) -> String { markdown }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Views/NoticeView.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Views/NoticeView.swift
@@ -1,0 +1,391 @@
+//
+//  NoticeView.swift
+//  AppProduct
+//
+//  Created by 이예지 on 1/14/26.
+//
+
+import SwiftUI
+import UMCFoundation
+import CoreDI
+import CoreDesignSystem
+import CoreUIComponents
+import NoticeDomain
+
+// MARK: - NoticeView
+/// 공지사항 메인 화면
+public struct NoticeView: View {
+    
+    // MARK: - Properties
+    // TODO: 나중에 교체
+    @State private var pathStore = PathStore()
+    // @Environment(\.di) var di
+    @Environment(ErrorHandler.self) var errorHandler
+    @AppStorage(AppStorageKey.schoolName) private var schoolName: String = ""
+    @AppStorage(AppStorageKey.chapterName) private var chapterName: String = ""
+    @AppStorage(AppStorageKey.responsiblePart) private var responsiblePart: String = ""
+    @AppStorage(AppStorageKey.organizationType) private var organizationType: String = ""
+    @AppStorage(AppStorageKey.memberRole) private var memberRoleRaw: String = ""
+    @AppStorage(AppStorageKey.chapterId) private var chapterId: String = ""
+    @AppStorage(AppStorageKey.schoolId) private var schoolId: String = ""
+    @AppStorage(AppStorageKey.generationOrganizations) private var generationOrganizationsJSON: String = "[]"
+    @AppStorage(AppStorageKey.noticeSelectedGisuId) private var noticeSelectedGisuId: String = ""
+    @State private var viewModel: NoticeViewModel
+    @State private var search: String = ""
+    @State private var searchTask: Task<Void, Never>?
+    @State private var isRetryingNotices: Bool = false
+    
+    /// PathStore 접근
+//    private var pathStore: PathStore {
+//        di.resolve(PathStore.self)
+//    }
+    
+    // MARK: - Initializer
+    public init(container: DIContainer, errorHandler: ErrorHandler) {
+        _viewModel = State(
+            initialValue: NoticeViewModel(container: container, errorHandler: errorHandler)
+        )
+    }
+    
+    // MARK: - Constants
+    /// 화면 내 반복되는 문구/수치를 한 곳에서 관리합니다.
+    private enum Constants {
+        /// 검색창 placeholder
+        static let searchPlaceholder: String = "제목, 내용 검색"
+        /// 초기/재로딩 상태 안내 문구
+        static let loadingMessage: String = "공지를 불러오고 있어요"
+        /// 빈 공지 상태 문구
+        static let emptyTitle: String = "아직 등록된 공지사항이 없어요"
+        static let emptySystemImage: String = "exclamationmark.triangle.text.page"
+        static let emptyDescription: String = "운영진이 공지사항을 등록하면 이곳에 표시됩니다"
+        /// 실패 상태 문구
+        static let failedTitle: String = "불러오지 못했어요"
+        static let failedSystemImage: String = "exclamationmark.triangle"
+        static let failedDescription: String = "공지사항을 불러오지 못했습니다. 잠시 후 다시 시도해주세요."
+        /// 재시도 버튼 문구/크기
+        static let retryTitle: String = "다시 시도"
+        static let retryMinimumWidth: CGFloat = 72
+        static let retryMinimumHeight: CGFloat = 20
+        /// 무한 스크롤 추가 로딩 인디케이터 하단 여백
+        static let loadingMoreBottomPadding: CGFloat = DefaultSpacing.spacing16
+        /// 사용자 컨텍스트 변경 감지용 signature 구분자
+        static let userContextSeparator: String = "|"
+    }
+    
+    // MARK: - Body
+    public var body: some View {
+        NavigationStack(path: noticePathBinding) {
+            content
+            .searchable(text: $search, prompt: Constants.searchPlaceholder)
+            .searchToolbarBehavior(.minimize)
+            .navigationTitle(viewModel.selectedMainFilter.labelText)
+            .onChange(of: search) { _, newValue in
+                handleSearchChanged(newValue)
+            }
+            .toolbar { toolbarContent }
+            .safeAreaBar(edge: .top) { topSafeAreaContent }
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(for: NavigationDestination.self, destination: navigationDestinationView)
+            .task {
+                applyUserContext()
+                syncSelectedGisuIdForNoticeEditor()
+                viewModel.fetchGisuList()
+            }
+            .onChange(of: pathStore.noticePath.count) { oldCount, newCount in
+                guard newCount < oldCount, newCount == 0 else { return }
+
+                Task {
+                    await reloadNoticesAfterReturningFromDetail()
+                }
+            }
+            .onChange(of: viewModel.selectedGeneration) { _, _ in
+                syncSelectedGisuIdForNoticeEditor()
+            }
+            .onChange(of: userContextSignature) { _, _ in
+                applyUserContext()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .generationMappingsUpdated)) { _ in
+                viewModel.fetchGisuList()
+            }
+            .onDisappear {
+                searchTask?.cancel()
+            }
+            .umcDefaultBackground()
+        }
+    }
+
+    // MARK: - Content Rendering
+    /// Loadable 상태에 따라 본문을 분기 렌더링합니다.
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.noticeItems {
+        case .idle, .loading:
+            progressContent
+        case .loaded(let noticeItem):
+            noticeContent(noticeItem)
+        case .failed:
+            failedContent()
+        }
+    }
+    
+    @ViewBuilder
+    private func noticeContent(_ data: [NoticeItemModel]) -> some View {
+        if data.isEmpty {
+            unavailableContent
+        } else {
+            availableContent(data)
+        }
+    }
+    
+    /// idle, loading
+    private var progressContent: some View {
+        VStack {
+            Spacer()
+            Progress(message: Constants.loadingMessage)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    
+    /// Loaded - 데이터가 있을 때
+    private func availableContent(_ data: [NoticeItemModel]) -> some View {
+        List(data) { item in
+            noticeRow(item)
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+            .listRowInsets(DefaultConstant.defaultListPadding)
+        }
+        .overlay(alignment: .bottom) {
+            if viewModel.isLoadingMore {
+                ProgressView()
+                    .padding(.bottom, Constants.loadingMoreBottomPadding)
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .tint(.indigo500)
+        .refreshable {
+            await reloadCurrentNoticeListWithMinimumDuration()
+        }
+    }
+    
+    
+    /// Failed - 데이터 로드 실패
+    private func failedContent() -> some View {
+        RetryContentUnavailableView(
+            title: Constants.failedTitle,
+            systemImage: Constants.failedSystemImage,
+            description: Constants.failedDescription,
+            retryTitle: Constants.retryTitle,
+            isRetrying: isRetryingNotices,
+            minRetryButtonWidth: Constants.retryMinimumWidth,
+            minRetryButtonHeight: Constants.retryMinimumHeight
+        ) {
+            await retryNotices()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+    
+    /// Loaded - 데이터가 없을 때
+    private var unavailableContent: some View {
+        ContentUnavailableView(
+            Constants.emptyTitle,
+            systemImage: Constants.emptySystemImage,
+            description: Text(Constants.emptyDescription)
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+
+    // MARK: - Retry
+    @MainActor
+    private func retryNotices() async {
+        guard !isRetryingNotices else { return }
+        isRetryingNotices = true
+        defer { isRetryingNotices = false }
+        await viewModel.retryCurrentRequest()
+    }
+
+    @MainActor
+    private func reloadNoticesAfterReturningFromDetail() async {
+        if viewModel.isSearchMode,
+           !viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            await viewModel.searchNotices(keyword: viewModel.searchQuery)
+        } else {
+            await viewModel.fetchNotices()
+        }
+    }
+
+    @MainActor
+    private func reloadCurrentNoticeList() async {
+        await reloadNoticesAfterReturningFromDetail()
+    }
+
+    @MainActor
+    private func reloadCurrentNoticeListWithMinimumDuration() async {
+        async let reloadTask: Void = reloadCurrentNoticeList()
+        async let delayTask: Void = waitForMinimumRefreshDuration()
+        _ = await (reloadTask, delayTask)
+    }
+
+    private func waitForMinimumRefreshDuration() async {
+        try? await Task.sleep(for: .seconds(2))
+    }
+
+    // MARK: - Search
+    /// 검색어 변경 시 1초 디바운스 후 실시간 검색합니다.
+    private func handleSearchChanged(_ newValue: String) {
+        searchTask?.cancel()
+        let keyword = search.trimmingCharacters(in: .whitespacesAndNewlines)
+        searchTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled else { return }
+            if keyword.isEmpty {
+                await viewModel.clearSearch()
+            } else {
+                await viewModel.searchNotices(keyword: keyword)
+            }
+        }
+    }
+
+    // MARK: - Row
+    /// 공지 셀 탭/무한스크롤 트리거를 묶은 row 구성입니다.
+    private func noticeRow(_ item: NoticeItemModel) -> some View {
+        NoticeItem(model: item) {
+            let noticeDetail = item.toNoticeDetail()
+            pathStore.noticePath.append(.notice(.detail(detailItem: noticeDetail)))
+        }
+        .task(id: item.id) {
+            await viewModel.loadNextPageIfNeeded(currentItem: item)
+        }
+    }
+
+    // MARK: - User Context
+    /// AppStorage 사용자 컨텍스트를 ViewModel 필터 라벨에 반영합니다.
+    private func applyUserContext() {
+        viewModel.applyUserContext(
+            schoolName: schoolName,
+            chapterName: chapterName,
+            responsiblePart: responsiblePart,
+            organizationTypeRawValue: organizationType,
+            chapterId: chapterId,
+            schoolId: schoolId,
+            memberRoleRawValue: memberRoleRaw,
+            generationOrganizationsJSON: generationOrganizationsJSON
+        )
+    }
+
+    /// 공지 생성 진입에 사용할 현재 선택 기수 ID를 AppStorage에 동기화합니다.
+    private func syncSelectedGisuIdForNoticeEditor() {
+        noticeSelectedGisuId = viewModel.selectedGisuIdForEditor ?? ""
+    }
+
+    /// 사용자 컨텍스트 변경 감지를 위한 서명 문자열입니다.
+    private var userContextSignature: String {
+        [
+            schoolName,
+            chapterName,
+            responsiblePart,
+            organizationType,
+            memberRoleRaw,
+            String(chapterId),
+            String(schoolId),
+            generationOrganizationsJSON
+        ]
+            .joined(separator: Constants.userContextSeparator)
+    }
+    
+    // MARK: - Bindings
+    /// 기수 선택 바인딩
+    private var generationBinding: Binding<Generation> {
+        Binding(
+            get: { viewModel.selectedGeneration },
+            set: { viewModel.selectGeneration($0) }
+        )
+    }
+
+    /// 현재 탭의 Notice NavigationPath 바인딩입니다.
+    private var noticePathBinding: Binding<[NavigationDestination]> {
+        Binding(
+            get: { pathStore.noticePath },
+            set: { newValue in
+                // NavigationStack이 동일 경로를 다시 쓰는 경우를 무시해
+                // "tried to update multiple times per frame" 경고를 줄입니다.
+                guard pathStore.noticePath != newValue else { return }
+                pathStore.noticePath = newValue
+            }
+        )
+    }
+
+    // MARK: - Toolbar / Navigation Builders
+    /// 상단 툴바(기수 + 메인 필터)를 구성합니다.
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        if !viewModel.baseMainFilterItems.isEmpty {
+            ToolbarTitleMenu {
+                ForEach(viewModel.baseMainFilterItems) { item in
+                    Button {
+                        viewModel.selectMainFilter(item)
+                        #if DEBUG
+                        print("[Notice][MainFilter] tapped: \(item.labelText)")
+                        #endif
+                    } label: {
+                        Label(item.labelText, systemImage: item.labelIcon)
+                            .imageScale(.small)
+                            .font(.subheadline)
+                    }
+                }
+
+                if viewModel.canSelectPartFilter {
+                    Menu {
+                        ForEach(viewModel.partFilterItems) { part in
+                            Button {
+                                viewModel.selectMainFilter(.part(part))
+                                #if DEBUG
+                                print("[Notice][MainFilter] part tapped: \(part.displayName)")
+                                #endif
+                            } label: {
+                                Label(part.displayName, systemImage: part.iconName)
+                                    .font(.subheadline)
+                            }
+                        }
+                    } label: {
+                        Label("파트", systemImage: "person.3.fill")
+                            .imageScale(.small)
+                            .font(.subheadline)
+                    }
+                }
+            }
+        }
+
+        ToolBarCollection.GenerationFilter(
+            title: viewModel.selectedGeneration.title,
+            generations: viewModel.generations,
+            selection: generationBinding
+        )
+
+        if viewModel.memberRole?.canAccessStaffNotice == true {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    pathStore.noticePath.append(.notice(.staffNotice))
+                } label: {
+                    Image(systemName: "person.badge.shield.checkmark")
+                        .imageScale(.medium)
+                }
+                .accessibilityLabel("운영진 공지")
+            }
+        }
+    }
+    /// 메인 필터 타입에 따라 노출되는 서브필터 영역입니다.
+    @ViewBuilder
+    private var topSafeAreaContent: some View {
+        if viewModel.showSubFilter {
+            NoticeSubFilter(viewModel: viewModel)
+        }
+    }
+
+    /// Notice 탭 내 destination 라우팅 뷰입니다.
+    private func navigationDestinationView(_ destination: NavigationDestination) -> some View {
+        NavigationRoutingView(destination: destination)
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

리팩토링 — AppProduct 모놀리스에서 UMCApp Tuist 모듈로 이식

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 해당 없음 (ViewModel/Logic 이식) -->

## 🛠️ 작업내용

- Generation 모델 UMCFoundation으로 이동
- UMCFoundation 확장 이식 (DateFormatter, NotificationName, ToolBarCollection)
- CoreDesignSystem 유틸리티 이식 (DefaultBackgroundModifier, ShadowReuse)
- CoreUIComponents 이식 (Progress, RetryContentUnavailableView, ChipButton)
- NoticePresentation 이식 (NoticeView, NoticeItem, 컴포넌트, Navigation)
- NoticeViewModel 이식 (NoticeList) — Fetch, Context, ViewModel 분리 구조
- NoticeReadStatus public init 추가 (NoticeDomain)
- NoticePresentation 임시 Stub 타입 이식 (Authorization, MemberProfile, MyPageRepository, UserSessionManager)
- NoticeDetailViewModel 이식 (+NoticeActions, +ReadStatus, NoticeReadStatusPermissionEvaluator)
- 변경된 파일: 37개

## 📋 추후 진행 상황

- NoticeDetail View 이식
- NoticeEditor View/ViewModel 이식
- Stub 타입을 실제 모듈(Auth, MyPage) 이식 후 교체

## 📌 리뷰 포인트

- `Presentation/Sources/Stubs/` — Auth/MyPage 모듈 이식 전까지의 임시 타입. TODO 주석 포함
- `NoticeDetailViewModel+ReadStatus.swift` — `fetchReadStatusPage` 반환 타입이 `NoticeReadStatusPage`(Domain)으로 변경됨. `NoticeReadStatusResponseDTO`(Data) 의존 제거
- `NoticeDetailViewModel+NoticeActions.swift` — `sendReminderToAllUnreadUsers`에서 `ReadStatusUser.id`(String) 사용. 기존 `challengerId`(Int) 제거
- `NoticeReadStatusPermissionEvaluator.swift` — `chapterId`/`schoolId` 파라미터 타입 `Int?` → `String?` 변경 (서버 ID는 String)
- `Features/Notice/Domain/` — 비즈니스 로직 확인 필요
- `Features/Notice/Presentation/` — UI 레이아웃 확인 필요

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)