### PR TITLE
♻️ [Refactor] 멤버 도메인 모델 + MemberRepositoryProtocol 이식 (v2 스펙)

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Enums/ChallengerPointType.swift
+++ b/UMCApp/Core/Foundation/Sources/Enums/ChallengerPointType.swift
@@ -1,0 +1,122 @@
+//
+//  ChallengerPointType.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 6/17/26.
+//
+
+import Foundation
+
+/// 챌린저 포인트(상벌점) 유형
+///
+/// 서버 API 의 포인트 타입 문자열과 1:1 매핑됩니다.
+/// 점수 표시(SF Symbol, Color)는 Presentation 레이어의 extension 에서 제공합니다.
+public enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identifiable {
+    case bestWorkbook = "BEST_WORKBOOK"
+    case warning = "WARNING"
+    case out = "OUT"
+    case custom = "CUSTOM"
+    case blogChallenge = "BLOG_CHALLENGE"
+    case bestWorkbookV2 = "BEST_WORKBOOK_V2"
+    case umcEventReview = "UMC_EVENT_REVIEW"
+    case peerReviewSubmission = "PEER_REVIEW_SUBMISSION"
+    case noWorkbookMission = "NO_WORKBOOK_MISSION"
+    case studyLate = "STUDY_LATE"
+    case studyAbsent = "STUDY_ABSENT"
+    case eventLate = "EVENT_LATE"
+    case eventEarlyLeave = "EVENT_EARLY_LEAVE"
+    case eventLateCancel = "EVENT_LATE_CANCEL"
+    case eventNoShow = "EVENT_NO_SHOW"
+    case partLeadFeedbackLate = "PART_LEAD_FEEDBACK_LATE"
+    case schoolCoreMeetingAbsent = "SCHOOL_CORE_MEETING_ABSENT"
+    case schoolCoreTaskNotCompleted = "SCHOOL_CORE_TASK_NOT_COMPLETED"
+
+    public var id: String { rawValue }
+
+    /// 포인트 유형의 한글 표시명
+    public var displayName: String {
+        switch self {
+        case .bestWorkbook: return "우수 워크북"
+        case .warning: return "경고"
+        case .out: return "아웃"
+        case .custom: return "기타"
+        case .blogChallenge: return "블로그 챌린지"
+        case .bestWorkbookV2: return "우수 워크북 V2"
+        case .umcEventReview: return "UMC 행사 후기"
+        case .peerReviewSubmission: return "동료 평가 제출"
+        case .noWorkbookMission: return "워크북 미제출"
+        case .studyLate: return "스터디 지각"
+        case .studyAbsent: return "스터디 결석"
+        case .eventLate: return "행사 지각"
+        case .eventEarlyLeave: return "행사 조퇴"
+        case .eventLateCancel: return "행사 당일 취소"
+        case .eventNoShow: return "행사 노쇼"
+        case .partLeadFeedbackLate: return "파트장 피드백 지연"
+        case .schoolCoreMeetingAbsent: return "회장단 회의 결석"
+        case .schoolCoreTaskNotCompleted: return "회장단 업무 미완료"
+        }
+    }
+
+    /// 유형별 기본 배점 (상점은 양수, 벌점은 음수)
+    public var defaultPointValue: Int {
+        switch self {
+        case .bestWorkbook: return 2
+        case .warning: return 1
+        case .out: return 1
+        case .custom: return 0
+        case .blogChallenge: return 3
+        case .bestWorkbookV2: return 2
+        case .umcEventReview: return 1
+        case .peerReviewSubmission: return 1
+        case .noWorkbookMission: return -4
+        case .studyLate: return -2
+        case .studyAbsent: return -4
+        case .eventLate: return -2
+        case .eventEarlyLeave: return -2
+        case .eventLateCancel: return -4
+        case .eventNoShow: return -10
+        case .partLeadFeedbackLate: return -4
+        case .schoolCoreMeetingAbsent: return -4
+        case .schoolCoreTaskNotCompleted: return -4
+        }
+    }
+
+    /// 상점(보상) 유형 여부
+    public var isReward: Bool {
+        defaultPointValue > 0
+    }
+
+    /// 사용자가 직접 배점을 입력해야 하는 유형 여부 (CUSTOM)
+    public var isCustom: Bool {
+        self == .custom
+    }
+
+    /// 부여에 필요한 최소 권한 레벨 (``ManagementTeam/level`` 기준)
+    public var minimumRequiredLevel: Int {
+        switch self {
+        case .bestWorkbook, .bestWorkbookV2, .blogChallenge,
+             .umcEventReview, .peerReviewSubmission:
+            return 20
+        case .noWorkbookMission, .studyLate, .studyAbsent,
+             .eventLate, .eventEarlyLeave, .eventLateCancel, .eventNoShow:
+            return 20
+        case .partLeadFeedbackLate:
+            return 30
+        case .schoolCoreMeetingAbsent, .schoolCoreTaskNotCompleted:
+            return 50
+        case .warning, .out:
+            return 20
+        case .custom:
+            return 20
+        }
+    }
+
+    /// 주어진 권한 레벨에서 부여 가능한 유형 목록
+    ///
+    /// `warning`/`out` 은 별도 흐름에서 처리하므로 목록에서 제외합니다.
+    public static func availableTypes(for level: Int) -> [ChallengerPointType] {
+        allCases.filter { type in
+            type != .warning && type != .out && level >= type.minimumRequiredLevel
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Enums/ChallengerPointType.swift
+++ b/UMCApp/Core/Foundation/Sources/Enums/ChallengerPointType.swift
@@ -58,6 +58,10 @@ public enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identi
     }
 
     /// 유형별 기본 배점 (상점은 양수, 벌점은 음수)
+    ///
+    /// - Note: `.warning`/`.out` 은 벌점 개념이지만 레거시 호환을 위해 양수(1)로 유지됩니다.
+    ///   (이 때문에 `isReward` 가 `true` 로 평가되는 예외) 두 유형은 `availableTypes(for:)` 에서
+    ///   이미 제외되므로 일반 부여 흐름에는 영향이 없습니다.
     public var defaultPointValue: Int {
         switch self {
         case .bestWorkbook: return 2
@@ -94,9 +98,11 @@ public enum ChallengerPointType: String, Codable, Sendable, CaseIterable, Identi
     /// 부여에 필요한 최소 권한 레벨 (``ManagementTeam/level`` 기준)
     public var minimumRequiredLevel: Int {
         switch self {
+        // 상점 유형 (일반 운영진 부여 가능)
         case .bestWorkbook, .bestWorkbookV2, .blogChallenge,
              .umcEventReview, .peerReviewSubmission:
             return 20
+        // 벌점 유형 (일반 운영진 부여 가능)
         case .noWorkbookMission, .studyLate, .studyAbsent,
              .eventLate, .eventEarlyLeave, .eventLateCancel, .eventNoShow:
             return 20

--- a/UMCApp/Core/Foundation/Sources/Enums/ManagementTeam.swift
+++ b/UMCApp/Core/Foundation/Sources/Enums/ManagementTeam.swift
@@ -1,0 +1,111 @@
+//
+//  ManagementTeam.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 6/17/26.
+//
+
+import Foundation
+
+/// 멤버 역할/권한 구분
+///
+/// 서버 API `roleType` 값과 1:1 매핑됩니다.
+/// 역할 배지의 시각 매핑(Color)은 Presentation 레이어의 extension 에서 제공합니다.
+///
+/// 계층 구조 (높은 → 낮은)
+/// 1. superAdmin (시스템 관리자)
+/// 2. centralPresident / centralVicePresident (총괄/부총괄)
+/// 3. centralOperatingTeamMember / centralEducationTeamMember (중앙 운영진)
+/// 4. chapterPresident (지부장)
+/// 5. schoolPresident / schoolVicePresident (교내 회장단)
+/// 6. schoolPartLeader (교내 파트장)
+/// 7. schoolEtcAdmin (교내 기타 운영진)
+/// 8. challenger (챌린저)
+public enum ManagementTeam: String, CaseIterable, Codable, Sendable, Comparable {
+
+    // MARK: - Cases
+
+    case superAdmin = "SUPER_ADMIN"
+    case centralPresident = "CENTRAL_PRESIDENT"
+    case centralVicePresident = "CENTRAL_VICE_PRESIDENT"
+    case centralOperatingTeamMember = "CENTRAL_OPERATING_TEAM_MEMBER"
+    case centralEducationTeamMember = "CENTRAL_EDUCATION_TEAM_MEMBER"
+    case chapterPresident = "CHAPTER_PRESIDENT"
+    case schoolPresident = "SCHOOL_PRESIDENT"
+    case schoolVicePresident = "SCHOOL_VICE_PRESIDENT"
+    case schoolPartLeader = "SCHOOL_PART_LEADER"
+    case schoolEtcAdmin = "SCHOOL_ETC_ADMIN"
+    case challenger = "CHALLENGER"
+
+    // MARK: - Level
+
+    /// 권한 레벨 (높을수록 상위 권한)
+    ///
+    /// 복수 역할 보유 시 레벨이 높은 역할을 우선 적용합니다.
+    /// superAdmin 은 시스템 역할이므로 별도로 최상위에 둡니다.
+    public var level: Int {
+        switch self {
+        case .superAdmin:                   return 110
+        case .centralPresident:             return 100
+        case .centralVicePresident:         return 90
+        case .centralOperatingTeamMember:   return 80
+        case .centralEducationTeamMember:   return 70
+        case .chapterPresident:             return 60
+        case .schoolPresident:              return 50
+        case .schoolVicePresident:          return 40
+        case .schoolPartLeader:             return 30
+        case .schoolEtcAdmin:               return 20
+        case .challenger:                   return 0
+        }
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: ManagementTeam, rhs: ManagementTeam) -> Bool {
+        lhs.level < rhs.level
+    }
+
+    /// 역할 목록에서 가장 상위 권한을 반환합니다.
+    public static func highestPriority<S: Sequence>(
+        in roles: S
+    ) -> ManagementTeam? where S.Element == ManagementTeam {
+        roles.max()
+    }
+
+    // MARK: - Display
+
+    /// 한글 표시명
+    public var korean: String {
+        switch self {
+        case .superAdmin:                   return "시스템 관리자"
+        case .centralPresident:             return "총괄"
+        case .centralVicePresident:         return "부총괄"
+        case .centralOperatingTeamMember:   return "중앙 운영 운영국"
+        case .centralEducationTeamMember:   return "중앙 운영 교육국"
+        case .chapterPresident:             return "지부장"
+        case .schoolPresident:              return "교내 회장"
+        case .schoolVicePresident:          return "교내 부회장"
+        case .schoolPartLeader:             return "교내 파트장"
+        case .schoolEtcAdmin:               return "교내 운영진"
+        case .challenger:                   return "챌린저"
+        }
+    }
+
+    /// 배지 아이콘 (이모지)
+    public var icon: String {
+        switch self {
+        case .superAdmin:                                              return "👑"
+        case .centralPresident, .centralVicePresident:                return "⭐️"
+        case .centralOperatingTeamMember, .centralEducationTeamMember: return "⭐️"
+        case .chapterPresident:                                       return "🏛️"
+        case .schoolPresident, .schoolVicePresident:                  return "🏫"
+        case .schoolPartLeader, .schoolEtcAdmin:                      return "🚩"
+        case .challenger:                                             return ""
+        }
+    }
+
+    /// 아이콘 포함 표시명 (아이콘이 없으면 한글 표시명만 반환)
+    public var displayName: String {
+        icon.isEmpty ? korean : "\(icon) \(korean)"
+    }
+}

--- a/UMCApp/Core/Foundation/Tests/ChallengerPointTypeTests.swift
+++ b/UMCApp/Core/Foundation/Tests/ChallengerPointTypeTests.swift
@@ -1,0 +1,151 @@
+//
+//  ChallengerPointTypeTests.swift
+//  UMCFoundationTests
+//
+//  Created by jaewon Lee on 6/17/26.
+//
+
+import Foundation
+import Testing
+@testable import UMCFoundation
+
+@Suite("ChallengerPointType — 상벌점 유형 규칙 (도메인 규칙)")
+struct ChallengerPointTypeTests {
+
+    // MARK: - rawValue Mapping
+
+    @Test(
+        "서버 rawValue ↔ enum 매핑이 정확하다",
+        arguments: [
+            ("BEST_WORKBOOK", ChallengerPointType.bestWorkbook),
+            ("WARNING", .warning),
+            ("OUT", .out),
+            ("CUSTOM", .custom),
+            ("STUDY_ABSENT", .studyAbsent),
+            ("SCHOOL_CORE_TASK_NOT_COMPLETED", .schoolCoreTaskNotCompleted)
+        ]
+    )
+    func rawValueMapping(raw: String, expected: ChallengerPointType) {
+        #expect(ChallengerPointType(rawValue: raw) == expected)
+        #expect(expected.rawValue == raw)
+    }
+
+    @Test("알 수 없는 rawValue 는 nil 을 반환한다")
+    func unknownRawValueReturnsNil() {
+        #expect(ChallengerPointType(rawValue: "NOT_A_POINT") == nil)
+    }
+
+    // MARK: - defaultPointValue
+
+    @Test(
+        "유형별 기본 배점이 정확하다",
+        arguments: [
+            (ChallengerPointType.bestWorkbook, 2),
+            (.blogChallenge, 3),
+            (.custom, 0),
+            (.studyAbsent, -4),
+            (.eventNoShow, -10)
+        ]
+    )
+    func defaultPointValueMapping(type: ChallengerPointType, expected: Int) {
+        #expect(type.defaultPointValue == expected)
+    }
+
+    // MARK: - isReward
+
+    @Test(
+        "기본 배점이 양수인 유형은 상점(isReward=true)",
+        arguments: [
+            ChallengerPointType.bestWorkbook,
+            .blogChallenge,
+            .umcEventReview
+        ]
+    )
+    func positiveDefaultIsReward(type: ChallengerPointType) {
+        #expect(type.isReward == true)
+    }
+
+    @Test(
+        "기본 배점이 0 이하인 유형은 상점이 아니다(isReward=false)",
+        arguments: [
+            ChallengerPointType.custom,
+            .studyAbsent,
+            .eventNoShow
+        ]
+    )
+    func nonPositiveDefaultIsNotReward(type: ChallengerPointType) {
+        #expect(type.isReward == false)
+    }
+
+    // MARK: - isCustom
+
+    @Test("custom 유형만 isCustom=true")
+    func onlyCustomIsCustom() {
+        #expect(ChallengerPointType.custom.isCustom == true)
+    }
+
+    @Test(
+        "custom 이 아닌 유형은 isCustom=false",
+        arguments: [
+            ChallengerPointType.bestWorkbook,
+            .warning,
+            .studyLate
+        ]
+    )
+    func nonCustomIsNotCustom(type: ChallengerPointType) {
+        #expect(type.isCustom == false)
+    }
+
+    // MARK: - minimumRequiredLevel
+
+    @Test(
+        "유형별 최소 권한 레벨이 정확하다",
+        arguments: [
+            (ChallengerPointType.bestWorkbook, 20),
+            (.partLeadFeedbackLate, 30),
+            (.schoolCoreMeetingAbsent, 50)
+        ]
+    )
+    func minimumRequiredLevelMapping(type: ChallengerPointType, expected: Int) {
+        #expect(type.minimumRequiredLevel == expected)
+    }
+
+    // MARK: - availableTypes(for:)
+
+    @Test("availableTypes 는 항상 warning/out 을 제외한다")
+    func availableTypesExcludeWarningAndOut() {
+        let available = ChallengerPointType.availableTypes(for: 110)
+
+        #expect(available.contains(.warning) == false)
+        #expect(available.contains(.out) == false)
+    }
+
+    @Test("레벨 20 은 레벨 30/50 전용 유형을 포함하지 않는다")
+    func level20ExcludesHigherLevelTypes() {
+        let available = ChallengerPointType.availableTypes(for: 20)
+
+        #expect(available.contains(.bestWorkbook) == true)
+        #expect(available.contains(.partLeadFeedbackLate) == false)
+        #expect(available.contains(.schoolCoreMeetingAbsent) == false)
+    }
+
+    @Test("레벨 30 은 파트장 전용 유형까지 포함한다")
+    func level30IncludesPartLeaderType() {
+        let available = ChallengerPointType.availableTypes(for: 30)
+
+        #expect(available.contains(.partLeadFeedbackLate) == true)
+        #expect(available.contains(.schoolCoreMeetingAbsent) == false)
+    }
+
+    @Test("레벨 50 은 회장단 전용 유형까지 포함한다")
+    func level50IncludesSchoolCoreType() {
+        let available = ChallengerPointType.availableTypes(for: 50)
+
+        #expect(available.contains(.schoolCoreMeetingAbsent) == true)
+    }
+
+    @Test("최소 레벨(0)에서는 부여 가능한 유형이 없다")
+    func level0HasNoAvailableTypes() {
+        #expect(ChallengerPointType.availableTypes(for: 0).isEmpty)
+    }
+}

--- a/UMCApp/Core/Foundation/Tests/ChallengerPointTypeTests.swift
+++ b/UMCApp/Core/Foundation/Tests/ChallengerPointTypeTests.swift
@@ -148,4 +148,18 @@ struct ChallengerPointTypeTests {
     func level0HasNoAvailableTypes() {
         #expect(ChallengerPointType.availableTypes(for: 0).isEmpty)
     }
+
+    // MARK: - 레거시 예외 동작 (warning / out)
+
+    @Test(
+        "warning/out 은 벌점 개념이지만 레거시 호환으로 양수 배점 → isReward=true (의도적 보존)",
+        arguments: [
+            ChallengerPointType.warning,
+            ChallengerPointType.out
+        ]
+    )
+    func warningAndOutHavePositiveDefaultForLegacy(type: ChallengerPointType) {
+        #expect(type.defaultPointValue > 0)
+        #expect(type.isReward == true)
+    }
 }

--- a/UMCApp/Core/Foundation/Tests/ManagementTeamTests.swift
+++ b/UMCApp/Core/Foundation/Tests/ManagementTeamTests.swift
@@ -1,0 +1,102 @@
+//
+//  ManagementTeamTests.swift
+//  UMCFoundationTests
+//
+//  Created by jaewon Lee on 6/17/26.
+//
+
+import Foundation
+import Testing
+@testable import UMCFoundation
+
+@Suite("ManagementTeam — 역할 권한 계층 (도메인 규칙)")
+struct ManagementTeamTests {
+
+    // MARK: - rawValue Mapping
+
+    @Test(
+        "서버 roleType rawValue ↔ enum 매핑이 정확하다",
+        arguments: [
+            ("SUPER_ADMIN", ManagementTeam.superAdmin),
+            ("CENTRAL_PRESIDENT", .centralPresident),
+            ("SCHOOL_PART_LEADER", .schoolPartLeader),
+            ("CHALLENGER", .challenger)
+        ]
+    )
+    func rawValueMapping(raw: String, expected: ManagementTeam) {
+        #expect(ManagementTeam(rawValue: raw) == expected)
+        #expect(expected.rawValue == raw)
+    }
+
+    // MARK: - level
+
+    @Test("superAdmin 이 전체에서 가장 높은 레벨이다")
+    func superAdminHasHighestLevel() {
+        let maxLevel = ManagementTeam.allCases.map(\.level).max()
+
+        #expect(ManagementTeam.superAdmin.level == maxLevel)
+    }
+
+    @Test("challenger 의 레벨은 0 이다")
+    func challengerLevelIsZero() {
+        #expect(ManagementTeam.challenger.level == 0)
+    }
+
+    // MARK: - Comparable
+
+    @Test(
+        "역할 쌍의 대소 비교가 레벨 순서를 따른다",
+        arguments: [
+            (ManagementTeam.challenger, ManagementTeam.schoolPartLeader),
+            (.schoolEtcAdmin, .schoolPresident),
+            (.chapterPresident, .centralPresident)
+        ]
+    )
+    func lowerLevelComparesLessThanHigher(lower: ManagementTeam, higher: ManagementTeam) {
+        #expect(lower < higher)
+    }
+
+    // MARK: - highestPriority(in:)
+
+    @Test("highestPriority 는 가장 상위 권한을 반환한다")
+    func highestPriorityReturnsMaxRole() {
+        let roles: [ManagementTeam] = [.challenger, .schoolPartLeader, .centralVicePresident]
+
+        #expect(ManagementTeam.highestPriority(in: roles) == .centralVicePresident)
+    }
+
+    @Test("빈 역할 목록의 highestPriority 는 nil 이다")
+    func highestPriorityOfEmptyIsNil() {
+        #expect(ManagementTeam.highestPriority(in: [ManagementTeam]()) == nil)
+    }
+
+    // MARK: - displayName / icon
+
+    @Test("challenger 는 아이콘이 없어 displayName 이 한글명과 같다")
+    func challengerDisplayNameEqualsKorean() {
+        #expect(ManagementTeam.challenger.icon.isEmpty)
+        #expect(ManagementTeam.challenger.displayName == ManagementTeam.challenger.korean)
+    }
+
+    @Test("아이콘이 있는 역할은 displayName 에 아이콘이 접두된다")
+    func iconedRoleDisplayNameHasIconPrefix() {
+        let role = ManagementTeam.superAdmin
+
+        #expect(role.icon.isEmpty == false)
+        #expect(role.displayName == "\(role.icon) \(role.korean)")
+    }
+
+    // MARK: - Korean
+
+    @Test(
+        "한글 표시명 매핑이 정확하다",
+        arguments: [
+            (ManagementTeam.centralPresident, "총괄"),
+            (.schoolPresident, "교내 회장"),
+            (.challenger, "챌린저")
+        ]
+    )
+    func koreanMapping(role: ManagementTeam, expected: String) {
+        #expect(role.korean == expected)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/MemberRepositoryProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/MemberRepositoryProtocol.swift
@@ -1,0 +1,78 @@
+//
+//  MemberRepositoryProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/17/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 운영진 멤버 관리 데이터 접근 Repository
+///
+/// 멤버 목록 조회(전체/페이지), 챌린저 상벌점 부여·삭제·이력 조회,
+/// 멤버 출석 이력 및 기수별 상벌점 요약 조회를 담당합니다.
+///
+/// 모든 서버 식별자는 `String` 으로 통일합니다.
+public protocol MemberRepositoryProtocol {
+
+    // MARK: - 멤버 목록
+
+    /// 멤버 목록 전체 조회
+    func fetchMembers() async throws -> [MemberManagementItem]
+
+    /// 멤버 목록 페이지 단위 조회 (offset 기반)
+    ///
+    /// - Parameter page: 0-based 페이지 인덱스
+    func fetchMembersPage(page: Int) async throws -> MemberPage
+
+    // MARK: - 상벌점 부여 / 삭제
+
+    /// 챌린저에게 포인트를 부여합니다.
+    ///
+    /// - Parameters:
+    ///   - challengerId: 대상 챌린저 식별자 (서버 응답)
+    ///   - pointType: 포인트 유형
+    ///   - pointValue: 배점 (`ChallengerPointType/isCustom` 인 경우 직접 입력)
+    ///   - description: 부여 사유
+    func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws
+
+    /// 챌린저 포인트를 삭제합니다.
+    ///
+    /// - Parameter challengerPointId: 삭제할 포인트 식별자 (서버 응답)
+    func deletePoint(challengerPointId: String) async throws
+
+    /// 특정 챌린저의 포인트 히스토리를 조회합니다.
+    ///
+    /// - Parameter challengerId: 조회 대상 챌린저 식별자 (서버 응답)
+    func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory]
+
+    // MARK: - 멤버 상세
+
+    /// 멤버 프로필에서 모든 활동 기수 텍스트를 조회합니다.
+    ///
+    /// - Parameter memberId: 조회 대상 멤버 식별자 (서버 응답)
+    func fetchAllGenerations(memberId: String) async throws -> String
+
+    /// 멤버의 기수별 상벌점 요약을 조회합니다.
+    ///
+    /// - Parameter memberId: 조회 대상 멤버 식별자 (서버 응답)
+    func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary]
+
+    /// 일정 출석 현황에서 특정 멤버의 출석 이력을 조회합니다.
+    ///
+    /// - Parameter memberId: 조회 대상 멤버 식별자 (서버 응답)
+    /// - Returns: 해당 멤버가 포함된 일정별 출석 기록. 결과 없으면 빈 배열 반환.
+    func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord]
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/MemberManagement/MemberManagementItem.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/MemberManagement/MemberManagementItem.swift
@@ -1,0 +1,137 @@
+//
+//  MemberManagementItem.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/17/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - GenerationPointSummary
+
+/// 기수별 상벌점 요약 데이터
+public struct GenerationPointSummary: Equatable, Identifiable {
+    public var id: Int { gisu }
+
+    /// 기수 (예: 9)
+    public let gisu: Int
+
+    /// 누적 상점
+    public let reward: Double
+
+    /// 누적 벌점
+    public let penalty: Double
+
+    public init(gisu: Int, reward: Double, penalty: Double) {
+        self.gisu = gisu
+        self.reward = reward
+        self.penalty = penalty
+    }
+}
+
+// MARK: - MemberManagementItem
+
+/// 멤버 관리 리스트에서 사용되는 데이터 모델입니다.
+///
+/// 멤버 카드 뷰와 멤버 상세 시트에서 공통으로 사용됩니다.
+public struct MemberManagementItem: Identifiable, Equatable {
+
+    // MARK: - Property
+
+    /// 고유 식별자 (클라이언트 생성)
+    public let id: UUID
+
+    /// 멤버 고유 식별자 (서버 응답)
+    public let memberID: String?
+
+    /// 챌린저 고유 식별자 (서버 응답)
+    public let challengerID: String?
+
+    /// 프로필 이미지 리소스
+    public let profile: String?
+
+    /// 멤버 이름
+    public let name: String
+
+    /// 멤버 닉네임
+    public let nickname: String
+
+    /// 기수 정보 (예: "9기")
+    public let generation: String
+
+    /// 소속 학교
+    public let school: String
+
+    /// 포지션 정보
+    public let position: String
+
+    /// 파트 정보 (iOS, Web 등)
+    public let part: UMCPartType
+
+    /// 현재 누적 벌점
+    public let penalty: Double
+
+    /// 현재 누적 상점
+    public let rewardPoints: Double
+
+    /// 뱃지 표시 여부
+    public let badge: Bool
+
+    /// 운영진 직책 정보 (회장, 부회장 등)
+    public let managementTeam: ManagementTeam
+
+    /// 출석/활동 기록 목록
+    public let attendanceRecords: [MemberAttendanceRecord]
+
+    /// 상벌점 히스토리
+    public let penaltyHistory: [OperatorMemberPenaltyHistory]
+
+    /// 상벌점 히스토리 열람 가능 여부
+    public let canViewPenaltyHistory: Bool
+
+    /// 기수별 상벌점 요약 목록
+    public let generationPoints: [GenerationPointSummary]
+
+    // MARK: - Initializer
+
+    public init(
+        id: UUID = .init(),
+        memberID: String? = nil,
+        challengerID: String? = nil,
+        profile: String?,
+        name: String,
+        nickname: String,
+        generation: String,
+        school: String,
+        position: String,
+        part: UMCPartType,
+        penalty: Double,
+        rewardPoints: Double = 0,
+        badge: Bool,
+        managementTeam: ManagementTeam,
+        attendanceRecords: [MemberAttendanceRecord],
+        penaltyHistory: [OperatorMemberPenaltyHistory],
+        canViewPenaltyHistory: Bool = true,
+        generationPoints: [GenerationPointSummary] = []
+    ) {
+        self.id = id
+        self.memberID = memberID
+        self.challengerID = challengerID
+        self.profile = profile
+        self.name = name
+        self.nickname = nickname
+        self.generation = generation
+        self.school = school
+        self.position = position
+        self.part = part
+        self.penalty = penalty
+        self.rewardPoints = rewardPoints
+        self.badge = badge
+        self.managementTeam = managementTeam
+        self.attendanceRecords = attendanceRecords
+        self.penaltyHistory = penaltyHistory
+        self.canViewPenaltyHistory = canViewPenaltyHistory
+        self.generationPoints = generationPoints
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/MemberManagement/MemberPage.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/MemberManagement/MemberPage.swift
@@ -1,0 +1,29 @@
+//
+//  MemberPage.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/17/26.
+//
+
+import Foundation
+
+/// 멤버 관리 목록의 한 페이지 (offset 기반 페이지네이션)
+///
+/// 멤버 조회 서버 API 가 offset(page) 기반이므로 페이지 인덱스를 그대로 보존합니다.
+public struct MemberPage: Equatable {
+
+    /// 현재 페이지의 멤버 목록
+    public let members: [MemberManagementItem]
+
+    /// 다음 페이지 존재 여부
+    public let hasNext: Bool
+
+    /// 현재 페이지 인덱스 (0-based)
+    public let currentPage: Int
+
+    public init(members: [MemberManagementItem], hasNext: Bool, currentPage: Int) {
+        self.members = members
+        self.hasNext = hasNext
+        self.currentPage = currentPage
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorMemberPenaltyHistory.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorMemberPenaltyHistory.swift
@@ -27,7 +27,10 @@ public struct OperatorMemberPenaltyHistory: Identifiable, Equatable {
     /// 사유
     public let reason: String
 
-    /// 포인트 점수 (절대값)
+    /// 포인트 점수의 절대값 (부호 없음)
+    ///
+    /// 상점/벌점 구분은 이 값의 부호가 아니라 ``pointType`` 의 ``ChallengerPointType/isReward`` 로만 판별합니다.
+    /// 따라서 항상 0 이상의 절대값을 보관합니다.
     public let penaltyScore: Double
 
     /// 포인트 유형
@@ -41,7 +44,7 @@ public struct OperatorMemberPenaltyHistory: Identifiable, Equatable {
         date: Date,
         reason: String,
         penaltyScore: Double,
-        pointType: ChallengerPointType = .out
+        pointType: ChallengerPointType
     ) {
         self.id = id
         self.challengerPointId = challengerPointId

--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorMemberPenaltyHistory.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/OperatorMemberPenaltyHistory.swift
@@ -1,0 +1,53 @@
+//
+//  OperatorMemberPenaltyHistory.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/17/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 운영진 멤버 관리 히스토리
+///
+/// 멤버 상벌점 히스토리를 나타내는 모델입니다.
+public struct OperatorMemberPenaltyHistory: Identifiable, Equatable {
+
+    // MARK: - Property
+
+    /// 고유 식별자 (클라이언트 생성)
+    public let id: UUID
+
+    /// 서버 포인트 식별자 (서버 응답)
+    public let challengerPointId: String?
+
+    /// 날짜
+    public let date: Date
+
+    /// 사유
+    public let reason: String
+
+    /// 포인트 점수 (절대값)
+    public let penaltyScore: Double
+
+    /// 포인트 유형
+    public let pointType: ChallengerPointType
+
+    // MARK: - Initializer
+
+    public init(
+        id: UUID = UUID(),
+        challengerPointId: String? = nil,
+        date: Date,
+        reason: String,
+        penaltyScore: Double,
+        pointType: ChallengerPointType = .out
+    ) {
+        self.id = id
+        self.challengerPointId = challengerPointId
+        self.date = date
+        self.reason = reason
+        self.penaltyScore = penaltyScore
+        self.pointType = pointType
+    }
+}


### PR DESCRIPTION
resolves #888

## ✨ PR 유형

♻️ Refactor — 레거시 `AppProduct/` 멤버 도메인을 신규 `UMCApp/` Tuist 모듈로 v2 스펙 신규 작성 이식

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1551" height="947" alt="스크린샷 2026-06-17 오후 2 37 07" src="https://github.com/user-attachments/assets/fc1ffb0e-ff28-4549-8747-e3765fb507d2" />

<img width="1595" height="991" alt="스크린샷 2026-06-17 오후 2 37 15" src="https://github.com/user-attachments/assets/7219fca2-bf89-4759-9021-cc9c3cf54cbf" />


## 🛠️ 작업내용

레거시 멤버 관리 도메인을 신규 모듈로 이식했습니다. 멤버 UseCase·Repository·Presentation 이식 전체의 **선행 기반**이며, 레거시는 참고만 하고 v2 스펙으로 신규 작성했습니다 (Mock은 신규 모듈에 미포함).

이식 대상
- `MemberRepositoryProtocol` (ActivityDomain Interfaces)
- 도메인 모델 3종: `MemberManagementItem`(+`GenerationPointSummary`) · `MemberPage` · `OperatorMemberPenaltyHistory`
- 공유 의존 enum 2종: `ManagementTeam` · `ChallengerPointType` (UMCFoundation)

핵심 결정

| 항목 | 결정 |
|------|------|
| 페이지네이션 | offset/page 유지 (`fetchMembersPage(page:)`) — 멤버 서버 API가 offset 기반 |
| enum 배치 | UMCFoundation 공유, Domain UI-free (Color → Presentation, Notice 권한 헬퍼 제외) |
| 숫자 타입 | 서버 ID만 `String`, ordinal/score(gisu·week·points)는 `Int`/`Double` |
| 재사용 | `MemberAttendanceRecord`·`UMCPartType` 기존 이식분 재사용 (중복 미생성) |

## 📋 추후 진행 상황

- 멤버 Repository 구현체(Data) + UseCase 이식
- 멤버 ViewModel / View 이식 (멤버 관리 Presentation)

## 📌 리뷰 포인트

- `Features/Activity/Domain/` — 멤버 도메인 모델·프로토콜 계약. 레거시 1:1 복사가 아닌 v2 신규 작성 (Int ID → `String`, `public` 노출).
- `Core/Foundation/Sources/Enums/` — 공유 enum 2종. Notice/MyPage 후속 이식 시 재사용될 계약. Domain UI-free 위해 Color(→Presentation)·Notice 작성권한 헬퍼(→Notice 도메인)는 **의도적 제외**.
- 숫자 규칙 정합성: ID만 `String`, ordinal/score는 `Int`/`Double` — 기존 이식분(`MemberAttendanceRecord.week: Int` 등)과 일치.
- (의도적 보존) `ChallengerPointType.warning`/`.out`의 `defaultPointValue`가 양수 → `isReward == true`. 레거시 동작 충실 이식이며 `availableTypes`에서 제외되는 타입이라 부여 흐름엔 영향 없음.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
