### PR TITLE
♻️ [Refactor] OperatorAttendanceUseCase 신규 모듈로 이식

### DIFF
--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/OperatorAttendanceUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/OperatorAttendanceUseCase.swift
@@ -1,0 +1,76 @@
+//
+//  OperatorAttendanceUseCase.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+
+/// `OperatorAttendanceUseCaseProtocol` 의 기본 구현체
+///
+/// 운영진 출석 관리 액션을 모두 `OperatorAttendanceRepositoryProtocol` 에 위임합니다.
+/// 위임 외 도메인 로직이 없으므로 인자를 변형 없이 그대로 전달합니다.
+/// `scheduleId` 는 서버 String ID 로 전 레이어 통일.
+public final class OperatorAttendanceUseCase: OperatorAttendanceUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: OperatorAttendanceRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: OperatorAttendanceRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - 조회
+
+    public func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> [ScheduleAttendanceInfo] {
+        try await repository.fetchAttendanceList(
+            from: from,
+            to: to,
+            attendanceStatus: attendanceStatus
+        )
+    }
+
+    public func fetchAttendanceDetail(
+        scheduleId: String,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> ScheduleAttendanceInfo {
+        try await repository.fetchAttendanceDetail(
+            scheduleId: scheduleId,
+            attendanceStatus: attendanceStatus
+        )
+    }
+
+    // MARK: - 액션
+
+    public func decideAttendances(
+        scheduleId: String,
+        decisions: [AttendanceDecisionInput]
+    ) async throws -> [AttendanceDecisionResult] {
+        try await repository.decideAttendances(
+            scheduleId: scheduleId,
+            decisions: decisions
+        )
+    }
+
+    public func updateScheduleLocation(
+        scheduleId: String,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    ) async throws {
+        try await repository.updateScheduleLocation(
+            scheduleId: scheduleId,
+            locationName: locationName,
+            latitude: latitude,
+            longitude: longitude
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/OperatorAttendanceUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/OperatorAttendanceUseCaseProtocol.swift
@@ -1,0 +1,70 @@
+//
+//  OperatorAttendanceUseCaseProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+
+/// 운영진 시점의 출석 관리 도메인 진입점
+///
+/// Mobile-First Admin 의 핵심 UseCase. 일정 출석 현황 조회 · 일괄 승인/반려 · 위치 변경 등
+/// 운영진이 출석 관리 화면에서 수행하는 액션을 단일 Protocol 로 노출합니다.
+///
+/// - 챌린저 본인의 출석 요청은 `ChallengerAttendanceUseCaseProtocol` 사용.
+/// - 모든 서버 식별자는 String 으로 전 레이어 통일됩니다.
+public protocol OperatorAttendanceUseCaseProtocol {
+
+    // MARK: - 조회
+
+    /// 운영진용 일정 출석 현황 목록 조회
+    ///
+    /// 직책별 조회 범위는 서버에서 자동 분기됩니다.
+    ///
+    /// - Parameters:
+    ///   - from: 조회 시작 시각 (`nil` 이면 서버 기본값)
+    ///   - to: 조회 종료 시각 (`nil` 이면 서버 기본값)
+    ///   - attendanceStatus: 필터링할 출석 상태 (`nil` 이면 모든 상태)
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> [ScheduleAttendanceInfo]
+
+    /// 단일 일정 출석 현황 조회
+    ///
+    /// - Parameters:
+    ///   - scheduleId: 일정 식별자 (서버 String ID)
+    ///   - attendanceStatus: 필터링할 출석 상태 (`nil` 이면 모든 상태)
+    func fetchAttendanceDetail(
+        scheduleId: String,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> ScheduleAttendanceInfo
+
+    // MARK: - 액션
+
+    /// 출석 일괄 승인/반려
+    ///
+    /// - Parameters:
+    ///   - scheduleId: 일정 식별자 (서버 String ID)
+    ///   - decisions: 참여자별 승인/반려 결정 목록
+    func decideAttendances(
+        scheduleId: String,
+        decisions: [AttendanceDecisionInput]
+    ) async throws -> [AttendanceDecisionResult]
+
+    /// 세션 출석 위치 변경
+    ///
+    /// - Parameters:
+    ///   - scheduleId: 일정 식별자 (서버 String ID)
+    ///   - locationName: 변경할 장소 이름
+    ///   - latitude: 변경할 위도
+    ///   - longitude: 변경할 경도
+    func updateScheduleLocation(
+        scheduleId: String,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    ) async throws
+}

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/OperatorAttendanceUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/OperatorAttendanceUseCaseTests.swift
@@ -9,6 +9,8 @@ import Foundation
 import Testing
 @testable import ActivityDomain
 
+#if DEBUG
+
 // MARK: - Helpers
 
 private func makeScheduleInfo(
@@ -64,8 +66,6 @@ private func makeUseCase(
 }
 
 // MARK: - Mocks
-
-#if DEBUG
 
 private final class MockOperatorAttendanceRepository: @unchecked Sendable,
     OperatorAttendanceRepositoryProtocol {
@@ -156,8 +156,6 @@ private final class MockOperatorAttendanceRepository: @unchecked Sendable,
 private enum TestError: Error, Equatable {
     case boom
 }
-
-#endif
 
 // MARK: - 조회 위임
 
@@ -293,6 +291,20 @@ struct OperatorAttendanceUseCaseErrorTests {
         }
     }
 
+    @Test("Repository 결정 에러는 삼키지 않고 그대로 전파된다")
+    func decideAttendancesPropagatesRepositoryError() async {
+        let repository = MockOperatorAttendanceRepository()
+        repository.errorToThrow = TestError.boom
+        let useCase = makeUseCase(repository: repository)
+
+        await #expect(throws: TestError.boom) {
+            _ = try await useCase.decideAttendances(
+                scheduleId: "1",
+                decisions: []
+            )
+        }
+    }
+
     @Test("Repository 위치변경 에러는 삼키지 않고 그대로 전파된다 (try? 회귀 가드)")
     func updateLocationPropagatesRepositoryError() async {
         let repository = MockOperatorAttendanceRepository()
@@ -309,3 +321,5 @@ struct OperatorAttendanceUseCaseErrorTests {
         }
     }
 }
+
+#endif

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/OperatorAttendanceUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/OperatorAttendanceUseCaseTests.swift
@@ -1,0 +1,311 @@
+//
+//  OperatorAttendanceUseCaseTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityDomain
+
+// MARK: - Helpers
+
+private func makeScheduleInfo(
+    scheduleId: String = "100",
+    participants: [ParticipantAttendance] = []
+) -> ScheduleAttendanceInfo {
+    ScheduleAttendanceInfo(
+        scheduleId: scheduleId,
+        name: "정기 세션",
+        description: "",
+        startsAt: Date(timeIntervalSince1970: 1_736_942_400),
+        endsAt: Date(timeIntervalSince1970: 1_736_949_600),
+        location: nil,
+        isOnline: true,
+        authorMemberId: "1",
+        attendancePolicy: nil,
+        tags: [],
+        participants: participants
+    )
+}
+
+private func makeDecisionResult(
+    status: ParticipantAttendanceStatus = .present
+) -> AttendanceDecisionResult {
+    AttendanceDecisionResult(
+        status: status,
+        decidedAt: Date(timeIntervalSince1970: 1_000),
+        decisionReason: nil,
+        excuseReason: nil,
+        latitude: nil,
+        longitude: nil,
+        decisionMakerMemberInfo: nil,
+        isPendingDecision: false
+    )
+}
+
+private func makeDecisionInput(
+    isApproved: Bool = true,
+    participantMemberId: String = "1",
+    reason: String = ""
+) -> AttendanceDecisionInput {
+    AttendanceDecisionInput(
+        isApproved: isApproved,
+        participantMemberId: participantMemberId,
+        reason: reason
+    )
+}
+
+private func makeUseCase(
+    repository: MockOperatorAttendanceRepository = MockOperatorAttendanceRepository()
+) -> OperatorAttendanceUseCase {
+    OperatorAttendanceUseCase(repository: repository)
+}
+
+// MARK: - Mocks
+
+#if DEBUG
+
+private final class MockOperatorAttendanceRepository: @unchecked Sendable,
+    OperatorAttendanceRepositoryProtocol {
+
+    // MARK: 스텁 결과
+
+    var fetchAttendanceListResult: [ScheduleAttendanceInfo] = []
+    var fetchAttendanceDetailResult: ScheduleAttendanceInfo = makeScheduleInfo()
+    var decideAttendancesResult: [AttendanceDecisionResult] = []
+
+    /// 설정 시 모든 메서드가 호출 기록 직후 이 에러를 던진다 (에러 전파 검증용)
+    var errorToThrow: Error?
+
+    // MARK: 호출 기록
+
+    private(set) var fetchAttendanceListCalls: [(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: ParticipantAttendanceStatus?
+    )] = []
+
+    private(set) var fetchAttendanceDetailCalls: [(
+        scheduleId: String,
+        attendanceStatus: ParticipantAttendanceStatus?
+    )] = []
+
+    private(set) var decideAttendancesCalls: [(
+        scheduleId: String,
+        decisions: [AttendanceDecisionInput]
+    )] = []
+
+    private(set) var updateScheduleLocationCalls: [(
+        scheduleId: String,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    )] = []
+
+    // MARK: Protocol
+
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> [ScheduleAttendanceInfo] {
+        fetchAttendanceListCalls.append((from, to, attendanceStatus))
+        if let errorToThrow {
+            throw errorToThrow
+        }
+        return fetchAttendanceListResult
+    }
+
+    func fetchAttendanceDetail(
+        scheduleId: String,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> ScheduleAttendanceInfo {
+        fetchAttendanceDetailCalls.append((scheduleId, attendanceStatus))
+        if let errorToThrow {
+            throw errorToThrow
+        }
+        return fetchAttendanceDetailResult
+    }
+
+    func decideAttendances(
+        scheduleId: String,
+        decisions: [AttendanceDecisionInput]
+    ) async throws -> [AttendanceDecisionResult] {
+        decideAttendancesCalls.append((scheduleId, decisions))
+        if let errorToThrow {
+            throw errorToThrow
+        }
+        return decideAttendancesResult
+    }
+
+    func updateScheduleLocation(
+        scheduleId: String,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    ) async throws {
+        updateScheduleLocationCalls.append((scheduleId, locationName, latitude, longitude))
+        if let errorToThrow {
+            throw errorToThrow
+        }
+    }
+}
+
+private enum TestError: Error, Equatable {
+    case boom
+}
+
+#endif
+
+// MARK: - 조회 위임
+
+@Suite("OperatorAttendanceUseCase — 조회 위임 (도메인 규칙)")
+struct OperatorAttendanceUseCaseFetchTests {
+
+    @Test("fetchAttendanceList — 기간·필터 인자 그대로 위임 + Repository 결과 반환")
+    func fetchAttendanceListDelegates() async throws {
+        let repository = MockOperatorAttendanceRepository()
+        let expected = [makeScheduleInfo(scheduleId: "7"), makeScheduleInfo(scheduleId: "8")]
+        repository.fetchAttendanceListResult = expected
+        let useCase = makeUseCase(repository: repository)
+        let from = Date(timeIntervalSince1970: 1_000)
+        let to = Date(timeIntervalSince1970: 2_000)
+
+        let result = try await useCase.fetchAttendanceList(
+            from: from,
+            to: to,
+            attendanceStatus: .presentPending
+        )
+
+        #expect(result == expected)
+        #expect(repository.fetchAttendanceListCalls.count == 1)
+        let call = try #require(repository.fetchAttendanceListCalls.first)
+        #expect(call.from == from)
+        #expect(call.to == to)
+        #expect(call.attendanceStatus == .presentPending)
+    }
+
+    @Test("fetchAttendanceList — nil 기간/필터를 변형 없이 그대로 전달")
+    func fetchAttendanceListForwardsNil() async throws {
+        let repository = MockOperatorAttendanceRepository()
+        let useCase = makeUseCase(repository: repository)
+
+        _ = try await useCase.fetchAttendanceList(
+            from: nil,
+            to: nil,
+            attendanceStatus: nil
+        )
+
+        let call = try #require(repository.fetchAttendanceListCalls.first)
+        #expect(call.from == nil)
+        #expect(call.to == nil)
+        #expect(call.attendanceStatus == nil)
+    }
+
+    @Test("fetchAttendanceDetail — scheduleId·필터 인자 그대로 위임 + Repository 결과 반환")
+    func fetchAttendanceDetailDelegates() async throws {
+        let repository = MockOperatorAttendanceRepository()
+        let expected = makeScheduleInfo(scheduleId: "42")
+        repository.fetchAttendanceDetailResult = expected
+        let useCase = makeUseCase(repository: repository)
+
+        let result = try await useCase.fetchAttendanceDetail(
+            scheduleId: "42",
+            attendanceStatus: .latePending
+        )
+
+        #expect(result == expected)
+        let call = try #require(repository.fetchAttendanceDetailCalls.first)
+        #expect(call.scheduleId == "42")
+        #expect(call.attendanceStatus == .latePending)
+    }
+}
+
+// MARK: - 액션 위임
+
+@Suite("OperatorAttendanceUseCase — 액션 위임 (도메인 규칙)")
+struct OperatorAttendanceUseCaseActionTests {
+
+    @Test("decideAttendances — 결정 목록 그대로 위임 + Repository 결과 반환")
+    func decideAttendancesDelegates() async throws {
+        let repository = MockOperatorAttendanceRepository()
+        let expected = [
+            makeDecisionResult(status: .present),
+            makeDecisionResult(status: .absent)
+        ]
+        repository.decideAttendancesResult = expected
+        let useCase = makeUseCase(repository: repository)
+        let decisions = [
+            makeDecisionInput(isApproved: true, participantMemberId: "1", reason: ""),
+            makeDecisionInput(isApproved: false, participantMemberId: "2", reason: "사유 불충분")
+        ]
+
+        let result = try await useCase.decideAttendances(
+            scheduleId: "9",
+            decisions: decisions
+        )
+
+        #expect(result == expected)
+        let call = try #require(repository.decideAttendancesCalls.first)
+        #expect(call.scheduleId == "9")
+        #expect(call.decisions == decisions)
+    }
+
+    @Test("updateScheduleLocation — 위치 인자 4종 그대로 위임")
+    func updateScheduleLocationDelegates() async throws {
+        let repository = MockOperatorAttendanceRepository()
+        let useCase = makeUseCase(repository: repository)
+
+        try await useCase.updateScheduleLocation(
+            scheduleId: "3",
+            locationName: "한성대 상상관",
+            latitude: 37.582,
+            longitude: 127.010
+        )
+
+        #expect(repository.updateScheduleLocationCalls.count == 1)
+        let call = try #require(repository.updateScheduleLocationCalls.first)
+        #expect(call.scheduleId == "3")
+        #expect(call.locationName == "한성대 상상관")
+        #expect(call.latitude == 37.582)
+        #expect(call.longitude == 127.010)
+    }
+}
+
+// MARK: - 에러 전파
+
+@Suite("OperatorAttendanceUseCase — 에러 전파 (도메인 규칙)")
+struct OperatorAttendanceUseCaseErrorTests {
+
+    @Test("Repository 조회 에러는 변환 없이 그대로 전파된다")
+    func fetchPropagatesRepositoryError() async {
+        let repository = MockOperatorAttendanceRepository()
+        repository.errorToThrow = TestError.boom
+        let useCase = makeUseCase(repository: repository)
+
+        await #expect(throws: TestError.boom) {
+            _ = try await useCase.fetchAttendanceDetail(
+                scheduleId: "1",
+                attendanceStatus: nil
+            )
+        }
+    }
+
+    @Test("Repository 위치변경 에러는 삼키지 않고 그대로 전파된다 (try? 회귀 가드)")
+    func updateLocationPropagatesRepositoryError() async {
+        let repository = MockOperatorAttendanceRepository()
+        repository.errorToThrow = TestError.boom
+        let useCase = makeUseCase(repository: repository)
+
+        await #expect(throws: TestError.boom) {
+            try await useCase.updateScheduleLocation(
+                scheduleId: "1",
+                locationName: "x",
+                latitude: 0,
+                longitude: 0
+            )
+        }
+    }
+}


### PR DESCRIPTION
resolves #746

## ✨ PR 유형

♻️ [Refactor] — 레거시 `OperatorAttendanceUseCase`를 신규 Tuist 모듈(`ActivityDomain`)로 이식

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="991" alt="스크린샷 2026-06-07 오후 5 18 29" src="https://github.com/user-attachments/assets/0ffda2f1-3623-4361-8c50-4fbdef7b6884" />
<img width="1512" height="991" alt="스크린샷 2026-06-07 오후 5 18 45" src="https://github.com/user-attachments/assets/b8e49b11-68cf-4d39-8762-200f9519f970" />


## 🛠️ 작업내용

- 운영진 출석 관리 UseCase(`OperatorAttendanceUseCaseProtocol` + `OperatorAttendanceUseCase`)를 `ActivityDomain` 모듈로 이식
- `OperatorAttendanceRepositoryProtocol`(#797)에 위임하는 순수 wrapper — 도메인 로직 없이 조회 2종 + 일괄 결정 + 위치 변경 4종 노출
- 타입 보정: 서버 ID `Int → String` 전 레이어 통일, 필터 `AttendanceStatusV2 → ParticipantAttendanceStatus`
- 계약 단위 테스트 7종 작성(Swift Testing) — 인자 verbatim 위임 / 결과 반환 / 에러 전파(try? 삼킴 회귀 가드) 검증, Mock은 `#if DEBUG` 격리

## 📋 추후 진행 상황

- 7차 `OperatorAttendanceViewModel`(#876)·8차 Operator 출석 화면이 본 UseCase에 의존
- 실 데이터 연동은 #877(AttendanceRouter) → #812(Repository) 머지 이후

## 📌 리뷰 포인트

- **위임 정합성** — `Features/Activity/Domain/Sources/UseCases/`: UseCase가 Repository에 1:1 위임만 하는지, 인자 누락·재배치 없는지
- **타입 통일** — 서버 ID 파라미터 전부 `String`, 필터 `ParticipantAttendanceStatus` 인지
- **테스트 계약 범위** — Mock `OperatorAttendanceRepository`로 위임/결과/에러 전파를 검증. 위임 wrapper라 도메인 분기는 없음

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
