### PR TITLE
♻️ [Refactor] ChallengerAttendanceViewModel 이식 — 출석 액션·상태 로직 UseCase 결선

### DIFF
--- a/UMCApp/Features/Activity/Presentation/Sources/Extensions/Date+HourMinutes.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Extensions/Date+HourMinutes.swift
@@ -1,0 +1,29 @@
+//
+//  Date+HourMinutes.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 6/12/26.
+//
+
+import Foundation
+
+extension Date {
+
+    /// "HH:mm" 24시간제 형식으로 변환 (예: "14:30")
+    ///
+    /// 출석 정책의 마감 시각 표시(`attendanceGuidanceText`)에 사용합니다.
+    func toHourMinutes() -> String {
+        Date.hourMinuteFormatter.string(from: self)
+    }
+}
+
+private extension Date {
+
+    static let hourMinuteFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
@@ -148,17 +148,18 @@ final class ChallengerAttendanceViewModel {
 
     /// 세션 진행 중일 때 주기적으로 상태를 갱신합니다.
     ///
+    /// 진행 중인 세션이 있으면 즉시 1회 갱신한 뒤 간격을 두고 반복하므로,
+    /// 화면 진입 직후 첫 갱신까지 대기 구간이 생기지 않습니다.
     /// `.task` 모디파이어에서 호출하면 뷰 사라질 때 자동 취소됩니다.
     /// 세션 시간 기반으로 진행 중 여부를 판단합니다.
     func startPollingIfNeeded(sessions: [Session]) async {
         while !Task.isCancelled {
             guard hasActiveSession(in: sessions) else { return }
+            await refreshAvailableSchedules()
+            await refreshMyHistory()
             try? await Task.sleep(for: .seconds(
                 PollingConfig.intervalSeconds
             ))
-            guard !Task.isCancelled else { break }
-            await refreshAvailableSchedules()
-            await refreshMyHistory()
         }
     }
 
@@ -176,7 +177,7 @@ final class ChallengerAttendanceViewModel {
     // MARK: - Action
 
     /// GPS 기반 출석 버튼 탭 처리
-    func attendanceBtnTapped(
+    func attendanceButtonTapped(
         userId: UserID,
         session: Session,
         scheduleId: String
@@ -210,9 +211,9 @@ final class ChallengerAttendanceViewModel {
             }
             errorHandler.handle(error, context: .init(
                 feature: "Activity",
-                action: "attendanceBtnTapped",
+                action: "attendanceButtonTapped",
                 retryAction: { [weak self] in
-                    await self?.attendanceBtnTapped(
+                    await self?.attendanceButtonTapped(
                         userId: userId,
                         session: session,
                         scheduleId: scheduleId
@@ -343,7 +344,7 @@ final class ChallengerAttendanceViewModel {
     }
 
     /// 출석 버튼에 표시할 텍스트
-    func buttonStyle(for session: Session) -> String {
+    func buttonTitle(for session: Session) -> String {
         session.buttonTitle(
             isLocationAuthorized: challengerAttendanceUseCase.isLocationAuthorized,
             isInsideGeofence: challengerAttendanceUseCase.isInsideGeofence,

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
@@ -1,0 +1,427 @@
+//
+//  ChallengerAttendanceViewModel.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 6/12/26.
+//
+
+import ActivityDomain
+import Foundation
+import UMCFoundation
+
+/// 챌린저(일반 참여자)의 출석 관련 상태 및 액션을 관리하는 ViewModel
+///
+/// 출석 요청(GPS)·사유 제출·시간대 판정·지오펜스/권한 상태 등 액션·상태 로직은
+/// `ChallengerAttendanceUseCaseProtocol` 에 연결되어 동작합니다.
+/// 세션 목록/이력 로딩은 Schedule 모듈 이식 후 결선됩니다 (하단 TODO 스텁 참고).
+@MainActor
+@Observable
+final class ChallengerAttendanceViewModel {
+
+    // MARK: - Property
+
+    private let errorHandler: ErrorHandler
+    private let challengerAttendanceUseCase: ChallengerAttendanceUseCaseProtocol
+
+    /// 출석 상태 변경 알림 관찰 토큰
+    ///
+    /// init(MainActor)에서 1회 설정 후 deinit(nonisolated)에서 해제만 하므로
+    /// 동시 접근이 발생하지 않습니다 — `nonisolated(unsafe)` 근거.
+    private nonisolated(unsafe) var statusObserver: (any NSObjectProtocol)?
+
+    /// 폴링 대상 세션 (View에서 주입)
+    private var pollingSessions: [Session] = []
+
+    /// 폴링 시 Session 상태 업데이트용 userId
+    private var pollingUserId: UserID?
+
+    /// 세션별 서버 출석 정책 캐시 (available schedules 조회 결과에서 추출)
+    ///
+    /// 시간대 판정(`timeWindow(for:now:)`)이 클라이언트 상수보다 서버 정책을
+    /// 우선하도록 보관합니다. Schedule 모듈 결선 전까지는 비어 있습니다.
+    private var schedulePolicies: [SessionID: ScheduleAttendancePolicy] = [:]
+
+    /// 폴링 설정
+    private enum PollingConfig {
+        static let intervalSeconds: Int = 30
+    }
+
+    // MARK: - Init
+
+    init(
+        errorHandler: ErrorHandler,
+        challengerAttendanceUseCase: ChallengerAttendanceUseCaseProtocol
+    ) {
+        self.errorHandler = errorHandler
+        self.challengerAttendanceUseCase = challengerAttendanceUseCase
+        observeAttendanceStatusChange()
+    }
+
+    deinit {
+        if let observer = statusObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Notification
+
+    private func observeAttendanceStatusChange() {
+        statusObserver = NotificationCenter.default.addObserver(
+            forName: .attendanceStatusChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.refreshMyHistory()
+            }
+        }
+    }
+
+    // MARK: - 세션 목록/이력 로딩 (Schedule 모듈 후행)
+
+    // TODO: Schedule 모듈 이식 후 세션 목록/이력 로딩 결선 - [26.06.12] 이재원
+    // — `ScheduleDetailData` 가 Schedule Feature 모듈에 정의 예정이라
+    //   `ChallengerAttendanceUseCaseProtocol` 의 fetchAvailableSchedules / fetchMyHistory 와
+    //   함께 동결됨 (PR #797 동결과 동일 사유).
+    // — 결선 시 복원 대상: availableSchedules / myHistory Loadable 상태,
+    //   syncSessionStates() 폴링 동기화, schedule(for:) 일정 매핑,
+    //   updateSchedulePolicies(_:) 호출부.
+
+    /// 화면 등장 시 로드 결정 메서드
+    func loadOnAppear() async {
+        // TODO: Schedule 모듈 이식 후 available schedules 시드 + 이력 로딩 복원 - [26.06.12] 이재원
+    }
+
+    /// 출석 가능 일정 갱신 (로딩 상태 변경 없이)
+    func refreshAvailableSchedules() async {
+        // TODO: Schedule 모듈 이식 후 fetchAvailableSchedules 결선 - [26.06.12] 이재원
+    }
+
+    /// 출석 이력 배경 갱신 (로딩 상태 변경 없이)
+    private func refreshMyHistory() async {
+        // TODO: Schedule 모듈 이식 후 fetchMyHistory 결선 - [26.06.12] 이재원
+    }
+
+    /// 출석 가능 일정 조회 (로딩 스피너 표시, .failed 재시도 버튼용)
+    func fetchAvailableSchedules() async {
+        // TODO: Schedule 모듈 이식 후 fetchAvailableSchedules 결선 - [26.06.12] 이재원
+    }
+
+    /// 내 출석 이력 조회 (로딩 스피너 표시, .failed 재시도 버튼용)
+    func fetchMyHistory() async {
+        // TODO: Schedule 모듈 이식 후 fetchMyHistory 결선 - [26.06.12] 이재원
+    }
+
+    /// 앱 foreground 복귀 시 전체 갱신 (두 API 병렬 호출)
+    func refreshAfterForeground() async {
+        async let schedules: Void = refreshAvailableSchedules()
+        async let history: Void = refreshMyHistory()
+        _ = await (schedules, history)
+    }
+
+    /// SessionID → scheduleId 매핑 (available schedules 기반)
+    func scheduleId(for sessionId: SessionID) -> String? {
+        // TODO: Schedule 모듈 이식 후 available schedules 페이로드에서 조회 - [26.06.12] 이재원
+        nil
+    }
+
+    /// 폴링으로 받은 서버 상태를 Session 객체에 동기화
+    private func syncSessionStates() {
+        // TODO: Schedule 모듈 이식 후 available schedules 상태 전파 복원 - [26.06.12] 이재원
+        // — pollingSessions / pollingUserId 를 사용해 schedule 상태를 매칭합니다.
+    }
+
+    // MARK: - Polling
+
+    /// 폴링에 필요한 세션 및 userId를 설정합니다.
+    ///
+    /// View 초기화 시 한 번 호출합니다.
+    func configurePollingSessions(
+        _ sessions: [Session],
+        userId: UserID
+    ) {
+        self.pollingSessions = sessions
+        self.pollingUserId = userId
+    }
+
+    /// 세션 진행 중일 때 주기적으로 상태를 갱신합니다.
+    ///
+    /// `.task` 모디파이어에서 호출하면 뷰 사라질 때 자동 취소됩니다.
+    /// 세션 시간 기반으로 진행 중 여부를 판단합니다.
+    func startPollingIfNeeded(sessions: [Session]) async {
+        while !Task.isCancelled {
+            guard hasActiveSession(in: sessions) else { return }
+            try? await Task.sleep(for: .seconds(
+                PollingConfig.intervalSeconds
+            ))
+            guard !Task.isCancelled else { break }
+            await refreshAvailableSchedules()
+            await refreshMyHistory()
+        }
+    }
+
+    /// 진행 중인 세션이 하나라도 있는지 확인
+    private func hasActiveSession(in sessions: [Session]) -> Bool {
+        sessions.contains { session in
+            let status = OperatorSessionStatus.from(
+                startTime: session.info.startTime,
+                endTime: session.info.endTime
+            )
+            return status == .inProgress
+        }
+    }
+
+    // MARK: - Action
+
+    /// GPS 기반 출석 버튼 탭 처리
+    func attendanceBtnTapped(
+        userId: UserID,
+        session: Session,
+        scheduleId: String
+    ) async {
+        let info = session.info
+
+        // .onTime = 정시 출석 가능 시간대
+        guard currentTimeWindow(for: session) == .onTime else { return }
+
+        // 복구용 이전 출석 — .loading 으로 덮어쓰기 전에 캡처해야 함
+        let previousAttendance = session.attendance
+        session.updateState(.loading)
+
+        do {
+            let result = try await challengerAttendanceUseCase.requestGPSAttendance(
+                sessionId: info.sessionId,
+                userId: userId,
+                scheduleId: scheduleId
+            )
+            session.updateState(.loaded(result))
+            session.markSubmitted()
+
+        } catch let error as DomainError {
+            session.updateState(.failed(.domain(error)))
+        } catch {
+            // 기타 에러 (네트워크 등) — 상태 복구 후 Alert
+            if let prev = previousAttendance {
+                session.updateState(.loaded(prev))
+            } else {
+                session.updateState(.idle)
+            }
+            errorHandler.handle(error, context: .init(
+                feature: "Activity",
+                action: "attendanceBtnTapped",
+                retryAction: { [weak self] in
+                    await self?.attendanceBtnTapped(
+                        userId: userId,
+                        session: session,
+                        scheduleId: scheduleId
+                    )
+                }
+            ))
+        }
+    }
+
+    /// 출석 사유 제출
+    ///
+    /// GPS 출석이 어려운 경우 사유를 제출합니다.
+    /// 시간대에 따라 지각/결석 사유 제출로 라우팅됩니다.
+    /// - Parameters:
+    ///   - userId: 사용자 ID
+    ///   - session: 출석 대상 세션
+    ///   - reason: 출석 사유
+    ///   - scheduleId: 일정 ID (서버 String ID)
+    func submitAttendanceReason(
+        userId: UserID,
+        session: Session,
+        reason: String,
+        scheduleId: String
+    ) async {
+        let info = session.info
+        let timeWindow = currentTimeWindow(for: session)
+
+        // 복구용 이전 출석 — .loading 으로 덮어쓰기 전에 캡처해야 함
+        let previousAttendance = session.attendance
+        session.updateState(.loading)
+
+        do {
+            let result = try await submitExcuse(
+                timeWindow: timeWindow,
+                sessionId: info.sessionId,
+                userId: userId,
+                reason: reason,
+                scheduleId: scheduleId
+            )
+            session.updateState(.loaded(result))
+            session.markSubmitted()
+
+        } catch let error as DomainError {
+            session.updateState(.failed(.domain(error)))
+        } catch {
+            // 기타 에러 (네트워크 등) — 상태 복구 후 Alert
+            if let prev = previousAttendance {
+                session.updateState(.loaded(prev))
+            } else {
+                session.updateState(.idle)
+            }
+            errorHandler.handle(error, context: .init(
+                feature: "Activity",
+                action: "submitAttendanceReason",
+                retryAction: { [weak self] in
+                    await self?.submitAttendanceReason(
+                        userId: userId,
+                        session: session,
+                        reason: reason,
+                        scheduleId: scheduleId
+                    )
+                }
+            ))
+        }
+    }
+
+    // MARK: - 상태 조회 (View 분기용)
+
+    /// 출석 버튼 위에 표시할 시간대별 안내 문구
+    ///
+    /// 출석 전(`beforeAttendance`) 상태에서만 문구를 반환합니다.
+    /// 정책 시각(available schedules)이 조회된 경우 마감 시각과 남은 시간을 함께 표시하고,
+    /// 아직 조회 전이면 시간대 설명만 표시합니다. 만료 시간대는 버튼 문구가 대신하므로 nil.
+    func attendanceGuidanceText(for session: Session, at now: Date) -> String? {
+        guard session.attendanceStatus == .beforeAttendance else { return nil }
+
+        let timeWindow = currentTimeWindow(for: session, now: now)
+        let policy = schedulePolicies[session.info.sessionId]
+
+        switch timeWindow {
+        case .tooEarly:
+            guard let start = policy?.checkInStartAt else {
+                return "아직 출석 시간 전이에요"
+            }
+            return "\(start.toHourMinutes())부터 출석할 수 있어요"
+        case .onTime:
+            guard let end = policy?.onTimeEndAt else {
+                return "지금 출석하면 정시로 인정돼요"
+            }
+            return "출석 인정 마감 \(end.toHourMinutes()) · \(remainingText(until: end, from: now))"
+        case .lateWindow:
+            guard let end = policy?.lateEndAt else {
+                return "지각 시간대예요 — 사유를 제출해 주세요"
+            }
+            return "지각 인정 마감 \(end.toHourMinutes()) · \(remainingText(until: end, from: now))"
+        case .expired:
+            return nil
+        }
+    }
+
+    /// 출석 요청 가능 여부 (시간대 + 지오펜스 + 위치 권한)
+    func isAttendanceAvailable(for session: Session) -> Bool {
+        session.canRequestAttendance(
+            timeWindow: currentTimeWindow(for: session),
+            isInsideGeofence: challengerAttendanceUseCase.isInsideGeofence,
+            isLocationAuthorized: challengerAttendanceUseCase.isLocationAuthorized
+        )
+    }
+
+    /// 사유 제출 가능 여부
+    func isReasonSubmittable(for session: Session) -> Bool {
+        session.canSubmitReason()
+    }
+
+    /// 세션의 현재 출석 시간대 (View 분기용)
+    func timeWindow(for session: Session, now: Date = Date()) -> AttendanceTimeWindow {
+        currentTimeWindow(for: session, now: now)
+    }
+
+    /// 사유 제출 보조 링크 노출 여부
+    ///
+    /// 정시/시작 전에는 GPS 출석이 기본 동작이므로 사유 제출을 보조 링크로 노출합니다.
+    /// 지각 시간대에는 사유 제출이 기본 버튼으로 승격되므로 링크를 숨기고,
+    /// 마감 후나 이미 제출한 세션에서도 숨깁니다.
+    func shouldShowReasonButton(for session: Session) -> Bool {
+        let window = currentTimeWindow(for: session)
+        return (window == .tooEarly || window == .onTime) && session.canSubmitReason()
+    }
+
+    /// 출석 버튼에 표시할 텍스트
+    func buttonStyle(for session: Session) -> String {
+        session.buttonTitle(
+            isLocationAuthorized: challengerAttendanceUseCase.isLocationAuthorized,
+            isInsideGeofence: challengerAttendanceUseCase.isInsideGeofence,
+            timeWindow: currentTimeWindow(for: session)
+        )
+    }
+
+    /// available schedules 조회 결과의 세션별 출석 정책을 반영합니다.
+    ///
+    /// 시간대 판정(`timeWindow(for:now:)`)이 서버 정책을 우선 사용하도록 캐시를 갱신합니다.
+    // TODO: Schedule 모듈 이식 후 refreshAvailableSchedules() 내부에서 호출하도록 결선 - [26.06.12] 이재원
+    func updateSchedulePolicies(_ policies: [SessionID: ScheduleAttendancePolicy]) {
+        schedulePolicies = policies
+    }
+
+    // MARK: - Helper Methods
+
+    /// 세션의 현재 출석 시간대
+    ///
+    /// 서버 출석 정책(available schedules)이 조회된 경우 정책 시각을 기준으로 판정하고,
+    /// 아직 조회 전이면 UseCase 의 클라이언트 상수 기반 계산으로 폴백합니다.
+    /// 정책과 상수가 다를 때(예: 지각 마감이 시작+30분보다 늦은 일정) 서버 정책이 우선입니다.
+    private func currentTimeWindow(
+        for session: Session,
+        now: Date = Date()
+    ) -> AttendanceTimeWindow {
+        guard let policy = schedulePolicies[session.info.sessionId] else {
+            return challengerAttendanceUseCase.isWithinAttendanceTime(
+                info: session.info,
+                now: now
+            )
+        }
+
+        if now < policy.checkInStartAt { return .tooEarly }
+        if now <= policy.onTimeEndAt { return .onTime }
+        if now <= policy.lateEndAt { return .lateWindow }
+        return .expired
+    }
+
+    /// 마감까지 남은 시간 표시 (예: "7분 남음", "1시간 12분 남음")
+    private func remainingText(until end: Date, from now: Date) -> String {
+        let minutes = max(0, Int(end.timeIntervalSince(now) / 60))
+        if minutes >= 60 {
+            let remainder = minutes % 60
+            return remainder == 0
+                ? "\(minutes / 60)시간 남음"
+                : "\(minutes / 60)시간 \(remainder)분 남음"
+        }
+        return "\(minutes)분 남음"
+    }
+
+    private func submitExcuse(
+        timeWindow: AttendanceTimeWindow,
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance {
+        switch timeWindow {
+        case .tooEarly, .onTime, .lateWindow:
+            return try await challengerAttendanceUseCase.submitLateReason(
+                sessionId: sessionId,
+                userId: userId,
+                reason: reason,
+                scheduleId: scheduleId
+            )
+        case .expired:
+            return try await challengerAttendanceUseCase.submitAbsentReason(
+                sessionId: sessionId,
+                userId: userId,
+                reason: reason,
+                scheduleId: scheduleId
+            )
+        }
+    }
+
+    // MARK: - Cleanup
+
+    /// 지오펜스 모니터링 중지
+    func geofenceCleanup() async {
+        await challengerAttendanceUseCase.stopGeofenceMonitoring()
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
@@ -25,8 +25,10 @@ final class ChallengerAttendanceViewModel {
 
     /// 출석 상태 변경 알림 관찰 토큰
     ///
-    /// init(MainActor)에서 1회 설정 후 deinit(nonisolated)에서 해제만 하므로
-    /// 동시 접근이 발생하지 않습니다 — `nonisolated(unsafe)` 근거.
+    /// UI 관찰 대상이 아닌 내부 구현 세부사항이라 `@ObservationIgnored` 로 추적에서 제외합니다.
+    /// deinit(nonisolated)에서 해제해야 하므로 `nonisolated(unsafe)` — init 1회 설정 + deinit
+    /// 해제만이라 동시 접근이 없습니다.
+    @ObservationIgnored
     private nonisolated(unsafe) var statusObserver: (any NSObjectProtocol)?
 
     /// 폴링 대상 세션 (View에서 주입)

--- a/UMCApp/Features/Activity/Presentation/Tests/ChallengerAttendanceViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/ChallengerAttendanceViewModelTests.swift
@@ -1,0 +1,714 @@
+//
+//  ChallengerAttendanceViewModelTests.swift
+//  ActivityPresentationTests
+//
+//  Created by jaewon Lee on 6/12/26.
+//
+
+import Foundation
+import Testing
+import ActivityDomain
+import UMCFoundation
+@testable import ActivityPresentation
+
+// MARK: - Helpers
+
+/// 결정론적 기준 시각 (epoch 100_000) — wall-clock 비의존
+private let fixedNow = Date(timeIntervalSince1970: 100_000)
+
+private func makeSessionInfo(
+    sessionId: String = "S-1",
+    startTime: Date = fixedNow,
+    endTime: Date = fixedNow.addingTimeInterval(3_600)
+) -> SessionInfo {
+    SessionInfo(
+        sessionId: SessionID(value: sessionId),
+        iconName: "calendar.badge",
+        title: "1주차 OT",
+        week: 1,
+        startTime: startTime,
+        endTime: endTime,
+        location: Coordinate(latitude: 37.5, longitude: 127.0)
+    )
+}
+
+@MainActor
+private func makeSession(
+    sessionId: String = "S-1",
+    initialAttendance: Attendance? = nil
+) -> Session {
+    Session(
+        info: makeSessionInfo(sessionId: sessionId),
+        initialAttendance: initialAttendance
+    )
+}
+
+private func makeAttendance(
+    status: AttendanceStatus = .present,
+    type: AttendanceType = .gps,
+    reason: String? = nil
+) -> Attendance {
+    Attendance(
+        sessionId: SessionID(value: "S-1"),
+        userId: UserID(value: "U-1"),
+        type: type,
+        status: status,
+        reason: reason
+    )
+}
+
+/// 정책 기준: checkIn = fixedNow-600, onTimeEnd = fixedNow+600, lateEnd = fixedNow+1200
+private func makePolicy(
+    checkInStartAt: Date = fixedNow.addingTimeInterval(-600),
+    onTimeEndAt: Date = fixedNow.addingTimeInterval(600),
+    lateEndAt: Date = fixedNow.addingTimeInterval(1_200)
+) -> ScheduleAttendancePolicy {
+    ScheduleAttendancePolicy(
+        checkInStartAt: checkInStartAt,
+        onTimeEndAt: onTimeEndAt,
+        lateEndAt: lateEndAt
+    )
+}
+
+@MainActor
+private func makeViewModel(
+    useCase: MockChallengerAttendanceUseCase,
+    errorHandler: ErrorHandler = ErrorHandler()
+) -> ChallengerAttendanceViewModel {
+    ChallengerAttendanceViewModel(
+        errorHandler: errorHandler,
+        challengerAttendanceUseCase: useCase
+    )
+}
+
+private struct DummyError: Error {}
+
+// MARK: - Mocks
+
+#if DEBUG
+
+private final class MockChallengerAttendanceUseCase: @unchecked Sendable,
+    ChallengerAttendanceUseCaseProtocol {
+
+    // MARK: 상태 제어
+
+    var isInsideGeofence: Bool = true
+    var isLocationAuthorized: Bool = true
+
+    var requestGPSAttendanceResult: Result<Attendance, Error> = .success(makeAttendance())
+    var submitLateReasonResult: Result<Attendance, Error> = .success(
+        makeAttendance(status: .pendingApproval, type: .reason, reason: "사유")
+    )
+    var submitAbsentReasonResult: Result<Attendance, Error> = .success(
+        makeAttendance(status: .pendingApproval, type: .reason, reason: "사유")
+    )
+
+    /// `isWithinAttendanceTime` 폴백 판정이 반환할 시간대
+    var timeWindowToReturn: AttendanceTimeWindow = .onTime
+
+    // MARK: 호출 기록
+
+    private(set) var requestGPSAttendanceCalls: [(
+        sessionId: SessionID,
+        userId: UserID,
+        scheduleId: String
+    )] = []
+
+    private(set) var submitLateReasonCalls: [(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    )] = []
+
+    private(set) var submitAbsentReasonCalls: [(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    )] = []
+
+    private(set) var isWithinAttendanceTimeCallCount: Int = 0
+    private(set) var stopGeofenceMonitoringCallCount: Int = 0
+
+    // MARK: Protocol
+
+    func requestGPSAttendance(
+        sessionId: SessionID,
+        userId: UserID,
+        scheduleId: String
+    ) async throws -> Attendance {
+        requestGPSAttendanceCalls.append((sessionId, userId, scheduleId))
+        return try requestGPSAttendanceResult.get()
+    }
+
+    func submitLateReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance {
+        submitLateReasonCalls.append((sessionId, userId, reason, scheduleId))
+        return try submitLateReasonResult.get()
+    }
+
+    func submitAbsentReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance {
+        submitAbsentReasonCalls.append((sessionId, userId, reason, scheduleId))
+        return try submitAbsentReasonResult.get()
+    }
+
+    func isWithinAttendanceTime(info: SessionInfo, now: Date) -> AttendanceTimeWindow {
+        isWithinAttendanceTimeCallCount += 1
+        return timeWindowToReturn
+    }
+
+    func getAddressToCurrentLocation() async throws -> Address {
+        Address(
+            fullAddress: "서울특별시 성북구 삼선동",
+            city: "서울특별시",
+            district: "성북구"
+        )
+    }
+
+    func stopGeofenceMonitoring() async {
+        stopGeofenceMonitoringCallCount += 1
+    }
+}
+
+#endif
+
+// MARK: - GPS 출석 요청
+
+// Suite 전체 @MainActor — SUT(ViewModel)와 Session 이 @MainActor 격리이므로 필요.
+@MainActor
+@Suite("ChallengerAttendanceViewModel — GPS 출석 요청 (도메인 규칙)")
+struct ChallengerAttendanceViewModelGPSTests {
+
+    @Test(
+        "정시가 아닌 시간대 → 출석 요청 미전송 + 상태 불변",
+        arguments: [
+            AttendanceTimeWindow.tooEarly,
+            AttendanceTimeWindow.lateWindow,
+            AttendanceTimeWindow.expired,
+        ]
+    )
+    func attendanceRequestBlockedOutsideOnTime(window: AttendanceTimeWindow) async {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = window
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+
+        await viewModel.attendanceBtnTapped(
+            userId: UserID(value: "U-1"),
+            session: session,
+            scheduleId: "42"
+        )
+
+        #expect(useCase.requestGPSAttendanceCalls.isEmpty)
+        #expect(session.attendanceLoadable == .idle)
+    }
+
+    @Test("정시 + 성공 → loaded 전이 + 제출 완료 + scheduleId String 전달")
+    func attendanceRequestSucceeds() async throws {
+        let expected = makeAttendance(status: .present)
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .onTime
+        useCase.requestGPSAttendanceResult = .success(expected)
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+
+        await viewModel.attendanceBtnTapped(
+            userId: UserID(value: "U-3"),
+            session: session,
+            scheduleId: "42"
+        )
+
+        let call = try #require(useCase.requestGPSAttendanceCalls.first)
+        #expect(call.scheduleId == "42")
+        #expect(call.userId == UserID(value: "U-3"))
+        #expect(call.sessionId == session.info.sessionId)
+        #expect(session.attendanceLoadable == .loaded(expected))
+        #expect(session.hasSubmitted == true)
+    }
+
+    @Test("정시 + DomainError → failed(.domain) 인라인 상태 (Alert 미발생)")
+    func attendanceRequestFailsWithDomainError() async {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.requestGPSAttendanceResult = .failure(DomainError.attendanceOutOfRange)
+        let errorHandler = ErrorHandler()
+        let viewModel = makeViewModel(useCase: useCase, errorHandler: errorHandler)
+        let session = makeSession()
+
+        await viewModel.attendanceBtnTapped(
+            userId: UserID(value: "U-1"),
+            session: session,
+            scheduleId: "42"
+        )
+
+        #expect(session.attendanceLoadable == .failed(.domain(.attendanceOutOfRange)))
+        #expect(session.hasSubmitted == false)
+        #expect(errorHandler.currentError == nil)
+    }
+
+    @Test("정시 + 기타 에러 + 기존 출석 없음 → idle 복구 + ErrorHandler Alert")
+    func attendanceRequestRecoversToIdleOnUnknownError() async {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.requestGPSAttendanceResult = .failure(DummyError())
+        let errorHandler = ErrorHandler()
+        let viewModel = makeViewModel(useCase: useCase, errorHandler: errorHandler)
+        let session = makeSession()
+
+        await viewModel.attendanceBtnTapped(
+            userId: UserID(value: "U-1"),
+            session: session,
+            scheduleId: "42"
+        )
+
+        #expect(session.attendanceLoadable == .idle)
+        #expect(errorHandler.currentError != nil)
+    }
+
+    @Test("정시 + 기타 에러 + 기존 출석 있음 → 이전 출석 상태로 복구")
+    func attendanceRequestRestoresPreviousAttendanceOnUnknownError() async {
+        let previous = makeAttendance(status: .beforeAttendance)
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.requestGPSAttendanceResult = .failure(DummyError())
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession(initialAttendance: previous)
+
+        await viewModel.attendanceBtnTapped(
+            userId: UserID(value: "U-1"),
+            session: session,
+            scheduleId: "42"
+        )
+
+        #expect(session.attendanceLoadable == .loaded(previous))
+    }
+}
+
+// MARK: - 사유 제출 라우팅
+
+@MainActor
+@Suite("ChallengerAttendanceViewModel — 사유 제출 라우팅 (도메인 규칙)")
+struct ChallengerAttendanceViewModelExcuseTests {
+
+    @Test(
+        "마감 전 시간대(시작 전/정시/지각) → 지각 사유로 제출",
+        arguments: [
+            AttendanceTimeWindow.tooEarly,
+            AttendanceTimeWindow.onTime,
+            AttendanceTimeWindow.lateWindow,
+        ]
+    )
+    func excuseRoutesToLateReasonBeforeExpiry(window: AttendanceTimeWindow) async throws {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = window
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+
+        await viewModel.submitAttendanceReason(
+            userId: UserID(value: "U-1"),
+            session: session,
+            reason: "지각 사유",
+            scheduleId: "7"
+        )
+
+        let call = try #require(useCase.submitLateReasonCalls.first)
+        #expect(call.reason == "지각 사유")
+        #expect(call.scheduleId == "7")
+        #expect(useCase.submitAbsentReasonCalls.isEmpty)
+        #expect(session.hasSubmitted == true)
+    }
+
+    @Test("마감 후(expired) → 결석 사유로 제출")
+    func excuseRoutesToAbsentReasonAfterExpiry() async throws {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .expired
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+
+        await viewModel.submitAttendanceReason(
+            userId: UserID(value: "U-1"),
+            session: session,
+            reason: "결석 사유",
+            scheduleId: "7"
+        )
+
+        let call = try #require(useCase.submitAbsentReasonCalls.first)
+        #expect(call.reason == "결석 사유")
+        #expect(useCase.submitLateReasonCalls.isEmpty)
+    }
+
+    @Test("사유 제출 성공 → loaded 전이 + 제출 완료")
+    func excuseSubmissionSucceeds() async {
+        let expected = makeAttendance(status: .pendingApproval, type: .reason, reason: "사유")
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .lateWindow
+        useCase.submitLateReasonResult = .success(expected)
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+
+        await viewModel.submitAttendanceReason(
+            userId: UserID(value: "U-1"),
+            session: session,
+            reason: "사유",
+            scheduleId: "7"
+        )
+
+        #expect(session.attendanceLoadable == .loaded(expected))
+        #expect(session.hasSubmitted == true)
+    }
+
+    @Test("빈 사유 거부(DomainError) → failed(.domain) 인라인 상태")
+    func excuseSubmissionFailsWithDomainError() async {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .lateWindow
+        useCase.submitLateReasonResult = .failure(DomainError.attendanceReasonRequired)
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+
+        await viewModel.submitAttendanceReason(
+            userId: UserID(value: "U-1"),
+            session: session,
+            reason: "",
+            scheduleId: "7"
+        )
+
+        #expect(session.attendanceLoadable == .failed(.domain(.attendanceReasonRequired)))
+        #expect(session.hasSubmitted == false)
+    }
+
+    @Test("기타 에러 → 상태 복구 + ErrorHandler Alert")
+    func excuseSubmissionRecoversOnUnknownError() async {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .lateWindow
+        useCase.submitLateReasonResult = .failure(DummyError())
+        let errorHandler = ErrorHandler()
+        let viewModel = makeViewModel(useCase: useCase, errorHandler: errorHandler)
+        let session = makeSession()
+
+        await viewModel.submitAttendanceReason(
+            userId: UserID(value: "U-1"),
+            session: session,
+            reason: "사유",
+            scheduleId: "7"
+        )
+
+        #expect(session.attendanceLoadable == .idle)
+        #expect(errorHandler.currentError != nil)
+    }
+
+    @Test("기타 에러 + 기존 출석 있음 → 이전 출석 상태로 복구")
+    func excuseSubmissionRestoresPreviousAttendanceOnUnknownError() async {
+        let previous = makeAttendance(status: .beforeAttendance)
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .lateWindow
+        useCase.submitLateReasonResult = .failure(DummyError())
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession(initialAttendance: previous)
+
+        await viewModel.submitAttendanceReason(
+            userId: UserID(value: "U-1"),
+            session: session,
+            reason: "사유",
+            scheduleId: "7"
+        )
+
+        #expect(session.attendanceLoadable == .loaded(previous))
+    }
+}
+
+// MARK: - 시간대 판정
+
+@MainActor
+@Suite("ChallengerAttendanceViewModel — 시간대 판정 (도메인 규칙)")
+struct ChallengerAttendanceViewModelTimeWindowTests {
+
+    @Test("정책 미조회 → UseCase 폴백 판정 사용")
+    func timeWindowFallsBackToUseCaseWithoutPolicy() {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .lateWindow
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+
+        let window = viewModel.timeWindow(for: session, now: fixedNow)
+
+        #expect(window == .lateWindow)
+        #expect(useCase.isWithinAttendanceTimeCallCount == 1)
+    }
+
+    @Test("정책 조회 후 → 서버 정책 우선 판정 (폴백 미사용)")
+    func timeWindowPrefersServerPolicy() {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .expired  // 폴백이 쓰였다면 expired 가 나와야 함
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+        viewModel.updateSchedulePolicies([session.info.sessionId: makePolicy()])
+
+        let window = viewModel.timeWindow(for: session, now: fixedNow)
+
+        #expect(window == .onTime)
+        #expect(useCase.isWithinAttendanceTimeCallCount == 0)
+    }
+
+    @Test(
+        "정책 시각 경계값 판정",
+        arguments: [
+            (offset: TimeInterval(-601), expected: AttendanceTimeWindow.tooEarly),
+            (offset: TimeInterval(-600), expected: AttendanceTimeWindow.onTime),
+            (offset: TimeInterval(600), expected: AttendanceTimeWindow.onTime),
+            (offset: TimeInterval(601), expected: AttendanceTimeWindow.lateWindow),
+            (offset: TimeInterval(1_200), expected: AttendanceTimeWindow.lateWindow),
+            (offset: TimeInterval(1_201), expected: AttendanceTimeWindow.expired),
+        ]
+    )
+    func timeWindowPolicyBoundaries(
+        offset: TimeInterval,
+        expected: AttendanceTimeWindow
+    ) {
+        let useCase = MockChallengerAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+        // 정책: checkIn = fixedNow-600, onTimeEnd = fixedNow+600, lateEnd = fixedNow+1200
+        viewModel.updateSchedulePolicies([session.info.sessionId: makePolicy()])
+
+        let window = viewModel.timeWindow(
+            for: session,
+            now: fixedNow.addingTimeInterval(offset)
+        )
+
+        #expect(window == expected)
+    }
+}
+
+// MARK: - 출석 안내 문구
+
+@MainActor
+@Suite("ChallengerAttendanceViewModel — 출석 안내 문구 (도메인 규칙)")
+struct ChallengerAttendanceViewModelGuidanceTests {
+
+    @Test("출석 전 상태가 아니면 안내 문구 없음")
+    func guidanceHiddenWhenAlreadyDecided() {
+        let useCase = MockChallengerAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession(initialAttendance: makeAttendance(status: .present))
+
+        #expect(viewModel.attendanceGuidanceText(for: session, at: fixedNow) == nil)
+    }
+
+    @Test(
+        "정책 미조회 — 시간대별 폴백 문구",
+        arguments: [
+            (window: AttendanceTimeWindow.tooEarly, expected: "아직 출석 시간 전이에요"),
+            (window: AttendanceTimeWindow.onTime, expected: "지금 출석하면 정시로 인정돼요"),
+            (window: AttendanceTimeWindow.lateWindow, expected: "지각 시간대예요 — 사유를 제출해 주세요"),
+        ]
+    )
+    func guidanceFallbackTextWithoutPolicy(
+        window: AttendanceTimeWindow,
+        expected: String
+    ) {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = window
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+
+        #expect(viewModel.attendanceGuidanceText(for: session, at: fixedNow) == expected)
+    }
+
+    @Test("마감(expired) 시간대 → 안내 문구 없음 (버튼 문구가 대신함)")
+    func guidanceHiddenWhenExpired() {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .expired
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+
+        #expect(viewModel.attendanceGuidanceText(for: session, at: fixedNow) == nil)
+    }
+
+    @Test("정책 조회 + 정시 → 마감 시각과 남은 시간 표시")
+    func guidanceShowsOnTimeDeadlineWithPolicy() throws {
+        let useCase = MockChallengerAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+        viewModel.updateSchedulePolicies([
+            session.info.sessionId: makePolicy(
+                onTimeEndAt: fixedNow.addingTimeInterval(420)  // 7분 뒤 마감
+            )
+        ])
+
+        let text = try #require(viewModel.attendanceGuidanceText(for: session, at: fixedNow))
+
+        #expect(text.hasPrefix("출석 인정 마감 "))
+        #expect(text.hasSuffix("· 7분 남음"))
+    }
+
+    @Test("정책 조회 + 지각 → 지각 마감 시각과 남은 시간 표시")
+    func guidanceShowsLateDeadlineWithPolicy() throws {
+        let useCase = MockChallengerAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+        viewModel.updateSchedulePolicies([
+            session.info.sessionId: makePolicy(
+                onTimeEndAt: fixedNow.addingTimeInterval(-60),  // 정시 마감 지남
+                lateEndAt: fixedNow.addingTimeInterval(720)     // 지각 마감 12분 뒤
+            )
+        ])
+
+        let text = try #require(viewModel.attendanceGuidanceText(for: session, at: fixedNow))
+
+        #expect(text.hasPrefix("지각 인정 마감 "))
+        #expect(text.hasSuffix("· 12분 남음"))
+    }
+
+    @Test("정책 조회 + 출석 시작 전 → 시작 시각 안내")
+    func guidanceShowsCheckInStartWithPolicy() throws {
+        let useCase = MockChallengerAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+        viewModel.updateSchedulePolicies([
+            session.info.sessionId: makePolicy(
+                checkInStartAt: fixedNow.addingTimeInterval(600)  // 10분 뒤 시작
+            )
+        ])
+
+        let text = try #require(viewModel.attendanceGuidanceText(for: session, at: fixedNow))
+
+        #expect(text.hasSuffix("부터 출석할 수 있어요"))
+    }
+
+    @Test(
+        "남은 시간 1시간 이상 → 시간/분 조합 표기",
+        arguments: [
+            (secondsLeft: TimeInterval(3_600), suffix: "· 1시간 남음"),
+            (secondsLeft: TimeInterval(4_320), suffix: "· 1시간 12분 남음"),
+        ]
+    )
+    func guidanceFormatsHourScaleRemaining(
+        secondsLeft: TimeInterval,
+        suffix: String
+    ) throws {
+        let useCase = MockChallengerAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+        viewModel.updateSchedulePolicies([
+            session.info.sessionId: makePolicy(
+                onTimeEndAt: fixedNow.addingTimeInterval(secondsLeft)
+            )
+        ])
+
+        let text = try #require(viewModel.attendanceGuidanceText(for: session, at: fixedNow))
+
+        #expect(text.hasSuffix(suffix))
+    }
+}
+
+// MARK: - 사유 보조 링크 노출
+
+@MainActor
+@Suite("ChallengerAttendanceViewModel — 사유 보조 링크 노출 (도메인 규칙)")
+struct ChallengerAttendanceViewModelReasonButtonTests {
+
+    @Test(
+        "정시/시작 전 + 미제출 세션 → 보조 링크 노출",
+        arguments: [AttendanceTimeWindow.tooEarly, AttendanceTimeWindow.onTime]
+    )
+    func reasonButtonVisibleBeforeLateWindow(window: AttendanceTimeWindow) {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = window
+        let viewModel = makeViewModel(useCase: useCase)
+
+        #expect(viewModel.shouldShowReasonButton(for: makeSession()) == true)
+    }
+
+    @Test(
+        "지각/마감 시간대 → 보조 링크 숨김 (지각은 기본 버튼으로 승격)",
+        arguments: [AttendanceTimeWindow.lateWindow, AttendanceTimeWindow.expired]
+    )
+    func reasonButtonHiddenFromLateWindow(window: AttendanceTimeWindow) {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = window
+        let viewModel = makeViewModel(useCase: useCase)
+
+        #expect(viewModel.shouldShowReasonButton(for: makeSession()) == false)
+    }
+
+    @Test("이미 제출한 세션 → 보조 링크 숨김")
+    func reasonButtonHiddenAfterSubmission() {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .onTime
+        let viewModel = makeViewModel(useCase: useCase)
+        let session = makeSession()
+        session.markSubmitted()
+
+        #expect(viewModel.shouldShowReasonButton(for: session) == false)
+    }
+}
+
+// MARK: - 버튼/가용성 위임
+
+@MainActor
+@Suite("ChallengerAttendanceViewModel — 버튼/가용성 위임 (도메인 규칙)")
+struct ChallengerAttendanceViewModelDelegationTests {
+
+    @Test("정시 + 권한 + 지오펜스 내부 → '현 위치로 출석체크'")
+    func buttonTitleAllReady() {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .onTime
+        let viewModel = makeViewModel(useCase: useCase)
+
+        #expect(viewModel.buttonStyle(for: makeSession()) == "현 위치로 출석체크")
+    }
+
+    @Test("위치 권한 없음 → '위치 권한 필요'")
+    func buttonTitleNeedsLocationPermission() {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .onTime
+        useCase.isLocationAuthorized = false
+        let viewModel = makeViewModel(useCase: useCase)
+
+        #expect(viewModel.buttonStyle(for: makeSession()) == "위치 권한 필요")
+    }
+
+    @Test("정시 + 권한 + 지오펜스 내부 → 출석 요청 가능")
+    func attendanceAvailableWhenAllReady() {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .onTime
+        let viewModel = makeViewModel(useCase: useCase)
+
+        #expect(viewModel.isAttendanceAvailable(for: makeSession()) == true)
+    }
+
+    @Test("지오펜스 밖 → 출석 요청 불가")
+    func attendanceUnavailableOutsideGeofence() {
+        let useCase = MockChallengerAttendanceUseCase()
+        useCase.timeWindowToReturn = .onTime
+        useCase.isInsideGeofence = false
+        let viewModel = makeViewModel(useCase: useCase)
+
+        #expect(viewModel.isAttendanceAvailable(for: makeSession()) == false)
+    }
+
+    @Test("미제출 세션 → 사유 제출 가능 위임")
+    func reasonSubmittableDelegatesToSession() {
+        let useCase = MockChallengerAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+
+        #expect(viewModel.isReasonSubmittable(for: makeSession()) == true)
+    }
+
+    @Test("geofenceCleanup → 지오펜스 모니터링 중지 위임")
+    func geofenceCleanupDelegates() async {
+        let useCase = MockChallengerAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.geofenceCleanup()
+
+        #expect(useCase.stopGeofenceMonitoringCallCount == 1)
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Tests/ChallengerAttendanceViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/ChallengerAttendanceViewModelTests.swift
@@ -203,7 +203,7 @@ struct ChallengerAttendanceViewModelGPSTests {
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
 
-        await viewModel.attendanceBtnTapped(
+        await viewModel.attendanceButtonTapped(
             userId: UserID(value: "U-1"),
             session: session,
             scheduleId: "42"
@@ -222,7 +222,7 @@ struct ChallengerAttendanceViewModelGPSTests {
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
 
-        await viewModel.attendanceBtnTapped(
+        await viewModel.attendanceButtonTapped(
             userId: UserID(value: "U-3"),
             session: session,
             scheduleId: "42"
@@ -244,7 +244,7 @@ struct ChallengerAttendanceViewModelGPSTests {
         let viewModel = makeViewModel(useCase: useCase, errorHandler: errorHandler)
         let session = makeSession()
 
-        await viewModel.attendanceBtnTapped(
+        await viewModel.attendanceButtonTapped(
             userId: UserID(value: "U-1"),
             session: session,
             scheduleId: "42"
@@ -263,7 +263,7 @@ struct ChallengerAttendanceViewModelGPSTests {
         let viewModel = makeViewModel(useCase: useCase, errorHandler: errorHandler)
         let session = makeSession()
 
-        await viewModel.attendanceBtnTapped(
+        await viewModel.attendanceButtonTapped(
             userId: UserID(value: "U-1"),
             session: session,
             scheduleId: "42"
@@ -281,7 +281,7 @@ struct ChallengerAttendanceViewModelGPSTests {
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession(initialAttendance: previous)
 
-        await viewModel.attendanceBtnTapped(
+        await viewModel.attendanceButtonTapped(
             userId: UserID(value: "U-1"),
             session: session,
             scheduleId: "42"
@@ -662,7 +662,7 @@ struct ChallengerAttendanceViewModelDelegationTests {
         useCase.timeWindowToReturn = .onTime
         let viewModel = makeViewModel(useCase: useCase)
 
-        #expect(viewModel.buttonStyle(for: makeSession()) == "현 위치로 출석체크")
+        #expect(viewModel.buttonTitle(for: makeSession()) == "현 위치로 출석체크")
     }
 
     @Test("위치 권한 없음 → '위치 권한 필요'")
@@ -672,7 +672,7 @@ struct ChallengerAttendanceViewModelDelegationTests {
         useCase.isLocationAuthorized = false
         let viewModel = makeViewModel(useCase: useCase)
 
-        #expect(viewModel.buttonStyle(for: makeSession()) == "위치 권한 필요")
+        #expect(viewModel.buttonTitle(for: makeSession()) == "위치 권한 필요")
     }
 
     @Test("정시 + 권한 + 지오펜스 내부 → 출석 요청 가능")

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -16,5 +16,6 @@ let project = featureProject(
         // 에러 enum(DomainError/RepositoryError/NetworkError)을 직접 참조하므로 명시 주입.
         .target(name: "ActivityDomain"),
         .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
-    ]
+    ],
+    includesPresentationTests: true
 )


### PR DESCRIPTION
resolves #874

## ✨ PR 유형

♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="1512" height="1012" alt="스크린샷 2026-06-13 오후 10 25 57" src="https://github.com/user-attachments/assets/018740b6-e5d2-4111-b8e4-f5ef94572a02" />
<img width="1512" height="1012" alt="스크린샷 2026-06-13 오후 10 26 09" src="https://github.com/user-attachments/assets/a61f95bf-930c-4cbf-b4fb-f63887a578d7" />


## 🛠️ 작업내용

레거시 `AppProduct`의 `ChallengerAttendanceViewModel`을 Tuist `UMCApp` Activity
Presentation 모듈로 이식했습니다. ViewModel은 `ChallengerAttendanceUseCaseProtocol`
(#809)에만 의존하며 Clean Architecture 단방향(View → ViewModel → UseCase)을 따릅니다.

**결선된 액션·상태 로직** (머지된 UseCase로 동작)
- GPS 출석 요청 / 사유 제출(지각·결석 시간대 라우팅)
- 시간대 판정 — 서버 출석 정책 우선, UseCase 상수 폴백
- 지오펜스·위치 권한 상태, 버튼 타이틀, 시간대별 안내 문구
- `scheduleId` 등 서버 ID는 전 레이어 String 통일

**Schedule 모듈 후행 (TODO 스텁)**
- 세션 목록/이력 로딩(`fetchAvailableSchedules`/`fetchMyHistory`)은 `ScheduleDetailData`
  동결로 형식 준수 TODO 스텁 처리 (#797 동결과 동일 사유)

**이식 시 정규화**
- 호출자 없는 `attendanceReasonBtnTapped`, 변경되지 않는 `isRetrying`, 미사용 의존성,
  디버그 print 미이식
- 기타 에러 시 이전 출석 복구 분기: `.loading`으로 덮어쓰기 **전**에 이전 상태를
  캡처하도록 정정 (레거시는 덮어쓴 뒤 읽어 항상 nil이라 복구 분기가 죽어 있었음)

## 📋 추후 진행 상황

- 7차 `ChallengerAttendanceView` 이식 (#875)
- Schedule 모듈 이식 후 세션 목록/이력 로딩 결선

## 📌 리뷰 포인트

- `Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift` — `@Observable`
  상태 관리(`@MainActor`), UseCase 결선 분기, 정책 우선 시간대 판정
- `Presentation/Tests/ChallengerAttendanceViewModelTests.swift` — 30 케이스 / 6 Suite
  (Swift Testing), ViewModel 커버리지 70.93% (라이브 메서드 100%)
- `Project.swift` — `includesPresentationTests: true` (UMCApp 첫 Presentation 테스트 타겟)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)