### PR TITLE
💄 [Design] 일정 상세 섹션 제목 타이포 계층 복원

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift
@@ -32,7 +32,7 @@ struct AttendancePolicyDisplaySection: View, Equatable {
     var body: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
             Text("출석 정책")
-                .appFont(.title2Emphasis, color: .black)
+                .appFont(.title3Emphasis, color: .black)
 
             policyCard
         }

--- a/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
+++ b/AppProduct/AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift
@@ -316,7 +316,7 @@ struct ScheduleDetailView: View {
     private func detailDescription(_ data: ScheduleDetailData) -> some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing12, content: {
             Text(Constants.detailTitle)
-                .appFont(.title2Emphasis, color: .black)
+                .appFont(.title3Emphasis, color: .black)
 
             Text(data.description)
                 .appFont(.callout, color: .grey600)


### PR DESCRIPTION
## ✨ PR 유형

Design — 일정 상세 화면(ScheduleDetailView)의 타이포그래피 계층 복원. 기능 변경 없는 순수 토큰 조정.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 시뮬레이터에서 일정 상세 화면 캡처 첨부 예정 -->
> ⚠️ UI 변경입니다 — before/after 스크린샷 첨부 부탁드립니다.

## 🛠️ 작업내용

일정 이름과 두 섹션 제목("출석 정책", "상세 안내")이 모두 `.title2Emphasis`(22pt Bold)라 동급으로 보여 정보 위계가 평탄했습니다. 두 섹션 제목을 한 단계 낮춰 계층을 복원했습니다.

- `AttendancePolicyDisplaySection.swift` — "출석 정책" 섹션 제목 `.title2Emphasis` → `.title3Emphasis`
- `ScheduleDetailView.swift` — "상세 안내" 섹션 제목 `.title2Emphasis` → `.title3Emphasis`
- 일정 이름은 `.title2Emphasis`(22pt) 유지

복원된 계층 사다리: **일정 이름 22pt → 섹션 제목 20pt → 카드 강조 16pt → 카드 레이블 13pt** (단조 감소)

> `.calloutEmphasis`(16pt)는 채택하지 않음 — 이미 16pt인 카드 내부 강조 행(`.calloutEmphasis`)·본문(`.callout`)과 충돌해 하단 위계가 역전됨. (soyeon-ui-review 검증 결과)

## 📋 추후 진행 상황

디자인팀 후속 확인(비차단):
- 일정 이름(22pt) vs 섹션 제목(20pt) **2pt 차이**가 충분한 위계 신호인지 확인 — 더 강한 대비 필요 시 일정 이름 `.title1Emphasis`(28pt) 격상 검토
- 섹션 제목 컬러 `.black` → `.grey700` 완화로 위계 보조 강화 검토(선택)

## 📌 리뷰 포인트

- `AppProduct/Features/Home/Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift` (line 35) — "출석 정책" 토큰
- `AppProduct/Features/Home/Presentation/Views/Registration/ScheduleDetailView.swift` (line 319) — "상세 안내" 토큰. 일정 이름(line 290)은 `.title2Emphasis` 유지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)