### PR TITLE
💄 [Design] 체크마크 등장에 .symbolEffect(.drawOn) 드로잉 애니메이션 적용 (#870)

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionCardContent.swift
@@ -71,7 +71,8 @@ struct ChallengerMissionCardContent: View, Equatable {
         MissionStatusResultView(
             icon: "checkmark.circle.fill",
             message: "미션을 통과하였습니다.",
-            color: .green
+            color: .green,
+            drawsOnAppear: true
         )
     }
 
@@ -126,6 +127,8 @@ fileprivate struct MissionStatusResultView: View, Equatable {
     let icon: String
     let message: String
     let color: Color
+    /// `true`이면 등장 시 아이콘에 draw-on 애니메이션을 적용합니다. (통과 등 긍정 상태 전용)
+    var drawsOnAppear: Bool = false
 
     private enum Constants {
 
@@ -138,6 +141,7 @@ fileprivate struct MissionStatusResultView: View, Equatable {
         HStack {
             Image(systemName: icon)
                 .foregroundStyle(color)
+                .symbolDrawOn(isActive: drawsOnAppear)
             Text(message)
                 .appFont(.callout, color: color)
         }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionStatusIcon.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Challenger/Mission/ChallengerMissionStatusIcon.swift
@@ -59,12 +59,14 @@ struct ChallengerMissionStatusIcon: View, Equatable {
         Image(systemName: "checkmark.circle.fill")
             .resizable()
             .foregroundStyle(status.missionListIconColor)
+            .symbolDrawOn(isActive: true)
     }
 
     private var passIcon: some View {
         Image(systemName: "checkmark.circle.fill")
             .resizable()
             .foregroundStyle(status.missionListIconColor)
+            .symbolDrawOn(isActive: true)
     }
 
     private var failIcon: some View {

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorSessionStatusIcon.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Components/Operation/Attendance/OperatorSessionStatusIcon.swift
@@ -70,6 +70,7 @@ struct OperatorSessionStatusIcon: View, Equatable {
         Image(systemName: "checkmark.circle.fill")
             .resizable()
             .foregroundStyle(status.iconColor)
+            .symbolDrawOn(isActive: true)
     }
     
     

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -188,6 +188,7 @@ struct ChallengerAttendanceSessionView: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 40))
                 .foregroundStyle(.green.opacity(0.7))
+                .symbolDrawOn(isActive: true)
 
             Text("모든 세션 출석을 완료했습니다")
                 .appFont(.body, color: .grey600)

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
@@ -610,6 +610,7 @@ private struct PendingApprovalSheetView: View {
                             ? "checkmark.circle.fill"
                             : "circle"
                     )
+                    .contentTransition(.symbolEffect(.replace))
                     .font(.system(size: 22))
                     .foregroundStyle(
                         selectedMemberIds.contains(participant.memberId) ? .indigo500 : .grey400
@@ -685,10 +686,12 @@ private struct PendingApprovalSheetView: View {
     // MARK: - Helper
 
     private func toggleSelection(for memberId: Int) {
-        if selectedMemberIds.contains(memberId) {
-            selectedMemberIds.remove(memberId)
-        } else {
-            selectedMemberIds.insert(memberId)
+        withAnimation(.easeInOut(duration: 0.2)) {
+            if selectedMemberIds.contains(memberId) {
+                selectedMemberIds.remove(memberId)
+            } else {
+                selectedMemberIds.insert(memberId)
+            }
         }
     }
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Components/FormEmailField.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Components/FormEmailField.swift
@@ -294,6 +294,7 @@ struct FormEmailField: View {
         HStack(spacing: DefaultSpacing.spacing8) {
             Image(systemName: Constants.successImage)
                 .foregroundStyle(.green)
+                .symbolDrawOn(isActive: true)
             Text(Constants.successMsg)
                 .appFont(.footnote, color: .green)
         }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginByIdPwView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/LoginByIdPwView.swift
@@ -134,7 +134,9 @@ struct LoginByIdPwView: View {
 
     private var autoLoginToggle: some View {
         Button {
-            viewModel.isAutoLoginEnabled.toggle()
+            withAnimation(.easeInOut(duration: 0.2)) {
+                viewModel.isAutoLoginEnabled.toggle()
+            }
         } label: {
             HStack(spacing: DefaultSpacing.spacing8) {
                 Image(
@@ -146,6 +148,7 @@ struct LoginByIdPwView: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: Constants.checkboxSize, height: Constants.checkboxSize)
                 .foregroundStyle(viewModel.isAutoLoginEnabled ? .indigo500 : .grey400)
+                .contentTransition(.symbolEffect(.replace))
                 Text(Constants.autoLoginLabel)
                     .appFont(.subheadline, color: .grey600)
             }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpByIdPwView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpByIdPwView.swift
@@ -165,6 +165,7 @@ struct SignUpByIdPwView: View {
             case .loaded(true):
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(.green)
+                    .symbolDrawOn(isActive: true)
                 Text("사용 가능한 이메일입니다.")
                     .appFont(.footnote, color: .green)
             case .loaded(false):

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
@@ -216,13 +216,16 @@ struct SignUpView: View {
 
     private var allAgreeButton: some View {
         Button(action: {
-            viewModel.toggleAllTerms(!viewModel.isAllTermsAgreed)
+            withAnimation(.easeInOut(duration: 0.2)) {
+                viewModel.toggleAllTerms(!viewModel.isAllTermsAgreed)
+            }
         }) {
             HStack(spacing: DefaultSpacing.spacing8) {
                 Image(
                     systemName: viewModel.isAllTermsAgreed
                     ? "checkmark.circle.fill" : "circle"
                 )
+                .contentTransition(.symbolEffect(.replace))
                 .foregroundStyle(viewModel.isAllTermsAgreed ? .indigo500 : .grey400)
                 Text(Constants.allAgreeTitle)
                     .appFont(.calloutEmphasis)
@@ -381,10 +384,13 @@ private struct SignUpTermsRow: View {
     var body: some View {
         HStack(spacing: DefaultSpacing.spacing8) {
             Button(action: {
-                onToggle()
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    onToggle()
+                }
             }) {
                 HStack(spacing: DefaultSpacing.spacing8) {
                     Image(systemName: isAgreed ? "checkmark.circle.fill" : "circle")
+                        .contentTransition(.symbolEffect(.replace))
                         .foregroundStyle(isAgreed ? .indigo500 : .grey400)
                     Text(title)
                         .appFont(.subheadline)

--- a/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/ActiveLogs.swift
+++ b/AppProduct/AppProduct/Features/MyPage/Presentation/Components/Section/MyPageProfileSection/ActiveLogs.swift
@@ -72,6 +72,8 @@ struct ActiveLogs: View {
                                 .labelStyle(.titleAndIcon)
                                 .labelIconToTitleSpacing(DefaultSpacing.spacing8)
                                 .appFont(.footnote, color: didRecentlyAdd ? .green : .indigo500)
+                                .contentTransition(.symbolEffect(.replace))
+                                .animation(.easeInOut(duration: 0.25), value: didRecentlyAdd)
                         }
                     }
                     .buttonStyle(.plain)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeVoteCard.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/DetailCard/NoticeVoteCard.swift
@@ -483,6 +483,7 @@ struct VoteResultRow: View {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(Color.indigo500)
                     .appFont(.callout)
+                    .symbolDrawOn(isActive: true)
             }
 
             Text(String(format: "%.1f%%", option.percentage(totalVotes: totalVotes)))

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeReadStatusButton.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Components/NoticeReadStatusButton.swift
@@ -80,6 +80,7 @@ struct NoticeReadStatusButton: View {
                     HStack(spacing: DefaultSpacing.spacing8) {
                         Image(systemName: "checkmark.circle.fill")
                             .appFont(.body, color: .green)
+                            .symbolDrawOn(isActive: true)
 
                         Text("수신 확인 현황")
                             .appFont(.calloutEmphasis, color: .black)

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AILoadingOverlay.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AILoadingOverlay.swift
@@ -84,6 +84,7 @@ struct AILoadingOverlay: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: DefaultConstant.iconSize, weight: .medium))
                 .foregroundStyle(.indigo500)
+                .symbolDrawOn(isActive: true)
         }
     }
 

--- a/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AISummaryDraftOverlay.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/Views/NoticeEditor/Overlay/AISummaryDraftOverlay.swift
@@ -54,6 +54,7 @@ struct AISummaryDraftOverlay: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: DefaultConstant.iconSize, weight: .medium))
                 .foregroundStyle(.indigo500)
+                .symbolDrawOn(isActive: true)
 
             Text("초안이 완성됐어요")
                 .appFont(.calloutEmphasis)

--- a/AppProduct/AppProduct/Utilities/Modifier/KeyboardToolbarModifier.swift
+++ b/AppProduct/AppProduct/Utilities/Modifier/KeyboardToolbarModifier.swift
@@ -42,6 +42,7 @@ struct KeyboardToolbarModifier<Field: Hashable & CaseIterable>: ViewModifier {
                 toolBarButton(action: {
                     focusedField = nil
                 }, image: "checkmark", size: .init(width: 20, height: 20))
+                .symbolDrawOn(isActive: true)
             })
         })
         .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
@@ -135,6 +136,7 @@ struct KeyboardDismissToolbarModifier: ViewModifier {
                     .tint(.grey900)
                     .padding(DefaultConstant.defaultBtnPadding)
                     .glassEffect(.regular.interactive(), in: .circle)
+                    .symbolDrawOn(isActive: true)
             }
         }
         .padding(.horizontal, DefaultConstant.defaultSafeHorizon)

--- a/AppProduct/AppProduct/Utilities/Modifier/SymbolDrawOnModifier.swift
+++ b/AppProduct/AppProduct/Utilities/Modifier/SymbolDrawOnModifier.swift
@@ -1,0 +1,54 @@
+//
+//  SymbolDrawOnModifier.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 6/3/26.
+//
+
+import SwiftUI
+
+// MARK: - View+SymbolDrawOn
+
+extension View {
+
+    /// 긍정적 상태 전환(승인·완료·읽음 확인·선택 등) 시 SF Symbol을 펜으로 긋듯
+    /// 선을 따라 그리는 `drawOn` 등장 애니메이션을 적용합니다.
+    ///
+    /// `isActive`가 `true`가 되는 순간 심볼이 그려지며 나타나고,
+    /// 비활성일 때는 효과 없이 심볼이 그대로 표시됩니다.
+    ///
+    /// - Important: `circle ↔ checkmark.circle.fill`처럼 두 심볼을 오가는 체크박스 토글에는
+    ///   적합하지 않습니다(빈 상태 심볼까지 다시 그려져 어색함).
+    ///   그런 경우는 `contentTransition(.symbolEffect(.replace))`를 사용하세요.
+    /// - Note: 손쉬운 사용의 "동작 줄이기"(Reduce Motion)가 켜져 있으면 모션을 생략하고
+    ///   심볼을 즉시 표시합니다. 비활성(`isActive == false`)일 때도 효과를 부착하지 않아
+    ///   어떤 상황에서도 심볼이 숨겨지지 않습니다.
+    ///
+    /// - Parameter isActive: 심볼을 그려서 등장시킬지 여부.
+    func symbolDrawOn(isActive: Bool) -> some View {
+        modifier(SymbolDrawOnModifier(isActive: isActive))
+    }
+}
+
+// MARK: - SymbolDrawOnModifier
+
+/// `symbolEffect(.drawOn:)`을 Reduce Motion 설정과 함께 적용하는 ViewModifier입니다.
+private struct SymbolDrawOnModifier: ViewModifier {
+
+    // MARK: - Property
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    let isActive: Bool
+
+    // MARK: - Body
+
+    func body(content: Content) -> some View {
+        if isActive && !reduceMotion {
+            content
+                .symbolEffect(.drawOn, isActive: true)
+        } else {
+            content
+        }
+    }
+}

--- a/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
+++ b/AppProduct/AppProduct/Utilities/ToolBar/ToolBarCollection.swift
@@ -84,6 +84,7 @@ struct ToolBarCollection {
                     ZStack {
                         Image(systemName: "checkmark")
                             .opacity(isLoading ? 0 : 1)
+                            .symbolDrawOn(isActive: !isLoading)
 
                         if isLoading {
                             ProgressView()


### PR DESCRIPTION
## ✨ PR 유형

- 💄 Design — 코드 레벨 모션 개선 (closes #870)

체크마크 계열 SF Symbol이 **상태 전환에 따라 새로 등장**할 때, 선을 따라 그려지는 `drawOn` 애니메이션으로 긍정적 피드백(승인·완료·읽음·선택)을 더 또렷하게 만듭니다.

## 📷 스크린샷 or 영상(UI 변경 시)

> 정적 캡처로는 드러나지 않는 **모션**(체크가 펜으로 긋듯 그려지는 draw-on) 변경입니다. 상태 전환 시점에만 동작하므로 인증/출석/공지 플로우에서 직접 확인 부탁드립니다.
- ✅ 시뮬레이터(iPhone 17 Pro · iOS 26.5) 빌드 성공 — 0 errors / 0 warnings
- ✅ 앱 정상 구동 확인

## 🛠️ 작업내용

**핵심 판단**: `.symbolEffect(.drawOn)`은 *"빈 상태 → 체크가 새로 그려지며 등장"* 패턴에 적합합니다. 반면 `circle ↔ checkmark.circle.fill` **체크박스 토글**에 그대로 쓰면 빈 상태(빈 원) affordance까지 다시 그려져 어색하므로, 토글에는 심볼-투-심볼 모핑인 `.contentTransition(.symbolEffect(.replace))`를 사용했습니다.
> 폴라리티는 Apple 공식 문서(*"The DrawOn animation makes the symbol visible"*) 기준으로 `isActive: true → 표시`로 확정했습니다.

- **공용 헬퍼 신규** — `symbolDrawOn(isActive:)` (`SymbolDrawOnModifier.swift`)
  - **Reduce Motion**(동작 줄이기) 켜지면 모션 생략
  - 비활성일 때는 효과를 부착하지 않아 **어떤 상황에서도 심볼이 숨겨지지 않음**
- **drawOn 적용 (체크 등장, 14곳)** — OperatorSessionStatusIcon(종료), ChallengerMissionStatusIcon(통과/완료), ChallengerMissionCardContent(통과), ChallengerAttendanceSessionView(전체 출석 완료), FormEmailField(인증 성공), SignUpByIdPwView(이메일 사용 가능), NoticeReadStatusButton, NoticeVoteCard(투표 선택 체크), AILoadingOverlay(완료), AISummaryDraftOverlay, ToolBarCollection(ConfirmBtn), KeyboardToolbarModifier
- **replace 모핑 (토글, 6곳)** — SignUpView(약관 ×2), LoginByIdPwView(자동로그인), AttendanceDetailView(선택), ActiveLogs(기록 추가); SignUpTermsSection·PointGrantFormSheet은 기존 적용 유지
- **제외** — OperatorStatusSectionStyle(소비처 없음), AttendanceListView(정적 권한 안내 아이콘), ToolBarCollection 메뉴 라벨(시스템 렌더링이라 심볼 효과 미동작)
- **두 빌드 축 확인** — UMCApp(Tuist)에는 해당 컴포넌트가 없음(`checkmark` 사용 0건) → AppProduct 단일 축 작업
- **(fix)** LoginByIdPwView에서 `.contentTransition`을 `Image.resizable()` 앞에 두어 발생하던 빌드 오류 수정

## 📋 추후 진행 상황

- (선택) 토글 케이스에도 draw-on을 원하면, 빈 원을 유지한 채 체크만 overlay로 그리는 구조로 별도 후속 작업 가능

## 📌 리뷰 포인트

- `symbolDrawOn` 헬퍼의 Reduce Motion 처리 + "비활성 시 효과 미부착" 설계 (`SymbolDrawOnModifier.swift`)
- 토글(circle↔check)에 drawOn 대신 `.replace`를 선택한 판단이 적절한지
- 상태 아이콘들의 `isActive: true` 상수 적용이 등장 시 의도대로 1회 그려지는지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
