### PR TITLE
♻️ [Refactor] Study 응답 DTO 이식 + toDomain 매핑 — v2 스키마

### DIFF
--- a/UMCApp/Features/Activity/Data/Sources/ActivityData.swift
+++ b/UMCApp/Features/Activity/Data/Sources/ActivityData.swift
@@ -1,4 +1,9 @@
-import ActivityDomain
+//
+//  ActivityData.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/7/26.
+//
 
 /// ActivityData 모듈 플레이스홀더.
 ///

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/CurriculumDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/CurriculumDTO.swift
@@ -1,0 +1,195 @@
+//
+//  CurriculumDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import ActivityDomain
+import UMCFoundation
+
+// MARK: - CurriculumDTO
+
+/// 파트별 커리큘럼 조회 응답 DTO
+///
+/// `GET /api/v2/curriculums/overview?gisuId={ID}&part={PART}&weekNo={N}`
+///
+/// 서버 식별자(`curriculumId`)는 `String`, 주차 목록은 `WeeklyCurriculumDTO` 배열로 디코딩한다.
+struct CurriculumDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let curriculumId: String
+    let title: String
+    let weeks: [WeeklyCurriculumDTO]
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case curriculumId
+        case title
+        case weeks
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        curriculumId = try container.decodeFlexibleStringIfPresent(forKey: .curriculumId) ?? ""
+        title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+        weeks = try container.decodeIfPresent([WeeklyCurriculumDTO].self, forKey: .weeks) ?? []
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(curriculumId, forKey: .curriculumId)
+        try container.encode(title, forKey: .title)
+        try container.encode(weeks, forKey: .weeks)
+    }
+}
+
+// MARK: - WeeklyCurriculumDTO
+
+/// 주차 커리큘럼 항목 DTO
+struct WeeklyCurriculumDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let weeklyCurriculumId: String
+    let weekNo: Int
+    let title: String
+    let startsAt: String
+    let endsAt: String
+    let isExtra: Bool
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case weeklyCurriculumId
+        case weekNo
+        case title
+        case startsAt
+        case endsAt
+        case isExtra
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        weeklyCurriculumId =
+            try container.decodeFlexibleStringIfPresent(forKey: .weeklyCurriculumId) ?? ""
+        weekNo = try container.decodeIntFlexibleIfPresent(forKey: .weekNo) ?? 0
+        title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+        startsAt = try container.decodeIfPresent(String.self, forKey: .startsAt) ?? ""
+        endsAt = try container.decodeIfPresent(String.self, forKey: .endsAt) ?? ""
+        isExtra = try container.decodeBoolFlexibleIfPresent(forKey: .isExtra) ?? false
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(weeklyCurriculumId, forKey: .weeklyCurriculumId)
+        try container.encode(weekNo, forKey: .weekNo)
+        try container.encode(title, forKey: .title)
+        try container.encode(startsAt, forKey: .startsAt)
+        try container.encode(endsAt, forKey: .endsAt)
+        try container.encode(isExtra, forKey: .isExtra)
+    }
+}
+
+// MARK: - CurriculumDTO + toDomain
+
+extension CurriculumDTO {
+
+    /// 커리큘럼 진행률 도메인 모델 ``CurriculumProgressModel`` 로 변환한다.
+    ///
+    /// `part` 는 DTO 본문에 없는 값으로, 조회 요청 시 사용한 파트 문자열을 호출자가 전달한다.
+    /// 종료된 주차 수(`completedCount`)는 각 주차 `endsAt` 와 `now` 비교로 계산한다.
+    ///
+    /// - Parameters:
+    ///   - part: 조회 파트의 서버 문자열 (예: `"IOS"`)
+    ///   - now: 진행률 계산 기준 시각 (테스트 결정론을 위해 주입 가능)
+    func toCurriculumProgress(part: String, now: Date = .now) -> CurriculumProgressModel {
+        let partType = UMCPartType(apiValue: part)
+        let partName = "\(partType?.name ?? part) PART CURRICULUM"
+
+        let completedCount = weeks.filter { week in
+            guard let endDate = week.parsedEndsAt else { return false }
+            return now > endDate
+        }.count
+        let totalCount = weeks.count
+
+        let currentWeekTitle: String = {
+            let inProgress = weeks.first { week in
+                guard let start = week.parsedStartsAt,
+                      let end = week.parsedEndsAt else { return false }
+                return start <= now && now <= end
+            }
+            return inProgress?.title ?? title
+        }()
+
+        return CurriculumProgressModel(
+            partType: partType,
+            partName: partName,
+            curriculumTitle: currentWeekTitle,
+            completedCount: completedCount,
+            totalCount: totalCount
+        )
+    }
+
+    /// 미션 카드 도메인 모델 목록 ``MissionCardModel`` 로 변환한다 (주차 오름차순 정렬).
+    ///
+    /// - Parameters:
+    ///   - platform: 카드에 표기할 플랫폼/파트 문자열
+    ///   - now: 미션 상태 계산 기준 시각 (테스트 결정론을 위해 주입 가능)
+    func toMissionCards(platform: String, now: Date = .now) -> [MissionCardModel] {
+        weeks
+            .map { $0.toMissionCard(platform: platform, now: now) }
+            .sorted { $0.week < $1.week }
+    }
+}
+
+// MARK: - WeeklyCurriculumDTO + Mapping
+
+extension WeeklyCurriculumDTO {
+
+    /// 주차 DTO 를 미션 카드 도메인 모델 ``MissionCardModel`` 로 변환한다.
+    func toMissionCard(platform: String, now: Date) -> MissionCardModel {
+        MissionCardModel(
+            week: weekNo,
+            platform: platform,
+            title: title,
+            missionTitle: title,
+            missionType: .link,
+            status: missionStatus(now: now),
+            isExtra: isExtra
+        )
+    }
+
+    /// `startsAt` / `endsAt` 와 `now` 를 비교해 미션 상태를 결정한다.
+    func missionStatus(now: Date) -> MissionStatus {
+        guard let start = parsedStartsAt, let end = parsedEndsAt else {
+            return .notStarted
+        }
+        if now < start {
+            return .notStarted
+        } else if now <= end {
+            return .inProgress
+        } else {
+            return .completed
+        }
+    }
+
+    var parsedStartsAt: Date? {
+        StudyGroupDateParser.parse(startsAt)
+    }
+
+    var parsedEndsAt: Date? {
+        StudyGroupDateParser.parse(endsAt)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/KeyedDecodingContainer+FlexibleDecoding.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/KeyedDecodingContainer+FlexibleDecoding.swift
@@ -42,6 +42,10 @@ extension KeyedDecodingContainer {
     }
 
     /// 키가 nil 이거나 변환 불가하면 nil 을 반환하는 ``decodeFlexibleString(forKey:)`` 의 Optional 버전.
+    ///
+    /// - Important: 필드 누락과 타입 불일치를 모두 `nil` 로 동일하게 처리한다.
+    ///   `decodeNil` 선검사 후 `try?` 로 변환을 시도하므로, 키가 존재해도 변환 불가능한
+    ///   타입(`Bool`·배열 등)이 오면 오류를 던지지 않고 조용히 `nil` 로 폴백한다.
     func decodeFlexibleStringIfPresent(forKey key: Key) throws -> String? {
         if (try? decodeNil(forKey: key)) == true {
             return nil

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/KeyedDecodingContainer+FlexibleDecoding.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/KeyedDecodingContainer+FlexibleDecoding.swift
@@ -1,0 +1,130 @@
+//
+//  KeyedDecodingContainer+FlexibleDecoding.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+
+/// 서버가 같은 필드를 Int / String / Double / Bool 등 혼합 타입으로 직렬화하는 상황을
+/// 흡수하기 위한 유연 디코딩 헬퍼.
+///
+/// 절대 규칙 2(서버 응답 정수 → 전 레이어 `String`)와 규칙 3(Response DTO 의 정수 필드는
+/// `decode(Int.self)` 직접 호출 금지)을 동시에 만족시키기 위해, 식별자/커서류는
+/// `decodeFlexibleString*` 으로, 실제 수량(개수·점수)은 `decodeIntFlexible*` 로 디코딩한다.
+///
+/// ActivityData 모듈 내부 전용(`internal`)이며, DTO 파일들이 공유한다.
+extension KeyedDecodingContainer {
+
+    // MARK: - String
+
+    /// 식별자/커서처럼 서버가 Int 또는 String 으로 보낼 수 있는 값을 `String` 으로 디코딩한다.
+    func decodeFlexibleString(forKey key: Key) throws -> String {
+        if let stringValue = try? decode(String.self, forKey: key) {
+            return stringValue
+        }
+        if let intValue = try? decode(Int.self, forKey: key) {
+            return String(intValue)
+        }
+        if let doubleValue = try? decode(Double.self, forKey: key) {
+            return String(Int(doubleValue))
+        }
+
+        throw DecodingError.typeMismatch(
+            String.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription:
+                    "Expected String/Int/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    /// 키가 nil 이거나 변환 불가하면 nil 을 반환하는 ``decodeFlexibleString(forKey:)`` 의 Optional 버전.
+    func decodeFlexibleStringIfPresent(forKey key: Key) throws -> String? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        return try? decodeFlexibleString(forKey: key)
+    }
+
+    // MARK: - Int
+
+    /// 실제 수량(개수·점수 등)을 Int / String / Double 형태로부터 유연하게 디코딩한다.
+    func decodeIntFlexible(forKey key: Key) throws -> Int {
+        if let intValue = try? decode(Int.self, forKey: key) {
+            return intValue
+        }
+        if let stringValue = try? decode(String.self, forKey: key),
+           let intValue = Int(stringValue) {
+            return intValue
+        }
+        if let doubleValue = try? decode(Double.self, forKey: key) {
+            return Int(doubleValue)
+        }
+
+        throw DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription:
+                    "Expected Int/String-number/Double for key '\(key.stringValue)'"
+            )
+        )
+    }
+
+    /// 키가 nil 이거나 변환 불가하면 nil 을 반환하는 ``decodeIntFlexible(forKey:)`` 의 Optional 버전.
+    func decodeIntFlexibleIfPresent(forKey key: Key) throws -> Int? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        return try? decodeIntFlexible(forKey: key)
+    }
+
+    // MARK: - Bool
+
+    /// Bool / Int(0·1) / String("true"·"false"·"1"·"0") 형태로부터 Bool 을 유연하게 디코딩한다.
+    func decodeBoolFlexibleIfPresent(forKey key: Key) throws -> Bool? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        if let boolValue = try? decode(Bool.self, forKey: key) {
+            return boolValue
+        }
+        if let intValue = try? decode(Int.self, forKey: key) {
+            return intValue != 0
+        }
+        if let stringValue = try? decode(String.self, forKey: key) {
+            switch stringValue.lowercased() {
+            case "true", "1":
+                return true
+            case "false", "0":
+                return false
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Double
+
+    /// Double / Int / String 형태로부터 Double 을 유연하게 디코딩한다.
+    func decodeDoubleFlexibleIfPresent(forKey key: Key) throws -> Double? {
+        if (try? decodeNil(forKey: key)) == true {
+            return nil
+        }
+        if let doubleValue = try? decode(Double.self, forKey: key) {
+            return doubleValue
+        }
+        if let intValue = try? decode(Int.self, forKey: key) {
+            return Double(intValue)
+        }
+        if let stringValue = try? decode(String.self, forKey: key),
+           let doubleValue = Double(stringValue) {
+            return doubleValue
+        }
+        return nil
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/MyStudyGroupsPageDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/MyStudyGroupsPageDTO.swift
@@ -1,0 +1,135 @@
+//
+//  MyStudyGroupsPageDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import ActivityDomain
+
+// MARK: - MyStudyGroupsPageDTO
+
+/// 스터디 그룹 상세 목록 페이지 DTO (커서 기반 페이지네이션)
+///
+/// `GET /api/v1/study-groups`
+///
+/// 도메인 ``StudyGroupDetailsPage/content`` 가 `[StudyGroupInfo]`(풀 정보)이므로,
+/// 페이지 항목은 ``StudyGroupDetailDTO``(풀 그룹 상세)로 디코딩한다.
+/// 서버가 `cursor` 래핑 / `content` 키 / `studyGroups` 키 중 어느 포맷으로 응답해도
+/// 흡수하도록 유연하게 디코딩한다. 커서(`nextCursor`)는 `String` 으로 통일한다.
+struct MyStudyGroupsPageDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let studyGroups: [StudyGroupDetailDTO]
+    let nextCursor: String?
+    let hasNext: Bool
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case cursor
+        case studyGroups
+        case content
+        case nextCursor
+        case hasNext
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // 서버가 cursor 래핑 포맷으로 응답하는 경우
+        if let cursor = try container.decodeIfPresent(
+            MyStudyGroupsCursorDTO.self,
+            forKey: .cursor
+        ) {
+            studyGroups = cursor.content
+            nextCursor = cursor.nextCursor
+            hasNext = cursor.hasNext
+            return
+        }
+
+        // content 키를 직접 포함하는 flat 포맷인 경우
+        if let content = try container.decodeIfPresent(
+            [StudyGroupDetailDTO].self,
+            forKey: .content
+        ) {
+            studyGroups = content
+            nextCursor = try container.decodeFlexibleStringIfPresent(forKey: .nextCursor)
+            hasNext = try container.decodeBoolFlexibleIfPresent(forKey: .hasNext) ?? false
+            return
+        }
+
+        // studyGroups 키를 직접 포함하는 포맷 (최종 fallback)
+        studyGroups = try container.decodeIfPresent(
+            [StudyGroupDetailDTO].self,
+            forKey: .studyGroups
+        ) ?? []
+        nextCursor = try container.decodeFlexibleStringIfPresent(forKey: .nextCursor)
+        hasNext = try container.decodeBoolFlexibleIfPresent(forKey: .hasNext) ?? false
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(studyGroups, forKey: .studyGroups)
+        try container.encodeIfPresent(nextCursor, forKey: .nextCursor)
+        try container.encode(hasNext, forKey: .hasNext)
+    }
+
+    // MARK: - toDomain
+
+    /// DTO 를 도메인 모델 ``StudyGroupDetailsPage`` 로 변환한다.
+    func toDomain() -> StudyGroupDetailsPage {
+        StudyGroupDetailsPage(
+            content: studyGroups.map { $0.toDomain() },
+            hasNext: hasNext,
+            nextCursor: nextCursor
+        )
+    }
+}
+
+// MARK: - MyStudyGroupsCursorDTO
+
+/// `cursor` 래핑 포맷의 내부 페이지 DTO
+private struct MyStudyGroupsCursorDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let content: [StudyGroupDetailDTO]
+    let nextCursor: String?
+    let hasNext: Bool
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case content
+        case nextCursor
+        case hasNext
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        content = try container.decodeIfPresent(
+            [StudyGroupDetailDTO].self,
+            forKey: .content
+        ) ?? []
+        nextCursor = try container.decodeFlexibleStringIfPresent(forKey: .nextCursor)
+        hasNext = try container.decodeBoolFlexibleIfPresent(forKey: .hasNext) ?? false
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(content, forKey: .content)
+        try container.encodeIfPresent(nextCursor, forKey: .nextCursor)
+        try container.encode(hasNext, forKey: .hasNext)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupDetailDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupDetailDTO.swift
@@ -151,7 +151,7 @@ struct StudyGroupChallengerDTO: Codable, Sendable, Equatable {
     let challengerId: String
     let memberId: String
     let name: String
-    let profileImageUrl: String?
+    let profileImageURL: String?
     let bestWorkbookPoint: Int?
 
     // MARK: - CodingKeys
@@ -160,7 +160,7 @@ struct StudyGroupChallengerDTO: Codable, Sendable, Equatable {
         case challengerId
         case memberId
         case name
-        case profileImageUrl
+        case profileImageURL = "profileImageUrl"
         case bestWorkbookPoint
     }
 
@@ -171,7 +171,7 @@ struct StudyGroupChallengerDTO: Codable, Sendable, Equatable {
         challengerId = try container.decodeFlexibleStringIfPresent(forKey: .challengerId) ?? ""
         memberId = try container.decodeFlexibleStringIfPresent(forKey: .memberId) ?? ""
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
-        profileImageUrl = try container.decodeIfPresent(String.self, forKey: .profileImageUrl)
+        profileImageURL = try container.decodeIfPresent(String.self, forKey: .profileImageURL)
         bestWorkbookPoint = try container.decodeIntFlexibleIfPresent(forKey: .bestWorkbookPoint)
     }
 
@@ -182,7 +182,7 @@ struct StudyGroupChallengerDTO: Codable, Sendable, Equatable {
         try container.encode(challengerId, forKey: .challengerId)
         try container.encode(memberId, forKey: .memberId)
         try container.encode(name, forKey: .name)
-        try container.encodeIfPresent(profileImageUrl, forKey: .profileImageUrl)
+        try container.encodeIfPresent(profileImageURL, forKey: .profileImageURL)
         try container.encodeIfPresent(bestWorkbookPoint, forKey: .bestWorkbookPoint)
     }
 }
@@ -245,7 +245,7 @@ extension StudyGroupDetailDTO {
             memberID: challenger.memberId.isEmpty ? nil : challenger.memberId,
             name: challenger.name,
             university: university,
-            profileImageURL: normalizedURL(challenger.profileImageUrl),
+            profileImageURL: normalizedURL(challenger.profileImageURL),
             role: role,
             bestWorkbookPoint: bestWorkbookPointByMemberID[challenger.memberId]
                 ?? challenger.bestWorkbookPoint
@@ -261,9 +261,11 @@ extension StudyGroupDetailDTO {
 
 // MARK: - StudyGroupDateParser
 
+// TODO: Core 승격 시 ISO8601DateParser 등 범용 이름으로 변경 - [26.06.19] jaewon
 /// ISO 8601 날짜 문자열 파서.
 ///
 /// 밀리초(fractional seconds) 포함 포맷을 먼저 시도하고, 실패하면 표준 포맷으로 재시도한다.
+/// ``CurriculumDTO`` 의 `parsedStartsAt` / `parsedEndsAt` 에서도 쓰여 DTO 범위를 넘어선다.
 enum StudyGroupDateParser {
     static func parse(_ value: String) -> Date? {
         ISO8601DateFormatter.withFractionalSeconds.date(from: value)

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupDetailDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupDetailDTO.swift
@@ -1,0 +1,286 @@
+//
+//  StudyGroupDetailDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import ActivityDomain
+import UMCFoundation
+
+// MARK: - StudyGroupDetailDTO
+
+/// 스터디 그룹 상세 응답 DTO
+///
+/// `GET /api/v1/study-groups/{groupId}`
+///
+/// 서버 식별자(`groupId`, `schoolId`, `challengerId`, `memberId`)는 전 레이어 `String` 통일
+/// 규칙에 따라 `String` 으로 디코딩한다.
+struct StudyGroupDetailDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let groupId: String
+    let name: String
+    let part: String
+    let partDisplayName: String?
+    let schools: [StudyGroupSchoolDTO]
+    let createdAt: String
+    let memberCount: Int
+    let mentors: [StudyGroupChallengerDTO]
+    let members: [StudyGroupChallengerDTO]
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case groupId
+        case name
+        case part
+        case partDisplayName
+        case schools
+        case createdAt
+        case memberCount
+        case mentors
+        case leader
+        case members
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        groupId = try container.decodeFlexibleStringIfPresent(forKey: .groupId) ?? ""
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        part = try container.decodeIfPresent(String.self, forKey: .part) ?? ""
+        partDisplayName = try container.decodeIfPresent(String.self, forKey: .partDisplayName)
+        schools = try container.decodeIfPresent([StudyGroupSchoolDTO].self, forKey: .schools) ?? []
+        createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt) ?? ""
+        memberCount = try container.decodeIntFlexibleIfPresent(forKey: .memberCount) ?? 0
+
+        if let decodedMentors = try container.decodeIfPresent(
+            [StudyGroupChallengerDTO].self,
+            forKey: .mentors
+        ) {
+            mentors = decodedMentors
+        } else if let legacyLeader = try container.decodeIfPresent(
+            StudyGroupChallengerDTO.self,
+            forKey: .leader
+        ) {
+            mentors = [legacyLeader]
+        } else {
+            mentors = []
+        }
+        members = try container.decodeIfPresent(
+            [StudyGroupChallengerDTO].self,
+            forKey: .members
+        ) ?? []
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(groupId, forKey: .groupId)
+        try container.encode(name, forKey: .name)
+        try container.encode(part, forKey: .part)
+        try container.encodeIfPresent(partDisplayName, forKey: .partDisplayName)
+        try container.encode(schools, forKey: .schools)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(memberCount, forKey: .memberCount)
+        try container.encode(mentors, forKey: .mentors)
+        try container.encode(members, forKey: .members)
+    }
+}
+
+// MARK: - StudyGroupSchoolDTO
+
+/// 스터디 그룹 소속 학교 정보 DTO
+struct StudyGroupSchoolDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let schoolId: String
+    let schoolName: String
+    let logoImageId: String?
+    let totalStudyGroupCount: Int
+    let totalMemberCount: Int
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case schoolId
+        case schoolName
+        case logoImageId
+        case totalStudyGroupCount
+        case totalMemberCount
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schoolId = try container.decodeFlexibleStringIfPresent(forKey: .schoolId) ?? ""
+        schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
+        logoImageId = try container.decodeFlexibleStringIfPresent(forKey: .logoImageId)
+        totalStudyGroupCount =
+            try container.decodeIntFlexibleIfPresent(forKey: .totalStudyGroupCount) ?? 0
+        totalMemberCount =
+            try container.decodeIntFlexibleIfPresent(forKey: .totalMemberCount) ?? 0
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schoolId, forKey: .schoolId)
+        try container.encode(schoolName, forKey: .schoolName)
+        try container.encodeIfPresent(logoImageId, forKey: .logoImageId)
+        try container.encode(totalStudyGroupCount, forKey: .totalStudyGroupCount)
+        try container.encode(totalMemberCount, forKey: .totalMemberCount)
+    }
+}
+
+// MARK: - StudyGroupChallengerDTO
+
+/// 스터디 그룹 소속 챌린저(멤버/리더) 정보 DTO
+struct StudyGroupChallengerDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let challengerId: String
+    let memberId: String
+    let name: String
+    let profileImageUrl: String?
+    let bestWorkbookPoint: Int?
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerId
+        case memberId
+        case name
+        case profileImageUrl
+        case bestWorkbookPoint
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        challengerId = try container.decodeFlexibleStringIfPresent(forKey: .challengerId) ?? ""
+        memberId = try container.decodeFlexibleStringIfPresent(forKey: .memberId) ?? ""
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        profileImageUrl = try container.decodeIfPresent(String.self, forKey: .profileImageUrl)
+        bestWorkbookPoint = try container.decodeIntFlexibleIfPresent(forKey: .bestWorkbookPoint)
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(challengerId, forKey: .challengerId)
+        try container.encode(memberId, forKey: .memberId)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(profileImageUrl, forKey: .profileImageUrl)
+        try container.encodeIfPresent(bestWorkbookPoint, forKey: .bestWorkbookPoint)
+    }
+}
+
+// MARK: - toDomain
+
+extension StudyGroupDetailDTO {
+
+    /// DTO 를 도메인 모델 ``StudyGroupInfo`` 로 변환한다.
+    ///
+    /// - Parameters:
+    ///   - defaultGroupName: 그룹명이 비어 있을 때 대체할 이름
+    ///   - bestWorkbookPointByMemberID: memberId → 베스트 워크북 점수 매핑 (없으면 DTO 내 점수 사용)
+    /// - Returns: 변환된 ``StudyGroupInfo`` 도메인 모델
+    func toDomain(
+        defaultGroupName: String? = nil,
+        bestWorkbookPointByMemberID: [String: Int] = [:]
+    ) -> StudyGroupInfo {
+        let partType = UMCPartType(apiValue: part) ?? .front(type: .ios)
+        let university = schools.first?.schoolName ?? ""
+        let parsedDate = StudyGroupDateParser.parse(createdAt) ?? Date()
+
+        let mentorItems = mentors.map { mentor in
+            makeMember(
+                from: mentor,
+                university: university,
+                role: .leader,
+                bestWorkbookPointByMemberID: bestWorkbookPointByMemberID
+            )
+        }
+
+        let memberItems = members.map { member in
+            makeMember(
+                from: member,
+                university: university,
+                role: .member,
+                bestWorkbookPointByMemberID: bestWorkbookPointByMemberID
+            )
+        }
+
+        return StudyGroupInfo(
+            serverID: groupId,
+            name: name.isEmpty ? (defaultGroupName ?? "") : name,
+            part: partType,
+            createdDate: parsedDate,
+            mentors: mentorItems,
+            members: memberItems
+        )
+    }
+
+    private func makeMember(
+        from challenger: StudyGroupChallengerDTO,
+        university: String,
+        role: StudyGroupMember.MemberRole,
+        bestWorkbookPointByMemberID: [String: Int]
+    ) -> StudyGroupMember {
+        StudyGroupMember(
+            serverID: challenger.memberId,
+            challengerID: challenger.challengerId.isEmpty ? nil : challenger.challengerId,
+            memberID: challenger.memberId.isEmpty ? nil : challenger.memberId,
+            name: challenger.name,
+            university: university,
+            profileImageURL: normalizedURL(challenger.profileImageUrl),
+            role: role,
+            bestWorkbookPoint: bestWorkbookPointByMemberID[challenger.memberId]
+                ?? challenger.bestWorkbookPoint
+                ?? 0
+        )
+    }
+
+    private func normalizedURL(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+// MARK: - StudyGroupDateParser
+
+/// ISO 8601 날짜 문자열 파서.
+///
+/// 밀리초(fractional seconds) 포함 포맷을 먼저 시도하고, 실패하면 표준 포맷으로 재시도한다.
+enum StudyGroupDateParser {
+    static func parse(_ value: String) -> Date? {
+        ISO8601DateFormatter.withFractionalSeconds.date(from: value)
+            ?? ISO8601DateFormatter.standard.date(from: value)
+    }
+}
+
+extension ISO8601DateFormatter {
+    static let withFractionalSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static let standard: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/WeeklyCurriculumOptionDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/WeeklyCurriculumOptionDTO.swift
@@ -110,6 +110,11 @@ struct WeeklyCurriculumOptionsResponseDTO: Codable, Sendable, Equatable {
 
     // MARK: - Encodable
 
+    /// 항상 `content` 키로 직렬화한다 (디코딩-인코딩 비대칭).
+    ///
+    /// 디코딩은 최상위 배열 / `content` / `weeklyCurriculums` 3가지 포맷을 흡수하지만,
+    /// 인코딩은 단일 정규 포맷(`content`)만 사용한다. `weeklyCurriculums` 포맷으로 받은
+    /// 데이터를 encode → decode 하면 `content` 경로로 복원되며 값은 동일하게 보존된다.
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(options, forKey: .content)

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/WeeklyCurriculumOptionDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/WeeklyCurriculumOptionDTO.swift
@@ -1,0 +1,124 @@
+//
+//  WeeklyCurriculumOptionDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import ActivityDomain
+
+// MARK: - WeeklyCurriculumOptionDTO
+
+/// 주차 커리큘럼 선택 옵션 응답 DTO
+///
+/// ``StudyRepositoryProtocol/fetchWeeklyCurriculumOptions()`` 의 단일 항목.
+/// 서버 식별자(`weeklyCurriculumId`)와 주차 번호(`weekNo`)는 모두 `String` 으로 디코딩한다.
+struct WeeklyCurriculumOptionDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let weeklyCurriculumId: String
+    let weekNo: String
+    let title: String
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case weeklyCurriculumId
+        case weekNo
+        case title
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        weeklyCurriculumId =
+            try container.decodeFlexibleStringIfPresent(forKey: .weeklyCurriculumId) ?? ""
+        weekNo = try container.decodeFlexibleStringIfPresent(forKey: .weekNo) ?? ""
+        title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(weeklyCurriculumId, forKey: .weeklyCurriculumId)
+        try container.encode(weekNo, forKey: .weekNo)
+        try container.encode(title, forKey: .title)
+    }
+
+    // MARK: - toDomain
+
+    /// DTO 를 도메인 모델 ``WeeklyCurriculumOption`` 으로 변환한다.
+    func toDomain() -> WeeklyCurriculumOption {
+        WeeklyCurriculumOption(
+            weeklyCurriculumId: weeklyCurriculumId,
+            weekNo: weekNo,
+            title: title
+        )
+    }
+}
+
+// MARK: - WeeklyCurriculumOptionsResponseDTO
+
+/// 주차 커리큘럼 옵션 목록 응답 DTO
+///
+/// 서버가 `content` 래핑 / `weeklyCurriculums` 키 / 최상위 배열 중 어느 포맷으로 보내도
+/// 흡수하도록 유연하게 디코딩한다.
+struct WeeklyCurriculumOptionsResponseDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let options: [WeeklyCurriculumOptionDTO]
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case content
+        case weeklyCurriculums
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        // 최상위가 배열인 포맷
+        if var unkeyed = try? decoder.unkeyedContainer() {
+            var decoded: [WeeklyCurriculumOptionDTO] = []
+            while !unkeyed.isAtEnd {
+                decoded.append(try unkeyed.decode(WeeklyCurriculumOptionDTO.self))
+            }
+            options = decoded
+            return
+        }
+
+        // 키 래핑 포맷 (content / weeklyCurriculums)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let content = try container.decodeIfPresent(
+            [WeeklyCurriculumOptionDTO].self,
+            forKey: .content
+        ) {
+            options = content
+            return
+        }
+        options = try container.decodeIfPresent(
+            [WeeklyCurriculumOptionDTO].self,
+            forKey: .weeklyCurriculums
+        ) ?? []
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(options, forKey: .content)
+    }
+
+    // MARK: - toDomain
+
+    /// DTO 목록을 도메인 모델 ``WeeklyCurriculumOption`` 배열로 변환한다.
+    func toDomain() -> [WeeklyCurriculumOption] {
+        options.map { $0.toDomain() }
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/CurriculumDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/CurriculumDTOTests.swift
@@ -1,0 +1,332 @@
+//
+//  CurriculumDTOTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import Testing
+import ActivityDomain
+import UMCFoundation
+@testable import ActivityData
+
+// MARK: - Fixed Timestamps
+//
+// 모든 시간 단언은 결정론을 위해 고정 epoch 를 사용한다.
+//   week1: 2026-06-01T00:00:00Z(starts) ~ 2026-06-07T00:00:00Z(ends)
+//   week2: 2026-06-08T00:00:00Z(starts) ~ 2026-06-14T00:00:00Z(ends)
+
+private enum FixedTime {
+    static let week1Start: TimeInterval = 1_780_272_000 // 2026-06-01T00:00:00Z
+    static let week1End: TimeInterval = 1_780_790_400 // 2026-06-07T00:00:00Z
+    static let week2Start: TimeInterval = 1_780_876_800 // 2026-06-08T00:00:00Z
+    static let week2End: TimeInterval = 1_781_395_200 // 2026-06-14T00:00:00Z
+
+    static let week1StartISO = "2026-06-01T00:00:00Z"
+    static let week1EndISO = "2026-06-07T00:00:00Z"
+    static let week2StartISO = "2026-06-08T00:00:00Z"
+    static let week2EndISO = "2026-06-14T00:00:00Z"
+}
+
+// MARK: - Helpers
+
+private func decodeCurriculum(_ json: String) throws -> CurriculumDTO {
+    try JSONDecoder().decode(CurriculumDTO.self, from: Data(json.utf8))
+}
+
+private func makeWeekJSON(
+    startsAt: String,
+    endsAt: String,
+    weeklyCurriculumId: String = "\"5001\"",
+    weekNo: String = "1",
+    title: String = "\"1주차: Swift 기초\"",
+    isExtra: String = "false"
+) -> String {
+    """
+    {
+        "weeklyCurriculumId": \(weeklyCurriculumId),
+        "weekNo": \(weekNo),
+        "title": \(title),
+        "startsAt": "\(startsAt)",
+        "endsAt": "\(endsAt)",
+        "isExtra": \(isExtra)
+    }
+    """
+}
+
+private func makeCurriculumJSON(
+    curriculumId: String = "\"900\"",
+    title: String = "\"iOS 커리큘럼\"",
+    weeks: [String]
+) -> String {
+    """
+    {
+        "curriculumId": \(curriculumId),
+        "title": \(title),
+        "weeks": [\(weeks.joined(separator: ","))]
+    }
+    """
+}
+
+private func date(_ epoch: TimeInterval) -> Date { Date(timeIntervalSince1970: epoch) }
+
+@Suite("CurriculumDTO — 디코딩/매핑")
+struct CurriculumDTOTests {
+
+    // MARK: - Decoding (happy path)
+
+    @Test("커리큘럼 전체 JSON 의 필드와 주차 목록을 디코딩한다")
+    func decodesFullCurriculumJSON() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO),
+            makeWeekJSON(
+                startsAt: FixedTime.week2StartISO,
+                endsAt: FixedTime.week2EndISO,
+                weeklyCurriculumId: "\"5002\"",
+                weekNo: "2"
+            )
+        ])
+        let dto = try decodeCurriculum(json)
+
+        #expect(dto.curriculumId == "900")
+        #expect(dto.title == "iOS 커리큘럼")
+        #expect(dto.weeks.count == 2)
+        #expect(dto.weeks.first?.weeklyCurriculumId == "5001")
+        #expect(dto.weeks.first?.weekNo == 1)
+    }
+
+    @Test("curriculumId 가 JSON 숫자로 와도 String 으로 디코딩한다")
+    func decodesCurriculumIdAsNumber() throws {
+        let json = makeCurriculumJSON(curriculumId: "900", weeks: [])
+        #expect(try decodeCurriculum(json).curriculumId == "900")
+    }
+
+    @Test("weekNo 가 숫자 String 으로 와도 Int 로 디코딩한다")
+    func decodesWeekNoAsString() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO, weekNo: "\"3\"")
+        ])
+        #expect(try decodeCurriculum(json).weeks.first?.weekNo == 3)
+    }
+
+    @Test("isExtra 가 String/Int 등 다양한 형태로 와도 Bool 로 디코딩한다")
+    func decodesIsExtraFlexibly() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO, isExtra: "\"true\"")
+        ])
+        #expect(try decodeCurriculum(json).weeks.first?.isExtra == true)
+    }
+
+    @Test("필드가 없으면 기본값으로 디코딩한다")
+    func decodesWithDefaults() throws {
+        let dto = try decodeCurriculum("{}")
+        #expect(dto.curriculumId == "")
+        #expect(dto.title == "")
+        #expect(dto.weeks.isEmpty)
+    }
+
+    @Test("주차 JSON 에 필드가 없으면 기본값으로 디코딩한다")
+    func decodesWeekWithDefaults() throws {
+        let json = makeCurriculumJSON(weeks: ["{}"])
+        let week = try #require(try decodeCurriculum(json).weeks.first)
+
+        #expect(week.weeklyCurriculumId == "")
+        #expect(week.weekNo == 0)
+        #expect(week.title == "")
+        #expect(week.startsAt == "")
+        #expect(week.endsAt == "")
+        #expect(week.isExtra == false)
+    }
+
+    @Test("custom encode 후 다시 디코딩하면 동일한 DTO 가 복원된다")
+    func encodeRoundTrip() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO)
+        ])
+        let original = try decodeCurriculum(json)
+        let restored = try JSONDecoder().decode(
+            CurriculumDTO.self,
+            from: JSONEncoder().encode(original)
+        )
+        #expect(restored == original)
+    }
+
+    // MARK: - toCurriculumProgress
+
+    @Test("toCurriculumProgress — totalCount 는 주차 수, partType/partName 은 part 인자로부터 매핑된다")
+    func progressMapsTotalsAndPart() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO),
+            makeWeekJSON(
+                startsAt: FixedTime.week2StartISO,
+                endsAt: FixedTime.week2EndISO,
+                weekNo: "2"
+            )
+        ])
+        let progress = try decodeCurriculum(json)
+            .toCurriculumProgress(part: "IOS", now: date(FixedTime.week1Start))
+
+        #expect(progress.totalCount == 2)
+        #expect(progress.partType == .front(type: .ios))
+        #expect(progress.partName == "iOS PART CURRICULUM")
+    }
+
+    @Test("toCurriculumProgress — 알 수 없는 part 는 partType nil, partName 에 원본 문자열을 쓴다")
+    func progressUnknownPartFallback() throws {
+        let json = makeCurriculumJSON(weeks: [])
+        let progress = try decodeCurriculum(json)
+            .toCurriculumProgress(part: "QUANTUM", now: date(FixedTime.week1Start))
+
+        #expect(progress.partType == nil)
+        #expect(progress.partName == "QUANTUM PART CURRICULUM")
+    }
+
+    @Test("toCurriculumProgress — now 가 주차 end 보다 이전이면 완료로 세지 않는다")
+    func progressNotCompletedBeforeEnd() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO)
+        ])
+        let progress = try decodeCurriculum(json)
+            .toCurriculumProgress(part: "IOS", now: date(FixedTime.week1End - 1))
+        #expect(progress.completedCount == 0)
+    }
+
+    @Test("toCurriculumProgress — now 가 주차 end 와 정확히 같으면 완료로 세지 않는다 (strict >)")
+    func progressNotCompletedAtExactEnd() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO)
+        ])
+        let progress = try decodeCurriculum(json)
+            .toCurriculumProgress(part: "IOS", now: date(FixedTime.week1End))
+        #expect(progress.completedCount == 0)
+    }
+
+    @Test("toCurriculumProgress — now 가 주차 end 보다 이후면 완료로 센다")
+    func progressCompletedAfterEnd() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO)
+        ])
+        let progress = try decodeCurriculum(json)
+            .toCurriculumProgress(part: "IOS", now: date(FixedTime.week1End + 1))
+        #expect(progress.completedCount == 1)
+    }
+
+    @Test("toCurriculumProgress — endsAt 파싱 불가 주차는 완료로 세지 않는다")
+    func progressIgnoresUnparsableEnd() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: "invalid-date")
+        ])
+        let progress = try decodeCurriculum(json)
+            .toCurriculumProgress(part: "IOS", now: date(FixedTime.week2End))
+        #expect(progress.completedCount == 0)
+    }
+
+    @Test("toCurriculumProgress — 진행 중 주차가 있으면 그 제목을 curriculumTitle 로 쓴다")
+    func progressUsesInProgressWeekTitle() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(
+                startsAt: FixedTime.week1StartISO,
+                endsAt: FixedTime.week1EndISO,
+                title: "\"진행 중 주차\""
+            )
+        ])
+        let progress = try decodeCurriculum(json)
+            .toCurriculumProgress(part: "IOS", now: date(FixedTime.week1Start + 1))
+        #expect(progress.curriculumTitle == "진행 중 주차")
+    }
+
+    @Test("toCurriculumProgress — 진행 중 주차가 없으면 커리큘럼 title 로 폴백한다")
+    func progressFallsBackToCurriculumTitle() throws {
+        let json = makeCurriculumJSON(title: "\"폴백 타이틀\"", weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO)
+        ])
+        let progress = try decodeCurriculum(json)
+            .toCurriculumProgress(part: "IOS", now: date(FixedTime.week2End))
+        #expect(progress.curriculumTitle == "폴백 타이틀")
+    }
+
+    // MARK: - toMissionCards
+
+    @Test("toMissionCards — 주차를 week 오름차순으로 정렬해 카드로 변환한다")
+    func missionCardsSortedByWeek() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(
+                startsAt: FixedTime.week2StartISO,
+                endsAt: FixedTime.week2EndISO,
+                weekNo: "2"
+            ),
+            makeWeekJSON(
+                startsAt: FixedTime.week1StartISO,
+                endsAt: FixedTime.week1EndISO,
+                weekNo: "1"
+            )
+        ])
+        let cards = try decodeCurriculum(json)
+            .toMissionCards(platform: "iOS", now: date(FixedTime.week1Start))
+
+        #expect(cards.map(\.week) == [1, 2])
+    }
+
+    @Test("toMissionCards — platform/missionTitle/missionType/isExtra 가 매핑된다")
+    func missionCardsMapFields() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(
+                startsAt: FixedTime.week1StartISO,
+                endsAt: FixedTime.week1EndISO,
+                title: "\"1주차 미션\"",
+                isExtra: "true"
+            )
+        ])
+        let card = try #require(
+            try decodeCurriculum(json)
+                .toMissionCards(platform: "iOS", now: date(FixedTime.week1Start)).first
+        )
+
+        #expect(card.platform == "iOS")
+        #expect(card.title == "1주차 미션")
+        #expect(card.missionTitle == "1주차 미션")
+        #expect(card.missionType == .link)
+        #expect(card.isExtra == true)
+    }
+
+    @Test(
+        "toMissionCards — now 의 위치에 따라 missionStatus 가 3개 영역으로 결정된다",
+        arguments: [
+            (FixedTime.week1Start - 1, MissionStatus.notStarted),
+            (FixedTime.week1Start, MissionStatus.inProgress),
+            (FixedTime.week1End, MissionStatus.inProgress),
+            (FixedTime.week1End + 1, MissionStatus.completed)
+        ]
+    )
+    func missionStatusAcrossTimeRegions(now: TimeInterval, expected: MissionStatus) throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: FixedTime.week1StartISO, endsAt: FixedTime.week1EndISO)
+        ])
+        let card = try #require(
+            try decodeCurriculum(json)
+                .toMissionCards(platform: "iOS", now: date(now)).first
+        )
+        #expect(card.status == expected)
+    }
+
+    @Test("toMissionCards — startsAt/endsAt 파싱 불가 주차는 notStarted 로 매핑된다")
+    func missionStatusUnparsableDatesNotStarted() throws {
+        let json = makeCurriculumJSON(weeks: [
+            makeWeekJSON(startsAt: "bad", endsAt: "bad")
+        ])
+        let card = try #require(
+            try decodeCurriculum(json)
+                .toMissionCards(platform: "iOS", now: date(FixedTime.week1End)).first
+        )
+        #expect(card.status == .notStarted)
+    }
+
+    @Test("toMissionCards — 빈 주차 목록이면 빈 카드 배열을 반환한다")
+    func missionCardsEmptyWhenNoWeeks() throws {
+        let json = makeCurriculumJSON(weeks: [])
+        let cards = try decodeCurriculum(json)
+            .toMissionCards(platform: "iOS", now: date(FixedTime.week1Start))
+        #expect(cards.isEmpty)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/FlexibleDecodingTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/FlexibleDecodingTests.swift
@@ -1,0 +1,338 @@
+//
+//  FlexibleDecodingTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityData
+
+// MARK: - Test Probe DTOs
+//
+// KeyedDecodingContainer 의 flexible 헬퍼는 internal extension 이라 직접 호출이 불가능하다.
+// 각 헬퍼를 정확히 한 번씩 호출하는 최소 프로브 DTO 를 통해 헬퍼의 분기를 검증한다.
+
+private struct FlexibleStringProbe: Decodable {
+    let value: String
+
+    private enum CodingKeys: String, CodingKey { case value }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        value = try container.decodeFlexibleString(forKey: .value)
+    }
+}
+
+private struct FlexibleStringIfPresentProbe: Decodable {
+    let value: String?
+
+    private enum CodingKeys: String, CodingKey { case value }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        value = try container.decodeFlexibleStringIfPresent(forKey: .value)
+    }
+}
+
+private struct FlexibleIntProbe: Decodable {
+    let value: Int
+
+    private enum CodingKeys: String, CodingKey { case value }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        value = try container.decodeIntFlexible(forKey: .value)
+    }
+}
+
+private struct FlexibleIntIfPresentProbe: Decodable {
+    let value: Int?
+
+    private enum CodingKeys: String, CodingKey { case value }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        value = try container.decodeIntFlexibleIfPresent(forKey: .value)
+    }
+}
+
+private struct FlexibleBoolIfPresentProbe: Decodable {
+    let value: Bool?
+
+    private enum CodingKeys: String, CodingKey { case value }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        value = try container.decodeBoolFlexibleIfPresent(forKey: .value)
+    }
+}
+
+private struct FlexibleDoubleIfPresentProbe: Decodable {
+    let value: Double?
+
+    private enum CodingKeys: String, CodingKey { case value }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        value = try container.decodeDoubleFlexibleIfPresent(forKey: .value)
+    }
+}
+
+// MARK: - Helpers
+
+private func decodeStringProbe(_ json: String) throws -> FlexibleStringProbe {
+    try JSONDecoder().decode(FlexibleStringProbe.self, from: Data(json.utf8))
+}
+
+private func decodeStringIfPresentProbe(_ json: String) throws -> FlexibleStringIfPresentProbe {
+    try JSONDecoder().decode(FlexibleStringIfPresentProbe.self, from: Data(json.utf8))
+}
+
+private func decodeIntProbe(_ json: String) throws -> FlexibleIntProbe {
+    try JSONDecoder().decode(FlexibleIntProbe.self, from: Data(json.utf8))
+}
+
+private func decodeIntIfPresentProbe(_ json: String) throws -> FlexibleIntIfPresentProbe {
+    try JSONDecoder().decode(FlexibleIntIfPresentProbe.self, from: Data(json.utf8))
+}
+
+private func decodeBoolIfPresentProbe(_ json: String) throws -> FlexibleBoolIfPresentProbe {
+    try JSONDecoder().decode(FlexibleBoolIfPresentProbe.self, from: Data(json.utf8))
+}
+
+private func decodeDoubleIfPresentProbe(_ json: String) throws -> FlexibleDoubleIfPresentProbe {
+    try JSONDecoder().decode(FlexibleDoubleIfPresentProbe.self, from: Data(json.utf8))
+}
+
+@Suite("KeyedDecodingContainer FlexibleDecoding — 유연 디코딩 헬퍼")
+struct FlexibleDecodingTests {
+
+    // MARK: - decodeFlexibleString
+
+    @Test("decodeFlexibleString — JSON String 값을 그대로 String 으로 디코딩한다")
+    func flexibleStringDecodesStringValue() throws {
+        let probe = try decodeStringProbe(#"{ "value": "abc" }"#)
+        #expect(probe.value == "abc")
+    }
+
+    @Test("decodeFlexibleString — JSON Int 값을 String 으로 변환한다")
+    func flexibleStringDecodesIntValue() throws {
+        let probe = try decodeStringProbe(#"{ "value": 42 }"#)
+        #expect(probe.value == "42")
+    }
+
+    @Test("decodeFlexibleString — JSON Double 값을 절삭한 Int 의 String 으로 변환한다")
+    func flexibleStringDecodesDoubleValue() throws {
+        let probe = try decodeStringProbe(#"{ "value": 42.9 }"#)
+        #expect(probe.value == "42")
+    }
+
+    @Test("decodeFlexibleString — Bool 등 변환 불가 타입이면 typeMismatch 를 throw 한다")
+    func flexibleStringThrowsOnInvalidType() {
+        #expect(throws: DecodingError.self) {
+            _ = try decodeStringProbe(#"{ "value": true }"#)
+        }
+    }
+
+    // MARK: - decodeFlexibleStringIfPresent
+
+    @Test("decodeFlexibleStringIfPresent — String 값을 디코딩한다")
+    func flexibleStringIfPresentDecodesString() throws {
+        let probe = try decodeStringIfPresentProbe(#"{ "value": "cursor-1" }"#)
+        #expect(probe.value == "cursor-1")
+    }
+
+    @Test("decodeFlexibleStringIfPresent — Int 값을 String 으로 변환한다")
+    func flexibleStringIfPresentDecodesInt() throws {
+        let probe = try decodeStringIfPresentProbe(#"{ "value": 7 }"#)
+        #expect(probe.value == "7")
+    }
+
+    @Test("decodeFlexibleStringIfPresent — 키가 없으면 nil 을 반환한다")
+    func flexibleStringIfPresentReturnsNilWhenMissing() throws {
+        let probe = try decodeStringIfPresentProbe(#"{ }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeFlexibleStringIfPresent — 명시적 null 이면 nil 을 반환한다")
+    func flexibleStringIfPresentReturnsNilWhenNull() throws {
+        let probe = try decodeStringIfPresentProbe(#"{ "value": null }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeFlexibleStringIfPresent — 변환 불가 타입이면 nil 을 반환한다 (throw 하지 않음)")
+    func flexibleStringIfPresentReturnsNilOnInvalidType() throws {
+        let probe = try decodeStringIfPresentProbe(#"{ "value": true }"#)
+        #expect(probe.value == nil)
+    }
+
+    // MARK: - decodeIntFlexible
+
+    @Test("decodeIntFlexible — JSON Int 값을 그대로 디코딩한다")
+    func intFlexibleDecodesInt() throws {
+        let probe = try decodeIntProbe(#"{ "value": 5 }"#)
+        #expect(probe.value == 5)
+    }
+
+    @Test("decodeIntFlexible — 숫자 String 을 Int 로 변환한다")
+    func intFlexibleDecodesNumericString() throws {
+        let probe = try decodeIntProbe(#"{ "value": "12" }"#)
+        #expect(probe.value == 12)
+    }
+
+    @Test("decodeIntFlexible — JSON Double 을 절삭해 Int 로 변환한다")
+    func intFlexibleDecodesDouble() throws {
+        let probe = try decodeIntProbe(#"{ "value": 8.7 }"#)
+        #expect(probe.value == 8)
+    }
+
+    @Test("decodeIntFlexible — 숫자가 아닌 String 이면 typeMismatch 를 throw 한다")
+    func intFlexibleThrowsOnNonNumericString() {
+        #expect(throws: DecodingError.self) {
+            _ = try decodeIntProbe(#"{ "value": "not-a-number" }"#)
+        }
+    }
+
+    @Test("decodeIntFlexible — Bool 등 변환 불가 타입이면 typeMismatch 를 throw 한다")
+    func intFlexibleThrowsOnInvalidType() {
+        #expect(throws: DecodingError.self) {
+            _ = try decodeIntProbe(#"{ "value": true }"#)
+        }
+    }
+
+    // MARK: - decodeIntFlexibleIfPresent
+
+    @Test("decodeIntFlexibleIfPresent — Int 값을 디코딩한다")
+    func intFlexibleIfPresentDecodesInt() throws {
+        let probe = try decodeIntIfPresentProbe(#"{ "value": 3 }"#)
+        #expect(probe.value == 3)
+    }
+
+    @Test("decodeIntFlexibleIfPresent — 숫자 String 을 Int 로 변환한다")
+    func intFlexibleIfPresentDecodesNumericString() throws {
+        let probe = try decodeIntIfPresentProbe(#"{ "value": "99" }"#)
+        #expect(probe.value == 99)
+    }
+
+    @Test("decodeIntFlexibleIfPresent — 키가 없으면 nil 을 반환한다")
+    func intFlexibleIfPresentReturnsNilWhenMissing() throws {
+        let probe = try decodeIntIfPresentProbe(#"{ }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeIntFlexibleIfPresent — 명시적 null 이면 nil 을 반환한다")
+    func intFlexibleIfPresentReturnsNilWhenNull() throws {
+        let probe = try decodeIntIfPresentProbe(#"{ "value": null }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeIntFlexibleIfPresent — 숫자가 아닌 String 이면 nil 을 반환한다 (throw 하지 않음)")
+    func intFlexibleIfPresentReturnsNilOnNonNumericString() throws {
+        let probe = try decodeIntIfPresentProbe(#"{ "value": "abc" }"#)
+        #expect(probe.value == nil)
+    }
+
+    // MARK: - decodeBoolFlexibleIfPresent
+
+    @Test("decodeBoolFlexibleIfPresent — JSON Bool 값을 디코딩한다")
+    func boolFlexibleIfPresentDecodesBool() throws {
+        #expect(try decodeBoolIfPresentProbe(#"{ "value": true }"#).value == true)
+        #expect(try decodeBoolIfPresentProbe(#"{ "value": false }"#).value == false)
+    }
+
+    @Test(
+        "decodeBoolFlexibleIfPresent — Int 0 은 false, 그 외 Int 는 true 로 변환한다",
+        arguments: [
+            (#"{ "value": 0 }"#, false),
+            (#"{ "value": 1 }"#, true),
+            (#"{ "value": 5 }"#, true)
+        ]
+    )
+    func boolFlexibleIfPresentDecodesInt(json: String, expected: Bool) throws {
+        #expect(try decodeBoolIfPresentProbe(json).value == expected)
+    }
+
+    @Test(
+        "decodeBoolFlexibleIfPresent — String true/false/1/0 을 Bool 로 변환한다",
+        arguments: [
+            (#"{ "value": "true" }"#, true),
+            (#"{ "value": "TRUE" }"#, true),
+            (#"{ "value": "1" }"#, true),
+            (#"{ "value": "false" }"#, false),
+            (#"{ "value": "0" }"#, false)
+        ]
+    )
+    func boolFlexibleIfPresentDecodesString(json: String, expected: Bool) throws {
+        #expect(try decodeBoolIfPresentProbe(json).value == expected)
+    }
+
+    @Test("decodeBoolFlexibleIfPresent — 인식 불가 String 이면 nil 을 반환한다")
+    func boolFlexibleIfPresentReturnsNilOnUnknownString() throws {
+        let probe = try decodeBoolIfPresentProbe(#"{ "value": "maybe" }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeBoolFlexibleIfPresent — 키가 없으면 nil 을 반환한다")
+    func boolFlexibleIfPresentReturnsNilWhenMissing() throws {
+        let probe = try decodeBoolIfPresentProbe(#"{ }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeBoolFlexibleIfPresent — 명시적 null 이면 nil 을 반환한다")
+    func boolFlexibleIfPresentReturnsNilWhenNull() throws {
+        let probe = try decodeBoolIfPresentProbe(#"{ "value": null }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeBoolFlexibleIfPresent — Double 등 처리 불가 타입이면 nil 을 반환한다")
+    func boolFlexibleIfPresentReturnsNilOnUnhandledType() throws {
+        let probe = try decodeBoolIfPresentProbe(#"{ "value": 1.5 }"#)
+        #expect(probe.value == nil)
+    }
+
+    // MARK: - decodeDoubleFlexibleIfPresent
+
+    @Test("decodeDoubleFlexibleIfPresent — JSON Double 값을 디코딩한다")
+    func doubleFlexibleIfPresentDecodesDouble() throws {
+        let probe = try decodeDoubleIfPresentProbe(#"{ "value": 3.14 }"#)
+        #expect(probe.value == 3.14)
+    }
+
+    @Test("decodeDoubleFlexibleIfPresent — JSON Int 를 Double 로 변환한다")
+    func doubleFlexibleIfPresentDecodesInt() throws {
+        let probe = try decodeDoubleIfPresentProbe(#"{ "value": 4 }"#)
+        #expect(probe.value == 4.0)
+    }
+
+    @Test("decodeDoubleFlexibleIfPresent — 숫자 String 을 Double 로 변환한다")
+    func doubleFlexibleIfPresentDecodesNumericString() throws {
+        let probe = try decodeDoubleIfPresentProbe(#"{ "value": "2.5" }"#)
+        #expect(probe.value == 2.5)
+    }
+
+    @Test("decodeDoubleFlexibleIfPresent — 숫자가 아닌 String 이면 nil 을 반환한다")
+    func doubleFlexibleIfPresentReturnsNilOnNonNumericString() throws {
+        let probe = try decodeDoubleIfPresentProbe(#"{ "value": "x" }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeDoubleFlexibleIfPresent — 키가 없으면 nil 을 반환한다")
+    func doubleFlexibleIfPresentReturnsNilWhenMissing() throws {
+        let probe = try decodeDoubleIfPresentProbe(#"{ }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeDoubleFlexibleIfPresent — 명시적 null 이면 nil 을 반환한다")
+    func doubleFlexibleIfPresentReturnsNilWhenNull() throws {
+        let probe = try decodeDoubleIfPresentProbe(#"{ "value": null }"#)
+        #expect(probe.value == nil)
+    }
+
+    @Test("decodeDoubleFlexibleIfPresent — Bool 등 처리 불가 타입이면 nil 을 반환한다")
+    func doubleFlexibleIfPresentReturnsNilOnUnhandledType() throws {
+        let probe = try decodeDoubleIfPresentProbe(#"{ "value": true }"#)
+        #expect(probe.value == nil)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/MyStudyGroupsPageDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/MyStudyGroupsPageDTOTests.swift
@@ -1,0 +1,181 @@
+//
+//  MyStudyGroupsPageDTOTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import Testing
+import ActivityDomain
+@testable import ActivityData
+
+// MARK: - Helpers
+
+private func decodePage(_ json: String) throws -> MyStudyGroupsPageDTO {
+    try JSONDecoder().decode(MyStudyGroupsPageDTO.self, from: Data(json.utf8))
+}
+
+/// 단일 스터디 그룹 상세 JSON (페이지 항목용). part/createdAt 고정.
+private func makeGroupJSON(groupId: String = "\"10\"", name: String = "\"iOS 1팀\"") -> String {
+    """
+    {
+        "groupId": \(groupId),
+        "name": \(name),
+        "part": "IOS",
+        "createdAt": "2026-05-11T09:30:00Z",
+        "memberCount": 1,
+        "schools": [],
+        "mentors": [ { "challengerId": "1", "memberId": "1", "name": "재원" } ],
+        "members": []
+    }
+    """
+}
+
+@Suite("MyStudyGroupsPageDTO — 디코딩/매핑")
+struct MyStudyGroupsPageDTOTests {
+
+    // MARK: - cursor 래핑 포맷
+
+    @Test("cursor 래핑 포맷 — content/nextCursor/hasNext 를 디코딩한다")
+    func decodesCursorWrappedFormat() throws {
+        let json = """
+        {
+            "cursor": {
+                "content": [\(makeGroupJSON())],
+                "nextCursor": "cursor-2",
+                "hasNext": true
+            }
+        }
+        """
+        let dto = try decodePage(json)
+
+        #expect(dto.studyGroups.count == 1)
+        #expect(dto.studyGroups.first?.groupId == "10")
+        #expect(dto.nextCursor == "cursor-2")
+        #expect(dto.hasNext == true)
+    }
+
+    @Test("cursor 래핑 포맷 — nextCursor 가 숫자로 와도 String 으로 디코딩한다")
+    func decodesCursorWrappedNumericCursor() throws {
+        let json = """
+        { "cursor": { "content": [], "nextCursor": 42, "hasNext": false } }
+        """
+        let dto = try decodePage(json)
+
+        #expect(dto.nextCursor == "42")
+        #expect(dto.hasNext == false)
+    }
+
+    // MARK: - content 키 직접 포함 (flat) 포맷
+
+    @Test("flat content 포맷 — content/nextCursor/hasNext 를 디코딩한다")
+    func decodesFlatContentFormat() throws {
+        let json = """
+        {
+            "content": [\(makeGroupJSON()), \(makeGroupJSON(groupId: "\"11\"", name: "\"iOS 2팀\""))],
+            "nextCursor": "next-1",
+            "hasNext": true
+        }
+        """
+        let dto = try decodePage(json)
+
+        #expect(dto.studyGroups.count == 2)
+        #expect(dto.nextCursor == "next-1")
+        #expect(dto.hasNext == true)
+    }
+
+    @Test("flat content 포맷 — hasNext 가 String 으로 와도 Bool 로 디코딩한다")
+    func decodesFlatContentStringHasNext() throws {
+        let json = """
+        { "content": [\(makeGroupJSON())], "nextCursor": null, "hasNext": "true" }
+        """
+        let dto = try decodePage(json)
+
+        #expect(dto.nextCursor == nil)
+        #expect(dto.hasNext == true)
+    }
+
+    // MARK: - studyGroups 키 직접 포함 (최종 fallback) 포맷
+
+    @Test("studyGroups 직접 포맷 — studyGroups/nextCursor/hasNext 를 디코딩한다")
+    func decodesDirectStudyGroupsFormat() throws {
+        let json = """
+        {
+            "studyGroups": [\(makeGroupJSON())],
+            "nextCursor": "tail",
+            "hasNext": false
+        }
+        """
+        let dto = try decodePage(json)
+
+        #expect(dto.studyGroups.count == 1)
+        #expect(dto.nextCursor == "tail")
+        #expect(dto.hasNext == false)
+    }
+
+    @Test("인식 가능한 키가 없으면 빈 목록 + 기본값으로 디코딩한다")
+    func decodesEmptyWhenNoRecognizedKeys() throws {
+        let dto = try decodePage("{}")
+
+        #expect(dto.studyGroups.isEmpty)
+        #expect(dto.nextCursor == nil)
+        #expect(dto.hasNext == false)
+    }
+
+    @Test("studyGroups 직접 포맷 — 빈 배열을 빈 목록으로 디코딩한다")
+    func decodesEmptyStudyGroupsArray() throws {
+        let dto = try decodePage(#"{ "studyGroups": [], "hasNext": false }"#)
+        #expect(dto.studyGroups.isEmpty)
+    }
+
+    // MARK: - Encodable round-trip
+
+    @Test("custom encode 후 다시 디코딩하면 동일한 DTO 가 복원된다")
+    func encodeRoundTrip() throws {
+        let original = try decodePage("""
+        {
+            "studyGroups": [\(makeGroupJSON())],
+            "nextCursor": "tail",
+            "hasNext": true
+        }
+        """)
+        let restored = try JSONDecoder().decode(
+            MyStudyGroupsPageDTO.self,
+            from: JSONEncoder().encode(original)
+        )
+        #expect(restored == original)
+    }
+
+    // MARK: - toDomain
+
+    @Test("toDomain — content/hasNext/nextCursor 를 도메인 페이지로 매핑한다")
+    func toDomainMapsPage() throws {
+        let json = """
+        {
+            "cursor": {
+                "content": [\(makeGroupJSON())],
+                "nextCursor": "cursor-2",
+                "hasNext": true
+            }
+        }
+        """
+        let page = try decodePage(json).toDomain()
+
+        #expect(page.content.count == 1)
+        #expect(page.content.first?.serverID == "10")
+        #expect(page.content.first?.name == "iOS 1팀")
+        #expect(page.content.first?.part == .front(type: .ios))
+        #expect(page.hasNext == true)
+        #expect(page.nextCursor == "cursor-2")
+    }
+
+    @Test("toDomain — 빈 페이지는 빈 content 와 nil cursor 로 매핑된다")
+    func toDomainMapsEmptyPage() throws {
+        let page = try decodePage("{}").toDomain()
+
+        #expect(page.content.isEmpty)
+        #expect(page.hasNext == false)
+        #expect(page.nextCursor == nil)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/StudyGroupDetailDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/StudyGroupDetailDTOTests.swift
@@ -1,0 +1,316 @@
+//
+//  StudyGroupDetailDTOTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import Testing
+import ActivityDomain
+import UMCFoundation
+@testable import ActivityData
+
+// MARK: - Helpers
+
+private func decodeDetail(_ json: String) throws -> StudyGroupDetailDTO {
+    try JSONDecoder().decode(StudyGroupDetailDTO.self, from: Data(json.utf8))
+}
+
+private func makeFullDetailJSON(
+    groupId: String = "\"10\"",
+    part: String = "\"IOS\"",
+    createdAt: String = "2026-05-11T09:30:00Z"
+) -> String {
+    """
+    {
+        "groupId": \(groupId),
+        "name": "iOS 1팀",
+        "part": \(part),
+        "partDisplayName": "iOS",
+        "schools": [
+            {
+                "schoolId": "100",
+                "schoolName": "한성대학교",
+                "logoImageId": "200",
+                "totalStudyGroupCount": 3,
+                "totalMemberCount": 24
+            }
+        ],
+        "createdAt": "\(createdAt)",
+        "memberCount": 5,
+        "mentors": [
+            {
+                "challengerId": "1001",
+                "memberId": "2001",
+                "name": "재원",
+                "profileImageUrl": "https://cdn.umc.it/p/1001.png",
+                "bestWorkbookPoint": 90
+            }
+        ],
+        "members": [
+            {
+                "challengerId": "1002",
+                "memberId": "2002",
+                "name": "의재",
+                "profileImageUrl": null,
+                "bestWorkbookPoint": 80
+            },
+            {
+                "challengerId": "1003",
+                "memberId": "2003",
+                "name": "민수",
+                "profileImageUrl": "",
+                "bestWorkbookPoint": null
+            }
+        ]
+    }
+    """
+}
+
+@Suite("StudyGroupDetailDTO — 디코딩/매핑")
+struct StudyGroupDetailDTOTests {
+
+    // MARK: - Decoding (happy path)
+
+    @Test("전체 JSON 의 모든 필드를 정확히 디코딩한다")
+    func decodesFullJSON() throws {
+        let dto = try decodeDetail(makeFullDetailJSON())
+
+        #expect(dto.groupId == "10")
+        #expect(dto.name == "iOS 1팀")
+        #expect(dto.part == "IOS")
+        #expect(dto.partDisplayName == "iOS")
+        #expect(dto.createdAt == "2026-05-11T09:30:00Z")
+        #expect(dto.memberCount == 5)
+        #expect(dto.schools.count == 1)
+        #expect(dto.mentors.count == 1)
+        #expect(dto.members.count == 2)
+    }
+
+    // MARK: - Decoding (server contract: number vs string IDs)
+
+    @Test("groupId 가 JSON 숫자로 와도 String 으로 디코딩한다")
+    func decodesGroupIdAsNumber() throws {
+        let dto = try decodeDetail(makeFullDetailJSON(groupId: "10"))
+        #expect(dto.groupId == "10")
+    }
+
+    @Test("groupId 가 JSON 문자열로 와도 동일한 String 으로 디코딩한다")
+    func decodesGroupIdAsString() throws {
+        let dto = try decodeDetail(makeFullDetailJSON(groupId: "\"10\""))
+        #expect(dto.groupId == "10")
+    }
+
+    @Test("schoolId/logoImageId/challengerId/memberId 가 숫자로 와도 String 으로 디코딩한다")
+    func decodesNestedIdsAsNumbers() throws {
+        let json = """
+        {
+            "groupId": 10,
+            "name": "g",
+            "part": "IOS",
+            "schools": [
+                { "schoolId": 100, "schoolName": "s", "logoImageId": 200,
+                  "totalStudyGroupCount": 1, "totalMemberCount": 2 }
+            ],
+            "createdAt": "2026-05-11T09:30:00Z",
+            "memberCount": 1,
+            "mentors": [
+                { "challengerId": 1001, "memberId": 2001, "name": "m" }
+            ],
+            "members": []
+        }
+        """
+        let dto = try decodeDetail(json)
+
+        #expect(dto.schools.first?.schoolId == "100")
+        #expect(dto.schools.first?.logoImageId == "200")
+        #expect(dto.mentors.first?.challengerId == "1001")
+        #expect(dto.mentors.first?.memberId == "2001")
+    }
+
+    // MARK: - Decoding (defaults / missing / null)
+
+    @Test("거의 모든 필드가 없어도 기본값으로 안전하게 디코딩한다")
+    func decodesWithDefaultsWhenFieldsMissing() throws {
+        let dto = try decodeDetail("{}")
+
+        #expect(dto.groupId == "")
+        #expect(dto.name == "")
+        #expect(dto.part == "")
+        #expect(dto.partDisplayName == nil)
+        #expect(dto.schools.isEmpty)
+        #expect(dto.createdAt == "")
+        #expect(dto.memberCount == 0)
+        #expect(dto.mentors.isEmpty)
+        #expect(dto.members.isEmpty)
+    }
+
+    @Test("partDisplayName 이 null 이면 nil 로 디코딩한다")
+    func decodesNullPartDisplayNameAsNil() throws {
+        let json = """
+        { "groupId": "1", "name": "g", "part": "IOS", "partDisplayName": null,
+          "createdAt": "2026-05-11T09:30:00Z", "memberCount": 0,
+          "mentors": [], "members": [] }
+        """
+        let dto = try decodeDetail(json)
+        #expect(dto.partDisplayName == nil)
+    }
+
+    @Test("mentors 키가 없고 legacy leader 단일 객체만 오면 mentors 배열로 흡수한다")
+    func decodesLegacyLeaderIntoMentors() throws {
+        let json = """
+        {
+            "groupId": "1",
+            "name": "g",
+            "part": "IOS",
+            "createdAt": "2026-05-11T09:30:00Z",
+            "memberCount": 1,
+            "leader": { "challengerId": "1001", "memberId": "2001", "name": "리더" },
+            "members": []
+        }
+        """
+        let dto = try decodeDetail(json)
+
+        #expect(dto.mentors.count == 1)
+        #expect(dto.mentors.first?.name == "리더")
+    }
+
+    @Test("mentors 와 leader 모두 없으면 mentors 는 빈 배열이다")
+    func decodesEmptyMentorsWhenNoMentorKeys() throws {
+        let json = """
+        { "groupId": "1", "name": "g", "part": "IOS",
+          "createdAt": "2026-05-11T09:30:00Z", "memberCount": 0, "members": [] }
+        """
+        let dto = try decodeDetail(json)
+        #expect(dto.mentors.isEmpty)
+    }
+
+    // MARK: - StudyGroupChallengerDTO bestWorkbookPoint
+
+    @Test("bestWorkbookPoint 가 숫자 String 으로 와도 Int 로 디코딩한다")
+    func decodesBestWorkbookPointAsString() throws {
+        let json = """
+        { "groupId": "1", "name": "g", "part": "IOS",
+          "createdAt": "2026-05-11T09:30:00Z", "memberCount": 1,
+          "mentors": [ { "challengerId": "1", "memberId": "1", "name": "m",
+                         "bestWorkbookPoint": "70" } ],
+          "members": [] }
+        """
+        let dto = try decodeDetail(json)
+        #expect(dto.mentors.first?.bestWorkbookPoint == 70)
+    }
+
+    // MARK: - Encodable round-trip (custom encode)
+
+    @Test("custom encode 후 다시 디코딩하면 동일한 DTO 가 복원된다")
+    func encodeRoundTripPreservesValues() throws {
+        let original = try decodeDetail(makeFullDetailJSON())
+        let encoded = try JSONEncoder().encode(original)
+        let restored = try JSONDecoder().decode(StudyGroupDetailDTO.self, from: encoded)
+
+        #expect(restored == original)
+    }
+
+    // MARK: - toDomain (mapping)
+
+    @Test("toDomain — serverID/name/createdDate 와 mentor/member 역할이 올바르게 매핑된다")
+    func toDomainMapsCoreFields() throws {
+        let dto = try decodeDetail(makeFullDetailJSON())
+        let info = dto.toDomain()
+
+        #expect(info.serverID == "10")
+        #expect(info.name == "iOS 1팀")
+        #expect(info.part == .front(type: .ios))
+        #expect(info.mentors.count == 1)
+        #expect(info.members.count == 2)
+        #expect(info.mentors.first?.role == .leader)
+        #expect(info.members.allSatisfy { $0.role == .member })
+    }
+
+    @Test(
+        "toDomain — 알려진 part 문자열을 UMCPartType 으로 매핑한다",
+        arguments: [
+            ("\"IOS\"", UMCPartType.front(type: .ios)),
+            ("\"ANDROID\"", UMCPartType.front(type: .android)),
+            ("\"WEB\"", UMCPartType.front(type: .web)),
+            ("\"SPRINGBOOT\"", UMCPartType.server(type: .spring)),
+            ("\"PLAN\"", UMCPartType.pm),
+            ("\"DESIGN\"", UMCPartType.design)
+        ]
+    )
+    func toDomainMapsKnownPart(partJSON: String, expected: UMCPartType) throws {
+        let dto = try decodeDetail(makeFullDetailJSON(part: partJSON))
+        #expect(dto.toDomain().part == expected)
+    }
+
+    @Test("toDomain — 알 수 없는 part 문자열은 .front(.ios) 로 폴백한다")
+    func toDomainFallsBackToIOSOnUnknownPart() throws {
+        let dto = try decodeDetail(makeFullDetailJSON(part: "\"QUANTUM\""))
+        #expect(dto.toDomain().part == .front(type: .ios))
+    }
+
+    @Test("toDomain — challengerID/memberID 가 String 으로 매핑되고 university 가 학교명으로 채워진다")
+    func toDomainMapsIdsAndUniversity() throws {
+        let dto = try decodeDetail(makeFullDetailJSON())
+        let mentor = try #require(dto.toDomain().mentors.first)
+
+        #expect(mentor.serverID == "2001")
+        #expect(mentor.challengerID == "1001")
+        #expect(mentor.memberID == "2001")
+        #expect(mentor.university == "한성대학교")
+        #expect(mentor.bestWorkbookPoint == 90)
+    }
+
+    @Test("toDomain — 빈 profileImageURL 은 nil 로, 유효한 URL 은 그대로 매핑한다")
+    func toDomainNormalizesProfileImageURL() throws {
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain()
+
+        #expect(info.mentors.first?.profileImageURL == "https://cdn.umc.it/p/1001.png")
+        // members[0]: profileImageUrl == null → nil
+        #expect(info.members[0].profileImageURL == nil)
+        // members[1]: profileImageUrl == "" → nil
+        #expect(info.members[1].profileImageURL == nil)
+    }
+
+    @Test("toDomain — bestWorkbookPoint 가 없으면 0 으로 폴백한다")
+    func toDomainFallsBackBestWorkbookPointToZero() throws {
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain()
+        // members[1].bestWorkbookPoint == null → 0
+        #expect(info.members[1].bestWorkbookPoint == 0)
+    }
+
+    @Test("toDomain — bestWorkbookPointByMemberID 오버라이드가 DTO 값보다 우선한다")
+    func toDomainOverridesBestWorkbookPointByMemberID() throws {
+        let info = try decodeDetail(makeFullDetailJSON())
+            .toDomain(bestWorkbookPointByMemberID: ["2001": 100])
+        #expect(info.mentors.first?.bestWorkbookPoint == 100)
+    }
+
+    @Test("toDomain — name 이 비어 있으면 defaultGroupName 으로 대체한다")
+    func toDomainUsesDefaultGroupNameWhenNameEmpty() throws {
+        let json = """
+        { "groupId": "1", "name": "", "part": "IOS",
+          "createdAt": "2026-05-11T09:30:00Z", "memberCount": 0,
+          "mentors": [], "members": [] }
+        """
+        let info = try decodeDetail(json).toDomain(defaultGroupName: "기본 그룹명")
+        #expect(info.name == "기본 그룹명")
+    }
+
+    // MARK: - toDomain (date parsing)
+
+    @Test("toDomain — fractional seconds 가 없는 ISO8601 createdAt 을 파싱한다")
+    func toDomainParsesISO8601WithoutFractionalSeconds() throws {
+        let dto = try decodeDetail(makeFullDetailJSON(createdAt: "2026-05-11T09:30:00Z"))
+        let expected = Date(timeIntervalSince1970: 1_778_491_800) // 2026-05-11T09:30:00Z
+        #expect(dto.toDomain().createdDate == expected)
+    }
+
+    @Test("toDomain — fractional seconds 가 있는 ISO8601 createdAt 을 파싱한다")
+    func toDomainParsesISO8601WithFractionalSeconds() throws {
+        let dto = try decodeDetail(makeFullDetailJSON(createdAt: "2026-05-11T09:30:00.000Z"))
+        let expected = Date(timeIntervalSince1970: 1_778_491_800)
+        #expect(dto.toDomain().createdDate == expected)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/WeeklyCurriculumOptionDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/WeeklyCurriculumOptionDTOTests.swift
@@ -1,0 +1,158 @@
+//
+//  WeeklyCurriculumOptionDTOTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import Testing
+import ActivityDomain
+@testable import ActivityData
+
+// MARK: - Helpers
+
+private func decodeOption(_ json: String) throws -> WeeklyCurriculumOptionDTO {
+    try JSONDecoder().decode(WeeklyCurriculumOptionDTO.self, from: Data(json.utf8))
+}
+
+private func decodeOptionsResponse(_ json: String) throws -> WeeklyCurriculumOptionsResponseDTO {
+    try JSONDecoder().decode(WeeklyCurriculumOptionsResponseDTO.self, from: Data(json.utf8))
+}
+
+@Suite("WeeklyCurriculumOptionDTO — 디코딩/매핑")
+struct WeeklyCurriculumOptionDTOTests {
+
+    // MARK: - Single DTO Decoding
+
+    @Test("단일 옵션 JSON 의 모든 필드를 디코딩한다")
+    func decodesSingleOption() throws {
+        let dto = try decodeOption(#"""
+        { "weeklyCurriculumId": "5001", "weekNo": "1", "title": "1주차" }
+        """#)
+
+        #expect(dto.weeklyCurriculumId == "5001")
+        #expect(dto.weekNo == "1")
+        #expect(dto.title == "1주차")
+    }
+
+    @Test("weeklyCurriculumId 와 weekNo 가 JSON 숫자로 와도 String 으로 디코딩한다")
+    func decodesNumericIdsAsString() throws {
+        let dto = try decodeOption(#"""
+        { "weeklyCurriculumId": 5001, "weekNo": 1, "title": "1주차" }
+        """#)
+
+        #expect(dto.weeklyCurriculumId == "5001")
+        #expect(dto.weekNo == "1")
+    }
+
+    @Test("필드가 없으면 빈 문자열 기본값으로 디코딩한다")
+    func decodesWithDefaults() throws {
+        let dto = try decodeOption("{}")
+
+        #expect(dto.weeklyCurriculumId == "")
+        #expect(dto.weekNo == "")
+        #expect(dto.title == "")
+    }
+
+    @Test("custom encode 후 다시 디코딩하면 동일한 DTO 가 복원된다")
+    func encodeRoundTrip() throws {
+        let original = try decodeOption(#"""
+        { "weeklyCurriculumId": "5001", "weekNo": "1", "title": "1주차" }
+        """#)
+        let restored = try JSONDecoder().decode(
+            WeeklyCurriculumOptionDTO.self,
+            from: JSONEncoder().encode(original)
+        )
+        #expect(restored == original)
+    }
+
+    // MARK: - toDomain (single)
+
+    @Test("toDomain — weeklyCurriculumId/weekNo/title 을 도메인 모델로 매핑한다")
+    func toDomainMapsFields() throws {
+        let option = try decodeOption(#"""
+        { "weeklyCurriculumId": "5001", "weekNo": "2", "title": "2주차 미션" }
+        """#).toDomain()
+
+        #expect(option.weeklyCurriculumId == "5001")
+        #expect(option.weekNo == "2")
+        #expect(option.title == "2주차 미션")
+        #expect(option.id == "5001")
+    }
+
+    // MARK: - Response Wrapper Decoding (multi-format)
+
+    @Test("응답 — 최상위 배열 포맷을 옵션 목록으로 디코딩한다")
+    func decodesTopLevelArray() throws {
+        let response = try decodeOptionsResponse(#"""
+        [
+            { "weeklyCurriculumId": "1", "weekNo": "1", "title": "1주차" },
+            { "weeklyCurriculumId": "2", "weekNo": "2", "title": "2주차" }
+        ]
+        """#)
+
+        #expect(response.options.count == 2)
+        #expect(response.options.map(\.weekNo) == ["1", "2"])
+    }
+
+    @Test("응답 — content 키 래핑 포맷을 옵션 목록으로 디코딩한다")
+    func decodesContentKeyWrapped() throws {
+        let response = try decodeOptionsResponse(#"""
+        { "content": [ { "weeklyCurriculumId": "1", "weekNo": "1", "title": "1주차" } ] }
+        """#)
+
+        #expect(response.options.count == 1)
+        #expect(response.options.first?.weeklyCurriculumId == "1")
+    }
+
+    @Test("응답 — weeklyCurriculums 키 포맷을 옵션 목록으로 디코딩한다")
+    func decodesWeeklyCurriculumsKey() throws {
+        let response = try decodeOptionsResponse(#"""
+        { "weeklyCurriculums": [ { "weeklyCurriculumId": "9", "weekNo": "3", "title": "3주차" } ] }
+        """#)
+
+        #expect(response.options.count == 1)
+        #expect(response.options.first?.weekNo == "3")
+    }
+
+    @Test("응답 — 인식 가능한 키가 없으면 빈 옵션 목록으로 디코딩한다")
+    func decodesEmptyWhenNoRecognizedKey() throws {
+        let response = try decodeOptionsResponse(#"{ "other": [] }"#)
+        #expect(response.options.isEmpty)
+    }
+
+    @Test("응답 — 빈 배열을 빈 옵션 목록으로 디코딩한다")
+    func decodesEmptyArray() throws {
+        let response = try decodeOptionsResponse("[]")
+        #expect(response.options.isEmpty)
+    }
+
+    // MARK: - toDomain (list)
+
+    @Test("toDomain — 응답 목록을 도메인 모델 배열로 변환한다")
+    func toDomainMapsList() throws {
+        let options = try decodeOptionsResponse(#"""
+        { "content": [
+            { "weeklyCurriculumId": "1", "weekNo": "1", "title": "1주차" },
+            { "weeklyCurriculumId": "2", "weekNo": "2", "title": "2주차" }
+        ] }
+        """#).toDomain()
+
+        #expect(options.count == 2)
+        #expect(options.map(\.weeklyCurriculumId) == ["1", "2"])
+        #expect(options.map(\.title) == ["1주차", "2주차"])
+    }
+
+    @Test("응답 — custom encode 는 content 키로 직렬화되어 round-trip 된다")
+    func responseEncodeRoundTrip() throws {
+        let original = try decodeOptionsResponse(#"""
+        { "content": [ { "weeklyCurriculumId": "1", "weekNo": "1", "title": "1주차" } ] }
+        """#)
+        let restored = try JSONDecoder().decode(
+            WeeklyCurriculumOptionsResponseDTO.self,
+            from: JSONEncoder().encode(original)
+        )
+        #expect(restored == original)
+    }
+}


### PR DESCRIPTION
resolves #811

## ✨ PR 유형

♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="1512" height="991" alt="스크린샷 2026-06-10 오전 10 48 03" src="https://github.com/user-attachments/assets/d1b836dc-23f4-4b9c-867d-ddc99b8de383" />
<img width="1512" height="991" alt="스크린샷 2026-06-10 오전 10 48 12" src="https://github.com/user-attachments/assets/0b6d0453-17b2-4f77-ba11-9c29d058cc29" />


## 🛠️ 작업내용

`StudyRepositoryProtocol`(#797) 반환 타입에 매핑할 v2 Study 응답 DTO를 `ActivityData` 모듈에 이식했습니다. (UMCApp 첫 Response DTO 세트)

- **Study 응답 DTO 4종 + 공유 디코딩 헬퍼** 신규 (`Data/Sources/DTOs/`)
  - `StudyGroupDetailDTO` → `StudyGroupInfo`
  - `CurriculumDTO` → `CurriculumProgressModel` / `[MissionCardModel]`
  - `WeeklyCurriculumOptionDTO` → `[WeeklyCurriculumOption]`
  - `MyStudyGroupsPageDTO` → `StudyGroupDetailsPage`
- 전 DTO custom `init(from:)` + `encode(to:)` (synthesized Codable 금지), 공유 `decodeIntFlexible`/`decodeFlexibleString` 헬퍼로 서버의 String/Int 혼재 응답 디코딩
- 서버 응답 식별자(groupId·challengerId·memberId·weeklyCurriculumId·nextCursor 등)는 전 레이어 `String` 통일
- `ActivityData` 테스트 타겟 활성화(`includesDataTests`) + Swift Testing 디코딩/매핑 테스트 추가

## 📋 추후 진행 상황

- StudyRouter(#813) / StudyRepository(#814) 구현 — 본 DTO를 입출력 타입으로 사용
- 공유 `KeyedDecodingContainer` 헬퍼는 2번째 Feature가 DTO 필요 시 Core 모듈로 승격 검토

## 📌 리뷰 포인트

- `MyStudyGroupsPageDTO`: 페이지 content를 풀 `StudyGroupInfo`(`StudyGroupDetailDTO`)로 디코딩하도록 설계 — 실제 목록 엔드포인트 응답이 경량 형태면 재논의 필요
- `CurriculumDTO`: Protocol이 두 타입을 독립 반환하므로 `toCurriculumProgress(part:now:)` / `toMissionCards(...)`로 분리. `completedCount` 경계(`now == endsAt`은 미완료) + 미션 상태 시간영역 로직
- `StudyGroupDetailDTO`: 알 수 없는 `part` 문자열 → `.front(.ios)` fallback 정책
- `ActivityData.swift`: 컴파일 불가했던 `ActivityRepository: ActivityUseCase` 스텁(미존재 프로토콜 참조)을 `enum ActivityData {}` 네임스페이스로 대체

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
