### PR TITLE
♻️ [Refactor] FetchStudyMembersUseCase 멤버 조회 책임으로 이식

### DIFF
--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/FetchStudyMembersUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/FetchStudyMembersUseCaseProtocol.swift
@@ -1,0 +1,28 @@
+//
+//  FetchStudyMembersUseCaseProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/8/26.
+//
+
+import Foundation
+
+/// 스터디 그룹 멤버 조회 도메인 진입점
+///
+/// 단일 스터디 그룹의 멘토(파트장) + 스터디원 전체 목록을 조회하는 **멤버 조회 전용** UseCase.
+/// 9차 운영진 스터디 관리 / 챌린저 스터디 화면이 구성원 표시에 의존합니다.
+///
+/// - Note: 그룹 생성·수정·삭제, 멤버·멘토 추가·제거 등 CRUD 는 `StudyRepositoryProtocol` 이
+///   직접 노출하므로 본 UseCase 의 책임에서 제외합니다 (facade 비대화 방지). 그룹-일정 연결은
+///   `ScheduleRepositoryProtocol` 이식 후 별도 도메인에서 다룹니다.
+public protocol FetchStudyMembersUseCaseProtocol {
+
+    /// 단일 스터디 그룹의 멘토 + 스터디원 전체 목록을 반환합니다.
+    ///
+    /// `StudyRepositoryProtocol/fetchStudyGroupDetail(groupId:)` 의 `mentors` 와 `members`
+    /// 를 멘토 우선 순서로 병합해 반환합니다.
+    ///
+    /// - Parameter groupId: 스터디 그룹 식별자 (서버 응답 String ID)
+    /// - Returns: 멘토 뒤에 스터디원이 이어지는 `[StudyGroupMember]`. 빈 그룹이면 빈 배열.
+    func fetchStudyGroupMembers(groupId: String) async throws -> [StudyGroupMember]
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/FetchStudyMembersUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/FetchStudyMembersUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  FetchStudyMembersUseCase.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/8/26.
+//
+
+import Foundation
+
+/// `FetchStudyMembersUseCaseProtocol` 의 기본 구현체
+///
+/// 스터디 그룹 상세 조회를 `StudyRepositoryProtocol` 에 위임하고, 응답의 멘토/스터디원을
+/// 단일 목록으로 병합합니다. `groupId` 는 서버 String ID 로 전 레이어 통일됩니다.
+public final class FetchStudyMembersUseCase: FetchStudyMembersUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: StudyRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: StudyRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func fetchStudyGroupMembers(
+        groupId: String
+    ) async throws -> [StudyGroupMember] {
+        let detail = try await repository.fetchStudyGroupDetail(groupId: groupId)
+        return detail.mentors + detail.members
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchStudyMembersUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchStudyMembersUseCaseTests.swift
@@ -33,7 +33,7 @@ private func makeGroupInfo(
     StudyGroupInfo(
         serverID: serverID,
         name: "iOS 스터디",
-        part: .front(type: .ios),
+        part: .front(type: .ios), // 테스트 결과와 무관 — 임의 고정값
         createdDate: Date(timeIntervalSince1970: 1_000),
         mentors: mentors,
         members: members
@@ -177,29 +177,24 @@ struct FetchStudyMembersUseCaseTests {
         #expect(repository.fetchStudyGroupDetailCalls == ["G-7"])
     }
 
-    @Test("멘토가 없고 스터디원만 있을 때 — 스터디원만 반환")
-    func returnsMembersOnlyWhenNoMentors() async throws {
+    @Test(
+        "멘토 없을 때 — 스터디원만 반환 (빈 그룹 포함)",
+        arguments: [
+            (members: [makeMember(serverID: "C-1", name: "챌린저A")], expected: ["C-1"]),
+            (members: [], expected: [String]())
+        ]
+    )
+    func returnsMembersOnlyWhenNoMentors(
+        members: [StudyGroupMember],
+        expected: [String]
+    ) async throws {
         let repository = MockStudyRepository()
-        repository.fetchStudyGroupDetailResult = makeGroupInfo(
-            mentors: [],
-            members: [makeMember(serverID: "C-1", name: "챌린저A")]
-        )
+        repository.fetchStudyGroupDetailResult = makeGroupInfo(mentors: [], members: members)
         let useCase = makeUseCase(repository: repository)
 
         let result = try await useCase.fetchStudyGroupMembers(groupId: "G-1")
 
-        #expect(result.map(\.serverID) == ["C-1"])
-    }
-
-    @Test("멘토·스터디원 모두 비었을 때 — 빈 배열 반환")
-    func returnsEmptyWhenGroupHasNoMembers() async throws {
-        let repository = MockStudyRepository()
-        repository.fetchStudyGroupDetailResult = makeGroupInfo(mentors: [], members: [])
-        let useCase = makeUseCase(repository: repository)
-
-        let result = try await useCase.fetchStudyGroupMembers(groupId: "G-1")
-
-        #expect(result.isEmpty)
+        #expect(result.map(\.serverID) == expected)
     }
 
     @Test("Repository 가 에러를 던지면 그대로 전파")

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchStudyMembersUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchStudyMembersUseCaseTests.swift
@@ -1,0 +1,215 @@
+//
+//  FetchStudyMembersUseCaseTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 6/8/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+// MARK: - Helpers
+
+private func makeMember(
+    serverID: String,
+    name: String,
+    role: StudyGroupMember.MemberRole = .member
+) -> StudyGroupMember {
+    StudyGroupMember(
+        serverID: serverID,
+        name: name,
+        university: "한성대학교",
+        role: role
+    )
+}
+
+private func makeGroupInfo(
+    serverID: String = "G-1",
+    mentors: [StudyGroupMember],
+    members: [StudyGroupMember]
+) -> StudyGroupInfo {
+    StudyGroupInfo(
+        serverID: serverID,
+        name: "iOS 스터디",
+        part: .front(type: .ios),
+        createdDate: Date(timeIntervalSince1970: 1_000),
+        mentors: mentors,
+        members: members
+    )
+}
+
+private func makeUseCase(
+    repository: MockStudyRepository = MockStudyRepository()
+) -> FetchStudyMembersUseCase {
+    FetchStudyMembersUseCase(repository: repository)
+}
+
+// MARK: - Mocks
+
+#if DEBUG
+
+/// `fetchStudyGroupDetail` 만 컨트롤하는 포커스드 Mock.
+/// 본 UseCase 가 호출하지 않는 나머지 계약 메서드는 호출 시 즉시 실패하도록 `unimplemented` 를 던집니다.
+private final class MockStudyRepository: @unchecked Sendable, StudyRepositoryProtocol {
+
+    enum MockError: Error {
+        /// 본 UseCase 가 호출하면 안 되는 계약 메서드를 건드렸음을 알리는 표식
+        case unimplemented
+        /// 에러 전파 경로 검증용 — Repository 가 의도적으로 실패할 때 던지는 스텁 에러
+        case stubbed
+    }
+
+    // MARK: 입출력 기록
+
+    var fetchStudyGroupDetailResult: StudyGroupInfo = makeGroupInfo(mentors: [], members: [])
+    var fetchStudyGroupDetailError: Error?
+    private(set) var fetchStudyGroupDetailCalls: [String] = []
+
+    // MARK: 본 UseCase 가 사용하는 메서드
+
+    func fetchStudyGroupDetail(groupId: String) async throws -> StudyGroupInfo {
+        fetchStudyGroupDetailCalls.append(groupId)
+        if let fetchStudyGroupDetailError {
+            throw fetchStudyGroupDetailError
+        }
+        return fetchStudyGroupDetailResult
+    }
+
+    // MARK: 본 UseCase 미사용 — 호출 시 unimplemented
+
+    func fetchCurriculumProgress() async throws -> CurriculumProgressModel {
+        throw MockError.unimplemented
+    }
+
+    func fetchMissions() async throws -> [MissionCardModel] {
+        throw MockError.unimplemented
+    }
+
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption] {
+        throw MockError.unimplemented
+    }
+
+    func fetchStudyGroupDetails() async throws -> [StudyGroupInfo] {
+        throw MockError.unimplemented
+    }
+
+    func fetchStudyGroupDetailsPage(
+        cursor: Int?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage {
+        throw MockError.unimplemented
+    }
+
+    func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: Int?
+    ) async throws -> String? {
+        throw MockError.unimplemented
+    }
+
+    func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws {
+        throw MockError.unimplemented
+    }
+
+    func updateStudyGroup(groupId: String, name: String) async throws {
+        throw MockError.unimplemented
+    }
+
+    func deleteStudyGroup(groupId: String) async throws {
+        throw MockError.unimplemented
+    }
+
+    func addStudyGroupMember(groupId: String, memberId: String) async throws {
+        throw MockError.unimplemented
+    }
+
+    func removeStudyGroupMember(groupId: String, memberId: String) async throws {
+        throw MockError.unimplemented
+    }
+
+    func addStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        throw MockError.unimplemented
+    }
+
+    func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        throw MockError.unimplemented
+    }
+
+    func linkStudyGroupSchedule(
+        scheduleId: String,
+        studyGroupId: String,
+        weeklyCurriculumId: String
+    ) async throws {
+        throw MockError.unimplemented
+    }
+}
+
+#endif
+
+// MARK: - 멤버 조회
+
+@Suite("FetchStudyMembersUseCase — 스터디 그룹 멤버 조회 (도메인 규칙)")
+struct FetchStudyMembersUseCaseTests {
+
+    @Test("멘토 + 스터디원 병합 — 멘토 우선 순서 유지 + groupId 위임")
+    func mergesMentorsBeforeMembersAndDelegatesGroupId() async throws {
+        let repository = MockStudyRepository()
+        let mentor = makeMember(serverID: "M-1", name: "멘토", role: .leader)
+        let memberA = makeMember(serverID: "C-1", name: "챌린저A")
+        let memberB = makeMember(serverID: "C-2", name: "챌린저B")
+        repository.fetchStudyGroupDetailResult = makeGroupInfo(
+            mentors: [mentor],
+            members: [memberA, memberB]
+        )
+        let useCase = makeUseCase(repository: repository)
+
+        let result = try await useCase.fetchStudyGroupMembers(groupId: "G-7")
+
+        #expect(result.map(\.serverID) == ["M-1", "C-1", "C-2"])
+        #expect(repository.fetchStudyGroupDetailCalls == ["G-7"])
+    }
+
+    @Test("멘토가 없고 스터디원만 있을 때 — 스터디원만 반환")
+    func returnsMembersOnlyWhenNoMentors() async throws {
+        let repository = MockStudyRepository()
+        repository.fetchStudyGroupDetailResult = makeGroupInfo(
+            mentors: [],
+            members: [makeMember(serverID: "C-1", name: "챌린저A")]
+        )
+        let useCase = makeUseCase(repository: repository)
+
+        let result = try await useCase.fetchStudyGroupMembers(groupId: "G-1")
+
+        #expect(result.map(\.serverID) == ["C-1"])
+    }
+
+    @Test("멘토·스터디원 모두 비었을 때 — 빈 배열 반환")
+    func returnsEmptyWhenGroupHasNoMembers() async throws {
+        let repository = MockStudyRepository()
+        repository.fetchStudyGroupDetailResult = makeGroupInfo(mentors: [], members: [])
+        let useCase = makeUseCase(repository: repository)
+
+        let result = try await useCase.fetchStudyGroupMembers(groupId: "G-1")
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("Repository 가 에러를 던지면 그대로 전파")
+    func propagatesRepositoryError() async {
+        let repository = MockStudyRepository()
+        repository.fetchStudyGroupDetailError = MockStudyRepository.MockError.stubbed
+        let useCase = makeUseCase(repository: repository)
+
+        await #expect(throws: MockStudyRepository.MockError.stubbed) {
+            _ = try await useCase.fetchStudyGroupMembers(groupId: "G-1")
+        }
+    }
+}


### PR DESCRIPTION
resolves #748

## ✨ PR 유형

♻️ [Refactor] — 레거시 UseCase를 신규 Tuist 모듈(`ActivityDomain`)로 이식

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="1512" height="991" alt="스크린샷 2026-06-08 오전 9 05 40" src="https://github.com/user-attachments/assets/6fabe793-b27d-4682-b0fd-b7a5eaa63366" />
<img width="1512" height="991" alt="스크린샷 2026-06-08 오전 9 05 51" src="https://github.com/user-attachments/assets/9f101654-6660-4610-8d8b-4cf0528ef72f" />

## 🛠️ 작업내용

레거시 `FetchStudyMembersUseCase`(14-메서드 facade)를 **순수 멤버 조회 책임**으로 축소 재정의해 이식했습니다.

- `FetchStudyMembersUseCaseProtocol` — 단일 메서드 `fetchStudyGroupMembers(groupId:)` 로 한정. 그룹 CRUD·일정 연결 facade는 제외 (#797 `StudyRepositoryProtocol` 이 직접 흡수)
- `FetchStudyMembersUseCase` — `StudyRepositoryProtocol.fetchStudyGroupDetail(groupId:)` 위임 후 `mentors + members` 병합 반환
- 서버 ID 파라미터 `Int → String` 정규화
- 단위 테스트 4종 (Swift Testing) — 병합 순서 / 멘토 없음 / 빈 그룹 / 에러 전파. Mock은 `#if DEBUG` 격리
  - `make build SCHEME=ActivityDomain` 빌드 성공, ActivityDomain 테스트 161건 전체 통과

## 📋 추후 진행 상황

- DIContainer 등록 + ViewModel 연결은 본 PR 범위 밖 (도메인 레이어 단독 이식) — 9차 스터디 Presentation 작업에서 진행

## 📌 리뷰 포인트

- 멤버 병합 순서(`mentors + members`)가 레거시와 동일하게 멘토 우선인지
- 단일 책임으로 축소한 Protocol 범위가 적절한지 (CRUD facade 제외 결정)
- 테스트 Mock이 `StudyRepositoryProtocol` 15메서드를 전부 구현하되 미사용 14개는 명시적 실패(`unimplemented`) 처리 — focused-mock으로 적절한지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)