### PR TITLE
♻️ [Refactor] FetchCurriculumUseCase (Protocol + Impl) 이식

### DIFF
--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/FetchCurriculumUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/FetchCurriculumUseCaseProtocol.swift
@@ -1,0 +1,25 @@
+//
+//  FetchCurriculumUseCaseProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/8/26.
+//
+
+import Foundation
+
+/// 스터디 커리큘럼 진행 현황 조회 도메인 진입점
+///
+/// `ChallengerStudyView` 커리큘럼 섹션의 데이터 소스입니다.
+/// 한 파트의 커리큘럼 종료 진척도(`CurriculumProgressModel`)를 조회합니다.
+///
+/// - Note: 레거시 `execute(weekNo:) -> CurriculumData` 는 주차별 상세
+///   (`fetchCurriculumData(weekNo:)`)에 의존했으나, `CurriculumData` 정의 위치
+///   미확정으로 동결되었습니다. 본 진입점은 분리된
+///   `StudyRepositoryProtocol.fetchCurriculumProgress()` 만 사용하므로
+///   `weekNo` 파라미터를 갖지 않습니다. 주차별 상세 조회는 정의 위치 확정 후
+///   후행 이슈에서 추가됩니다.
+public protocol FetchCurriculumUseCaseProtocol {
+
+    /// 커리큘럼 진행률 조회
+    func execute() async throws -> CurriculumProgressModel
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/FetchCurriculumUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/FetchCurriculumUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  FetchCurriculumUseCase.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/8/26.
+//
+
+import Foundation
+
+/// `FetchCurriculumUseCaseProtocol` 의 기본 구현체
+///
+/// `StudyRepositoryProtocol.fetchCurriculumProgress()` 에 위임하는 단순 조회 UseCase 입니다.
+public final class FetchCurriculumUseCase: FetchCurriculumUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: StudyRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: StudyRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute() async throws -> CurriculumProgressModel {
+        try await repository.fetchCurriculumProgress()
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchCurriculumUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchCurriculumUseCaseTests.swift
@@ -1,0 +1,178 @@
+//
+//  FetchCurriculumUseCaseTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 6/8/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+// MARK: - Helpers
+
+private func makeProgress(
+    partName: String = "iOS",
+    curriculumTitle: String = "1주차 OT",
+    completedCount: Int = 2,
+    totalCount: Int = 8
+) -> CurriculumProgressModel {
+    CurriculumProgressModel(
+        partName: partName,
+        curriculumTitle: curriculumTitle,
+        completedCount: completedCount,
+        totalCount: totalCount
+    )
+}
+
+private func makeUseCase(
+    repository: MockStudyRepository = MockStudyRepository()
+) -> FetchCurriculumUseCase {
+    FetchCurriculumUseCase(repository: repository)
+}
+
+// MARK: - Mocks
+
+#if DEBUG
+
+private enum MockStudyRepositoryError: Error {
+    case fetchFailed
+}
+
+/// `StudyRepositoryProtocol` 의 테스트 전용 Mock.
+///
+/// 본 UseCase 가 계약하는 `fetchCurriculumProgress()` 만 제어 가능한 stub 으로 노출하고,
+/// 나머지 메서드는 계약 밖이므로 호출 시 `fatalError` 로 즉시 실패합니다.
+private final class MockStudyRepository: @unchecked Sendable, StudyRepositoryProtocol {
+
+    // MARK: 커리큘럼 stub 제어
+
+    var fetchCurriculumProgressResult: CurriculumProgressModel = makeProgress()
+    var fetchCurriculumProgressError: Error?
+    private(set) var fetchCurriculumProgressCallCount = 0
+
+    func fetchCurriculumProgress() async throws -> CurriculumProgressModel {
+        fetchCurriculumProgressCallCount += 1
+        if let error = fetchCurriculumProgressError {
+            throw error
+        }
+        return fetchCurriculumProgressResult
+    }
+
+    // MARK: 계약 밖 메서드 (호출 시 실패 — 본 UseCase 는 사용하지 않음)
+
+    func fetchMissions() async throws -> [MissionCardModel] {
+        fatalError("fetchMissions 는 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption] {
+        fatalError("fetchWeeklyCurriculumOptions 는 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func fetchStudyGroupDetails() async throws -> [StudyGroupInfo] {
+        fatalError("fetchStudyGroupDetails 는 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func fetchStudyGroupDetailsPage(
+        cursor: Int?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage {
+        fatalError("fetchStudyGroupDetailsPage 는 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func fetchStudyGroupDetail(groupId: String) async throws -> StudyGroupInfo {
+        fatalError("fetchStudyGroupDetail 은 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: Int?
+    ) async throws -> String? {
+        fatalError("resolveChallengerId 는 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws {
+        fatalError("createStudyGroup 은 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func updateStudyGroup(groupId: String, name: String) async throws {
+        fatalError("updateStudyGroup 은 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func deleteStudyGroup(groupId: String) async throws {
+        fatalError("deleteStudyGroup 은 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func addStudyGroupMember(groupId: String, memberId: String) async throws {
+        fatalError("addStudyGroupMember 는 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func removeStudyGroupMember(groupId: String, memberId: String) async throws {
+        fatalError("removeStudyGroupMember 는 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func addStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        fatalError("addStudyGroupMentor 는 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        fatalError("removeStudyGroupMentor 는 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+
+    func linkStudyGroupSchedule(
+        scheduleId: String,
+        studyGroupId: String,
+        weeklyCurriculumId: String
+    ) async throws {
+        fatalError("linkStudyGroupSchedule 은 FetchCurriculumUseCase 계약 밖입니다.")
+    }
+}
+
+#endif
+
+// MARK: - 커리큘럼 진행률 조회
+
+@Suite("FetchCurriculumUseCase — 커리큘럼 진행률 조회 (도메인 규칙)")
+struct FetchCurriculumUseCaseTests {
+
+    @Test("정상 — Repository.fetchCurriculumProgress 위임 + 결과 그대로 반환 + 1회 호출")
+    func executeDelegatesToRepository() async throws {
+        let repository = MockStudyRepository()
+        let expected = makeProgress(
+            partName: "Spring",
+            curriculumTitle: "3주차 세션",
+            completedCount: 5,
+            totalCount: 10
+        )
+        repository.fetchCurriculumProgressResult = expected
+        let useCase = makeUseCase(repository: repository)
+
+        let result = try await useCase.execute()
+
+        #expect(repository.fetchCurriculumProgressCallCount == 1)
+        // 변환 없는 패스스루 검증 — 도메인 의미 필드 단위 비교.
+        // (`id` 는 로컬 생성 UUID 라 검증 대상에서 제외)
+        #expect(result.partName == "Spring")
+        #expect(result.curriculumTitle == "3주차 세션")
+        #expect(result.completedCount == 5)
+        #expect(result.totalCount == 10)
+    }
+
+    @Test("Repository 에러 → 변환 없이 그대로 전파")
+    func executePropagatesRepositoryError() async {
+        let repository = MockStudyRepository()
+        repository.fetchCurriculumProgressError = MockStudyRepositoryError.fetchFailed
+        let useCase = makeUseCase(repository: repository)
+
+        await #expect(throws: MockStudyRepositoryError.fetchFailed) {
+            _ = try await useCase.execute()
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchCurriculumUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchCurriculumUseCaseTests.swift
@@ -10,6 +10,9 @@ import Testing
 import UMCFoundation
 @testable import ActivityDomain
 
+// 이 테스트 파일은 전부 #if DEBUG 전용 Mock 에 의존하므로 본문 전체를 가드한다.
+#if DEBUG
+
 // MARK: - Helpers
 
 private func makeProgress(
@@ -33,8 +36,6 @@ private func makeUseCase(
 }
 
 // MARK: - Mocks
-
-#if DEBUG
 
 private enum MockStudyRepositoryError: Error {
     case fetchFailed
@@ -135,8 +136,6 @@ private final class MockStudyRepository: @unchecked Sendable, StudyRepositoryPro
     }
 }
 
-#endif
-
 // MARK: - 커리큘럼 진행률 조회
 
 @Suite("FetchCurriculumUseCase — 커리큘럼 진행률 조회 (도메인 규칙)")
@@ -176,3 +175,5 @@ struct FetchCurriculumUseCaseTests {
         }
     }
 }
+
+#endif


### PR DESCRIPTION
resolves #749

## ✨ PR 유형

♻️ [Refactor] — 레거시 `FetchCurriculumUseCase` 를 Tuist 모듈 `ActivityDomain` 으로 이식 (Protocol + 구현 + 단위 테스트)

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="991" alt="스크린샷 2026-06-10 오전 8 48 30" src="https://github.com/user-attachments/assets/1bfedad5-862e-4ebd-b9f6-f6230375682e" />
<img width="1512" height="991" alt="스크린샷 2026-06-10 오전 8 48 37" src="https://github.com/user-attachments/assets/8aceb776-573a-44b6-aadc-123be1598e9c" />


## 🛠️ 작업내용

레거시 `AppProduct/.../FetchCurriculumUseCase` 를 신규 모듈 `UMCApp/Features/Activity/Domain` 으로 이식.

- `FetchCurriculumUseCaseProtocol` — `execute() async throws -> CurriculumProgressModel`
- `FetchCurriculumUseCase` — `StudyRepositoryProtocol.fetchCurriculumProgress()` 위임
- 단위 테스트 — Mock `StudyRepositoryProtocol`(`#if DEBUG`)로 위임·에러 전파 계약 검증 (Swift Testing)

**핵심 결정 — 레거시 시그니처 재정의 (1:1 복사 X):**
- `CurriculumData`(진행률+미션 번들)는 정의 위치 미확정으로 동결 → 재생성하지 않고 `CurriculumProgressModel` 직접 반환
- `weekNo` 파라미터는 동결된 주차별 상세 경로 전용이라 제거 (사유는 Protocol doc 주석에 명시)

## 📋 추후 진행 상황

- `ChallengerStudyViewModel` 이식 + DIContainer wiring (별도 티켓)
- 주차별 상세(`CurriculumData` / `weekNo`) 경로 — 정의 위치 확정 후 후행 이슈

## 📌 리뷰 포인트

- **시그니처 재정의 타당성**: progress-only 범위(weekNo 제거 / CurriculumData 미재생성)가 이슈 의도에 부합하는지
- **Mock 설계**: `StudyRepositoryProtocol` 14개 메서드 중 계약 밖 메서드를 `fatalError` 로 처리 — 의도치 않은 의존 시 즉시 실패
- `Features/Activity/Domain/` — UseCase 비즈니스 로직(단순 위임) 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
