### PR TITLE
💄 [Design] 출석 정책 표시 섹션 가로 3분할 그리드로 재설계

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift
@@ -11,8 +11,9 @@ import SwiftUI
 
 /// 일정 상세 화면에서 출석 정책 시각을 read-only 로 표시하는 섹션 컴포넌트
 ///
-/// - 체크인 시작(`checkInStartAt`), 정시 종료(`onTimeEndAt`), 결석 시작(`lateEndAt`) 3개 행을
-///   `Divider()` 로 구분하여 세로 카드로 배치합니다.
+/// - 체크인 시작(`checkInStartAt`) → 정시 종료(`onTimeEndAt`) → 지각 종료(`lateEndAt`) 순서의
+///   3개 임계값을 시간 흐름대로 **가로 3분할** 카드에 배치합니다. (세로 나열 대비 화면 점유 약 60% 절감)
+/// - 컬럼은 항상 균등 너비이므로 세 시각이 같거나 역전되거나 간격이 짧아도 레이아웃이 깨지지 않습니다.
 /// - 비대면 / 출석 비필수 일정은 `AttendancePolicy` 자체가 `nil` 이므로 호출 측에서 노출을 제어합니다.
 /// - Container-Presenter 패턴(`Equatable`)으로 불필요한 리렌더링을 방지합니다.
 struct AttendancePolicyDisplaySection: View, Equatable {
@@ -20,6 +21,10 @@ struct AttendancePolicyDisplaySection: View, Equatable {
     // MARK: - Property
 
     let policy: AttendancePolicy
+
+    private enum Constants {
+        static let title: String = "출석 정책"
+    }
 
     // MARK: - Equatable
 
@@ -31,7 +36,7 @@ struct AttendancePolicyDisplaySection: View, Equatable {
 
     var body: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
-            Text("출석 정책")
+            Text(Constants.title)
                 .appFont(.title2Emphasis, color: .black)
 
             policyCard
@@ -41,35 +46,18 @@ struct AttendancePolicyDisplaySection: View, Equatable {
     // MARK: - Card
 
     private var policyCard: some View {
-        VStack(spacing: .zero) {
-            policyRow(
-                iconName: "door.right.hand.open",
-                label: "체크인 시작",
-                tintColor: .green,
-                date: policy.checkInStartAt
-            )
-            .accessibilityLabel(accessibilityLabel(for: "체크인 시작", date: policy.checkInStartAt))
+        HStack(spacing: .zero) {
+            policyColumn(role: .checkIn, date: policy.checkInStartAt)
 
             Divider()
 
-            policyRow(
-                iconName: "clock.badge.checkmark",
-                label: "정시 종료",
-                tintColor: .orange,
-                date: policy.onTimeEndAt
-            )
-            .accessibilityLabel(accessibilityLabel(for: "정시 종료", date: policy.onTimeEndAt))
+            policyColumn(role: .onTime, date: policy.onTimeEndAt)
 
             Divider()
 
-            policyRow(
-                iconName: "xmark.circle",
-                label: "결석 시작",
-                tintColor: .red,
-                date: policy.lateEndAt
-            )
-            .accessibilityLabel(accessibilityLabel(for: "결석 시작", date: policy.lateEndAt))
+            policyColumn(role: .late, date: policy.lateEndAt)
         }
+        .frame(maxWidth: .infinity)
         .background {
             ConcentricRectangle(
                 corners: .concentric(minimum: DefaultConstant.concentricRadius),
@@ -80,46 +68,86 @@ struct AttendancePolicyDisplaySection: View, Equatable {
         }
     }
 
-    // MARK: - Row
+    // MARK: - Column
 
-    private func policyRow(
-        iconName: String,
-        label: String,
-        tintColor: Color,
-        date: Date
-    ) -> some View {
-        HStack(spacing: DefaultSpacing.spacing16) {
-            policyIcon(systemName: iconName, tintColor: tintColor)
+    private func policyColumn(role: Role, date: Date) -> some View {
+        VStack(spacing: DefaultSpacing.spacing8) {
+            policyIcon(systemName: role.iconName, tintColor: role.tintColor)
 
-            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
-                Text(AttendancePolicyDisplaySection.kstTimeText(for: date, anchor: policy.checkInStartAt))
+            VStack(spacing: DefaultSpacing.spacing4) {
+                Text(timeText(for: date))
                     .appFont(.calloutEmphasis)
                     .foregroundStyle(.black)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
 
-                Text(label)
+                Text(role.label)
                     .appFont(.footnote)
                     .foregroundStyle(.grey500)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
-
-            Spacer()
         }
-        .padding(DefaultSpacing.spacing16)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, DefaultSpacing.spacing16)
+        .padding(.horizontal, DefaultSpacing.spacing8)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel(for: role.label, date: date))
     }
 
     private func policyIcon(systemName: String, tintColor: Color) -> some View {
         Image(systemName: systemName)
             .foregroundStyle(tintColor)
-            .font(.system(size: 16))
-            .padding()
+            .imageScale(.medium)
+            .padding(DefaultSpacing.spacing12)
             .background(tintColor.opacity(0.4), in: .circle)
-            .glassEffect(.clear, in: .circle)
+    }
+
+    // MARK: - Role
+
+    /// 출석 정책 3개 임계값의 표시 메타데이터 (아이콘 / 라벨 / 색상 시맨틱)
+    ///
+    /// 색상: green(체크인 가능) → orange(정시 마감) → red(지각 마감) 으로 시간 흐름의 위험도를 표현합니다.
+    private enum Role {
+        case checkIn
+        case onTime
+        case late
+
+        var iconName: String {
+            switch self {
+            case .checkIn: "door.right.hand.open"
+            case .onTime: "clock.badge.checkmark"
+            case .late: "xmark.circle"
+            }
+        }
+
+        /// 표시 라벨. 입력 폼(`AttendancePolicyTimeSection`) 및 도메인(`lateEndAt`)과 용어를 통일합니다.
+        var label: String {
+            switch self {
+            case .checkIn: "체크인 시작"
+            case .onTime: "정시 종료"
+            case .late: "지각 종료"
+            }
+        }
+
+        var tintColor: Color {
+            switch self {
+            case .checkIn: .green
+            case .onTime: .orange
+            case .late: .red
+            }
+        }
     }
 
     // MARK: - Helper
 
-    /// 정책 시각을 KST 기준으로 표시합니다.
+    /// 정책 시각을 KST 기준 표시 문자열로 변환합니다.
     ///
-    /// 같은 날이면 `"HH:mm"`, 다른 날(자정을 넘는 정책 등)이면 `"M/d HH:mm"`.
+    /// 기준점(`checkInStartAt`)과 같은 날이면 `"HH:mm"`, 다른 날(자정을 넘는 정책 등)이면 `"M/d HH:mm"`.
+    private func timeText(for date: Date) -> String {
+        Self.kstTimeText(for: date, anchor: policy.checkInStartAt)
+    }
+
     private static func kstTimeText(for date: Date, anchor: Date) -> String {
         if Calendar.kstGregorian.isDate(date, inSameDayAs: anchor) {
             return Self.kstHourMinuteFormatter.string(from: date)
@@ -161,6 +189,7 @@ struct AttendancePolicyDisplaySection: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview {
     let now = Date()
     let policy = AttendancePolicy(
@@ -173,3 +202,4 @@ struct AttendancePolicyDisplaySection: View, Equatable {
             .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
     }
 }
+#endif


### PR DESCRIPTION
## ✨ PR 유형

Design — 일정 상세(ScheduleDetailView)의 **출석 정책 표시 섹션** 레이아웃 재설계 (UI 변경)

## 📷 스크린샷 or 영상(UI 변경 시)

> ⚠️ 해당 화면은 로그인·데이터 게이트 뒤에 있어 실기기 캡처를 첨부하지 못했습니다. 리뷰어분께서는 `AttendancePolicyDisplaySection`의 `#Preview` 로 확인 부탁드립니다. (구조 비교 ↓)

```
Before (세로 3행, full-width ~210pt)      After (가로 3분할 그리드 ~95pt)
┌──────────────────────────┐         ┌──────────────────────────────┐
│ 🟢  13:50                 │         │   🟢       🟠       🔴        │
│     체크인 시작            │         │  13:50    14:00    14:15      │
├──────────────────────────┤         │ 체크인시작  정시종료  지각종료   │
│ 🟠  14:00 / 정시 종료      │         └──────────────────────────────┘
├──────────────────────────┤           시간 흐름 좌→우 · green→orange→red
│ 🔴  14:15 / 결석 시작 ←버그 │
└──────────────────────────┘
```

## 🛠️ 작업내용

- `AttendancePolicyDisplaySection` 을 **세로 3행 → 가로 3분할 컴팩트 그리드**로 재설계 (화면 점유 약 210pt → 약 95pt, ~60% 절감)
- 컬럼은 시간값에 **비례하지 않는 균등 고정 그리드** → 세 시각이 같거나 역전되거나 간격이 짧아도 레이아웃이 깨지지 않음
- 아이콘에 `.imageScale(.medium)` 적용해 **Dynamic Type 추종** (기존 고정 `.font(.system(size:))` 제거)
- 간격/패딩을 전부 `DefaultSpacing` 토큰으로 정리, 텍스트 `lineLimit(1) + minimumScaleFactor(0.8)` 로 자정 넘는 `M/d HH:mm`·큰 글씨 대응
- 표시 라벨 **"결석 시작" → "지각 종료" 통일** (도메인 `lateEndAt`·입력 폼 `AttendancePolicyTimeSection` 과 용어 일치 — 기존 표시 라벨이 카피 불일치였음)
- KST 날짜 포맷 로직·셀별 VoiceOver 접근성 라벨 보존, `#Preview` 에 `#if DEBUG` 가드 추가
- 카드 컨테이너(`ConcentricRectangle().fill(.white).glass()`)는 상단 날짜/장소 카드와 동일 패턴 유지

## 📋 추후 진행 상황

- 일정 상세 화면 **섹션 제목 타이포 계층 정리**(일정 이름·"출석 정책"·"상세 안내"가 모두 `.title2Emphasis` 동급) — 화면 전체 일관성 영향이 있어 별도 작업으로 분리 예정

## 📌 리뷰 포인트

- `AppProduct/AppProduct/Features/Home/Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift` — 가로 3분할 그리드 레이아웃, `Role` enum(아이콘/라벨/색상 시맨틱), Dynamic Type·접근성 처리, "지각 종료" 라벨 통일 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)