### PR TITLE
🐛 [Fix] 이메일 인증 완료 체크마크 SF Symbol 미표시 수정 (#903)

### DIFF
--- a/AppProduct/AppProduct/Utilities/Modifier/SymbolDrawOnModifier.swift
+++ b/AppProduct/AppProduct/Utilities/Modifier/SymbolDrawOnModifier.swift
@@ -39,6 +39,13 @@ private struct SymbolDrawOnModifier: ViewModifier {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    /// 등장 직후 `false → true` 전환을 주기 위한 내부 상태.
+    ///
+    /// `.drawOn`은 `isActive`가 `false → true`로 **전환되는 순간**에만 그리기 애니메이션을
+    /// 재생합니다. 심볼이 이미 `isActive == true`인 상태로 새로 삽입되면 전환 트리거가
+    /// 없어 "그려지지 않은(=비표시)" 상태로 남으므로, 등장 시점에 직접 토글합니다.
+    @State private var hasDrawn = false
+
     let isActive: Bool
 
     // MARK: - Body
@@ -46,7 +53,8 @@ private struct SymbolDrawOnModifier: ViewModifier {
     func body(content: Content) -> some View {
         if isActive && !reduceMotion {
             content
-                .symbolEffect(.drawOn, isActive: true)
+                .symbolEffect(.drawOn, isActive: hasDrawn)
+                .onAppear { hasDrawn = true }
         } else {
             content
         }


### PR DESCRIPTION
## ✨ PR 유형

- 🐛 버그 수정 (이메일 인증 완료 가이드 체크마크 SF Symbol 미표시)

resolves #903

## 🛠️ 작업내용

이메일 인증 완료 후 "인증되었습니다." 앞 `checkmark.circle.fill` 심볼이 보이지 않던 문제를 수정했습니다.

**원인**
`.symbolEffect(.drawOn, isActive:)`은 `isActive`가 `false → true`로 **전환되는 순간**에만 그리기 애니메이션을 재생합니다. 성공 메시지 뷰는 `verificationState == .verified`일 때 새로 삽입되는데, 이때 심볼이 이미 `isActive == true` 상태로 등장하므로 전환 트리거를 받지 못해 "그려지지 않은(=비표시)" 상태로 남았습니다.

**수정**
`SymbolDrawOnModifier` 내부에 `@State hasDrawn`을 추가하고, `onAppear`에서 `false → true`로 토글해 등장 시점에 항상 drawOn 전환이 발생하도록 보강했습니다. 호출부(`symbolDrawOn(isActive: true)`)는 그대로 두고 모디파이어만 고쳐, 같은 패턴을 쓰는 모든 화면에서 일관되게 동작합니다.

```swift
@State private var hasDrawn = false
...
content
    .symbolEffect(.drawOn, isActive: hasDrawn)
    .onAppear { hasDrawn = true }
```

## 📌 리뷰 포인트

- **블라스트 반경**: 호출부 변경 없이 공용 `SymbolDrawOnModifier`를 수정했습니다. `symbolDrawOn(isActive: true)`을 쓰는 다른 화면(`SignUpByIdPwView`, `NoticeReadStatusButton`, `ChallengerMissionStatusIcon`, `OperatorSessionStatusIcon` 등)도 등장 시 동일하게 그려집니다 — 모두 의도한 "긍정 상태 등장 애니메이션"이라 회귀가 아닌 개선입니다.
- **Reduce Motion**: `reduceMotion`일 때는 기존대로 효과 없이 정적 표시되어 심볼이 항상 보입니다.
- 모든 호출부가 `isActive`에 상수 `true`/`false`를 넘기므로 내부 `@State` 분기 전환 이슈는 발생하지 않습니다.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
- [x] 시뮬레이터 빌드 성공 (iPhone 17 Pro, iOS 26.5)
