### PR TITLE
♻️ [Refactor] StudyRouter 이식 (Moya TargetType) — 조회 case

### DIFF
--- a/UMCApp/Features/Activity/Data/Sources/DTOs/CurriculumOverviewQuery.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/CurriculumOverviewQuery.swift
@@ -1,0 +1,30 @@
+//
+//  CurriculumOverviewQuery.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+
+/// `GET /api/v2/curriculums/overview` 쿼리 파라미터.
+///
+/// 서버 식별자 `gisuId` 는 전 레이어 `String` 통일 규칙을 따릅니다.
+/// `weekNo` 는 주차 번호(클라이언트 입력)로 미지정 시 `nil`.
+struct CurriculumOverviewQuery {
+    let gisuId: String
+    let part: String
+    let weekNo: Int?
+
+    /// Moya `URLEncoding.queryString` 직렬화용 파라미터 사전.
+    var toParameters: [String: Any] {
+        var parameters: [String: Any] = [
+            "gisuId": gisuId,
+            "part": part
+        ]
+        if let weekNo {
+            parameters["weekNo"] = weekNo
+        }
+        return parameters
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/MyStudyGroupsQuery.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/MyStudyGroupsQuery.swift
@@ -1,0 +1,28 @@
+//
+//  MyStudyGroupsQuery.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+
+/// `GET /api/v1/study-groups/managed` 페이지네이션 쿼리 파라미터.
+///
+/// `cursor` 는 첫 페이지에서 `nil`. `cursor`/`size` 는 페이지네이션 정수이며
+/// 서버 식별자가 아니므로 `Int` 를 유지합니다.
+struct MyStudyGroupsQuery {
+    let cursor: Int?
+    let size: Int
+
+    /// Moya `URLEncoding.queryString` 직렬화용 파라미터 사전.
+    var toParameters: [String: Any] {
+        var parameters: [String: Any] = [
+            "size": size
+        ]
+        if let cursor {
+            parameters["cursor"] = cursor
+        }
+        return parameters
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
@@ -1,0 +1,75 @@
+//
+//  StudyRouter.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import Moya
+import CoreNetwork
+internal import Alamofire
+
+/// Study(Activity) Feature 조회 API 라우터.
+///
+/// 조회 계열 case 만 정의합니다. CRUD case(생성/수정/삭제/멤버·멘토/일정 연결)는
+/// 후속 작업에서 동일 enum 에 case 추가만으로 확장합니다.
+enum StudyRouter {
+    /// 커리큘럼 개요 조회 — `GET /api/v2/curriculums/overview`
+    case getCurriculum(query: CurriculumOverviewQuery)
+    /// 운영 스터디 그룹 페이지 조회 — `GET /api/v1/study-groups/managed`
+    case getMyStudyGroups(query: MyStudyGroupsQuery)
+    /// 단일 스터디 그룹 상세 조회 — `GET /api/v1/study-groups/{groupId}`
+    case getStudyGroupDetail(groupId: String)
+    /// 멤버 프로필 조회 (resolveChallengerId 용) — `GET /api/v1/member/profile/{memberId}`
+    case getMemberProfile(memberId: String)
+}
+
+extension StudyRouter: BaseTargetType {
+
+    // MARK: - Path
+
+    var path: String {
+        switch self {
+        case .getCurriculum:
+            return "/api/v2/curriculums/overview"
+        case .getMyStudyGroups:
+            return "/api/v1/study-groups/managed"
+        case .getStudyGroupDetail(let groupId):
+            return "/api/v1/study-groups/\(groupId)"
+        case .getMemberProfile(let memberId):
+            return "/api/v1/member/profile/\(memberId)"
+        }
+    }
+
+    // MARK: - Method
+
+    var method: Moya.Method {
+        switch self {
+        case .getCurriculum,
+             .getMyStudyGroups,
+             .getStudyGroupDetail,
+             .getMemberProfile:
+            return .get
+        }
+    }
+
+    // MARK: - Task
+
+    var task: Task {
+        switch self {
+        case .getCurriculum(let query):
+            return .requestParameters(
+                parameters: query.toParameters,
+                encoding: URLEncoding.queryString
+            )
+        case .getMyStudyGroups(let query):
+            return .requestParameters(
+                parameters: query.toParameters,
+                encoding: URLEncoding.queryString
+            )
+        case .getStudyGroupDetail, .getMemberProfile:
+            return .requestPlain
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
@@ -14,7 +14,10 @@ internal import Alamofire
 ///
 /// 조회 계열 case 만 정의합니다. CRUD case(생성/수정/삭제/멤버·멘토/일정 연결)는
 /// 후속 작업에서 동일 enum 에 case 추가만으로 확장합니다.
-enum StudyRouter {
+///
+/// 연관값(Query DTO·식별자 String)이 모두 `Sendable` 이므로 라우터도 `Sendable`.
+/// 동시성 경계를 넘어 안전하게 전달되며, 테스트의 파라미터화(`@Test(arguments:)`)도 가능.
+enum StudyRouter: Sendable {
     /// 커리큘럼 개요 조회 — `GET /api/v2/curriculums/overview`
     case getCurriculum(query: CurriculumOverviewQuery)
     /// 운영 스터디 그룹 페이지 조회 — `GET /api/v1/study-groups/managed`

--- a/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
@@ -48,22 +48,19 @@ struct StudyRouterTests {
 
     // MARK: - Method
 
-    @Test("모든 조회 case 의 HTTP method 는 GET 이다")
-    func methodIsGetForAllCases() {
-        // Given
-        let routers: [StudyRouter] = [
-            .getCurriculum(
+    @Test(
+        "모든 조회 case 의 HTTP method 는 GET 이다",
+        arguments: [
+            StudyRouter.getCurriculum(
                 query: CurriculumOverviewQuery(gisuId: "7", part: "BE", weekNo: nil)
             ),
-            .getMyStudyGroups(query: MyStudyGroupsQuery(cursor: 10, size: 20)),
-            .getStudyGroupDetail(groupId: "42"),
-            .getMemberProfile(memberId: "99")
+            StudyRouter.getMyStudyGroups(query: MyStudyGroupsQuery(cursor: 10, size: 20)),
+            StudyRouter.getStudyGroupDetail(groupId: "42"),
+            StudyRouter.getMemberProfile(memberId: "99")
         ]
-
-        // Then
-        for router in routers {
-            #expect(router.method == .get)
-        }
+    )
+    func methodIsGet(router: StudyRouter) {
+        #expect(router.method == .get)
     }
 
     // MARK: - Task
@@ -106,16 +103,12 @@ struct StudyRouterTests {
         // Given
         let router = StudyRouter.getStudyGroupDetail(groupId: "42")
 
-        // When
-        let isPlain: Bool
-        if case .requestPlain = router.task {
-            isPlain = true
-        } else {
-            isPlain = false
-        }
-
         // Then
-        #expect(isPlain)
+        if case .requestPlain = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestPlain 여야 함 — 실제: \(router.task)")
+        }
     }
 
     @Test("getMemberProfile 의 task 는 requestPlain 이다")
@@ -123,16 +116,12 @@ struct StudyRouterTests {
         // Given
         let router = StudyRouter.getMemberProfile(memberId: "99")
 
-        // When
-        let isPlain: Bool
-        if case .requestPlain = router.task {
-            isPlain = true
-        } else {
-            isPlain = false
-        }
-
         // Then
-        #expect(isPlain)
+        if case .requestPlain = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestPlain 여야 함 — 실제: \(router.task)")
+        }
     }
 
     // MARK: - CurriculumOverviewQuery.toParameters
@@ -164,6 +153,20 @@ struct StudyRouterTests {
         #expect(parameters["gisuId"] as? String == "7")
     }
 
+    @Test("CurriculumOverviewQuery 는 part 가 빈 문자열이어도 파라미터에 그대로 포함한다 (경계값)")
+    func curriculumQueryIncludesEmptyPart() {
+        // Given — part 빈 문자열 경계값. 서버 필수 필드 빈 값 허용 여부는 미확정이라
+        // 추측 기반 가드(assert) 대신 현재 DTO 계약(가공 없이 그대로 전달)을 박제한다.
+        let query = CurriculumOverviewQuery(gisuId: "7", part: "", weekNo: nil)
+
+        // When
+        let parameters = query.toParameters
+
+        // Then
+        #expect(parameters["part"] as? String == "")
+        #expect(parameters.count == 2)
+    }
+
     // MARK: - MyStudyGroupsQuery.toParameters
 
     @Test("MyStudyGroupsQuery 는 cursor 가 있으면 파라미터에 포함한다")
@@ -192,5 +195,20 @@ struct StudyRouterTests {
         #expect(parameters.count == 1)
         #expect(parameters["cursor"] == nil)
         #expect(parameters["size"] as? Int == 20)
+    }
+
+    @Test("MyStudyGroupsQuery 는 size 가 0 이어도 파라미터에 그대로 포함한다 (경계값)")
+    func myStudyGroupsQueryIncludesZeroSize() {
+        // Given — size: 0 경계값. 서버 size=0 허용 여부가 미확정이라 DTO 레벨
+        // precondition 등 추측 기반 변경 대신 현재 계약(그대로 전달)을 박제한다.
+        // (#814 Repository 이식 전 서버 계약 확인 시 본 테스트를 근거로 정책 결정)
+        let query = MyStudyGroupsQuery(cursor: nil, size: 0)
+
+        // When
+        let parameters = query.toParameters
+
+        // Then
+        #expect(parameters["size"] as? Int == 0)
+        #expect(parameters.count == 1)
     }
 }

--- a/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
@@ -1,0 +1,196 @@
+//
+//  StudyRouterTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/7/26.
+//
+
+import Foundation
+import Testing
+import Moya
+import Alamofire
+@testable import ActivityData
+
+@Suite("StudyRouter — 조회 엔드포인트 매핑 (API 계약)")
+struct StudyRouterTests {
+
+    // MARK: - Helpers
+
+    private func requestParameters(
+        of task: Moya.Task
+    ) -> (parameters: [String: Any], encoding: ParameterEncoding)? {
+        guard case let .requestParameters(parameters, encoding) = task else {
+            return nil
+        }
+        return (parameters, encoding)
+    }
+
+    // MARK: - Path
+
+    @Test("각 case 는 명세된 path 로 매핑된다")
+    func pathMapsEachCase() {
+        // Given
+        let curriculum = StudyRouter.getCurriculum(
+            query: CurriculumOverviewQuery(gisuId: "7", part: "BE", weekNo: 3)
+        )
+        let managed = StudyRouter.getMyStudyGroups(
+            query: MyStudyGroupsQuery(cursor: nil, size: 20)
+        )
+        let detail = StudyRouter.getStudyGroupDetail(groupId: "42")
+        let profile = StudyRouter.getMemberProfile(memberId: "99")
+
+        // Then
+        #expect(curriculum.path == "/api/v2/curriculums/overview")
+        #expect(managed.path == "/api/v1/study-groups/managed")
+        #expect(detail.path == "/api/v1/study-groups/42")
+        #expect(profile.path == "/api/v1/member/profile/99")
+    }
+
+    // MARK: - Method
+
+    @Test("모든 조회 case 의 HTTP method 는 GET 이다")
+    func methodIsGetForAllCases() {
+        // Given
+        let routers: [StudyRouter] = [
+            .getCurriculum(
+                query: CurriculumOverviewQuery(gisuId: "7", part: "BE", weekNo: nil)
+            ),
+            .getMyStudyGroups(query: MyStudyGroupsQuery(cursor: 10, size: 20)),
+            .getStudyGroupDetail(groupId: "42"),
+            .getMemberProfile(memberId: "99")
+        ]
+
+        // Then
+        for router in routers {
+            #expect(router.method == .get)
+        }
+    }
+
+    // MARK: - Task
+
+    @Test("getCurriculum 은 query DTO 를 queryString 으로 인코딩한다")
+    func getCurriculumTaskEncodesQueryString() throws {
+        // Given
+        let router = StudyRouter.getCurriculum(
+            query: CurriculumOverviewQuery(gisuId: "7", part: "BE", weekNo: 3)
+        )
+
+        // When
+        let extracted = try #require(requestParameters(of: router.task))
+
+        // Then
+        #expect(extracted.parameters["gisuId"] as? String == "7")
+        #expect(extracted.parameters["part"] as? String == "BE")
+        #expect(extracted.parameters["weekNo"] as? Int == 3)
+        #expect((extracted.encoding as? URLEncoding)?.destination == .queryString)
+    }
+
+    @Test("getMyStudyGroups 는 query DTO 를 queryString 으로 인코딩한다")
+    func getMyStudyGroupsTaskEncodesQueryString() throws {
+        // Given
+        let router = StudyRouter.getMyStudyGroups(
+            query: MyStudyGroupsQuery(cursor: 10, size: 20)
+        )
+
+        // When
+        let extracted = try #require(requestParameters(of: router.task))
+
+        // Then
+        #expect(extracted.parameters["size"] as? Int == 20)
+        #expect(extracted.parameters["cursor"] as? Int == 10)
+        #expect((extracted.encoding as? URLEncoding)?.destination == .queryString)
+    }
+
+    @Test("getStudyGroupDetail 의 task 는 requestPlain 이다")
+    func getStudyGroupDetailTaskIsPlain() {
+        // Given
+        let router = StudyRouter.getStudyGroupDetail(groupId: "42")
+
+        // When
+        let isPlain: Bool
+        if case .requestPlain = router.task {
+            isPlain = true
+        } else {
+            isPlain = false
+        }
+
+        // Then
+        #expect(isPlain)
+    }
+
+    @Test("getMemberProfile 의 task 는 requestPlain 이다")
+    func getMemberProfileTaskIsPlain() {
+        // Given
+        let router = StudyRouter.getMemberProfile(memberId: "99")
+
+        // When
+        let isPlain: Bool
+        if case .requestPlain = router.task {
+            isPlain = true
+        } else {
+            isPlain = false
+        }
+
+        // Then
+        #expect(isPlain)
+    }
+
+    // MARK: - CurriculumOverviewQuery.toParameters
+
+    @Test("CurriculumOverviewQuery 는 weekNo 가 있으면 파라미터에 포함한다")
+    func curriculumQueryIncludesWeekNoWhenPresent() {
+        // Given
+        let query = CurriculumOverviewQuery(gisuId: "7", part: "BE", weekNo: 5)
+
+        // When
+        let parameters = query.toParameters
+
+        // Then
+        #expect(parameters.count == 3)
+        #expect(parameters["weekNo"] as? Int == 5)
+    }
+
+    @Test("CurriculumOverviewQuery 는 weekNo 가 nil 이면 파라미터에서 제외한다")
+    func curriculumQueryOmitsWeekNoWhenNil() {
+        // Given
+        let query = CurriculumOverviewQuery(gisuId: "7", part: "BE", weekNo: nil)
+
+        // When
+        let parameters = query.toParameters
+
+        // Then
+        #expect(parameters.count == 2)
+        #expect(parameters["weekNo"] == nil)
+        #expect(parameters["gisuId"] as? String == "7")
+    }
+
+    // MARK: - MyStudyGroupsQuery.toParameters
+
+    @Test("MyStudyGroupsQuery 는 cursor 가 있으면 파라미터에 포함한다")
+    func myStudyGroupsQueryIncludesCursorWhenPresent() {
+        // Given
+        let query = MyStudyGroupsQuery(cursor: 15, size: 20)
+
+        // When
+        let parameters = query.toParameters
+
+        // Then
+        #expect(parameters.count == 2)
+        #expect(parameters["cursor"] as? Int == 15)
+        #expect(parameters["size"] as? Int == 20)
+    }
+
+    @Test("MyStudyGroupsQuery 는 cursor 가 nil 이면 파라미터에서 제외한다")
+    func myStudyGroupsQueryOmitsCursorWhenNil() {
+        // Given
+        let query = MyStudyGroupsQuery(cursor: nil, size: 20)
+
+        // When
+        let parameters = query.toParameters
+
+        // Then
+        #expect(parameters.count == 1)
+        #expect(parameters["cursor"] == nil)
+        #expect(parameters["size"] as? Int == 20)
+    }
+}


### PR DESCRIPTION
resolves #813

## ✨ PR 유형

♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="1624" height="991" alt="스크린샷 2026-06-12 오후 9 01 14" src="https://github.com/user-attachments/assets/6b8c1613-df50-4a54-9a11-45c9ff5bb42c" />
<img width="1624" height="991" alt="스크린샷 2026-06-12 오후 9 01 20" src="https://github.com/user-attachments/assets/498ea961-87d3-42cb-841c-f7522336ff64" />


## 🛠️ 작업내용

레거시 `StudyRouter`(단일 Router, 조회+CRUD)의 **조회 계열 case 4종**을 UMCApp `ActivityData`
모듈로 이식했습니다. 먼저 머지된 `AttendanceRouter`(#877)와 동일한 모듈 구조·컨벤션을 따릅니다.

- `StudyRouter`(`BaseTargetType`) — `getCurriculum` / `getMyStudyGroups` /
  `getStudyGroupDetail` / `getMemberProfile`
- Query 파라미터를 `CurriculumOverviewQuery` / `MyStudyGroupsQuery`의 `toParameters`로 캡슐화 —
  Router `task` 내 인라인 딕셔너리 0건
- 서버 식별자 파라미터 `String` 통일(`gisuId`/`groupId`/`memberId`), 페이지네이션·주차
  (`cursor`/`size`/`weekNo`)는 `Int` 유지 — `StudyRepositoryProtocol` 시그니처와 정합
- 단일 path 변수 case는 DTO 없이 `.requestPlain`
- `StudyRouterTests`(Swift Testing) — path/method/task 매핑 + DTO 옵셔널 분기 (10 case)

> CRUD case(생성/수정/삭제/멤버·멘토/일정 연결)는 본 이슈 범위 제외 — 후속(8차)에서 동일 enum 확장.

## 📋 추후 진행 상황

- StudyRouter CRUD case 이식 (8차) — Body DTO + `.requestJSONEncodable`
- `StudyRepository` 구현체 이식 (#814) — 본 Router로 조회 구현 unblock

## 📌 리뷰 포인트

- `Data/Sources/Routers/StudyRouter.swift` — case → path/method/task 매핑 (`AttendanceRouter`와 동일 패턴)
- `Data/Sources/DTOs/*Query.swift` — `toParameters` 옵셔널 키 제외 로직
- **순수 추가 변경** — develop의 `ActivityData.swift` 플레이스홀더 및 `Project.swift`
  (이미 `includesDataTests` 활성)는 미변경

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
