### PR TITLE
🐛 [Fix] 출석 현황/상세 — 필터 칩 상단 고정·가장자리 스크롤 + 전체 칩 필터 버그

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/AttendanceListViewModel.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/ViewModels/Operation/AttendanceListViewModel.swift
@@ -175,6 +175,15 @@ final class AttendanceListViewModel {
         await fetch()
     }
 
+    /// "전체" 칩 선택 — 상태 필터를 해제하고 전체 목록을 다시 불러온다.
+    /// 이미 전체(필터 없음)면 불필요한 재조회를 막기 위해 아무 것도 하지 않는다.
+    @MainActor
+    func clearFilter() async {
+        guard selectedFilter != nil else { return }
+        selectedFilter = nil
+        await fetch()
+    }
+
     /// 기간 프리셋 선택
     ///
     /// `.custom` 선택 시에는 `fromDate`/`toDate` 를 현재 값으로 유지하며

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
@@ -302,6 +302,9 @@ struct AttendanceDetailView: View {
                 }
             }
         }
+        // 칩 행이 좌우 가장자리까지 자연스럽게 스크롤되도록: 부모 16pt 패딩 상쇄 + 콘텐츠 16pt 인셋.
+        .contentMargins(.horizontal, DefaultConstant.defaultSafeHorizon, for: .scrollContent)
+        .padding(.horizontal, -DefaultConstant.defaultSafeHorizon)
     }
 
     @ViewBuilder

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
@@ -39,59 +39,76 @@ struct AttendanceListView: View {
     // MARK: - Body
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
-            // 필터 칩·기간 필터·승인 대기 배너는 권한 보유자에게만 노출 (권한 거부 시 폴백 안내만 표시)
-            if !viewModel.isPermissionDenied {
-                filterChipRow
+        listStateContent
+            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+            .animation(.easeInOut(duration: 0.2), value: viewModel.isFilterExpanded)
+            .animation(.easeInOut(duration: 0.2), value: viewModel.totalPendingCount > 0)
+            // 필터 칩·기간 필터·승인 대기 배너는 VStack 본문에 넣지 않고 상단 safeAreaBar 로
+            // 고정한다. 칩이 네비게이션 바 바로 아래에 붙고, 목록은 그 아래에서 스크롤된다.
+            // (권한 거부 시에는 바를 숨기고 폴백 안내만 노출)
+            .safeAreaBar(edge: .top) {
+                if !viewModel.isPermissionDenied {
+                    topFilterBar
+                }
+            }
+            .navigationTitle("출석 현황")
+            .navigationBarTitleDisplayMode(.inline)
+            .task {
+                if case .idle = viewModel.listState {
+                    await viewModel.fetch()
+                }
+            }
+            .task(id: viewModel.listState.isComplete) {
+                guard viewModel.listState.isComplete else { return }
+                await viewModel.startPollingIfNeeded()
+            }
+            .onChange(of: scenePhase) { _, phase in
+                if phase == .active {
+                    Task { await viewModel.refreshList() }
+                }
+            }
+    }
 
-                if viewModel.isFilterExpanded {
-                    periodFilterExpandedRow
-                        .transition(.opacity.combined(with: .move(edge: .top)))
-                }
+    /// listState 에 따른 본문(목록/로딩/빈/에러/권한). 상단 safeAreaBar 아래의 스크롤 영역이다.
+    @ViewBuilder
+    private var listStateContent: some View {
+        switch viewModel.listState {
+        case .idle, .loading:
+            loadingView
+        case .loaded(let infos):
+            if infos.isEmpty {
+                emptyView
+            } else {
+                listContent(infos: infos)
+            }
+        case .failed(let error):
+            if error.isPermissionDenied {
+                permissionDeniedView
+            } else {
+                errorView(error: error)
+            }
+        }
+    }
 
-                if viewModel.totalPendingCount > 0 {
-                    pendingInboxBanner
-                        .transition(.opacity.combined(with: .move(edge: .top)))
-                }
+    /// 상단 고정 필터 바(safeAreaBar 콘텐츠).
+    /// 칩 행은 `contentMargins` 로 가장자리까지 스크롤되고, 기간/대기 배너는 16pt 인셋으로 정렬한다.
+    private var topFilterBar: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            filterChipRow
+
+            if viewModel.isFilterExpanded {
+                periodFilterExpandedRow
+                    .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
-            switch viewModel.listState {
-            case .idle, .loading:
-                loadingView
-            case .loaded(let infos):
-                if infos.isEmpty {
-                    emptyView
-                } else {
-                    listContent(infos: infos)
-                }
-            case .failed(let error):
-                if error.isPermissionDenied {
-                    permissionDeniedView
-                } else {
-                    errorView(error: error)
-                }
+            if viewModel.totalPendingCount > 0 {
+                pendingInboxBanner
+                    .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
-        .animation(.easeInOut(duration: 0.2), value: viewModel.isFilterExpanded)
-        .animation(.easeInOut(duration: 0.2), value: viewModel.totalPendingCount > 0)
-        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
-        .padding(.top, DefaultConstant.defaultSafeTop)
-        .navigationTitle("출석 현황")
-        .navigationBarTitleDisplayMode(.inline)
-        .task {
-            if case .idle = viewModel.listState {
-                await viewModel.fetch()
-            }
-        }
-        .task(id: viewModel.listState.isComplete) {
-            guard viewModel.listState.isComplete else { return }
-            await viewModel.startPollingIfNeeded()
-        }
-        .onChange(of: scenePhase) { _, phase in
-            if phase == .active {
-                Task { await viewModel.refreshList() }
-            }
-        }
+        .padding(.vertical, DefaultSpacing.spacing8)
     }
 
     // MARK: - Constants
@@ -118,7 +135,7 @@ struct AttendanceListView: View {
                     "전체",
                     isSelected: viewModel.selectedFilter == nil
                 ) {
-                    Task { await viewModel.filterButtonTapped(viewModel.selectedFilter ?? .present) }
+                    Task { await viewModel.clearFilter() }
                 }
                 .buttonSize(.small)
 
@@ -136,6 +153,8 @@ struct AttendanceListView: View {
                 periodFilterToggleButton
             }
         }
+        // safeAreaBar 안에서 칩 행이 좌우 가장자리까지 스크롤되도록 콘텐츠만 16pt 인셋.
+        .contentMargins(.horizontal, DefaultConstant.defaultSafeHorizon, for: .scrollContent)
     }
 
     private var periodFilterToggleButton: some View {
@@ -273,7 +292,7 @@ struct AttendanceListView: View {
             .padding(DefaultSpacing.spacing16)
             .frame(maxWidth: .infinity, alignment: .leading)
             .glassEffect(
-                .regular.interactive(),
+                .regular,
                 in: ConcentricRectangle(
                     corners: .concentric(minimum: DefaultConstant.concentricRadius),
                     isUniform: true

--- a/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
+++ b/AppProduct/AppProduct/Features/Tab/Presentation/Views/UmcBottonAccessoryView.swift
@@ -148,9 +148,9 @@ fileprivate struct ActivityAccessoryView: View {
     /// 운영진/챌린저 모드 전환 버튼
     private var adminToggleButton: some View {
         Button {
-            withAnimation(.snappy) {
-                userSession.toggleAdminMode()
-            }
+            // withAnimation 으로 감싸면 ActivityView 의 무거운 콘텐츠 교체(출석 체크 ↔ 출석 현황)까지
+            // 함께 애니메이션돼 두 화면이 겹쳐 보이는 잔상·경계선이 생긴다. 모드 전환은 즉시 처리한다.
+            userSession.toggleAdminMode()
         } label: {
             HStack(spacing: DefaultSpacing.spacing8) {
                 Image(systemName: userSession.isAdminModeEnabled

--- a/AppProduct/AppProductTests/ActivityTest/AttendanceListViewModelTests.swift
+++ b/AppProduct/AppProductTests/ActivityTest/AttendanceListViewModelTests.swift
@@ -1,0 +1,178 @@
+//
+//  AttendanceListViewModelTests.swift
+//  AppProductTests
+//
+//  출석 현황 목록 ViewModel 의 기능 로직 검증.
+//  - "전체" 칩(clearFilter) 동작 및 회귀 방지
+//  - 상태 필터 토글
+//  - "승인 대기" 배너 네비게이션 보장(firstPendingScheduleId)
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+struct AttendanceListViewModelTests {
+
+    // MARK: - Fixtures
+
+    private func participant(
+        memberId: Int,
+        status: AttendanceStatusV2
+    ) -> ParticipantAttendance {
+        ParticipantAttendance(
+            memberId: memberId,
+            name: "멤버\(memberId)",
+            nickname: "닉\(memberId)",
+            profileImageUrl: "",
+            schoolId: 1,
+            schoolName: "테스트대학교",
+            attendanceStatus: status,
+            isLocationVerified: true,
+            excuseReason: nil
+        )
+    }
+
+    private func schedule(
+        scheduleId: Int,
+        participants: [ParticipantAttendance]
+    ) -> ScheduleAttendanceInfo {
+        ScheduleAttendanceInfo(
+            scheduleId: scheduleId,
+            name: "일정\(scheduleId)",
+            description: "",
+            startsAt: Date(),
+            endsAt: Date().addingTimeInterval(3600),
+            location: nil,
+            isOnline: false,
+            authorMemberId: 1,
+            attendancePolicy: nil,
+            tags: [],
+            participants: participants
+        )
+    }
+
+    @MainActor
+    private func makeViewModel(list: [ScheduleAttendanceInfo]) -> AttendanceListViewModel {
+        AttendanceListViewModel(
+            container: DIContainer(),
+            errorHandler: ErrorHandler(),
+            useCase: StubOperatorAttendanceUseCase(list: list)
+        )
+    }
+
+    // MARK: - "전체" 칩 (clearFilter) — 필터 버그 수정 검증
+
+    @Test("clearFilter 는 선택된 상태 필터를 해제한다")
+    @MainActor
+    func clearFilterResetsSelectedFilter() async {
+        let vm = makeViewModel(list: [])
+        await vm.filterButtonTapped(.presentPending)
+        #expect(vm.selectedFilter == .presentPending)
+
+        await vm.clearFilter()
+        #expect(vm.selectedFilter == nil)
+    }
+
+    @Test("이미 전체(필터 없음) 상태에서 clearFilter 는 다른 필터로 바뀌지 않는다 (#버그 회귀 방지)")
+    @MainActor
+    func clearFilterIsNoOpWhenAlreadyAll() async {
+        let vm = makeViewModel(list: [])
+        #expect(vm.selectedFilter == nil)
+
+        await vm.clearFilter()
+        // 과거 버그(filterButtonTapped(selectedFilter ?? .present))였다면 여기서 .presentPending 으로
+        // 잘못 전환됐을 것. clearFilter 는 전체 상태를 그대로 유지해야 한다.
+        #expect(vm.selectedFilter == nil)
+    }
+
+    @Test("filterButtonTapped 는 같은 필터를 다시 누르면 해제(토글)한다")
+    @MainActor
+    func filterButtonTogglesSelection() async {
+        let vm = makeViewModel(list: [])
+        await vm.filterButtonTapped(.late)
+        #expect(vm.selectedFilter == .late)
+
+        await vm.filterButtonTapped(.late)
+        #expect(vm.selectedFilter == nil)
+    }
+
+    // MARK: - "승인 대기" 배너 네비게이션 로직 검증
+
+    @Test("승인 대기 건이 있으면 firstPendingScheduleId 는 첫 번째 대기 일정 id 를 반환한다")
+    @MainActor
+    func firstPendingScheduleIdReturnsPendingSchedule() async {
+        let noPending = schedule(
+            scheduleId: 102,
+            participants: [participant(memberId: 3, status: .present)]
+        )
+        let pending = schedule(
+            scheduleId: 101,
+            participants: [
+                participant(memberId: 1, status: .presentPending),
+                participant(memberId: 2, status: .present)
+            ]
+        )
+        let vm = makeViewModel(list: [noPending, pending])
+        await vm.fetch()
+
+        #expect(vm.totalPendingCount == 1)
+        // 배너의 guard(firstPendingScheduleId)가 통과해 올바른 일정(101)으로 push 됨을 보장
+        #expect(vm.firstPendingScheduleId == 101)
+    }
+
+    @Test("배너 노출 조건(totalPendingCount>0)이면 firstPendingScheduleId 는 항상 non-nil 이다")
+    @MainActor
+    func bannerInvariantPendingImpliesNonNilScheduleId() async {
+        let vm = makeViewModel(list: [
+            schedule(scheduleId: 201, participants: [
+                participant(memberId: 10, status: .latePending),
+                participant(memberId: 11, status: .excusedPending)
+            ])
+        ])
+        await vm.fetch()
+
+        #expect(vm.totalPendingCount > 0)
+        #expect(vm.firstPendingScheduleId != nil)
+    }
+}
+
+// MARK: - Stub
+
+private struct StubOperatorAttendanceUseCase: OperatorAttendanceUseCaseProtocol {
+    let list: [ScheduleAttendanceInfo]
+
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> [ScheduleAttendanceInfo] {
+        list
+    }
+
+    func fetchAttendanceDetail(
+        scheduleId: Int,
+        attendanceStatus: AttendanceStatusV2?
+    ) async throws -> ScheduleAttendanceInfo {
+        guard let match = list.first(where: { $0.scheduleId == scheduleId }) ?? list.first else {
+            throw StubError.notFound
+        }
+        return match
+    }
+
+    func decideAttendances(
+        scheduleId: Int,
+        decisions: [AttendanceDecisionInput]
+    ) async throws -> [AttendanceDecisionResult] {
+        []
+    }
+
+    func updateScheduleLocation(
+        scheduleId: Int,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    ) async throws {}
+}
+
+private enum StubError: Error { case notFound }

--- a/AppProduct/AppProductTests/AuthTest/IdPwAuthUseCaseTests.swift
+++ b/AppProduct/AppProductTests/AuthTest/IdPwAuthUseCaseTests.swift
@@ -361,6 +361,10 @@ private actor StubAuthRepository: AuthRepositoryProtocol {
     func registerCredential(rawPassword: String) async throws {
         fatalError("registerCredential not used in these tests")
     }
+
+    func changePassword(currentPassword: String, newPassword: String) async throws {
+        fatalError("changePassword not used in these tests")
+    }
 }
 
 // MARK: - InMemoryTokenStore


### PR DESCRIPTION
## ✨ PR 유형

- 🐛 버그 수정 — "전체" 칩 필터 오동작
- 💄 UI 개선 — 필터 칩 상단 고정(safeAreaBar) · 좌우 가장자리 스크롤
- ✅ 테스트 — 출석 현황 ViewModel 단위 테스트 추가 + 깨진 테스트 타겟 복구

## 📷 스크린샷 or 영상(UI 변경 시)

> 시뮬레이터(iPhone 17 Pro)에서 출석 현황/상세를 DEBUG 하니스로 직접 렌더해 검증.

- **출석 현황(목록)**: 필터 칩이 네비게이션 바 바로 아래에 붙고(이전엔 아래로 처짐), 좌우 가장자리까지 자연스럽게 스크롤(이전엔 16pt 경계에서 어중간하게 잘림). 목록은 그 아래 스크롤 영역으로 분리.
- **출석 상세**: 필터 칩 행도 동일하게 가장자리까지 스크롤되도록 통일.

## 🛠️ 작업내용

### 출석 현황 목록 (`AttendanceListView`)
1. **필터 칩 → `safeAreaBar(edge: .top)` 상단 고정 바** — 기존엔 VStack 본문 안이라 `padding(.top)`+spacing 으로 처지고 부모 16pt 패딩 때문에 칩 스크롤 영역이 좌우로 압축됐다. safeAreaBar 로 빼서 칩은 상단 고정, 목록은 아래 스크롤 영역으로 분리.
2. **칩 `contentMargins(.horizontal, 16, for: .scrollContent)`** — 첫 칩 16pt 인셋, 마지막 칩은 가장자리에서 자연 peek.
3. **"전체" 칩 필터 버그 수정** — 기존 `filterButtonTapped(selectedFilter ?? .present)` 는 이미 전체 상태에서 "전체" 를 누르면 `.present` 필터로 잘못 전환됐다. `clearFilter()` 추가해 필터만 해제하도록 수정.
4. 승인 대기 배너 `glassEffect` 의 `.interactive()` 제거(탭 응답 안정화).

### 출석 상세 (`AttendanceDetailView`)
- 필터 칩 행에 동일한 `contentMargins` 적용 → 목록 화면과 통일.

### 테스트 (`AppProductTests`)
- **`AttendanceListViewModelTests`(신규, 5케이스)** — `clearFilter` 동작·회귀 방지, 필터 토글, **"승인 대기" 배너 네비게이션 보장**(`totalPendingCount>0` ⟹ `firstPendingScheduleId` non-nil 이라 push 보장) 검증. 전부 통과.
- **`IdPwAuthUseCaseTests`** — `StubAuthRepository` 에 누락된 `changePassword` 추가. #832 프로토콜 확장 후 스텁 미갱신으로 **깨져 있던 테스트 타겟 빌드를 복구**.

## 📋 추후 진행 상황

- 디자인은 하니스 스냅샷, 기능 로직은 단위 테스트로 검증했습니다. 물리적 탭 레이어(UI) 검증은 UI 테스트 타겟이 없어 제외 — 핵심 로직(`firstPendingScheduleId`)은 단위 테스트로 보장됩니다.

## 📌 리뷰 포인트

- `safeAreaBar(edge: .top)` 로 분리한 필터 바와 목록 스크롤 영역의 상호작용.
- `contentMargins`로 칩이 부모 레이아웃을 밀어내지 않고 가장자리까지 스크롤되는지.
- `clearFilter()` 도입으로 "전체" 칩 선택 시 의도대로 필터만 해제되는지(단위 테스트 포함).

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)