### PR TITLE
🐛 [Fix] 출석 위치 상태바 — 주소 마퀴 복원 · 미인증 아이콘 분기 · 미리보기 긴 주소 표시 (#818 후속)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/ActivityCompactMapView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/ActivityCompactMapView.swift
@@ -157,11 +157,13 @@ private struct LocationStatusBarContextPreview: View {
     private enum Constants {
         static let verifyIconSize: CGFloat = 12
         static let spacing: CGFloat = 4
+        static let rowSpacing: CGFloat = 8
         static let previewWidth: CGFloat = 320
     }
 
     var body: some View {
-        HStack(spacing: Constants.spacing) {
+        // 상태 행(위) + 전체폭 주소 행(아래). 주소는 줄바꿈을 허용해 긴 주소도 전부 보인다.
+        VStack(alignment: .leading, spacing: Constants.rowSpacing) {
             HStack(spacing: Constants.spacing) {
                 if isUserInsideGeofence {
                     Image(.Map.verifyLocation)
@@ -177,16 +179,19 @@ private struct LocationStatusBarContextPreview: View {
 
                 Text(isUserInsideGeofence ? "위치 인증됨" : "위치 미인증")
                     .appFont(.caption1, color: isUserInsideGeofence ? .indigo500 : .red)
+
+                Spacer(minLength: 0)
             }
 
-            Spacer(minLength: 0)
+            HStack(alignment: .top, spacing: Constants.spacing) {
+                Text(sessionAddress)
+                    .appFont(.caption1, color: .grey600)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text(sessionAddress)
-                .appFont(.caption1, color: .grey600)
-                .lineLimit(1)
-
-            Image(systemName: "ellipsis.circle")
-                .foregroundStyle(.grey500)
+                Image(systemName: "ellipsis.circle")
+                    .foregroundStyle(.grey500)
+            }
         }
         .padding(DefaultConstant.defaultBtnPadding)
         .frame(width: Constants.previewWidth)

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/ActivityCompactMapView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Map/ActivityCompactMapView.swift
@@ -96,12 +96,22 @@ fileprivate struct LocationStatusBarView: View {
     /// 지오펜스 내 위치 인증 상태 표시
     private var verifyLocationStatus: some View {
         HStack(spacing: Constants.statusBarSpacing) {
-            Image(.Map.verifyLocation)
-                .resizable()
-                .frame(
-                    width: Constants.verifyIconSize,
-                    height: Constants.verifyIconSize)
-            
+            if mapViewModel.isUserInsideGeofence {
+                Image(.Map.verifyLocation)
+                    .resizable()
+                    .frame(
+                        width: Constants.verifyIconSize,
+                        height: Constants.verifyIconSize)
+            } else {
+                Image(systemName: "location.slash.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(
+                        width: Constants.verifyIconSize,
+                        height: Constants.verifyIconSize)
+                    .foregroundStyle(.red)
+            }
+
             Text(mapViewModel.isUserInsideGeofence
                  ? "위치 인증됨" : "위치 미인증")
                 .appFont(.caption1,
@@ -153,9 +163,17 @@ private struct LocationStatusBarContextPreview: View {
     var body: some View {
         HStack(spacing: Constants.spacing) {
             HStack(spacing: Constants.spacing) {
-                Image(.Map.verifyLocation)
-                    .resizable()
-                    .frame(width: Constants.verifyIconSize, height: Constants.verifyIconSize)
+                if isUserInsideGeofence {
+                    Image(.Map.verifyLocation)
+                        .resizable()
+                        .frame(width: Constants.verifyIconSize, height: Constants.verifyIconSize)
+                } else {
+                    Image(systemName: "location.slash.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: Constants.verifyIconSize, height: Constants.verifyIconSize)
+                        .foregroundStyle(.red)
+                }
 
                 Text(isUserInsideGeofence ? "위치 인증됨" : "위치 미인증")
                     .appFont(.caption1, color: isUserInsideGeofence ? .indigo500 : .red)
@@ -182,6 +200,10 @@ private struct LocationStatusBarContextPreview: View {
 /// 2벌째가 1벌째의 시작 위치에 정확히 도달하는 순간 오프셋이 0으로 리셋되므로
 /// 시각적으로 이음매(깜빡임)가 없습니다. 텍스트가 컨테이너 안에 들어가면 스크롤하지 않고
 /// 우측 정렬로 고정 표시합니다.
+///
+/// - Note: 크기 기준은 `fixedSize` 없는 '고스트 텍스트'(한 줄 높이 + 부모 폭)로 고정하고,
+///   보이는 마퀴는 그 위 overlay 의 `GeometryReader` 가 준 폭으로만 그립니다. 덕분에 콘텐츠의
+///   intrinsic 폭이 부모 HStack 으로 새어 좌측 위치 상태를 밀어내는 일이 없습니다.
 fileprivate struct MarqueeText: View {
 
     let text: String
@@ -191,63 +213,90 @@ fileprivate struct MarqueeText: View {
     /// 반복되는 두 벌 사이의 간격(pt)
     var spacing: CGFloat = 48
 
-    @State private var textSize: CGSize = .zero
+    @State private var textWidth: CGFloat = 0
+    @State private var containerWidth: CGFloat = 0
     @State private var offset: CGFloat = 0
 
-    var body: some View {
-        GeometryReader { proxy in
-            let containerWidth = proxy.size.width
-            let needsScroll = textSize.width > containerWidth + 1
-
-            Group {
-                if needsScroll {
-                    HStack(spacing: spacing) {
-                        label
-                        label
-                    }
-                    .offset(x: offset)
-                    .frame(width: containerWidth, alignment: .leading)
-                    .clipped()
-                    .onAppear { startScrolling() }
-                    .onChange(of: textSize.width) { startScrolling() }
-                    .onChange(of: containerWidth) { startScrolling() }
-                } else {
-                    label
-                        .frame(width: containerWidth, alignment: .trailing)
-                }
-            }
-        }
-        .frame(height: textSize.height)
-        .background(measurementLayer)
+    private var needsScroll: Bool {
+        textWidth > 0 && containerWidth > 0 && textWidth > containerWidth + 1
     }
 
-    private var label: some View {
+    var body: some View {
+        // 크기 기준 '고스트': lineLimit(1) 한 줄 높이 + 부모 폭(maxWidth:.infinity).
+        // fixedSize 를 쓰지 않으므로 거대한 intrinsic 폭이 부모로 새어 위치 상태를
+        // 화면 밖으로 밀어내는 일이 없다. 보이는 마퀴는 그 위 overlay 로만 그린다.
         Text(text)
             .appFont(.caption1, color: color)
+            .lineLimit(1)
+            .frame(maxWidth: .infinity)
+            .hidden()
+            .overlay {
+                GeometryReader { geo in
+                    visibleMarquee(width: geo.size.width)
+                        .onAppear { updateContainer(geo.size.width) }
+                        .onChange(of: geo.size.width) { _, newWidth in
+                            updateContainer(newWidth)
+                        }
+                }
+            }
+            .background(widthProbe)
+    }
+
+    /// 실제로 보이는 마퀴. `width` 는 GeometryReader 가 준 확정 컨테이너 폭이라 순환 의존이 없다.
+    @ViewBuilder
+    private func visibleMarquee(width: CGFloat) -> some View {
+        if needsScroll {
+            HStack(spacing: spacing) {
+                singleLine
+                singleLine
+            }
+            .fixedSize()
+            .offset(x: offset)
+            .frame(width: width, alignment: .leading)
+            .clipped()
+        } else {
+            singleLine
+                .frame(width: width, alignment: .trailing)
+        }
+    }
+
+    private var singleLine: some View {
+        Text(text)
+            .appFont(.caption1, color: color)
+            .lineLimit(1)
             .fixedSize()
     }
 
-    /// 텍스트의 자연 크기를 측정하기 위한 숨겨진 레이어
-    private var measurementLayer: some View {
+    /// 텍스트 자연 폭 측정용 — background 라 부모 레이아웃에 영향이 없다.
+    private var widthProbe: some View {
         Text(text)
             .appFont(.caption1, color: color)
+            .lineLimit(1)
             .fixedSize()
             .hidden()
             .background(
-                GeometryReader { geometry in
+                GeometryReader { geo in
                     Color.clear.preference(
-                        key: MarqueeSizeKey.self,
-                        value: geometry.size
-                    )
+                        key: MarqueeSizeKey.self, value: geo.size.width)
                 }
             )
-            .onPreferenceChange(MarqueeSizeKey.self) { textSize = $0 }
+            .onPreferenceChange(MarqueeSizeKey.self) { width in
+                guard width > 0, abs(width - textWidth) > 0.5 else { return }
+                textWidth = width
+                restartScrolling()
+            }
     }
 
-    private func startScrolling() {
-        let distance = textSize.width + spacing
-        guard distance > 0 else { return }
+    private func updateContainer(_ width: CGFloat) {
+        guard width > 0, abs(width - containerWidth) > 0.5 else { return }
+        containerWidth = width
+        restartScrolling()
+    }
+
+    private func restartScrolling() {
         offset = 0
+        guard needsScroll else { return }
+        let distance = textWidth + spacing
         withAnimation(
             .linear(duration: Double(distance / velocity))
                 .repeatForever(autoreverses: false)
@@ -258,9 +307,9 @@ fileprivate struct MarqueeText: View {
 }
 
 private struct MarqueeSizeKey: PreferenceKey {
-    static var defaultValue: CGSize = .zero
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = nextValue()
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

- 🐛 버그 수정 — 출석 위치 상태바(주소 마퀴 · 인증 아이콘)
- 💄 UI 개선 — 길게 누르기 미리보기 긴 주소 표시

## 📷 스크린샷 or 영상(UI 변경 시)

> 시뮬레이터(iPhone 17 Pro)에서 직접 검증한 동작입니다. (아래 동작의 캡처/영상 첨부 예정)

- **주소 마퀴(긴 주소)**: 좌측 "위치 인증/미인증" 상태가 유지된 채 주소가 오른쪽→왼쪽으로 끊김 없이 흐름 — 이전엔 위치 상태가 화면 밖으로 밀리고(레이아웃 깨짐) 스크롤도 멈췄음
- **주소 마퀴(짧은 주소)**: 우측 정렬 고정(스크롤 안 함)
- **위치 인증 아이콘**: 인증=초록 체크 / 미인증=빨간 `location.slash.fill`
- **길게 누르기 미리보기**: 긴 주소가 2줄로 줄바꿈되어 전부 표시 — 이전엔 한 줄로 잘림

## 🛠️ 작업내용

출석 체크 화면(`ActivityCompactMapView`)의 지도 하단 위치 상태바 관련 수정 3건 (단일 파일).

1. **주소 마퀴 애니메이션 사라짐 + 줄 내림(레이아웃 깨짐) 수정**
   - 원인: #818 의 `MarqueeText` 가 `GeometryReader` 를 뷰 자체 크기로 쓰고 컨테이너 폭을 자기 콘텐츠 폭으로 측정하는 **순환 의존**. 긴 주소에서 콘텐츠 `fixedSize` intrinsic 폭이 부모 HStack 으로 새어 좌측 위치 상태를 화면 밖으로 밀어내고 스크롤도 멈춤.
   - 수정: `fixedSize` 없는 '고스트 텍스트'로 한 줄 높이 + 부모 폭만 고정하고, 보이는 마퀴는 그 위 `overlay` 의 `GeometryReader` 가 준 확정 폭으로만 그려 intrinsic 폭 누수를 차단. 넘칠 때 2벌 seamless 스크롤, 들어오면 우측 정렬 고정.

2. **"위치 미인증"인데 초록 체크 아이콘 수정**
   - `isUserInsideGeofence` 와 무관하게 항상 초록 체크로 고정 렌더되던 것을, 인증=초록 체크 / 미인증=빨간 `location.slash.fill` 로 분기 (상태바·컨텍스트 미리보기 동일 적용).

3. **길게 누르기 미리보기에서 긴 주소 잘림 수정**
   - `LocationStatusBarContextPreview` 가 `.lineLimit(1)` + 고정폭이라 긴 주소를 한 줄로 자르던 것을, 상태 행 + 전체폭 주소 행(VStack) + 줄바꿈 허용으로 재배치해 긴 주소도 전부 표시. (클립보드 복사는 기존에도 `sessionAddress` 전체를 복사함 — 표시만 개선)

## 📋 추후 진행 상황

- 없음 — 해당 화면 위치 상태바 관련 보고된 이슈 모두 반영 완료.

## 📌 리뷰 포인트

- `MarqueeText` 의 '고스트 텍스트 + overlay' 구조: 콘텐츠 intrinsic 폭이 부모 레이아웃으로 새지 않는지(좌측 위치 상태가 항상 화면 안인지)
- 마퀴 넘침 판정(`needsScroll`) · seamless 2벌 스크롤이 긴/짧은 주소 모두 자연스러운지
- 미리보기 VStack 재배치가 짧은 주소에서도 어색하지 않은지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)