### PR TITLE
🐛 [Fix] 챌린저 공지 작성 시 targetNoticeTab 누락 400 수정

### DIFF
--- a/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
+++ b/AppProduct/AppProduct/Features/Home/Data/DTO/NoticeListDTO.swift
@@ -112,7 +112,8 @@ struct NoticeListResponseDTO: Codable {
                 targetGisuId: 0,
                 targetChapterId: nil,
                 targetSchoolId: nil,
-                targetParts: nil as [UMCPartType]?
+                targetParts: nil as [UMCPartType]?,
+                targetNoticeTab: StaffNoticeTab.challengerServerValue
             )
         self.authorChallengerId = try container.decodeStringFlexibleIfPresent(forKey: .authorChallengerId) ?? "0"
         self.authorNickname = try container.decodeIfPresent(String.self, forKey: .authorNickname) ?? ""
@@ -152,9 +153,13 @@ struct TargetInfoDTO: Codable {
     let targetChapterId: Int?
     let targetSchoolId: Int?
     let targetParts: [UMCPartType]?
-    /// 운영진 공지 탭 식별자 (CENTRAL_MEMBER / SCHOOL_CORE / SCHOOL_PART_LEADER).
-    /// 챌린저 공지 작성 시 nil.
-    let targetNoticeTab: String?
+    /// 공지 대상 탭 식별자. 서버 `NoticeTab` enum 과 1:1 매핑됩니다.
+    /// 챌린저 공지는 `CHALLENGER`, 운영진 공지는
+    /// `CENTRAL_MEMBER` / `SCHOOL_CORE` / `SCHOOL_PART_LEADER`.
+    ///
+    /// 서버 `POST /api/v1/notices` 는 이 값을 `@NotNull` 필수로 받으므로
+    /// non-optional 로 두어 누락 시 컴파일 단계에서 막습니다.
+    let targetNoticeTab: String
 
     private enum CodingKeys: String, CodingKey {
         case targetGisuId
@@ -169,7 +174,7 @@ struct TargetInfoDTO: Codable {
         targetChapterId: Int?,
         targetSchoolId: Int?,
         targetParts: UMCPartType?,
-        targetNoticeTab: String? = nil
+        targetNoticeTab: String
     ) {
         self.targetGisuId = targetGisuId
         self.targetChapterId = targetChapterId
@@ -183,7 +188,7 @@ struct TargetInfoDTO: Codable {
         targetChapterId: Int?,
         targetSchoolId: Int?,
         targetParts: [UMCPartType]?,
-        targetNoticeTab: String? = nil
+        targetNoticeTab: String
     ) {
         self.targetGisuId = targetGisuId
         self.targetChapterId = targetChapterId
@@ -199,6 +204,7 @@ struct TargetInfoDTO: Codable {
         self.targetSchoolId = try container.decodeIntFlexibleIfPresent(forKey: .targetSchoolId)
         self.targetParts = try container.decodeIfPresent([UMCPartType].self, forKey: .targetParts)
         self.targetNoticeTab = try container.decodeIfPresent(String.self, forKey: .targetNoticeTab)
+            ?? StaffNoticeTab.challengerServerValue
     }
 
     /// 공지 생성/수정 요청 인코딩 시 null 규칙을 맞춥니다.
@@ -222,7 +228,7 @@ struct TargetInfoDTO: Codable {
             try container.encodeNil(forKey: .targetParts)
         }
 
-        try container.encodeIfPresent(targetNoticeTab, forKey: .targetNoticeTab)
+        try container.encode(targetNoticeTab, forKey: .targetNoticeTab)
     }
 }
 

--- a/AppProduct/AppProduct/Features/Notice/Domain/Enums/StaffNoticeTab.swift
+++ b/AppProduct/AppProduct/Features/Notice/Domain/Enums/StaffNoticeTab.swift
@@ -17,6 +17,12 @@ enum StaffNoticeTab: String, CaseIterable, Identifiable, Equatable, Hashable {
     case schoolCore = "SCHOOL_CORE"
     case schoolPartLeader = "SCHOOL_PART_LEADER"
 
+    /// 챌린저(일반) 공지 작성 시 서버에 전달하는 `targetNoticeTab` 값.
+    ///
+    /// 서버 `NoticeTab` enum 의 `CHALLENGER` 와 1:1. 매직 스트링을 새로 만들지 않고
+    /// `ManagementTeam.challenger.rawValue` 를 단일 출처로 참조합니다.
+    static let challengerServerValue = ManagementTeam.challenger.rawValue
+
     var id: String { rawValue }
 
     var labelText: String {

--- a/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
+++ b/AppProduct/AppProduct/Features/Notice/Presentation/ViewModels/NoticeEditor/NoticeEditorViewModel+Submit.swift
@@ -192,14 +192,16 @@ extension NoticeEditorViewModel {
                 targetGisuId: 0,
                 targetChapterId: nil,
                 targetSchoolId: selectedSchoolFromSheet,
-                targetParts: nil as [UMCPartType]?
+                targetParts: nil as [UMCPartType]?,
+                targetNoticeTab: StaffNoticeTab.challengerServerValue
             )
         case .central:
             return TargetInfoDTO(
                 targetGisuId: currentGeneration,
                 targetChapterId: selectedSchoolFromSheet == nil ? selectedBranchId : nil,
                 targetSchoolId: selectedSchoolFromSheet,
-                targetParts: selectedParts
+                targetParts: selectedParts,
+                targetNoticeTab: StaffNoticeTab.challengerServerValue
             )
         case .branch:
             let resolvedChapterId: Int? = if memberRole?.canWriteChallengerChapterNotice == true,
@@ -213,21 +215,24 @@ extension NoticeEditorViewModel {
                 targetGisuId: currentGeneration,
                 targetChapterId: resolvedChapterId,
                 targetSchoolId: nil,
-                targetParts: selectedParts
+                targetParts: selectedParts,
+                targetNoticeTab: StaffNoticeTab.challengerServerValue
             )
         case .school:
             return TargetInfoDTO(
                 targetGisuId: currentGeneration,
                 targetChapterId: nil,
                 targetSchoolId: selectedSchoolFromSheet,
-                targetParts: selectedParts
+                targetParts: selectedParts,
+                targetNoticeTab: StaffNoticeTab.challengerServerValue
             )
         case .part(let part):
             return TargetInfoDTO(
                 targetGisuId: currentGeneration,
                 targetChapterId: nil,
                 targetSchoolId: nil,
-                targetParts: [part]
+                targetParts: [part],
+                targetNoticeTab: StaffNoticeTab.challengerServerValue
             )
         case .management(let scenario):
             let managementParts = subCategorySelection.selectedParts.isEmpty

--- a/AppProduct/AppProductTests/NoticeTest/NoticeListDecodeTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/NoticeListDecodeTests.swift
@@ -1,0 +1,152 @@
+//
+//  NoticeListDecodeTests.swift
+//  AppProductTests
+//
+//  홈 최근 공지 리스트 응답(NoticeListResponseDTO) 디코드 회귀 검증.
+//  TargetInfoDTO.targetNoticeTab 을 non-optional 로 전환한 뒤에도
+//  서버 응답이 키를 주든 빠뜨리든 크래시 없이 디코드되는지 고정한다.
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+// MARK: - Helpers
+
+/// `NoticeListResponseDTO` 의 `Codable` 채택이 main-actor 격리
+/// (SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor)라서 디코딩을 메인 액터에서 수행한다.
+@MainActor
+private func decodeNoticeList(_ json: String) throws -> NoticeListResponseDTO {
+    let data = try #require(json.data(using: .utf8))
+    return try JSONDecoder().decode(NoticeListResponseDTO.self, from: data)
+}
+
+/// 서버 응답 형태(숫자는 String 직렬화)의 단일 공지 JSON.
+/// `targetInfoBody` 로 targetInfo 영역만 갈아끼워 케이스별 회귀를 만든다.
+private func makeNoticeJSON(targetInfoBody: String) -> String {
+    """
+    {
+        "id": "101",
+        "noticeId": "101",
+        "title": "공지 제목",
+        "content": "공지 내용",
+        "shouldSendNotification": true,
+        "viewCount": "42",
+        "createdAt": "2026-06-09T12:00:00.000Z",
+        "targetInfo": \(targetInfoBody),
+        "authorChallengerId": "7",
+        "authorNickname": "닉네임",
+        "authorName": "이름"
+    }
+    """
+}
+
+// MARK: - Tests
+
+@Suite("NoticeListResponseDTO — 홈 리스트 디코드 회귀 (도메인 규칙)")
+@MainActor
+struct NoticeListDecodeTests {
+
+    @Test("targetNoticeTab 키가 있으면 값이 그대로 보존된다")
+    func decodesPresentTargetNoticeTab() throws {
+        let json = makeNoticeJSON(targetInfoBody: """
+        {
+            "targetGisuId": "14",
+            "targetChapterId": null,
+            "targetSchoolId": "3",
+            "targetParts": null,
+            "targetNoticeTab": "SCHOOL_CORE"
+        }
+        """)
+
+        let dto = try decodeNoticeList(json)
+
+        #expect(dto.targetInfo.targetNoticeTab == "SCHOOL_CORE")
+        #expect(dto.targetInfo.targetGisuId == 14)
+        #expect(dto.targetInfo.targetSchoolId == 3)
+    }
+
+    @Test("targetNoticeTab 키가 없으면 CHALLENGER 로 폴백한다 (서버 생략 방어)")
+    func decodesMissingTargetNoticeTabAsChallenger() throws {
+        let json = makeNoticeJSON(targetInfoBody: """
+        {
+            "targetGisuId": "14",
+            "targetChapterId": null,
+            "targetSchoolId": null,
+            "targetParts": null
+        }
+        """)
+
+        let dto = try decodeNoticeList(json)
+
+        #expect(dto.targetInfo.targetNoticeTab == "CHALLENGER")
+    }
+
+    @Test("targetNoticeTab 이 null 이어도 CHALLENGER 로 폴백한다")
+    func decodesNullTargetNoticeTabAsChallenger() throws {
+        let json = makeNoticeJSON(targetInfoBody: """
+        {
+            "targetGisuId": "14",
+            "targetChapterId": null,
+            "targetSchoolId": null,
+            "targetParts": null,
+            "targetNoticeTab": null
+        }
+        """)
+
+        let dto = try decodeNoticeList(json)
+
+        #expect(dto.targetInfo.targetNoticeTab == "CHALLENGER")
+    }
+
+    @Test("targetInfo 자체가 null 이면 폴백 TargetInfoDTO 가 동작한다")
+    func decodesNullTargetInfoWithFallback() throws {
+        let json = makeNoticeJSON(targetInfoBody: "null")
+
+        let dto = try decodeNoticeList(json)
+
+        // init(from:) 의 폴백 TargetInfoDTO(targetNoticeTab: CHALLENGER) 경로.
+        #expect(dto.targetInfo.targetGisuId == 0)
+        #expect(dto.targetInfo.targetNoticeTab == "CHALLENGER")
+    }
+
+    @Test("targetInfo 키 자체가 없어도 폴백 TargetInfoDTO 가 동작한다")
+    func decodesMissingTargetInfoWithFallback() throws {
+        let json = """
+        {
+            "id": "101",
+            "noticeId": "101",
+            "title": "공지 제목",
+            "content": "공지 내용",
+            "shouldSendNotification": true,
+            "viewCount": "42",
+            "createdAt": "2026-06-09T12:00:00.000Z",
+            "authorChallengerId": "7",
+            "authorNickname": "닉네임",
+            "authorName": "이름"
+        }
+        """
+
+        let dto = try decodeNoticeList(json)
+
+        #expect(dto.targetInfo.targetNoticeTab == "CHALLENGER")
+    }
+
+    @Test("운영진 응답의 targetParts(apiValue 배열)도 정상 디코드된다")
+    func decodesManagementTargetParts() throws {
+        let json = makeNoticeJSON(targetInfoBody: """
+        {
+            "targetGisuId": "14",
+            "targetChapterId": null,
+            "targetSchoolId": "3",
+            "targetParts": ["IOS", "SPRINGBOOT"],
+            "targetNoticeTab": "SCHOOL_PART_LEADER"
+        }
+        """)
+
+        let dto = try decodeNoticeList(json)
+
+        #expect(dto.targetInfo.targetNoticeTab == "SCHOOL_PART_LEADER")
+        #expect(dto.targetInfo.targetParts == [.front(type: .ios), .server(type: .spring)])
+    }
+}

--- a/AppProduct/AppProductTests/NoticeTest/TargetInfoDTOEncodingTests.swift
+++ b/AppProduct/AppProductTests/NoticeTest/TargetInfoDTOEncodingTests.swift
@@ -1,0 +1,225 @@
+//
+//  TargetInfoDTOEncodingTests.swift
+//  AppProductTests
+//
+//  공지 작성(POST /api/v1/notices) 요청의 targetInfo 인코딩 계약 검증.
+//  - 챌린저 5케이스: targetNoticeTab == "CHALLENGER" 키 항상 포함 (400 회귀 가드)
+//  - 운영진 3시나리오: CENTRAL_MEMBER / SCHOOL_CORE / SCHOOL_PART_LEADER
+//  - null 규칙: targetGisuId<=0 → null, targetParts 빈배열 → null
+//
+
+@testable import AppProduct
+import Foundation
+import Testing
+
+// MARK: - Helpers
+
+/// `JSONEncoder` 결과를 키 순서에 의존하지 않게 `[String: Any]` 로 파싱한다.
+/// 인코더의 `outputFormatting` 정렬에 의존하지 않기 위해 JSONSerialization 사용.
+///
+/// `TargetInfoDTO` 의 `Codable` 채택이 main-actor 격리(SWIFT_DEFAULT_ACTOR_ISOLATION
+/// = MainActor)라서 인코딩을 메인 액터에서 수행한다.
+@MainActor
+private func encodeToJSONObject(_ dto: TargetInfoDTO) throws -> [String: Any] {
+    let data = try JSONEncoder().encode(dto)
+    let object = try JSONSerialization.jsonObject(with: data)
+    return try #require(object as? [String: Any])
+}
+
+/// 챌린저 `.all` 케이스 — `targetGisuId = 0` (null 규칙과 contract 키 공존 검증용).
+private func makeChallengerAll(schoolId: Int? = nil) -> TargetInfoDTO {
+    TargetInfoDTO(
+        targetGisuId: 0,
+        targetChapterId: nil,
+        targetSchoolId: schoolId,
+        targetParts: nil as [UMCPartType]?,
+        targetNoticeTab: StaffNoticeTab.challengerServerValue
+    )
+}
+
+/// 챌린저 `.central` 케이스.
+private func makeChallengerCentral(
+    gisuId: Int = 14,
+    chapterId: Int? = nil,
+    schoolId: Int? = nil,
+    parts: [UMCPartType]? = nil
+) -> TargetInfoDTO {
+    TargetInfoDTO(
+        targetGisuId: gisuId,
+        targetChapterId: chapterId,
+        targetSchoolId: schoolId,
+        targetParts: parts,
+        targetNoticeTab: StaffNoticeTab.challengerServerValue
+    )
+}
+
+/// 챌린저 `.branch` 케이스.
+private func makeChallengerBranch(
+    gisuId: Int = 14,
+    chapterId: Int? = 7,
+    parts: [UMCPartType]? = nil
+) -> TargetInfoDTO {
+    TargetInfoDTO(
+        targetGisuId: gisuId,
+        targetChapterId: chapterId,
+        targetSchoolId: nil,
+        targetParts: parts,
+        targetNoticeTab: StaffNoticeTab.challengerServerValue
+    )
+}
+
+/// 챌린저 `.school` 케이스.
+private func makeChallengerSchool(
+    gisuId: Int = 14,
+    schoolId: Int? = 3,
+    parts: [UMCPartType]? = nil
+) -> TargetInfoDTO {
+    TargetInfoDTO(
+        targetGisuId: gisuId,
+        targetChapterId: nil,
+        targetSchoolId: schoolId,
+        targetParts: parts,
+        targetNoticeTab: StaffNoticeTab.challengerServerValue
+    )
+}
+
+/// 챌린저 `.part` 케이스 — 단일 파트 지정.
+private func makeChallengerPart(
+    gisuId: Int = 14,
+    part: UMCPartType = .front(type: .ios)
+) -> TargetInfoDTO {
+    TargetInfoDTO(
+        targetGisuId: gisuId,
+        targetChapterId: nil,
+        targetSchoolId: nil,
+        targetParts: [part],
+        targetNoticeTab: StaffNoticeTab.challengerServerValue
+    )
+}
+
+/// 운영진 시나리오 — 임의 탭 값을 받는 빌더 (buildTargetInfo의 `.management` 형태 모사).
+private func makeManagement(
+    gisuId: Int = 14,
+    schoolId: Int? = nil,
+    parts: [UMCPartType]? = nil,
+    serverTab: String
+) -> TargetInfoDTO {
+    TargetInfoDTO(
+        targetGisuId: gisuId,
+        targetChapterId: nil,
+        targetSchoolId: schoolId,
+        targetParts: parts,
+        targetNoticeTab: serverTab
+    )
+}
+
+// MARK: - 챌린저 contract 키 (400 회귀 가드)
+
+@Suite("TargetInfoDTO — 공지 작성 인코딩 (도메인 규칙)")
+@MainActor
+struct TargetInfoDTOEncodingTests {
+
+    @Test("챌린저 .all (targetGisuId 0) 인코딩 시 targetNoticeTab 키가 CHALLENGER 로 포함된다")
+    func challengerAllEmitsChallengerTab() throws {
+        let json = try encodeToJSONObject(makeChallengerAll())
+
+        #expect(json["targetNoticeTab"] as? String == "CHALLENGER")
+    }
+
+    @Test("챌린저 .all 은 targetGisuId 가 null 이어도 targetNoticeTab 은 그대로 출력된다")
+    func challengerAllNullGisuStillEmitsTab() throws {
+        let json = try encodeToJSONObject(makeChallengerAll())
+
+        // null 규칙(targetGisuId<=0 → null)과 contract 키가 충돌하지 않음을 고정.
+        #expect(json["targetGisuId"] is NSNull)
+        #expect(json["targetNoticeTab"] as? String == "CHALLENGER")
+    }
+
+    @Test(
+        "챌린저 5케이스 모두 targetNoticeTab 키가 CHALLENGER 로 포함된다",
+        arguments: [
+            "all", "central", "branch", "school", "part"
+        ]
+    )
+    func challengerAllCasesEmitChallengerTab(caseName: String) throws {
+        let dto: TargetInfoDTO = switch caseName {
+        case "all":     makeChallengerAll()
+        case "central": makeChallengerCentral()
+        case "branch":  makeChallengerBranch()
+        case "school":  makeChallengerSchool()
+        default:        makeChallengerPart()
+        }
+
+        let json = try encodeToJSONObject(dto)
+
+        #expect(json.keys.contains("targetNoticeTab"))
+        #expect(json["targetNoticeTab"] as? String == "CHALLENGER")
+    }
+
+    // MARK: - 운영진 3시나리오 회귀 (바이트 동일 보장)
+
+    @Test(
+        "운영진 시나리오는 각 서버 탭 값을 그대로 인코딩한다",
+        arguments: [
+            ("CENTRAL_MEMBER", StaffNoticeTab.centralMember.rawValue),
+            ("SCHOOL_CORE", StaffNoticeTab.schoolCore.rawValue),
+            ("SCHOOL_PART_LEADER", StaffNoticeTab.schoolPartLeader.rawValue)
+        ]
+    )
+    func managementScenariosEmitOwnTab(expected: String, serverTab: String) throws {
+        let json = try encodeToJSONObject(
+            makeManagement(serverTab: serverTab)
+        )
+
+        #expect(json["targetNoticeTab"] as? String == expected)
+    }
+
+    // MARK: - null 규칙 회귀 가드
+
+    @Test("targetGisuId 가 0 이하면 targetGisuId 키는 null 이다", arguments: [0, -1])
+    func nonPositiveGisuEncodesNull(gisuId: Int) throws {
+        let json = try encodeToJSONObject(
+            makeManagement(gisuId: gisuId, serverTab: "CENTRAL_MEMBER")
+        )
+
+        #expect(json["targetGisuId"] is NSNull)
+    }
+
+    @Test("targetGisuId 가 양수면 정수로 인코딩된다")
+    func positiveGisuEncodesNumber() throws {
+        let json = try encodeToJSONObject(
+            makeManagement(gisuId: 14, serverTab: "CENTRAL_MEMBER")
+        )
+
+        #expect(json["targetGisuId"] as? Int == 14)
+    }
+
+    @Test("targetParts 가 nil 이면 targetParts 키는 null 이다")
+    func nilPartsEncodesNull() throws {
+        let json = try encodeToJSONObject(
+            makeChallengerCentral(parts: nil)
+        )
+
+        #expect(json["targetParts"] is NSNull)
+    }
+
+    @Test("targetParts 가 빈 배열이면 targetParts 키는 null 이다")
+    func emptyPartsEncodesNull() throws {
+        let json = try encodeToJSONObject(
+            makeChallengerCentral(parts: [])
+        )
+
+        #expect(json["targetParts"] is NSNull)
+    }
+
+    @Test("targetParts 에 값이 있으면 apiValue 배열로 인코딩된다")
+    func nonEmptyPartsEncodesApiValues() throws {
+        let json = try encodeToJSONObject(
+            makeChallengerPart(part: .front(type: .ios))
+        )
+
+        #expect(json["targetParts"] as? [String] == ["IOS"])
+        // 파트 지정 케이스에서도 contract 키는 유지.
+        #expect(json["targetNoticeTab"] as? String == "CHALLENGER")
+    }
+}


### PR DESCRIPTION
resolves #880

## ✨ PR 유형

Bug — 챌린저 공지 작성 시 `targetNoticeTab` 누락으로 발생하던 HTTP 400 해결

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="350" height="800" alt="simulator_screenshot_43290EF4-47DC-4309-88CC-C2A12AF24511" src="https://github.com/user-attachments/assets/0661839e-37be-4b42-b551-65137f2a1545" />
<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-09 at 23 23 41" src="https://github.com/user-attachments/assets/ba8469b9-4b6c-4a4c-987c-610305363111" />


## 🛠️ 작업내용

- 챌린저 공지 5개 케이스(`.all`/`.central`/`.branch`/`.school`/`.part`)의 `buildTargetInfo()`가
  `targetNoticeTab`을 보내지 않아 서버 필수 검증(`@NotNull`)에서 400 발생
  → 5개 케이스 모두 `StaffNoticeTab.challengerServerValue`(= `CHALLENGER`) 주입
- `TargetInfoDTO.targetNoticeTab`을 옵셔널 → non-optional `String`으로 전환하고
  `encode(to:)`를 `encodeIfPresent` → `encode`로 변경해 키 누락을 원천 차단 (400 직접 원인 제거)
- `init(from:)` 및 targetInfo 부재 폴백 생성자에 `CHALLENGER` 기본값 추가 (서버 생략 방어)
- `CHALLENGER` 매직 스트링을 `ManagementTeam.challenger.rawValue` 단일 출처(SSOT)로 통일
- Swift Testing 단위 테스트 추가 — 인코딩 계약 9 + 디코드 회귀 6 (총 15 케이스, 전부 통과)

## 📋 추후 진행 상황

## 📌 리뷰 포인트

- `NoticeListDTO.swift` — `TargetInfoDTO` non-optional 전환 + `encode` 규칙
  (`targetGisuId ≤ 0`·빈 `targetParts`는 `null`, `targetNoticeTab`은 항상 포함)
- `NoticeEditorViewModel+Submit.swift` — 챌린저 5개 케이스 `targetNoticeTab` 주입,
  운영진 3개 케이스(`centralMember`/`schoolCore`/`schoolPartLeader`)는 기존 동작 유지
- `StaffNoticeTab.swift` — `challengerServerValue` SSOT 참조

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
