### PR TITLE
✨ [Feat] 소셜 로그인 이메일을 회원가입 인증 필드에 자동 입력 (#902)

### DIFF
--- a/AppProduct/AppProduct/Core/Manager/Auth/GoogleLoginManager.swift
+++ b/AppProduct/AppProduct/Core/Manager/Auth/GoogleLoginManager.swift
@@ -54,6 +54,22 @@ final class GoogleLoginManager {
         return result.user.accessToken.tokenString
     }
 
+    /// 구글 로그인을 수행하고 서버 전송용 OAuth `accessToken`과 계정 이메일을 함께 반환합니다.
+    ///
+    /// 이메일은 신규 회원가입 진입 시 인증 필드 프리필에 사용합니다.
+    ///
+    /// - Returns: (OAuth accessToken, 계정 이메일) 튜플. 이메일은 프로필 스코프 미동의 등으로
+    ///   제공되지 않을 수 있어 옵셔널입니다.
+    /// - Throws: `GoogleLoginError.presentationContextNotFound` 또는 GoogleSignIn SDK 에러
+    @MainActor
+    func login() async throws -> (accessToken: String, email: String?) {
+        let result = try await signIn()
+        return (
+            result.user.accessToken.tokenString,
+            result.user.profile?.email
+        )
+    }
+
     // MARK: - Private Function
 
     /// GoogleSignIn 로그인을 수행하고 결과를 반환합니다.

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
@@ -72,6 +72,7 @@ final class LoginViewModel {
             loginState = .loaded(result)
             destination = try await resolveDestination(
                 from: result,
+                email: email,
                 postRegisterLoginContext: .kakao(
                     accessToken: accessToken,
                     email: email
@@ -128,6 +129,9 @@ final class LoginViewModel {
                     )
                     SocialType.addConnected(.apple)
                     self.loginState = .loaded(result)
+                    // Apple은 최초 1회 인증 시에만 email을 제공하고 이후엔 nil입니다.
+                    // 신규 회원이라면 첫 인증이므로 email이 있어 가입 화면 프리필이 가능하고,
+                    // nil인 경우엔 가입 화면에서 빈 필드로 폴백되어 수동 입력합니다.
                     self.destination = try await self.resolveDestination(
                         from: result,
                         email: email,
@@ -164,15 +168,17 @@ final class LoginViewModel {
         destination = nil
 
         do {
-            let accessToken = try await googleLoginManager.fetchAccessToken()
+            let (accessToken, email) = try await googleLoginManager.login()
             #if DEBUG
             print("[Auth] 구글 accessToken: \(accessToken)")
+            print("[Auth] 구글 email: \(email ?? "nil")")
             #endif
             let result = try await loginUseCase.executeGoogle(accessToken: accessToken)
             SocialType.addConnected(.google)
             loginState = .loaded(result)
             destination = try await resolveDestination(
                 from: result,
+                email: email,
                 postRegisterLoginContext: .google(accessToken: accessToken)
             )
         } catch {


### PR DESCRIPTION
## ✨ PR 유형

- ✨ 기능 추가 (소셜 로그인 이메일 → 회원가입 인증 필드 자동 입력)

resolves #902

## 🛠️ 작업내용

소셜 로그인(카카오/애플/구글)으로 **신규 가입 진입** 시, 해당 소셜 계정의 이메일을 회원가입 이메일 인증 필드에 자동 프리필합니다. 프리필 인프라(`SignUpViewModel.email = initialEmail`)는 이미 존재했고, **각 경로에서 가입 화면까지 email을 전달(threading)하는 부분**만 채웠습니다.

| Provider | 변경 |
|---|---|
| **카카오** | `loginWithKakao`가 이미 받아온 `email`을 `resolveDestination`에 전달 (기존 누락) |
| **구글** | `GoogleLoginManager.login()` 신규 추가 → `accessToken` + `user.profile?.email` 반환, `loginWithGoogle`에서 전달 |
| **애플** | 기존대로 전달 동작 확인 + "최초 1회만 email 제공" 제약 주석화 |

**결선 흐름**
`resolveDestination(email:)` → `LoginDestination.signUp(email:)` → `SignUpView(initialEmail:)` → `SignUpViewModel.email` 로 이어져 곧바로 이메일 인증 요청이 가능합니다.

## 📌 리뷰 포인트

- **구글**: 연동 해제용 `fetchAccessToken()`은 그대로 두고 로그인용 `login()`을 별도로 추가했습니다(이메일은 idToken 디코드가 아니라 `user.profile?.email`에서 획득).
- **폴백**: 소셜이 이메일을 주지 않거나(애플 2회차, 구글 프로필 스코프 미동의) 권한 거부 시, `initialEmail`이 `nil`이라 빈 필드로 폴백되어 크래시 없이 수동 입력 가능합니다.
- 베이스에 선행 커밋 `b7840f70`(구글 OAuth accessToken 전환)이 포함됩니다 — develop에 해당 커밋이 머지되면 이 PR diff에서 자동으로 빠집니다.

## ⚠️ 의존
- #903 (체크마크 미표시) 은 본 이슈의 하위 이슈이며 별도 PR(#904)로 분리했습니다.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
- [x] 시뮬레이터 빌드 성공 (iPhone 17 Pro, iOS 26.5)
