### PR TITLE
🐛 [Fix] Apple 회원가입 직후 OAuth 오류 팝업 해소 — 토큰 우선 복구 + 실패 안내 (#901)

### DIFF
--- a/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
+++ b/AppProduct/AppProduct/Core/Mock/DesignPreview/LoginPreview.swift
@@ -106,8 +106,8 @@ private struct PreviewVerifyCodeUseCase: VerifyEmailCodeUseCaseProtocol {
 }
 
 private struct PreviewRegisterUseCase: RegisterUseCaseProtocol {
-    func execute(request: RegisterRequestDTO) async throws -> String {
-        "1"
+    func execute(request: RegisterRequestDTO) async throws -> RegisterResult {
+        RegisterResult(memberId: "1", tokenPair: nil)
     }
 }
 

--- a/AppProduct/AppProduct/Features/Auth/Data/DTOs/RegisterResponseDTO.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/DTOs/RegisterResponseDTO.swift
@@ -8,10 +8,79 @@
 import Foundation
 
 /// 회원가입 API 응답 DTO
+///
+/// 서버가 회원가입 응답에 토큰을 함께 내려주면(`accessToken`/`refreshToken`) 별도 재로그인
+/// 없이 그대로 세션을 복구할 수 있습니다. 토큰 필드는 서버 스펙에 따라 없을 수 있으므로
+/// 옵셔널로 디코딩하고, 없으면 기존 소셜 재로그인 경로로 폴백합니다.
 struct RegisterResponseDTO: Codable {
 
     // MARK: - Property
 
     /// 생성된 회원 ID (서버가 String 반환)
     let memberId: String
+
+    /// JWT 액세스 토큰 (서버가 가입 응답에 포함할 경우)
+    let accessToken: String?
+
+    /// JWT 리프레시 토큰 (서버가 가입 응답에 포함할 경우)
+    let refreshToken: String?
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case memberId
+        case accessToken
+        case refreshToken
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        memberId = try container.decode(String.self, forKey: .memberId)
+        accessToken = try container.decodeIfPresent(
+            String.self,
+            forKey: .accessToken
+        )
+        refreshToken = try container.decodeIfPresent(
+            String.self,
+            forKey: .refreshToken
+        )
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(memberId, forKey: .memberId)
+        try container.encodeIfPresent(accessToken, forKey: .accessToken)
+        try container.encodeIfPresent(refreshToken, forKey: .refreshToken)
+    }
+
+    // MARK: - Mapping
+
+    /// Domain 모델로 변환합니다.
+    ///
+    /// `accessToken`/`refreshToken`이 모두 비어있지 않을 때만 `tokenPair`를 구성합니다.
+    func toDomain() -> RegisterResult {
+        let trimmedAccess = accessToken?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        let trimmedRefresh = refreshToken?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+
+        let tokenPair: TokenPair?
+        if let trimmedAccess, !trimmedAccess.isEmpty,
+           let trimmedRefresh, !trimmedRefresh.isEmpty {
+            tokenPair = TokenPair(
+                accessToken: trimmedAccess,
+                refreshToken: trimmedRefresh
+            )
+        } else {
+            tokenPair = nil
+        }
+
+        return RegisterResult(memberId: memberId, tokenPair: tokenPair)
+    }
 }

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -377,10 +377,10 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
     /// 회원가입을 수행합니다.
     ///
     /// - Parameter request: 회원가입 요청 DTO
-    /// - Returns: 생성된 회원 ID (서버 응답 String 기준)
+    /// - Returns: 회원 ID + (서버가 제공할 경우) 토큰 쌍
     func register(
         request: RegisterRequestDTO
-    ) async throws -> String {
+    ) async throws -> RegisterResult {
         do {
             let response = try await adapter.requestWithoutAuth(
                 AuthRouter.register(body: request)
@@ -390,7 +390,7 @@ final class AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
                 from: response.data
             )
             let dto = try apiResponse.unwrap()
-            return dto.memberId
+            return dto.toDomain()
         } catch let NetworkError.requestFailed(statusCode, data) {
             #if DEBUG
             if let data,

--- a/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
+++ b/AppProduct/AppProduct/Features/Auth/Data/Repositories/Mock/MockAuthRepository.swift
@@ -197,9 +197,9 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
 
     func register(
         request: RegisterRequestDTO
-    ) async throws -> String {
+    ) async throws -> RegisterResult {
         try await Task.sleep(for: .milliseconds(500))
-        return "1"
+        return RegisterResult(memberId: "1", tokenPair: nil)
     }
 
     func registerExistingChallenger(

--- a/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
@@ -126,10 +126,10 @@ protocol AuthRepositoryProtocol: Sendable {
 
     /// 회원가입
     /// - Parameter request: 회원가입 요청 DTO
-    /// - Returns: 생성된 회원 ID (서버 응답 String 기준)
+    /// - Returns: 회원 ID + (서버가 제공할 경우) 토큰 쌍
     func register(
         request: RegisterRequestDTO
-    ) async throws -> String
+    ) async throws -> RegisterResult
 
     /// 기존 챌린저 코드 인증
     /// - Parameter code: 운영진 발급 6자리 코드

--- a/AppProduct/AppProduct/Features/Auth/Domain/Models/RegisterResult.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/Models/RegisterResult.swift
@@ -1,0 +1,24 @@
+//
+//  RegisterResult.swift
+//  AppProduct
+//
+//  Created by euijjang97 on 6/18/26.
+//
+
+import Foundation
+
+/// 소셜 회원가입 결과
+///
+/// 서버가 가입 응답에 토큰을 함께 내려주면 `tokenPair`가 채워져 별도 재로그인 없이
+/// 즉시 세션을 복구할 수 있습니다. 토큰이 없으면 `nil`이며, 호출부는 기존 소셜
+/// 재로그인 경로로 폴백합니다.
+struct RegisterResult: Equatable, Sendable {
+
+    // MARK: - Property
+
+    /// 생성된 회원 ID (서버 응답 String)
+    let memberId: String
+
+    /// 가입과 동시에 발급된 토큰 쌍 (서버가 제공하지 않으면 `nil`)
+    let tokenPair: TokenPair?
+}

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/RegisterUseCase.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/Implementations/RegisterUseCase.swift
@@ -10,21 +10,41 @@ import Foundation
 // MARK: - RegisterUseCase
 
 /// 회원가입 UseCase 구현체
+///
+/// 서버가 가입 응답에 토큰을 함께 내려주면(`RegisterResult.tokenPair`) 즉시 저장하여
+/// 별도 소셜 재로그인 없이 세션을 복구합니다. 이는 Apple의 1회용 `authorizationCode`를
+/// 재사용하다 거절당하던 문제(#901)를 근본적으로 차단합니다. 토큰이 없으면 호출부가
+/// 기존 소셜 재로그인 경로로 폴백합니다.
 final class RegisterUseCase: RegisterUseCaseProtocol {
 
     // MARK: - Property
 
     private let repository: AuthRepositoryProtocol
+    private let tokenStore: TokenStore
 
     // MARK: - Init
 
-    init(repository: AuthRepositoryProtocol) {
+    init(
+        repository: AuthRepositoryProtocol,
+        tokenStore: TokenStore
+    ) {
         self.repository = repository
+        self.tokenStore = tokenStore
     }
 
     // MARK: - Function
 
-    func execute(request: RegisterRequestDTO) async throws -> String {
-        try await repository.register(request: request)
+    func execute(request: RegisterRequestDTO) async throws -> RegisterResult {
+        let result = try await repository.register(request: request)
+
+        // 서버가 가입과 동시에 토큰을 발급한 경우 즉시 저장하고 재로그인을 생략합니다.
+        if let tokenPair = result.tokenPair {
+            try await tokenStore.save(
+                accessToken: tokenPair.accessToken,
+                refreshToken: tokenPair.refreshToken
+            )
+        }
+
+        return result
     }
 }

--- a/AppProduct/AppProduct/Features/Auth/Domain/UseCases/RegisterUseCaseProtocol.swift
+++ b/AppProduct/AppProduct/Features/Auth/Domain/UseCases/RegisterUseCaseProtocol.swift
@@ -12,7 +12,10 @@ import Foundation
 /// 회원가입 UseCase Protocol
 protocol RegisterUseCaseProtocol {
     /// 회원가입 실행
+    ///
+    /// 서버가 가입 응답에 토큰을 함께 내려주면 즉시 저장하여 별도 재로그인 없이
+    /// 세션을 복구합니다.
     /// - Parameter request: 회원가입 요청 DTO
-    /// - Returns: 생성된 회원 ID (서버 응답 String 기준)
-    func execute(request: RegisterRequestDTO) async throws -> String
+    /// - Returns: 회원 ID + (서버가 제공할 경우) 토큰 쌍
+    func execute(request: RegisterRequestDTO) async throws -> RegisterResult
 }

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
@@ -112,7 +112,8 @@ final class AuthUseCaseProvider: AuthUseCaseProviding {
             repository: repository
         )
         self.registerUseCase = RegisterUseCase(
-            repository: repository
+            repository: repository,
+            tokenStore: tokenStore
         )
         self.registerExistingChallengerUseCase = RegisterExistingChallengerUseCase(
             repository: repository

--- a/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
@@ -75,6 +75,13 @@ final class SignUpViewModel {
     /// 회원가입 상태 (성공 시 서버 응답 memberId 보관)
     private(set) var registerState: Loadable<String> = .idle
 
+    /// 가입은 성공했으나 세션 복구에 실패해 수동 재로그인이 필요한지 여부
+    ///
+    /// 서버가 가입 응답에 토큰을 주지 않고 소셜 재로그인마저 실패한 경우
+    /// (예: Apple의 1회용 `authorizationCode` 소비)에 `true`가 됩니다.
+    /// 이때 화면은 모호한 오류 대신 "다시 로그인" 안내를 노출합니다.
+    private(set) var requiresManualLoginAfterRegister = false
+
     /// 폼 유효성 검증 상태
     var isFormValid: Bool {
         !name.isEmpty &&
@@ -247,13 +254,28 @@ final class SignUpViewModel {
         #endif
 
         do {
-            let memberId = try await registerUseCase
+            let result = try await registerUseCase
                 .execute(request: request)
-            try await restoreSessionAfterRegisterIfNeeded()
+
+            // 서버가 가입 응답에 토큰을 제공했다면 UseCase가 이미 저장했으므로 재로그인 생략.
+            // 토큰이 없을 때만 기존 소셜 재로그인으로 세션을 복구하되, 가입은 성공했는데
+            // 복구만 실패한 경우(예: Apple의 1회용 authorizationCode 소비)에는 가입 자체는
+            // 성공으로 처리하고 화면에서 수동 재로그인을 안내합니다.
+            if result.tokenPair == nil {
+                do {
+                    try await restoreSessionAfterRegisterIfNeeded()
+                } catch {
+                    #if DEBUG
+                    print("[Auth] register 성공 / 세션 복구 실패: \(error)")
+                    #endif
+                    requiresManualLoginAfterRegister = true
+                }
+            }
+
             #if DEBUG
-            print("[Auth] register 성공: memberId=\(memberId)")
+            print("[Auth] register 성공: memberId=\(result.memberId)")
             #endif
-            registerState = .loaded(memberId)
+            registerState = .loaded(result.memberId)
         } catch let error as AppError {
             #if DEBUG
             print("[Auth] register 실패: \(error)")

--- a/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/AppProduct/AppProduct/Features/Auth/Presentation/Views/SignUpView.swift
@@ -105,7 +105,11 @@ struct SignUpView: View {
                         false,
                         forKey: AppStorageKey.canAutoLogin
                     )
-                    appFlow.showPendingApproval()
+                    if viewModel.requiresManualLoginAfterRegister {
+                        promptManualLoginAfterRegister()
+                    } else {
+                        appFlow.showPendingApproval()
+                    }
                     return
                 }
 
@@ -475,6 +479,19 @@ extension SignUpView {
         }
     }
 
+    /// 가입은 완료됐으나 세션 복구에 실패한 경우, 모호한 오류 대신 명확한 재로그인을 안내합니다.
+    @MainActor
+    private func promptManualLoginAfterRegister() {
+        alertPrompt = AlertPrompt(
+            title: "가입이 완료됐어요",
+            message: "로그인 화면에서 다시 로그인하면 바로 이용할 수 있어요.",
+            positiveBtnTitle: "로그인으로 이동",
+            positiveBtnAction: {
+                appFlow.showLogin()
+            }
+        )
+    }
+
     @MainActor
     private func handleRegisterFailure(_ error: AppError) {
         if error.isOAuthVerificationExpired {
@@ -589,8 +606,8 @@ private struct SignUpPreviewVerifyCodeUseCase: VerifyEmailCodeUseCaseProtocol {
 }
 
 private struct SignUpPreviewRegisterUseCase: RegisterUseCaseProtocol {
-    func execute(request: RegisterRequestDTO) async throws -> String {
-        "1"
+    func execute(request: RegisterRequestDTO) async throws -> RegisterResult {
+        RegisterResult(memberId: "1", tokenPair: nil)
     }
 }
 

--- a/AppProduct/AppProductTests/AuthTest/IdPwAuthUseCaseTests.swift
+++ b/AppProduct/AppProductTests/AuthTest/IdPwAuthUseCaseTests.swift
@@ -338,7 +338,7 @@ private actor StubAuthRepository: AuthRepositoryProtocol {
 
     func register(
         request: RegisterRequestDTO
-    ) async throws -> String {
+    ) async throws -> RegisterResult {
         fatalError("register not used in these tests")
     }
 

--- a/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
+++ b/AppProduct/AppProductTests/AuthTest/SignUpViewModelTests.swift
@@ -167,8 +167,8 @@ private actor MockLoginUseCase: LoginUseCaseProtocol {
 }
 
 private struct MockRegisterUseCase: RegisterUseCaseProtocol {
-    func execute(request: RegisterRequestDTO) async throws -> String {
-        "1"
+    func execute(request: RegisterRequestDTO) async throws -> RegisterResult {
+        RegisterResult(memberId: "1", tokenPair: nil)
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

- 🐛 버그 수정 (Apple 회원가입 완료 직후 "OAuth 인증 정보가 올바르지 않아요" 팝업)

resolves #901

## 🛠️ 작업내용

**원인**: 소셜 신규 가입 완료 후 `restoreSessionAfterRegisterIfNeeded()`가 **이미 소비된 동일 Apple `authorizationCode`(1회용·약 5분 만료)를 재전송**해 서버가 거절했습니다. Kakao/Google은 재사용 가능한 OAuth accessToken이라 드러나지 않던 문제입니다.

**전략**: 안전 기본 + 실패 UX (서버 변경 불필요, 회귀 없음)

1. **토큰 우선 복구** — 서버가 가입 응답에 토큰을 내려주면 재로그인 없이 그대로 세션 복구
   - `RegisterResponseDTO`에 `accessToken`/`refreshToken`을 **옵셔널**로 디코딩 (custom Codable, 규칙 #3 준수). 두 값이 모두 유효할 때만 `tokenPair` 구성
   - `RegisterResult` 도메인 모델 신설(`memberId` + `tokenPair?`) → register 경로의 반환 타입을 전 레이어에서 통일
   - `RegisterUseCase`에 `tokenStore` 주입 — 토큰이 있으면 즉시 저장하고 재로그인 생략 (이메일 가입 `RegisterByEmailUseCase`와 동일 패턴)
2. **세션 복구 실패 안내** — 토큰이 없을 때만 기존 소셜 재로그인으로 복구하되, **가입은 성공했는데 복구만 실패**(Apple 코드 소비)한 경우 가입 자체는 성공 처리하고 `requiresManualLoginAfterRegister` 플래그로 표시 → 화면에서 모호한 "오류" 대신 **"가입이 완료됐어요 → 로그인으로 이동"** 안내

## 동작 매트릭스

| 서버가 가입 응답에 토큰 반환? | Apple | Kakao/Google |
|---|---|---|
| **O** | 팝업 없이 즉시 복구 ✅ | 팝업 없이 즉시 복구 ✅ |
| **X** (현 상태 추정) | "가입 완료 → 다시 로그인" 안내 (모호한 오류 제거) ✅ | 기존대로 재로그인 복구 ✅ |

## 📋 추후 진행 상황

- **백엔드 협의 필요**: 소셜 회원가입 응답에 `accessToken`/`refreshToken`을 포함하면 Apple 포함 모든 provider가 팝업·재로그인 없이 즉시 복구됩니다. 본 PR은 서버가 토큰을 주든 안 주든 안전하게 동작하도록 옵셔널로 받아 처리합니다(서버 미반환 시 Apple은 안내 플로우로 graceful 처리).

## 📌 리뷰 포인트

- `RegisterResponseDTO`를 synthesized → custom `init(from:)`/`encode(to:)`로 전환 (규칙 #3)
- register 반환 타입 변경(`String` → `RegisterResult`)에 따라 Repository/UseCase/Protocol/Mock/프리뷰/테스트 구현체 전부 동기화
- 기존 세션 복구 테스트 2건(`restoreSessionWithKakaoAfterRegister`, `restoreSessionWithAppleAfterRegister`) **통과 확인** — `tokenPair == nil` 경로에서 재로그인이 그대로 1회 호출됨
- 베이스에 선행 커밋 `b7840f70`(구글 OAuth 전환) 포함 — develop에 머지되면 diff에서 자동 제외됨

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
- [x] 시뮬레이터 빌드 성공 (iPhone 17 Pro, iOS 26.5)
- [x] 관련 단위 테스트 통과 (SignUpViewModelTests 2/2)
