### PR TITLE
♻️ [Refactor] 출석 API AttendanceRouter 이식 (Moya TargetType)

### DIFF
--- a/UMCApp/Features/Activity/Data/Sources/ActivityData.swift
+++ b/UMCApp/Features/Activity/Data/Sources/ActivityData.swift
@@ -1,5 +1,9 @@
 import ActivityDomain
 
-public struct ActivityRepository: ActivityUseCase {
+/// ActivityData 모듈 플레이스홀더.
+///
+/// 실제 출석 Repository 구현은 별도 작업에서 추가됩니다. 모듈 타겟이 빈 소스로
+/// 생성되지 않도록 최소 타입만 유지합니다.
+public struct ActivityRepository {
     public init() {}
 }

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/AttendanceDetailQuery.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/AttendanceDetailQuery.swift
@@ -1,0 +1,25 @@
+//
+//  AttendanceDetailQuery.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/6/26.
+//
+
+import Foundation
+
+/// 운영진용 단일 일정 출석 현황 조회 Query DTO
+///
+/// `GET /api/v2/schedules/{scheduleId}/attendance` 쿼리 파라미터.
+///
+/// - `attendanceStatus` 미지정 시 모든 상태를 반환합니다. 이 경우 파라미터가 비어
+///   라우터가 `requestPlain` 으로 전송하도록 빈 딕셔너리를 반환합니다.
+struct AttendanceDetailQuery: Encodable {
+    /// 출석 상태 필터 (옵션)
+    let attendanceStatus: String?
+
+    /// Query Parameter Dictionary 변환 (nil 항목은 키 제거)
+    var toParameters: [String: Any] {
+        guard let attendanceStatus else { return [:] }
+        return ["attendanceStatus": attendanceStatus]
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/AttendanceDetailQuery.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/AttendanceDetailQuery.swift
@@ -13,7 +13,7 @@ import Foundation
 ///
 /// - `attendanceStatus` 미지정 시 모든 상태를 반환합니다. 이 경우 파라미터가 비어
 ///   라우터가 `requestPlain` 으로 전송하도록 빈 딕셔너리를 반환합니다.
-struct AttendanceDetailQuery: Encodable {
+struct AttendanceDetailQuery {
     /// 출석 상태 필터 (옵션)
     let attendanceStatus: String?
 

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/AttendanceListQuery.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/AttendanceListQuery.swift
@@ -17,7 +17,7 @@ import UMCFoundation
 ///
 /// `from` / `to` 는 서버가 UTC ISO8601 datetime 문자열을 기대하므로
 /// ``UMCFoundation/ServerDateTimeConverter/toUTCDateTimeString(_:)`` 로 변환합니다.
-struct AttendanceListQuery: Encodable {
+struct AttendanceListQuery {
     /// 조회 시작 시각 (옵션)
     let from: Date?
     /// 조회 종료 시각 (옵션)

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/AttendanceListQuery.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/AttendanceListQuery.swift
@@ -1,0 +1,42 @@
+//
+//  AttendanceListQuery.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/6/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 운영진용 일정 출석 현황 목록 조회 Query DTO
+///
+/// `GET /api/v2/schedules/attendance` 쿼리 파라미터.
+///
+/// - `from` / `to` 미지정 시 서버 기본값(요청 시점 -1개월 ~ +24시간)이 적용됩니다.
+/// - `attendanceStatus` 미지정 시 모든 상태를 반환합니다.
+///
+/// `from` / `to` 는 서버가 UTC ISO8601 datetime 문자열을 기대하므로
+/// ``UMCFoundation/ServerDateTimeConverter/toUTCDateTimeString(_:)`` 로 변환합니다.
+struct AttendanceListQuery: Encodable {
+    /// 조회 시작 시각 (옵션)
+    let from: Date?
+    /// 조회 종료 시각 (옵션)
+    let to: Date?
+    /// 출석 상태 필터 (옵션)
+    let attendanceStatus: String?
+
+    /// Query Parameter Dictionary 변환 (nil 항목은 키 제거)
+    var toParameters: [String: Any] {
+        var params: [String: Any] = [:]
+        if let from {
+            params["from"] = ServerDateTimeConverter.toUTCDateTimeString(from)
+        }
+        if let to {
+            params["to"] = ServerDateTimeConverter.toUTCDateTimeString(to)
+        }
+        if let attendanceStatus {
+            params["attendanceStatus"] = attendanceStatus
+        }
+        return params
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/DecideAttendanceItemDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/DecideAttendanceItemDTO.swift
@@ -1,0 +1,25 @@
+//
+//  DecideAttendanceItemDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/6/26.
+//
+
+import Foundation
+
+/// 출석 일괄 승인/반려 요청 배열 항목 DTO
+///
+/// `POST /api/v2/schedules/{scheduleId}/attendances/decide` body array item.
+/// 운영진이 다수 참여자의 출석을 한 번에 승인/반려할 때 각 결정을 표현합니다.
+///
+/// - Note: `participantMemberId` 는 서버가 모든 정수 ID를 문자열로 직렬화하므로
+///   `String` 으로 유지합니다 (도메인의 `AttendanceDecisionInput.participantMemberId`
+///   와 동일 타입). Int 변환은 필요한 연산 시점에만 수행합니다.
+struct DecideAttendanceItemDTO: Encodable, Sendable {
+    /// 승인 여부 (`false` 이면 반려)
+    let isApproved: Bool
+    /// 결정 대상 참여자 멤버 ID (서버 응답 — 전 레이어 `String` 통일)
+    let participantMemberId: String
+    /// 결정 사유 (빈 문자열 허용)
+    let reason: String
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/ExcuseAttendanceRequestDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/ExcuseAttendanceRequestDTO.swift
@@ -1,0 +1,27 @@
+//
+//  ExcuseAttendanceRequestDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/6/26.
+//
+
+import Foundation
+
+/// 사유 출석 제출 요청 DTO
+///
+/// `POST /api/v2/schedules/{scheduleId}/attendances/excuse` body.
+/// 지오펜스 밖 등으로 정시 출석이 불가능한 챌린저가 사유와 함께 출석을 제출할 때 사용합니다.
+///
+/// - Note: request 엔드포인트의 ``RequestAttendanceRequestDTO/locationVerified`` 와 달리
+///   이 엔드포인트는 `isVerified` 라는 필드명을 사용합니다. 서버 스펙 그대로 필드명을
+///   유지해야 하므로 두 DTO의 위치 인증 필드명이 다릅니다.
+struct ExcuseAttendanceRequestDTO: Encodable, Sendable {
+    /// 사유 내용 (빈 문자열은 서버에서 거부)
+    let excuseReason: String
+    /// GPS 위치 인증 여부 (request의 `locationVerified` 와 필드명이 다름)
+    let isVerified: Bool
+    /// 위도
+    let latitude: Double
+    /// 경도
+    let longitude: Double
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/RequestAttendanceRequestDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/RequestAttendanceRequestDTO.swift
@@ -1,0 +1,25 @@
+//
+//  RequestAttendanceRequestDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/6/26.
+//
+
+import Foundation
+
+/// GPS 출석 요청 DTO
+///
+/// `POST /api/v2/schedules/{scheduleId}/attendances/request` body.
+/// 챌린저 본인이 현재 위치 기반으로 출석을 체크할 때 사용합니다.
+///
+/// - Note: excuse 엔드포인트의 ``ExcuseAttendanceRequestDTO/isVerified`` 와 달리
+///   이 엔드포인트는 `locationVerified` 라는 필드명을 사용합니다. 서버 스펙 그대로
+///   필드명을 유지해야 하므로 두 DTO의 위치 인증 필드명이 다릅니다.
+struct RequestAttendanceRequestDTO: Encodable, Sendable {
+    /// 위도
+    let latitude: Double
+    /// GPS 위치 인증 여부 (excuse의 `isVerified` 와 필드명이 다름)
+    let locationVerified: Bool
+    /// 경도
+    let longitude: Double
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/UpdateScheduleLocationRequestDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/UpdateScheduleLocationRequestDTO.swift
@@ -1,0 +1,40 @@
+//
+//  UpdateScheduleLocationRequestDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/6/26.
+//
+
+import Foundation
+
+/// 세션 출석 위치 변경 요청 DTO
+///
+/// `PATCH /api/v2/schedules/{scheduleId}` body. 운영진이 일정의 출석 기준 위치만
+/// 부분 갱신할 때 사용합니다. 서버는 `{ "location": { ... } }` 형태의 중첩 JSON을
+/// 기대하므로 위치 페이로드를 ``Location`` 으로 감싸 인코딩합니다.
+///
+/// - Note: Schedule/Home 도메인의 위치 타입을 재사용하지 않고 ActivityData 내부에서
+///   자체 완결적으로 정의합니다 (모듈 간 결합 회피).
+struct UpdateScheduleLocationRequestDTO: Encodable, Sendable {
+
+    /// 위치 변경 페이로드 (`location` 키로 중첩 인코딩)
+    let location: Location
+
+    init(latitude: Double, longitude: Double, locationName: String) {
+        self.location = Location(
+            latitude: latitude,
+            longitude: longitude,
+            locationName: locationName
+        )
+    }
+
+    /// 일정 위치 중첩 페이로드
+    struct Location: Encodable, Sendable {
+        /// 위도
+        let latitude: Double
+        /// 경도
+        let longitude: Double
+        /// 위치 표시 이름
+        let locationName: String
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Routers/AttendanceRouter.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Routers/AttendanceRouter.swift
@@ -1,0 +1,98 @@
+//
+//  AttendanceRouter.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/6/26.
+//
+
+import Foundation
+import CoreNetwork
+internal import Alamofire
+import Moya
+
+/// 출석 API 라우터
+///
+/// 운영진/챌린저 출석 도메인의 엔드포인트를 정의합니다. 조회(목록/상세), 일괄 결정,
+/// GPS 출석 요청, 사유 출석 제출, 일정 위치 변경을 단일 라우터로 묶어 표현합니다.
+///
+/// - Note: `scheduleId` / `participantMemberId` 등 서버 식별자는 전 레이어 `String`
+///   으로 통일합니다. 쿼리 파라미터는 각 Query DTO의 `toParameters` 로, 바디는 Request
+///   DTO로 캡슐화하며 라우터 `task` 에 인라인 딕셔너리를 두지 않습니다.
+enum AttendanceRouter {
+    /// 출석 현황 목록 조회 (운영진, 기간/상태 필터)
+    case fetchAttendanceList(query: AttendanceListQuery)
+    /// 단일 일정 출석 현황 조회 (운영진, 상태 필터)
+    case fetchAttendanceDetail(scheduleId: String, query: AttendanceDetailQuery)
+    /// 출석 일괄 승인/반려 (운영진)
+    case decideAttendances(scheduleId: String, body: [DecideAttendanceItemDTO])
+    /// GPS 출석 요청 (챌린저 본인)
+    case requestAttendance(scheduleId: String, body: RequestAttendanceRequestDTO)
+    /// 사유 출석 제출 (챌린저 본인)
+    case excuseAttendance(scheduleId: String, body: ExcuseAttendanceRequestDTO)
+    /// 일정 출석 위치 변경 (운영진, 부분 갱신)
+    case updateScheduleLocation(scheduleId: String, body: UpdateScheduleLocationRequestDTO)
+}
+
+extension AttendanceRouter: BaseTargetType {
+
+    // MARK: - Path
+
+    var path: String {
+        switch self {
+        case .fetchAttendanceList:
+            return "/api/v2/schedules/attendance"
+        case .fetchAttendanceDetail(let scheduleId, _):
+            return "/api/v2/schedules/\(scheduleId)/attendance"
+        case .decideAttendances(let scheduleId, _):
+            return "/api/v2/schedules/\(scheduleId)/attendances/decide"
+        case .requestAttendance(let scheduleId, _):
+            return "/api/v2/schedules/\(scheduleId)/attendances/request"
+        case .excuseAttendance(let scheduleId, _):
+            return "/api/v2/schedules/\(scheduleId)/attendances/excuse"
+        case .updateScheduleLocation(let scheduleId, _):
+            return "/api/v2/schedules/\(scheduleId)"
+        }
+    }
+
+    // MARK: - Method
+
+    var method: Moya.Method {
+        switch self {
+        case .fetchAttendanceList, .fetchAttendanceDetail:
+            return .get
+        case .decideAttendances, .requestAttendance, .excuseAttendance:
+            return .post
+        case .updateScheduleLocation:
+            return .patch
+        }
+    }
+
+    // MARK: - Task
+
+    var task: Moya.Task {
+        switch self {
+        case .fetchAttendanceList(let query):
+            return .requestParameters(
+                parameters: query.toParameters,
+                encoding: URLEncoding.queryString
+            )
+        case .fetchAttendanceDetail(_, let query):
+            let params = query.toParameters
+            guard !params.isEmpty else {
+                return .requestPlain
+            }
+            return .requestParameters(
+                parameters: params,
+                encoding: URLEncoding.queryString
+            )
+        case .decideAttendances(_, let body):
+            return .requestJSONEncodable(body)
+        case .requestAttendance(_, let body):
+            return .requestJSONEncodable(body)
+        case .excuseAttendance(_, let body):
+            return .requestJSONEncodable(body)
+        case .updateScheduleLocation(_, let body):
+            return .requestJSONEncodable(body)
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Routers/AttendanceRouter.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Routers/AttendanceRouter.swift
@@ -72,8 +72,12 @@ extension AttendanceRouter: BaseTargetType {
     var task: Moya.Task {
         switch self {
         case .fetchAttendanceList(let query):
+            let params = query.toParameters
+            guard !params.isEmpty else {
+                return .requestPlain
+            }
             return .requestParameters(
-                parameters: query.toParameters,
+                parameters: params,
                 encoding: URLEncoding.queryString
             )
         case .fetchAttendanceDetail(_, let query):

--- a/UMCApp/Features/Activity/Data/Tests/AttendanceRouterTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/AttendanceRouterTests.swift
@@ -1,0 +1,464 @@
+//
+//  AttendanceRouterTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Testing
+import Foundation
+import Moya
+import Alamofire
+@testable import ActivityData
+
+// MARK: - Helpers
+
+private func makeListQuery(
+    from: Date? = nil,
+    to: Date? = nil,
+    attendanceStatus: String? = nil
+) -> AttendanceListQuery {
+    AttendanceListQuery(from: from, to: to, attendanceStatus: attendanceStatus)
+}
+
+private func makeDetailQuery(
+    attendanceStatus: String? = nil
+) -> AttendanceDetailQuery {
+    AttendanceDetailQuery(attendanceStatus: attendanceStatus)
+}
+
+private func encodeToJSON(_ value: some Encodable) throws -> [String: Any] {
+    let data = try JSONEncoder().encode(value)
+    let obj = try JSONSerialization.jsonObject(with: data)
+    return try #require(obj as? [String: Any])
+}
+
+// MARK: - Suite: path / method
+
+@Suite("AttendanceRouter — path/method/task 계약")
+struct AttendanceRouterPathMethodTests {
+
+    // MARK: - fetchAttendanceList
+
+    @Test("fetchAttendanceList — path가 /api/v2/schedules/attendance")
+    func fetchAttendanceListPath() {
+        let router = AttendanceRouter.fetchAttendanceList(query: makeListQuery())
+        #expect(router.path == "/api/v2/schedules/attendance")
+    }
+
+    @Test("fetchAttendanceList — method가 .get")
+    func fetchAttendanceListMethod() {
+        let router = AttendanceRouter.fetchAttendanceList(query: makeListQuery())
+        #expect(router.method == .get)
+    }
+
+    // MARK: - fetchAttendanceDetail
+
+    @Test("fetchAttendanceDetail — scheduleId '42'가 path에 보간됨")
+    func fetchAttendanceDetailPathInterpolation() {
+        let router = AttendanceRouter.fetchAttendanceDetail(
+            scheduleId: "42",
+            query: makeDetailQuery()
+        )
+        #expect(router.path == "/api/v2/schedules/42/attendance")
+    }
+
+    @Test("fetchAttendanceDetail — method가 .get")
+    func fetchAttendanceDetailMethod() {
+        let router = AttendanceRouter.fetchAttendanceDetail(
+            scheduleId: "42",
+            query: makeDetailQuery()
+        )
+        #expect(router.method == .get)
+    }
+
+    // MARK: - decideAttendances
+
+    @Test("decideAttendances — scheduleId '42'가 path에 보간됨")
+    func decideAttendancesPathInterpolation() {
+        let router = AttendanceRouter.decideAttendances(
+            scheduleId: "42",
+            body: []
+        )
+        #expect(router.path == "/api/v2/schedules/42/attendances/decide")
+    }
+
+    @Test("decideAttendances — method가 .post")
+    func decideAttendancesMethod() {
+        let router = AttendanceRouter.decideAttendances(scheduleId: "42", body: [])
+        #expect(router.method == .post)
+    }
+
+    // MARK: - requestAttendance
+
+    @Test("requestAttendance — scheduleId '42'가 path에 보간됨")
+    func requestAttendancePathInterpolation() {
+        let body = RequestAttendanceRequestDTO(
+            latitude: 37.5, locationVerified: true, longitude: 127.0
+        )
+        let router = AttendanceRouter.requestAttendance(scheduleId: "42", body: body)
+        #expect(router.path == "/api/v2/schedules/42/attendances/request")
+    }
+
+    @Test("requestAttendance — method가 .post")
+    func requestAttendanceMethod() {
+        let body = RequestAttendanceRequestDTO(
+            latitude: 37.5, locationVerified: true, longitude: 127.0
+        )
+        let router = AttendanceRouter.requestAttendance(scheduleId: "42", body: body)
+        #expect(router.method == .post)
+    }
+
+    // MARK: - excuseAttendance
+
+    @Test("excuseAttendance — scheduleId '42'가 path에 보간됨")
+    func excuseAttendancePathInterpolation() {
+        let body = ExcuseAttendanceRequestDTO(
+            excuseReason: "사유", isVerified: true, latitude: 37.5, longitude: 127.0
+        )
+        let router = AttendanceRouter.excuseAttendance(scheduleId: "42", body: body)
+        #expect(router.path == "/api/v2/schedules/42/attendances/excuse")
+    }
+
+    @Test("excuseAttendance — method가 .post")
+    func excuseAttendanceMethod() {
+        let body = ExcuseAttendanceRequestDTO(
+            excuseReason: "사유", isVerified: true, latitude: 37.5, longitude: 127.0
+        )
+        let router = AttendanceRouter.excuseAttendance(scheduleId: "42", body: body)
+        #expect(router.method == .post)
+    }
+
+    // MARK: - updateScheduleLocation
+
+    @Test("updateScheduleLocation — scheduleId '42'가 path에 보간됨")
+    func updateScheduleLocationPathInterpolation() {
+        let body = UpdateScheduleLocationRequestDTO(
+            latitude: 37.5, longitude: 127.0, locationName: "한성대입구역"
+        )
+        let router = AttendanceRouter.updateScheduleLocation(scheduleId: "42", body: body)
+        #expect(router.path == "/api/v2/schedules/42")
+    }
+
+    @Test("updateScheduleLocation — method가 .patch")
+    func updateScheduleLocationMethod() {
+        let body = UpdateScheduleLocationRequestDTO(
+            latitude: 37.5, longitude: 127.0, locationName: "한성대입구역"
+        )
+        let router = AttendanceRouter.updateScheduleLocation(scheduleId: "42", body: body)
+        #expect(router.method == .patch)
+    }
+}
+
+// MARK: - Suite: task shape
+
+@Suite("AttendanceRouter — task 형태 계약")
+struct AttendanceRouterTaskTests {
+
+    // MARK: - fetchAttendanceList task
+
+    @Test("fetchAttendanceList — 모든 파라미터 nil 시 task가 .requestParameters (빈 dict + URLEncoding)")
+    func fetchAttendanceListTaskAllNil() {
+        let router = AttendanceRouter.fetchAttendanceList(query: makeListQuery())
+        if case let .requestParameters(parameters, encoding) = router.task {
+            #expect(parameters.isEmpty)
+            let usesURLEncoding = encoding is URLEncoding
+            #expect(usesURLEncoding)
+        } else {
+            Issue.record("task가 .requestParameters 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    @Test("fetchAttendanceList — from/to/status 지정 시 task가 .requestParameters (키 3개 포함)")
+    func fetchAttendanceListTaskWithAllParams() {
+        let fixedDate = Date(timeIntervalSince1970: 0)
+        let query = makeListQuery(
+            from: fixedDate,
+            to: fixedDate,
+            attendanceStatus: "PRESENT"
+        )
+        let router = AttendanceRouter.fetchAttendanceList(query: query)
+        if case let .requestParameters(parameters, encoding) = router.task {
+            #expect(parameters["attendanceStatus"] as? String == "PRESENT")
+            #expect(parameters["from"] != nil)
+            #expect(parameters["to"] != nil)
+            let usesURLEncoding = encoding is URLEncoding
+            #expect(usesURLEncoding)
+        } else {
+            Issue.record("task가 .requestParameters 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    // MARK: - fetchAttendanceDetail task
+
+    @Test("fetchAttendanceDetail — attendanceStatus nil → task가 .requestPlain")
+    func fetchAttendanceDetailTaskRequestPlain() {
+        let router = AttendanceRouter.fetchAttendanceDetail(
+            scheduleId: "42",
+            query: makeDetailQuery(attendanceStatus: nil)
+        )
+        if case .requestPlain = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestPlain 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    @Test("fetchAttendanceDetail — attendanceStatus 지정 시 task가 .requestParameters (attendanceStatus 키 포함)")
+    func fetchAttendanceDetailTaskWithStatus() {
+        let router = AttendanceRouter.fetchAttendanceDetail(
+            scheduleId: "42",
+            query: makeDetailQuery(attendanceStatus: "LATE")
+        )
+        if case let .requestParameters(parameters, encoding) = router.task {
+            #expect(parameters["attendanceStatus"] as? String == "LATE")
+            let usesURLEncoding = encoding is URLEncoding
+            #expect(usesURLEncoding)
+        } else {
+            Issue.record("task가 .requestParameters 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    // MARK: - decideAttendances task
+
+    @Test("decideAttendances — task가 .requestJSONEncodable")
+    func decideAttendancesTaskIsJSONEncodable() {
+        let items = [
+            DecideAttendanceItemDTO(isApproved: true, participantMemberId: "7", reason: "")
+        ]
+        let router = AttendanceRouter.decideAttendances(scheduleId: "42", body: items)
+        if case .requestJSONEncodable = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestJSONEncodable 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    // MARK: - requestAttendance task
+
+    @Test("requestAttendance — task가 .requestJSONEncodable")
+    func requestAttendanceTaskIsJSONEncodable() {
+        let body = RequestAttendanceRequestDTO(
+            latitude: 37.5, locationVerified: true, longitude: 127.0
+        )
+        let router = AttendanceRouter.requestAttendance(scheduleId: "42", body: body)
+        if case .requestJSONEncodable = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestJSONEncodable 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    // MARK: - excuseAttendance task
+
+    @Test("excuseAttendance — task가 .requestJSONEncodable")
+    func excuseAttendanceTaskIsJSONEncodable() {
+        let body = ExcuseAttendanceRequestDTO(
+            excuseReason: "사유", isVerified: true, latitude: 37.5, longitude: 127.0
+        )
+        let router = AttendanceRouter.excuseAttendance(scheduleId: "42", body: body)
+        if case .requestJSONEncodable = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestJSONEncodable 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    // MARK: - updateScheduleLocation task
+
+    @Test("updateScheduleLocation — task가 .requestJSONEncodable")
+    func updateScheduleLocationTaskIsJSONEncodable() {
+        let body = UpdateScheduleLocationRequestDTO(
+            latitude: 37.5, longitude: 127.0, locationName: "한성대입구역"
+        )
+        let router = AttendanceRouter.updateScheduleLocation(scheduleId: "42", body: body)
+        if case .requestJSONEncodable = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestJSONEncodable 여야 함 — 실제: \(router.task)")
+        }
+    }
+}
+
+// MARK: - Suite: DTO JSON 인코딩 계약
+
+@Suite("AttendanceRouter — DTO JSON 인코딩 계약")
+struct AttendanceRouterDTOEncodingTests {
+
+    // MARK: - RequestAttendanceRequestDTO
+
+    @Test("RequestAttendanceRequestDTO — latitude/longitude/locationVerified 키 정확히 인코딩")
+    func requestAttendanceDTOEncodesCorrectly() throws {
+        let dto = RequestAttendanceRequestDTO(
+            latitude: 37.5678,
+            locationVerified: true,
+            longitude: 127.0123
+        )
+        let json = try encodeToJSON(dto)
+
+        #expect(json["latitude"] as? Double == 37.5678)
+        #expect(json["longitude"] as? Double == 127.0123)
+        #expect(json["locationVerified"] as? Bool == true)
+        #expect(json.keys.count == 3)
+    }
+
+    @Test("RequestAttendanceRequestDTO — isVerified 키 없음 (서버 필드명 locationVerified 만 존재)")
+    func requestAttendanceDTOHasNoIsVerifiedKey() throws {
+        let dto = RequestAttendanceRequestDTO(
+            latitude: 37.5, locationVerified: false, longitude: 127.0
+        )
+        let json = try encodeToJSON(dto)
+        #expect(json["isVerified"] == nil)
+        #expect(json["locationVerified"] as? Bool == false)
+    }
+
+    // MARK: - ExcuseAttendanceRequestDTO
+
+    @Test("ExcuseAttendanceRequestDTO — excuseReason/isVerified/latitude/longitude 키 정확히 인코딩")
+    func excuseAttendanceDTOEncodesCorrectly() throws {
+        let dto = ExcuseAttendanceRequestDTO(
+            excuseReason: "지각 사유",
+            isVerified: false,
+            latitude: 37.1,
+            longitude: 127.2
+        )
+        let json = try encodeToJSON(dto)
+
+        #expect(json["excuseReason"] as? String == "지각 사유")
+        #expect(json["isVerified"] as? Bool == false)
+        #expect(json["latitude"] as? Double == 37.1)
+        #expect(json["longitude"] as? Double == 127.2)
+        #expect(json.keys.count == 4)
+    }
+
+    @Test("ExcuseAttendanceRequestDTO — locationVerified 키 없음 (서버 필드명 isVerified 만 존재)")
+    func excuseAttendanceDTOHasNoLocationVerifiedKey() throws {
+        let dto = ExcuseAttendanceRequestDTO(
+            excuseReason: "사유", isVerified: true, latitude: 37.5, longitude: 127.0
+        )
+        let json = try encodeToJSON(dto)
+        #expect(json["locationVerified"] == nil)
+        #expect(json["isVerified"] as? Bool == true)
+    }
+
+    // MARK: - DecideAttendanceItemDTO
+
+    @Test("DecideAttendanceItemDTO — participantMemberId가 JSON 문자열로 직렬화됨 (Int 아님)")
+    func decideAttendanceDTOParticipantMemberIdIsString() throws {
+        let dto = DecideAttendanceItemDTO(
+            isApproved: true,
+            participantMemberId: "7",
+            reason: "승인"
+        )
+        let json = try encodeToJSON(dto)
+
+        // 핵심 계약: String "7" 이어야 하며 숫자 7이 아님
+        #expect(json["participantMemberId"] as? String == "7")
+        // Int로 역변환 불가임을 명시 확인
+        #expect(json["participantMemberId"] as? Int == nil)
+        #expect(json["isApproved"] as? Bool == true)
+        #expect(json["reason"] as? String == "승인")
+        #expect(json.keys.count == 3)
+    }
+
+    @Test("DecideAttendanceItemDTO — isApproved false 시 정확히 인코딩")
+    func decideAttendanceDTOIsApprovedFalse() throws {
+        let dto = DecideAttendanceItemDTO(
+            isApproved: false,
+            participantMemberId: "99",
+            reason: "반려 사유"
+        )
+        let json = try encodeToJSON(dto)
+        #expect(json["isApproved"] as? Bool == false)
+        #expect(json["participantMemberId"] as? String == "99")
+    }
+
+    // MARK: - UpdateScheduleLocationRequestDTO
+
+    @Test("UpdateScheduleLocationRequestDTO — { location: { latitude, longitude, locationName } } 중첩 구조로 인코딩")
+    func updateScheduleLocationDTOEncodesNestedStructure() throws {
+        let dto = UpdateScheduleLocationRequestDTO(
+            latitude: 37.5678,
+            longitude: 127.0123,
+            locationName: "한성대입구역"
+        )
+        let json = try encodeToJSON(dto)
+
+        // 최상위 키는 "location" 하나만
+        #expect(json.keys.count == 1)
+        let location = try #require(json["location"] as? [String: Any])
+        #expect(location["latitude"] as? Double == 37.5678)
+        #expect(location["longitude"] as? Double == 127.0123)
+        #expect(location["locationName"] as? String == "한성대입구역")
+        #expect(location.keys.count == 3)
+    }
+
+    // MARK: - AttendanceListQuery.toParameters
+
+    @Test("AttendanceListQuery.toParameters — 모든 값 nil → 빈 딕셔너리")
+    func attendanceListQueryAllNilIsEmpty() {
+        let query = makeListQuery()
+        #expect(query.toParameters.isEmpty)
+    }
+
+    @Test("AttendanceListQuery.toParameters — attendanceStatus만 지정 시 해당 키만 포함")
+    func attendanceListQueryStatusOnly() {
+        let query = makeListQuery(attendanceStatus: "ABSENT")
+        let params = query.toParameters
+        #expect(params.keys.count == 1)
+        #expect(params["attendanceStatus"] as? String == "ABSENT")
+    }
+
+    @Test("AttendanceListQuery.toParameters — from/to 지정 시 UTC ISO8601 문자열로 변환됨")
+    func attendanceListQueryFromToConvertedToUTCString() {
+        // epoch 0 = 1970-01-01T00:00:00.000Z (결정론적)
+        let fixedDate = Date(timeIntervalSince1970: 0)
+        let query = makeListQuery(from: fixedDate, to: fixedDate)
+        let params = query.toParameters
+
+        #expect(params["from"] != nil)
+        #expect(params["to"] != nil)
+        #expect(params["attendanceStatus"] == nil)
+
+        // ISO8601 with fractional seconds, UTC — 문자열 형태 검증
+        let fromStr = params["from"] as? String
+        let toStr = params["to"] as? String
+        #expect(fromStr?.hasPrefix("1970-01-01T00:00:00") == true)
+        #expect(toStr?.hasPrefix("1970-01-01T00:00:00") == true)
+        // UTC suffix ('Z' 또는 '+00:00') 포함 확인
+        let endsWithZ = fromStr?.hasSuffix("Z") == true
+        let endsWithOffset = fromStr?.hasSuffix("+00:00") == true
+        #expect(endsWithZ || endsWithOffset)
+    }
+
+    @Test("AttendanceListQuery.toParameters — from/to/status 모두 지정 시 키 3개")
+    func attendanceListQueryAllParams() {
+        let fixedDate = Date(timeIntervalSince1970: 1_000)
+        let query = makeListQuery(from: fixedDate, to: fixedDate, attendanceStatus: "PRESENT")
+        let params = query.toParameters
+        #expect(params.keys.count == 3)
+        #expect(params["attendanceStatus"] as? String == "PRESENT")
+        #expect(params["from"] != nil)
+        #expect(params["to"] != nil)
+    }
+
+    // MARK: - [DecideAttendanceItemDTO] 배열 와이어 형태
+
+    @Test("[DecideAttendanceItemDTO] — 최상위 JSON 배열로 직렬화 + 각 항목 participantMemberId가 String")
+    func decideAttendanceArrayEncodesAsTopLevelArray() throws {
+        let items = [
+            DecideAttendanceItemDTO(isApproved: true, participantMemberId: "7", reason: "승인"),
+            DecideAttendanceItemDTO(isApproved: false, participantMemberId: "8", reason: "반려"),
+        ]
+        let data = try JSONEncoder().encode(items)
+        let array = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        )
+
+        #expect(array.count == 2)
+        #expect(array[0]["participantMemberId"] as? String == "7")
+        #expect(array[1]["participantMemberId"] as? String == "8")
+        #expect(array[0]["isApproved"] as? Bool == true)
+        #expect(array[1]["isApproved"] as? Bool == false)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/AttendanceRouterTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/AttendanceRouterTests.swift
@@ -157,15 +157,13 @@ struct AttendanceRouterTaskTests {
 
     // MARK: - fetchAttendanceList task
 
-    @Test("fetchAttendanceList — 모든 파라미터 nil 시 task가 .requestParameters (빈 dict + URLEncoding)")
+    @Test("fetchAttendanceList — 모든 파라미터 nil 시 task가 .requestPlain (detail과 동일 분기)")
     func fetchAttendanceListTaskAllNil() {
         let router = AttendanceRouter.fetchAttendanceList(query: makeListQuery())
-        if case let .requestParameters(parameters, encoding) = router.task {
-            #expect(parameters.isEmpty)
-            let usesURLEncoding = encoding is URLEncoding
-            #expect(usesURLEncoding)
+        if case .requestPlain = router.task {
+            // 기대하는 case — 빈 파라미터는 detail과 동일하게 .requestPlain
         } else {
-            Issue.record("task가 .requestParameters 여야 함 — 실제: \(router.task)")
+            Issue.record("task가 .requestPlain 여야 함 — 실제: \(router.task)")
         }
     }
 

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -8,5 +8,9 @@ let project = featureProject(
     presentationExtraDependencies: [
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
     ],
-    includesDomainTests: true
+    includesDomainTests: true,
+    includesDataTests: true,
+    dataTestDependencies: [
+        .external(name: "Moya"),
+    ]
 )


### PR DESCRIPTION
resolves #810

## ✨ PR 유형

♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="991" alt="스크린샷 2026-06-07 오전 12 33 44" src="https://github.com/user-attachments/assets/250f4ad1-0c72-4990-91ba-b24f4e657264" />
<img width="1512" height="991" alt="스크린샷 2026-06-07 오전 12 33 37" src="https://github.com/user-attachments/assets/fe164a8e-def1-47ff-aa64-435e93aa03cc" />

## 🛠️ 작업내용

레거시 `ScheduleV2Router`에 묶여 있던 출석 관련 엔드포인트를 `ActivityData` 모듈의
단일 `AttendanceRouter`(Moya `BaseTargetType`)로 분리 이식.

- **`AttendanceRouter`** — 6 case: 출석 명단 조회 / 상세 조회 / 일괄 승인·거절 /
  GPS 출석 요청 / 사유 출석 / 일정 위치 변경
- **Request·Query DTO 6종** — 파라미터를 Query/Body DTO로 캡슐화 (Router `task` 인라인 딕셔너리 0건)
- 모든 서버 ID 파라미터 `String` 통일 (레거시 `Int` → `String`)
- **계약 단위 테스트 32종** (Swift Testing) — path/method/task 매핑 + DTO JSON 인코딩 검증
- `Project.swift`에 `ActivityDataTests` 타겟 등록 (`includesDataTests`)

> `ActivityData.swift`: 기존 스텁이 존재하지 않는 타입(`ActivityUseCase`)을 채택해
> 컴파일 불가 상태였어, 잘못된 conformance만 제거하는 최소 수정 동반.

## 📋 추후 진행 상황

- #812 출석 Repository 구현체가 본 `AttendanceRouter`를 사용해 실 API 연동
  (현재 더미 데이터 Presentation → 실 데이터 전환의 네트워킹 기반)
- 출석 가능 일정 조회는 Schedule 도메인 이식 후 별도 추가

## 📌 리뷰 포인트

- **단일 Router 설계**: Challenger/Operator 액션을 한 `AttendanceRouter`로 통합.
  권한 경계는 전송 계층이 아닌 Domain Protocol(`ChallengerAttendanceRepositoryProtocol` /
  `OperatorAttendanceRepositoryProtocol`)에서 분리 — Router 응집 축은 API 리소스(`/schedules/.../attendance`)
- **GPS 필드명 비대칭**: 출석 요청은 `locationVerified`, 사유 출석은 `isVerified` — 서버 스펙 그대로.
  테스트가 양방향(키 존재/부재)으로 고정
- **`participantMemberId: String`**: 레거시 `Int`에서 교정. JSON이 문자열 `"7"`로 직렬화되는지 단언
- **일정 위치 변경**: `PATCH /api/v2/schedules/{id}`에 `{location:{...}}`만 보내는 부분 갱신.
  레거시와 와이어 바디 동일 — 서버가 location-only 바디를 나머지 필드 보존(merge)으로 처리하는지 확인 권장

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
