### PR TITLE
💄 [Design] 로그인 — Google 버튼 아웃라인화 · ID/PW→"UMC 계정 로그인" teal 적용

### DIFF
--- a/AppProduct/AppProduct/Core/Common/Enum/SocialType.swift
+++ b/AppProduct/AppProduct/Core/Common/Enum/SocialType.swift
@@ -16,8 +16,8 @@ enum SocialType: String, CaseIterable, Hashable {
     case apple = "Apple로 계속하기"
     /// 구글 로그인
     case google = "Google로 계속하기"
-    /// 이메일로 계속하기
-    case email = "ID/PW로 계속하기"
+    /// UMC 계정(ID/PW) 로그인
+    case email = "UMC 계정 로그인"
 
     static var allCases: [SocialType] {
         [.kakao, .apple, .google, .email]
@@ -64,9 +64,9 @@ enum SocialType: String, CaseIterable, Hashable {
         case .apple:
             return Color.black // 애플 고유 검정색
         case .google:
-            return Color.grey100 // 흰 화면과 구분되는 연한 회색 배경
+            return Color.clear // 아웃라인 스타일 — 회색 테두리는 LoginActionStack에서 처리
         case .email:
-            return Color.clear
+            return Color.green100 // UMC 계정 로그인 — teal 계열 배경(green100 ≈ teal-100)
         }
     }
     
@@ -80,7 +80,7 @@ enum SocialType: String, CaseIterable, Hashable {
         case .google:
             return .black // 흰 배경엔 검은 글씨
         case .email:
-            return .black
+            return .green700 // teal-100 배경 위 teal 계열 텍스트(green700 ≈ teal-600)
         }
     }
     

--- a/AppProduct/AppProduct/Core/Common/UIComponents/Auth/LoginActionStack.swift
+++ b/AppProduct/AppProduct/Core/Common/UIComponents/Auth/LoginActionStack.swift
@@ -103,6 +103,11 @@ struct LoginActionStack: View {
         .disabled(isLoading)
         .accessibilityLabel(Text("Google로 시작하기"))
         .accessibilityHint(Text("Google 계정으로 로그인합니다"))
+        .overlay {
+            Capsule()
+                .fill(.clear)
+                .strokeBorder(Color.grey500, style: .init(lineWidth: 0.5))
+        }
     }
 
     private var idPwLoginButton: some View {
@@ -112,11 +117,6 @@ struct LoginActionStack: View {
         .buttonBorderShape(.capsule)
         .disabled(isLoading)
         .accessibilityHint(Text("아이디와 비밀번호 입력 화면으로 이동합니다"))
-        .overlay {
-            Capsule()
-                .fill(.clear)
-                .strokeBorder(Color.grey500, style: .init(lineWidth: 0.5))
-        }
     }
 
     private var supportFooter: some View {


### PR DESCRIPTION
## ✨ PR 유형

- 💄 UI / 디자인 (로그인 진입 화면 버튼 스타일 정비)

Closes #869

## 📷 스크린샷 or 영상(UI 변경 시)

> 시뮬레이터(iPhone 17 Pro / iOS 26.5) 빌드·실행 성공으로 컴파일·런타임 검증 완료. 실기기 라이트/다크 캡처는 코멘트에 추가 예정입니다.

**변경 요약**
- **Google 버튼**: 배경 `clear` + `grey500` 0.5pt 회색 테두리 (Google 브랜드 가이드의 outlined 스타일)
- **UMC 계정 로그인 버튼**: 배경 `green100`(≈ teal-100) · 텍스트 `green700`(≈ teal-600), 기존 회색 테두리 제거

## 🛠️ 작업내용

- `SocialType.google.color`: `grey100` → `clear` — 아웃라인 스타일로 전환
- `SocialType.email` rawValue: `"ID/PW로 계속하기"` → `"UMC 계정 로그인"`
- `SocialType.email` 색상: 배경 `green100`(≈ `#EBF9F5`, teal-100), 텍스트 `green700`(≈ `#2A8969`, teal-600)
- `LoginActionStack`: 회색 테두리 `overlay` 를 `idPwLoginButton` → `googleLoginButton` 으로 이관

## 📋 추후 진행 상황

- 색상 토큰은 **이슈의 '택일' 항목에서 기존 `green` 팔레트 재사용으로 결정** (신규 teal colorset 미추가). 블로그 brand teal(`#0B6B64`)과 정확히 일치시키려면 추후 `Colors.xcassets` 에 teal colorset 신규 추가가 필요하며, 이는 디자인팀 확정 후 별도 작업으로 진행합니다.

## 📌 리뷰 포인트

- **색 토큰 재사용 결정**: 정확한 teal 대신 기존 `green100`/`green700` 재사용. `green700` 이 blog teal-600 보다 초록 쪽으로 미세하게 치우칩니다.
- **라이트/다크 대비**: 다크모드는 `green700`(라이트 민트) on `green100`(딥 그린)으로 대비 우수(≈ 6.6:1). 라이트모드는 `green700` on `green100` 대비가 `.callout` 텍스트 기준 ≈ 4:1 (WCAG AA Large 통과, AA normal 4.5:1 에는 약간 못 미침) — 허용 여부 확인 필요.
- Google 버튼 테두리가 기존 ID/PW 버튼과 동일한 0.5pt `grey500` 인지 시각 확인.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
