### PR TITLE
💄 [Design] 출석 현황 UX 개선 — 목록 상태색 · 상세 배너/스탯 · 챌린저 빈 상태 가이드

### DIFF
--- a/AppProduct/AppProduct/Features/Activity/Presentation/Extensions/OperatorSessionStatus+UI.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Extensions/OperatorSessionStatus+UI.swift
@@ -29,4 +29,23 @@ extension OperatorSessionStatus {
         case .ended: return .gray
         }
     }
+
+    /// 출석 현황 목록 카드 전용 강조 색상 (좌측 액센트 바 + 상태 배지).
+    /// inProgress=진행중(브랜드 강조), beforeStart=예정(액센트), ended=마감(디엠퍼사이즈).
+    var listAccentColor: Color {
+        switch self {
+        case .inProgress: return .indigo500
+        case .beforeStart: return .orange500
+        case .ended: return .grey400
+        }
+    }
+
+    /// 목록 카드 상태 배지에 표시할 짧은 라벨.
+    var listBadgeText: String {
+        switch self {
+        case .inProgress: return "진행중"
+        case .beforeStart: return "예정"
+        case .ended: return "마감"
+        }
+    }
 }

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -56,7 +56,7 @@ struct ChallengerAttendanceSessionView: View {
         )
         self._attendanceViewModel = .init(wrappedValue: attendanceViewModel)
     }
-    
+
     private enum Constants {
         static let animationResponse: Double = 0.35
         static let animationDamping: Double = 0.8
@@ -186,7 +186,7 @@ struct ChallengerAttendanceSessionView: View {
     private var emptySessionView: some View {
         VStack(spacing: DefaultSpacing.spacing12) {
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 40))
+                .font(.system(size: DefaultConstant.iconSize))
                 .foregroundStyle(.green.opacity(0.7))
 
             Text("모든 세션 출석을 완료했습니다")
@@ -210,9 +210,7 @@ struct ChallengerAttendanceSessionView: View {
             sectionHeader
 
             switch attendanceViewModel.myHistory {
-            case .idle:
-                Color.clear
-            case .loading:
+            case .idle, .loading:
                 ProgressView()
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, DefaultSpacing.spacing32)
@@ -240,14 +238,21 @@ struct ChallengerAttendanceSessionView: View {
     private var emptyHistoryView: some View {
         VStack(spacing: DefaultSpacing.spacing12) {
             Image(systemName: "clock.badge.checkmark")
-                .font(.system(size: 40))
-                .foregroundStyle(.grey400)
+                .font(.system(size: DefaultConstant.iconSize))
+                .foregroundStyle(.indigo400)
 
-            Text("출석 이력이 없습니다")
-                .appFont(.body, color: .grey600)
+            VStack(spacing: DefaultSpacing.spacing4) {
+                Text("아직 출석 기록이 없어요")
+                    .appFont(.calloutEmphasis, color: .grey700)
+
+                Text("출석 가능한 세션에서 출석을 완료하면\n이곳에 나의 출석 현황이 표시됩니다.")
+                    .appFont(.footnote, color: .grey500)
+                    .multilineTextAlignment(.center)
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, DefaultSpacing.spacing32)
+        .padding(.horizontal, DefaultSpacing.spacing16)
         .background(
             .white,
             in: RoundedRectangle(

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceDetailView.swift
@@ -149,6 +149,10 @@ struct AttendanceDetailView: View {
     @ViewBuilder
     private func content(info: ScheduleAttendanceInfo) -> some View {
         ScrollView {
+            // 주의: GlassEffectContainer 로 감싸지 않는다. 헤더/스탯/참여자 카드가
+            // `ConcentricRectangle`(적응형 코너)을 쓰는데, 컨테이너 내부에서는 코너 상속이
+            // 끊겨 `.interactive()` 글래스(승인 대기 배너)의 눌림 효과가 카드와 다른 크기로
+            // morphing된다. (StudyGroupCard 의 동일 이슈 주석 참고)
             VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
                 headerCard(info: info)
                 statsRow(info: info)
@@ -234,18 +238,19 @@ struct AttendanceDetailView: View {
         } label: {
             HStack(spacing: DefaultSpacing.spacing8) {
                 Image(systemName: "clock.badge.exclamationmark")
-                    .font(.system(size: 14))
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.orange600)
                 Text("승인 대기 \(count)건")
-                    .appFont(.calloutEmphasis)
+                    .appFont(.calloutEmphasis, color: .orange700)
                 Spacer()
                 Image(systemName: DefaultConstant.chevronForwardImage)
-                    .font(.system(size: 12))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.orange400)
             }
-            .foregroundStyle(.orange)
             .padding(DefaultSpacing.spacing12)
             .frame(maxWidth: .infinity)
             .glassEffect(
-                .regular.tint(.orange).interactive(),
+                .regular.tint(.orange.opacity(0.16)).interactive(),
                 in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius))
             )
         }
@@ -254,18 +259,49 @@ struct AttendanceDetailView: View {
 
     private func statsRow(info: ScheduleAttendanceInfo) -> some View {
         HStack(spacing: DefaultSpacing.spacing12) {
-            statBlock(label: "출석", value: "\(info.presentCount) / \(info.totalCount)")
-            statBlock(label: "대기", value: "\(info.pendingCount)")
-            statBlock(label: "출석률", value: rateText(info: info))
+            statBlock(
+                icon: "person.fill.checkmark",
+                tint: .indigo500,
+                label: "출석",
+                value: "\(info.presentCount) / \(info.totalCount)",
+                valueColor: .grey700
+            )
+            statBlock(
+                icon: "clock.badge",
+                tint: .orange500,
+                label: "대기",
+                value: "\(info.pendingCount)",
+                valueColor: info.pendingCount > 0 ? .orange600 : .grey400
+            )
+            statBlock(
+                icon: "chart.pie.fill",
+                tint: .indigo500,
+                label: "출석률",
+                value: rateText(info: info),
+                valueColor: .indigo600
+            )
         }
     }
 
-    private func statBlock(label: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
-            Text(label)
-                .appFont(.caption1, color: .grey500)
+    private func statBlock(
+        icon: String,
+        tint: Color,
+        label: String,
+        value: String,
+        valueColor: Color
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(tint)
+                Text(label)
+                    .appFont(.caption1, color: .grey500)
+            }
             Text(value)
-                .appFont(.calloutEmphasis, color: .grey700)
+                .appFont(.title3Emphasis, color: valueColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(DefaultSpacing.spacing12)
@@ -321,6 +357,15 @@ struct AttendanceDetailView: View {
             .frame(maxWidth: .infinity)
             .padding(.vertical, DefaultSpacing.spacing24)
         } else {
+            // LazyVStack is used here instead of List because:
+            // (1) Rows apply glassEffect, which requires GlassEffectContainer wrapping
+            //     that the parent ScrollView already provides — List is incompatible
+            //     with GlassEffectContainer (design-system.md: "적용 불가: List").
+            // (2) Nesting a List inside a ScrollView collapses the list to zero height
+            //     in SwiftUI, breaking layout. Splitting header/list while sharing
+            //     scroll position is not possible without UIKit interop.
+            // swipeActions on LazyVStack rows manages its own gesture state per-cell
+            // and behaves identically to List swipeActions on iOS 26.
             LazyVStack(spacing: DefaultSpacing.spacing8) {
                 ForEach(participants) { participant in
                     ParticipantAttendanceRow(
@@ -402,6 +447,24 @@ struct AttendanceDetailView: View {
 
     // MARK: - Helper
 
+    // DateFormatter is expensive to allocate (~0.5 ms each); static lets ensure
+    // they are created once per process lifetime rather than on every body render.
+    private static let startDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.M.d (E) HH:mm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return formatter
+    }()
+
+    private static let endTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return formatter
+    }()
+
     private var pendingCount: Int {
         guard case .loaded(let info) = viewModel.detailState else { return 0 }
         return info.pendingCount
@@ -412,17 +475,8 @@ struct AttendanceDetailView: View {
     }
 
     private func dateRangeText(info: ScheduleAttendanceInfo) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.M.d (E) HH:mm"
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-        let start = formatter.string(from: info.startsAt)
-
-        let endFormatter = DateFormatter()
-        endFormatter.dateFormat = "HH:mm"
-        endFormatter.locale = Locale(identifier: "ko_KR")
-        endFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-        let end = endFormatter.string(from: info.endsAt)
+        let start = Self.startDateFormatter.string(from: info.startsAt)
+        let end = Self.endTimeFormatter.string(from: info.endsAt)
         return "\(start) ~ \(end)"
     }
 

--- a/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
+++ b/AppProduct/AppProduct/Features/Activity/Presentation/Views/Operation/AttendanceListView.swift
@@ -289,7 +289,7 @@ struct AttendanceListView: View {
             Spacer()
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 36))
-                .foregroundStyle(.orange)
+                .foregroundStyle(.orange500)
             Text(error.userMessage)
                 .appFont(.subheadline, color: .grey600)
                 .multilineTextAlignment(.center)
@@ -312,7 +312,7 @@ struct AttendanceListView: View {
             HStack(spacing: DefaultSpacing.spacing12) {
                 Image(systemName: "tray.and.arrow.down.fill")
                     .font(.system(size: 18))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(.orange500)
 
                 Text("승인 대기 \(viewModel.totalPendingCount)건")
                     .appFont(.calloutEmphasis, color: .grey700)
@@ -411,10 +411,16 @@ struct AttendanceListView: View {
     @ViewBuilder
     private func listContent(infos: [ScheduleAttendanceInfo]) -> some View {
         ScrollView {
+            // 주의: GlassEffectContainer 로 감싸지 않는다. 카드 배경이 `ConcentricRectangle`
+            // (적응형 코너)을 쓰는데, 컨테이너 내부에서는 코너 상속이 끊겨 `.interactive()`
+            // 글래스의 눌림(liquid) 효과가 카드와 다른 크기로 morphing된다.
+            // (StudyGroupCard 의 동일 이슈 주석 참고) → 카드별 glassEffect 를 독립적으로 둔다.
             LazyVStack(spacing: DefaultSpacing.spacing12) {
                 ForEach(infos) { info in
                     Button {
-                        di.resolve(PathStore.self).activityPath.append(.activity(.attendanceDetail(scheduleId: info.scheduleId)))
+                        di.resolve(PathStore.self).activityPath.append(
+                            .activity(.attendanceDetail(scheduleId: info.scheduleId))
+                        )
                     } label: {
                         AttendanceListRow(info: info)
                     }
@@ -439,66 +445,102 @@ private struct AttendanceListRow: View, Equatable {
             && lhs.info.pendingCount == rhs.info.pendingCount
     }
 
+    private var status: OperatorSessionStatus {
+        OperatorSessionStatus.from(startTime: info.startsAt, endTime: info.endsAt)
+    }
+
+    /// 진행중 카드만 은은한 indigo 틴트로 강조.
+    /// (`Glass` 는 로컬 `AppProduct.Glass` 그림자 모디파이어와 이름이 겹치므로
+    ///  SwiftUI 글래스 타입을 명시적으로 한정한다.)
+    private var cardGlass: SwiftUICore.Glass {
+        switch status {
+        case .inProgress:
+            return .regular.tint(.indigo500.opacity(0.10)).interactive()
+        default:
+            return .regular.interactive()
+        }
+    }
+
+    private var statusBadge: some View {
+        Text(status.listBadgeText)
+            .appFont(.caption2Emphasis, color: status.listAccentColor)
+            .padding(.horizontal, DefaultSpacing.spacing8)
+            .padding(.vertical, DefaultSpacing.spacing4)
+            .glassEffect(
+                .clear.tint(status.listAccentColor.opacity(0.18)),
+                in: Capsule()
+            )
+            .accessibilityLabel("상태 \(status.listBadgeText)")
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
-            HStack(alignment: .firstTextBaseline) {
-                Text(info.name)
-                    .appFont(.calloutEmphasis, color: .grey700)
-                    .lineLimit(1)
-                Spacer()
-                Text(rateText)
-                    .appFont(.footnote, color: .grey500)
-            }
+        HStack(alignment: .top, spacing: DefaultSpacing.spacing12) {
+            Capsule()
+                .fill(status.listAccentColor)
+                .frame(width: 4)
 
-            HStack(spacing: DefaultSpacing.spacing8) {
-                Image(systemName: "calendar")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.grey500)
-                Text(dateRangeText)
-                    .appFont(.footnote, color: .grey500)
-            }
-
-            if let location = info.location {
-                HStack(spacing: DefaultSpacing.spacing8) {
-                    Image(systemName: "mappin.and.ellipse")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.grey500)
-                    Text(location.locationName)
-                        .appFont(.footnote, color: .grey500)
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(info.name)
+                        .appFont(.calloutEmphasis, color: status == .ended ? .grey500 : .grey700)
                         .lineLimit(1)
+                    Spacer()
+                    statusBadge
                 }
-            } else if info.isOnline {
+
                 HStack(spacing: DefaultSpacing.spacing8) {
-                    Image(systemName: "video")
+                    Image(systemName: "calendar")
                         .font(.system(size: 12))
                         .foregroundStyle(.grey500)
-                    Text("비대면")
+                    Text(dateRangeText)
                         .appFont(.footnote, color: .grey500)
                 }
-            }
 
-            HStack(spacing: DefaultSpacing.spacing8) {
-                Text("출석 \(info.presentCount) / \(info.totalCount)")
-                    .appFont(.footnote, color: .grey600)
-                if info.pendingCount > 0 {
-                    InfoBadge(
-                        "대기 \(info.pendingCount)",
-                        textColor: .orange,
-                        tintColor: .yellow,
-                        glassVariant: .clear
-                    )
+                if let location = info.location {
+                    HStack(spacing: DefaultSpacing.spacing8) {
+                        Image(systemName: "mappin.and.ellipse")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.grey500)
+                        Text(location.locationName)
+                            .appFont(.footnote, color: .grey500)
+                            .lineLimit(1)
+                    }
+                } else if info.isOnline {
+                    HStack(spacing: DefaultSpacing.spacing8) {
+                        Image(systemName: "video")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.grey500)
+                        Text("비대면")
+                            .appFont(.footnote, color: .grey500)
+                    }
+                }
+
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    Text("출석 \(info.presentCount) / \(info.totalCount)")
+                        .appFont(.footnote, color: .grey600)
+                    Text(rateText)
+                        .appFont(.footnote, color: .grey500)
+                    if info.pendingCount > 0 {
+                        InfoBadge(
+                            "대기 \(info.pendingCount)",
+                            textColor: .orange500,
+                            tintColor: .orange300,
+                            glassVariant: .clear
+                        )
+                    }
                 }
             }
         }
         .padding(DefaultSpacing.spacing16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .glassEffect(
-            .regular.interactive(),
+            cardGlass,
             in: ConcentricRectangle(
                 corners: .concentric(minimum: DefaultConstant.concentricRadius),
                 isUniform: true
             )
         )
+        .opacity(status == .ended ? 0.85 : 1)
     }
 
     private var rateText: String {


### PR DESCRIPTION
## ✨ PR 유형

- 💄 **Design / UI·UX 개선** (출석 현황 3개 화면)
- 🐛 **버그 수정** (Liquid Glass 인터랙티브 글래스 눌림 효과 크기 불일치)

> `design/870`(로그인 디자인) 과는 별개의 병렬 작업이며, `develop` 기준으로 분기했습니다.

## 📷 스크린샷 or 영상(UI 변경 시)

시뮬레이터(iPhone 17 Pro / iOS 26.5)에서 라이브 확인 완료. (이미지 첨부 예정 — GitHub 웹에서 드래그 첨부)

- **목록**: `11기 연합 OT`(진행중·indigo) / `디자인 시스템 워크숍`(예정·orange) / `iOS 8주차·PM DAY·연합 네트워킹`(마감·grey) 상태별 색상 구분 확인
- **상세**: 승인 대기 배너 톤 완화 + 출석/대기/출석률 스탯 아이콘·컬러·위계 재설계 확인
- **챌린저**: 비어 있던 `나의 출석 현황` 에 안내 가이드 카드 표시 확인

## 🛠️ 작업내용

### 1. 출석 현황 목록 — 진행 상태 색상 구분
- 기존엔 모든 카드가 동일한 흰색 글래스라 마감/진행중/예정 구분이 어려웠음.
- `OperatorSessionStatus.from(startTime:endTime:)` 로 상태를 도출해
  - **좌측 색상 액센트 바** + **상태 배지**(진행중 `indigo` / 예정 `orange` / 마감 `grey`)
  - 진행중 카드는 은은한 indigo 틴트 글래스로 강조, 마감 카드는 opacity 0.85 + 제목 grey 로 디엠퍼사이즈
  - 색상에만 의존하지 않도록 `진행중 / 예정 / 마감` 텍스트 배지를 함께 노출(접근성)
- `OperatorSessionStatus+UI.swift` 에 목록 전용 `listAccentColor` / `listBadgeText` 를 **추가만** (기존 `iconColor`/`textColor` 미변경).
- `대기 N` 배지/아이콘을 시스템 컬러(`.orange`/`.yellow`) → 디자인 토큰(`.orange500`/`.orange300`)으로 정리.

### 2. 출석 현황 상세 — 배너 톤 완화 + 스탯 위계
- 승인 대기 배너: 과포화 `.tint(.orange)` → `.tint(.orange.opacity(0.16))` + `orange700` 텍스트로 가독성 확보.
- 출석/대기/출석률 스탯 블록: 아이콘(`person.fill.checkmark` / `clock.badge` / `chart.pie.fill`) + 시맨틱 컬러 + `title3Emphasis` 값 위계로 재설계. (대기 0건이면 grey 로 디엠퍼사이즈)

### 3. 챌린저 '나의 출석 현황' — 빈 상태 가이드
- `.idle` 상태가 `Color.clear` 로 빠져 섹션 헤더만 뜨고 본문이 빈 화면이 되던 문제 수정 → `.loading` 과 통합해 로딩 인디케이터 표시.
- 데이터 없음 시 아이콘 + 제목(`아직 출석 기록이 없어요`) + 안내문으로 구성된 가이드 카드로 강화.

### 🐛 Liquid Glass 눌림 효과 크기 불일치 수정
- 증상: 목록 카드 탭 시 Liquid Glass 눌림(liquid) 효과가 카드 크기와 다르게 나타남.
- 원인: 카드 글래스가 `ConcentricRectangle`(부모 코너 상속형)을 쓰는데, `GlassEffectContainer` 내부에서는 코너 상속이 끊겨 `.interactive()` 글래스가 다른 크기로 morphing됨. (코드베이스의 `StudyGroupCard` 가 동일 이슈를 주석으로 명시)
- 조치: 목록/상세에 추가돼 있던 `GlassEffectContainer` 를 제거해 컨테이너 도입 이전의 검증된 글래스 동작을 복원. 적응형 `ConcentricRectangle` 코너는 유지(정적 외형 변화 없음). 재발 방지를 위해 두 곳에 사유 주석 추가.

## 📋 추후 진행 상황
- 디자인팀과 상태 색상 팔레트(예정=orange vs 다른 톤) 최종 합의 시 토큰 미세 조정 가능.
- (선택) 출석 현황 상세 화면에 더미 데이터 기반 `#Preview` 추가.

## 📌 리뷰 포인트
- `OperatorSessionStatus+UI.swift` 의 추가 프로퍼티가 기존 `iconColor`/`textColor` 사용처(`OperatorSessionStatusIcon` 등)에 영향 없는지 (additive).
- 글래스 버그 수정 방향: `GlassEffectContainer` 제거 vs `StudyGroupCard` 처럼 명시 `.rect(cornerRadius:)` 로 전환 — 본 PR은 이 카드들의 적응형 코너 디자인 의도를 살리기 위해 **컨테이너 제거**를 택함. (대안 선호 시 논의 가능)
- 색상에만 의존하지 않는 상태 표기(텍스트 배지) 적절성.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다 (gitmoji + [Type])
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가? (글래스 버그 사유/상태 팔레트 의도 주석)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
