### PR TITLE
♻️ [Refactor] StudyRepository 구현체 이식(조회 구현 + CRUD 스텁)

### DIFF
--- a/UMCApp/Features/Activity/Data/Sources/DTOs/MemberProfileDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/MemberProfileDTO.swift
@@ -1,0 +1,89 @@
+//
+//  MemberProfileDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/24/26.
+//
+
+import Foundation
+
+// MARK: - MemberProfileDTO
+
+/// 멤버 프로필 응답 DTO (챌린저 ID 해석 전용)
+///
+/// `GET /api/v1/member/profile/{memberId}`
+///
+/// ``StudyRepository/resolveChallengerId(memberId:preferredGeneration:)`` 가
+/// `challengerRecords` 만 사용하므로 본 DTO 는 해당 필드만 디코딩한다(나머지 응답 필드는
+/// `Codable` 이 무시). 서버 식별자는 전 레이어 `String` 통일 규칙에 따라 `String` 으로 디코딩한다.
+struct MemberProfileDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let challengerRecords: [MemberChallengerRecordDTO]
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerRecords
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        challengerRecords = try container.decodeIfPresent(
+            [MemberChallengerRecordDTO].self,
+            forKey: .challengerRecords
+        ) ?? []
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(challengerRecords, forKey: .challengerRecords)
+    }
+}
+
+// MARK: - MemberChallengerRecordDTO
+
+/// 멤버의 기수별 챌린저 활동 레코드 DTO (챌린저 ID 해석에 필요한 필드만)
+struct MemberChallengerRecordDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let challengerId: String
+    let memberId: String
+    let gisu: Int
+    let gisuId: String
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerId
+        case memberId
+        case gisu
+        case gisuId
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        challengerId = try container.decodeFlexibleStringIfPresent(forKey: .challengerId) ?? ""
+        memberId = try container.decodeFlexibleStringIfPresent(forKey: .memberId) ?? ""
+        gisu = try container.decodeIntFlexibleIfPresent(forKey: .gisu) ?? 0
+        gisuId = try container.decodeFlexibleStringIfPresent(forKey: .gisuId) ?? ""
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(challengerId, forKey: .challengerId)
+        try container.encode(memberId, forKey: .memberId)
+        try container.encode(gisu, forKey: .gisu)
+        try container.encode(gisuId, forKey: .gisuId)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/StudyContextProviding.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/StudyContextProviding.swift
@@ -1,0 +1,78 @@
+//
+//  StudyContextProviding.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/24/26.
+//
+
+import Foundation
+
+/// 스터디 조회에 필요한 현재 사용자 컨텍스트(기수·담당 파트) 제공자.
+///
+/// ``StudyRepositoryProtocol`` 의 커리큘럼 조회와 챌린저 ID 해석은 파라미터로 기수·파트를
+/// 받지 않으므로, Repository 가 이 추상화에서 값을 읽습니다. 운영 코드는
+/// ``UserDefaultsStudyContextProvider`` 를, 테스트는 가짜 구현을 주입합니다.
+///
+/// - Note: ``NetworkRequesting`` 과 동일하게 비-`Sendable` 의존성으로 두고, Repository 가
+///   `@unchecked Sendable` 로 감쌉니다.
+protocol StudyContextProviding {
+
+    /// 현재(우선) 기수 식별자 — 서버 응답이므로 `String`. 미설정 시 `nil`.
+    var gisuId: String? { get }
+
+    /// 현재 담당 파트의 서버 API 문자열 (예: `"IOS"`).
+    var part: String { get }
+}
+
+// MARK: - UserDefaultsStudyContextProvider
+
+/// `UserDefaults` 기반 기본 컨텍스트 제공자.
+///
+/// 레거시 `AppStorageKey` 와 동일한 키(`gisuId`, `responsiblePart`)를 읽어, 향후 세션
+/// 저장소가 도입되어도 같은 키를 공유하면 그대로 호환됩니다. `UserDefaults` 결합을 이
+/// 작은 어댑터 한 곳에 격리해 Repository 본체는 추상화에만 의존합니다.
+struct UserDefaultsStudyContextProvider: StudyContextProviding {
+
+    // MARK: - Property
+
+    private let defaults: UserDefaults
+
+    /// 담당 파트 키에 매핑되는 알려진 서버 파트 문자열.
+    private static let knownParts: Set<String> = [
+        "PLAN", "DESIGN", "WEB", "ANDROID", "IOS", "NODEJS", "SPRINGBOOT"
+    ]
+
+    /// 담당 파트 미설정/미지원 시 사용할 기본 파트.
+    private static let fallbackPart = "IOS"
+
+    // MARK: - Init
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    // MARK: - StudyContextProviding
+
+    /// `gisuId` 를 `String` 우선으로 읽고, 레거시 `Int` 저장값(>0)이면 문자열로 변환합니다.
+    var gisuId: String? {
+        if let value = defaults.string(forKey: Key.gisuId), !value.isEmpty {
+            return value
+        }
+        let legacyInt = defaults.integer(forKey: Key.gisuId)
+        return legacyInt > 0 ? String(legacyInt) : nil
+    }
+
+    /// 담당 파트를 대문자로 정규화하고, 알려지지 않은 값이면 기본 파트로 대체합니다.
+    var part: String {
+        let stored = defaults.string(forKey: Key.responsiblePart) ?? Self.fallbackPart
+        let normalized = stored.uppercased()
+        return Self.knownParts.contains(normalized) ? normalized : Self.fallbackPart
+    }
+
+    // MARK: - Storage Key
+
+    private enum Key {
+        static let gisuId = "gisuId"
+        static let responsiblePart = "responsiblePart"
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
@@ -1,0 +1,277 @@
+//
+//  StudyRepository.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/24/26.
+//
+
+import Foundation
+import ActivityDomain
+import CoreNetwork
+import UMCFoundation
+import Moya
+
+/// 스터디 Repository 구현체
+///
+/// ``StudyRepositoryProtocol`` 전체를 채택한다. 조회 계열(커리큘럼/미션/주차 옵션, 운영진
+/// 스터디 그룹 조회, 챌린저 ID 해석)은 ``StudyRouter`` 조회 case 로 실구현하고, 운영진 스터디
+/// 그룹 CRUD·일정 연결은 라우터 case 가 아직 없어 미구현 에러를 던지는 스텁으로 둔다(8차에서
+/// 실구현). ``NetworkRequesting`` 으로 요청을 보낸 뒤 `APIResponse<DTO>` 를 디코딩하고
+/// `toDomain()` 으로 도메인 모델에 매핑한다.
+///
+/// - Note: 서버 식별자는 전 레이어 `String` 으로 통일된다. 커리큘럼 조회에 필요한 현재
+///   기수·담당 파트는 ``StudyContextProviding`` 에서 읽는다(신규 모듈에는 레거시
+///   `AppStorageKey` 세션 저장소가 아직 없어 컨텍스트 제공자를 주입한다).
+public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
+
+    // MARK: - Property
+
+    private let networkRequesting: any NetworkRequesting
+    private let context: StudyContextProviding
+    private let decoder: JSONDecoder
+
+    // MARK: - Constants
+
+    private enum Constants {
+        /// 운영진 스터디 그룹 전체 조회 시 페이지당 항목 수.
+        static let studyGroupsPageSize = 100
+    }
+
+    // MARK: - Init
+
+    /// 운영(DI) 진입점.
+    ///
+    /// 인증 어댑터 ``CoreNetwork/MoyaNetworkAdapter`` 와 `UserDefaults` 기반 기본 컨텍스트
+    /// 제공자를 사용한다. 테스트는 ``init(networkRequesting:context:decoder:)`` 에 가짜
+    /// 구현을 주입한다.
+    public convenience init(
+        adapter: MoyaNetworkAdapter,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.init(
+            networkRequesting: adapter,
+            context: UserDefaultsStudyContextProvider(),
+            decoder: decoder
+        )
+    }
+
+    /// 의존성을 직접 주입하는 지정 이니셜라이저 (모듈 내부 · 테스트 전용).
+    init(
+        networkRequesting: any NetworkRequesting,
+        context: StudyContextProviding,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.networkRequesting = networkRequesting
+        self.context = context
+        self.decoder = decoder
+    }
+
+    // MARK: - 커리큘럼 / 미션
+
+    public func fetchCurriculumProgress() async throws -> CurriculumProgressModel {
+        let curriculum = try await fetchCurriculum()
+        return curriculum.dto.toCurriculumProgress(part: curriculum.part)
+    }
+
+    public func fetchMissions() async throws -> [MissionCardModel] {
+        let curriculum = try await fetchCurriculum()
+        let platform = UMCPartType(apiValue: curriculum.part)?.name ?? curriculum.part
+        return curriculum.dto.toMissionCards(platform: platform)
+    }
+
+    /// 주차 커리큘럼 옵션을 조회한다.
+    ///
+    /// 전용 엔드포인트가 아직 없어 커리큘럼 개요(`getCurriculum`)의 주차 목록에서 파생한다.
+    /// 주차 번호(`weekNo`)는 도메인 모델이 `String` 이므로 변환해 담는다.
+    public func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption] {
+        let curriculum = try await fetchCurriculum()
+        return curriculum.dto.weeks
+            .sorted { $0.weekNo < $1.weekNo }
+            .map {
+                WeeklyCurriculumOption(
+                    weeklyCurriculumId: $0.weeklyCurriculumId,
+                    weekNo: String($0.weekNo),
+                    title: $0.title
+                )
+            }
+    }
+
+    // MARK: - 운영진 스터디 그룹 조회
+
+    public func fetchStudyGroupDetails() async throws -> [StudyGroupInfo] {
+        var allDetails: [StudyGroupInfo] = []
+        var cursor: Int?
+        var hasNext = true
+
+        while hasNext {
+            let page = try await fetchStudyGroupDetailsPage(
+                cursor: cursor,
+                size: Constants.studyGroupsPageSize
+            )
+            allDetails.append(contentsOf: page.content)
+
+            hasNext = page.hasNext
+            cursor = page.nextCursor.flatMap(Int.init)
+            // 다음 페이지가 있다고 했으나 커서가 없으면 무한 루프 방지를 위해 중단한다.
+            if hasNext && cursor == nil {
+                break
+            }
+        }
+
+        return allDetails
+    }
+
+    public func fetchStudyGroupDetailsPage(
+        cursor: Int?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage {
+        let response = try await networkRequesting.request(
+            StudyRouter.getMyStudyGroups(
+                query: MyStudyGroupsQuery(cursor: cursor, size: size)
+            )
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<MyStudyGroupsPageDTO>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap().toDomain()
+    }
+
+    public func fetchStudyGroupDetail(groupId: String) async throws -> StudyGroupInfo {
+        let response = try await networkRequesting.request(
+            StudyRouter.getStudyGroupDetail(groupId: groupId)
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<StudyGroupDetailDTO>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap().toDomain()
+    }
+
+    public func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: Int?
+    ) async throws -> String? {
+        let response = try await networkRequesting.request(
+            StudyRouter.getMemberProfile(memberId: memberId)
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<MemberProfileDTO>.self,
+            from: response.data
+        )
+        let profile = try apiResponse.unwrap()
+
+        let records = profile.challengerRecords.filter {
+            $0.memberId == memberId && !$0.challengerId.isEmpty
+        }
+
+        if let preferredGeneration, preferredGeneration > 0,
+           let matched = records.first(where: { $0.gisu == preferredGeneration }) {
+            return matched.challengerId
+        }
+
+        if let preferredGisuId = context.gisuId,
+           let matched = records.first(where: { $0.gisuId == preferredGisuId }) {
+            return matched.challengerId
+        }
+
+        return records.first?.challengerId
+    }
+
+    // MARK: - 운영진 스터디 그룹 CRUD (8차 실구현 — 미구현 스텁)
+
+    public func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws {
+        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
+        throw StudyRepositoryError.unimplemented(operation: "createStudyGroup")
+    }
+
+    public func updateStudyGroup(groupId: String, name: String) async throws {
+        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
+        throw StudyRepositoryError.unimplemented(operation: "updateStudyGroup")
+    }
+
+    public func deleteStudyGroup(groupId: String) async throws {
+        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
+        throw StudyRepositoryError.unimplemented(operation: "deleteStudyGroup")
+    }
+
+    public func addStudyGroupMember(groupId: String, memberId: String) async throws {
+        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
+        throw StudyRepositoryError.unimplemented(operation: "addStudyGroupMember")
+    }
+
+    public func removeStudyGroupMember(groupId: String, memberId: String) async throws {
+        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
+        throw StudyRepositoryError.unimplemented(operation: "removeStudyGroupMember")
+    }
+
+    public func addStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
+        throw StudyRepositoryError.unimplemented(operation: "addStudyGroupMentor")
+    }
+
+    public func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
+        throw StudyRepositoryError.unimplemented(operation: "removeStudyGroupMentor")
+    }
+
+    public func linkStudyGroupSchedule(
+        scheduleId: String,
+        studyGroupId: String,
+        weeklyCurriculumId: String
+    ) async throws {
+        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
+        throw StudyRepositoryError.unimplemented(operation: "linkStudyGroupSchedule")
+    }
+}
+
+// MARK: - Private Helper
+
+private extension StudyRepository {
+
+    /// 커리큘럼 조회의 공통 단계: 컨텍스트에서 기수·파트를 읽어 ``StudyRouter/getCurriculum``
+    /// 을 호출하고 ``CurriculumDTO`` 로 디코딩한다.
+    ///
+    /// 현재 운영 기수(`gisuId`)가 없으면 네트워크 호출 없이
+    /// ``DomainError/curriculumUnavailableForGeneration`` 을 던진다.
+    ///
+    /// - Note: 레거시는 `CURRICULUM-0001`(커리큘럼 미등록) 본문을 별도 도메인 에러로
+    ///   승격했으나, 신규 모듈에는 대응 case 가 아직 없어 서버 실패는 표준
+    ///   ``RepositoryError/serverError(code:message:)`` 경로로 노출한다(도메인 vocabulary
+    ///   추가 시 후속 보강).
+    /// - Returns: 디코딩한 ``CurriculumDTO`` 와 조회에 사용한 파트 문자열
+    func fetchCurriculum() async throws -> (dto: CurriculumDTO, part: String) {
+        guard let gisuId = context.gisuId else {
+            throw DomainError.curriculumUnavailableForGeneration
+        }
+        let part = context.part
+        let response = try await networkRequesting.request(
+            StudyRouter.getCurriculum(
+                query: CurriculumOverviewQuery(gisuId: gisuId, part: part, weekNo: nil)
+            )
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<CurriculumDTO>.self,
+            from: response.data
+        )
+        return (try apiResponse.unwrap(), part)
+    }
+}
+
+// MARK: - StudyRepositoryError
+
+/// ``StudyRepository`` 의 미구현 스텁 메서드가 호출됐음을 알리는 에러.
+///
+/// 운영진 스터디 그룹 CRUD·일정 연결은 라우터 case 가 추가되는 8차에서 실구현된다.
+/// 그 전까지 호출되면 본 에러를 던져 "아직 미구현" 임을 명확히 한다.
+enum StudyRepositoryError: Error, Equatable {
+
+    /// 아직 구현되지 않은 운영진 스터디 CRUD/연결 작업 (`operation`: 메서드 이름)
+    case unimplemented(operation: String)
+}

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/MemberProfileDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/MemberProfileDTOTests.swift
@@ -1,0 +1,63 @@
+//
+//  MemberProfileDTOTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/24/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityData
+
+@Suite("MemberProfileDTO — 챌린저 레코드 디코딩 (서버 contract)")
+struct MemberProfileDTOTests {
+
+    // MARK: - Helpers
+
+    private func decode(_ json: String) throws -> MemberProfileDTO {
+        try JSONDecoder().decode(MemberProfileDTO.self, from: Data(json.utf8))
+    }
+
+    // MARK: - challengerRecords
+
+    @Test("challengerRecords 를 String 식별자로 디코딩한다")
+    func decodesRecordsWithStringIdentifiers() throws {
+        let dto = try decode("""
+        {
+          "challengerRecords": [
+            { "challengerId": "10", "memberId": "100", "gisu": 7, "gisuId": "70" }
+          ]
+        }
+        """)
+
+        let record = try #require(dto.challengerRecords.first)
+        #expect(dto.challengerRecords.count == 1)
+        #expect(record.challengerId == "10")
+        #expect(record.memberId == "100")
+        #expect(record.gisu == 7)
+        #expect(record.gisuId == "70")
+    }
+
+    @Test("숫자로 내려온 식별자도 String 으로 디코딩한다 (유연 디코딩)")
+    func decodesNumericIdentifiersAsString() throws {
+        let dto = try decode("""
+        {
+          "challengerRecords": [
+            { "challengerId": 10, "memberId": 100, "gisu": "7", "gisuId": 70 }
+          ]
+        }
+        """)
+
+        let record = try #require(dto.challengerRecords.first)
+        #expect(record.challengerId == "10")
+        #expect(record.memberId == "100")
+        #expect(record.gisu == 7)
+        #expect(record.gisuId == "70")
+    }
+
+    @Test("challengerRecords 키가 없으면 빈 배열로 디코딩한다")
+    func decodesMissingRecordsAsEmpty() throws {
+        let dto = try decode("{}")
+        #expect(dto.challengerRecords.isEmpty)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
@@ -1,0 +1,442 @@
+//
+//  StudyRepositoryTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/24/26.
+//
+
+import Testing
+import Foundation
+import Moya
+import ActivityDomain
+import UMCFoundation
+@testable import ActivityData
+
+#if DEBUG
+
+// MARK: - Test Double
+
+/// ``NetworkRequesting`` 가짜 구현 (FIFO outcome 큐).
+///
+/// 페이지네이션처럼 호출이 여러 번 일어나는 흐름을 위해 미리 설정한 결과를 순서대로
+/// 반환하고, 호출된 라우터의 경로·메서드를 기록해 엔드포인트 계약을 검증합니다.
+private final class StubNetworkRequesting: NetworkRequesting, @unchecked Sendable {
+
+    enum Outcome {
+        /// 200 응답으로 주어진 JSON 본문을 반환
+        case success(Data)
+        /// 요청 단계에서 에러를 던짐 (비-2xx 등)
+        case failure(Error)
+    }
+
+    enum StubError: Error {
+        /// 준비된 outcome 보다 많은 요청이 들어왔음
+        case noOutcomeQueued
+    }
+
+    private var outcomes: [Outcome]
+    private(set) var requestedPaths: [String] = []
+    private(set) var requestedMethods: [Moya.Method] = []
+
+    var requestCount: Int { requestedPaths.count }
+    var lastPath: String? { requestedPaths.last }
+    var lastMethod: Moya.Method? { requestedMethods.last }
+
+    init(_ outcomes: [Outcome]) {
+        self.outcomes = outcomes
+    }
+
+    func request<T: TargetType>(_ target: T) async throws -> Response {
+        requestedPaths.append(target.path)
+        requestedMethods.append(target.method)
+        guard !outcomes.isEmpty else {
+            throw StubError.noOutcomeQueued
+        }
+        switch outcomes.removeFirst() {
+        case .success(let data):
+            return Response(statusCode: 200, data: data)
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+/// ``StudyContextProviding`` 가짜 구현 — 기수·파트를 직접 지정합니다.
+private struct StubStudyContext: StudyContextProviding {
+    var gisuId: String?
+    var part: String
+
+    init(gisuId: String? = "7", part: String = "IOS") {
+        self.gisuId = gisuId
+        self.part = part
+    }
+}
+
+// MARK: - Fixtures
+
+private enum Fixture {
+
+    /// 주차 2개(역순)로 구성된 커리큘럼. 종료일이 모두 과거라 진행률이 결정론적.
+    static let curriculumObject = """
+    {
+      "curriculumId": "1",
+      "title": "iOS 커리큘럼",
+      "weeks": [
+        {
+          "weeklyCurriculumId": "w2", "weekNo": 2, "title": "2주차",
+          "startsAt": "2000-01-08T00:00:00.000Z",
+          "endsAt": "2000-01-14T00:00:00.000Z", "isExtra": false
+        },
+        {
+          "weeklyCurriculumId": "w1", "weekNo": 1, "title": "1주차",
+          "startsAt": "2000-01-01T00:00:00.000Z",
+          "endsAt": "2000-01-07T00:00:00.000Z", "isExtra": false
+        }
+      ]
+    }
+    """
+
+    /// 단일 스터디 그룹 상세 (멘토 1 + 스터디원 1)
+    static let studyGroupDetailObject = """
+    {
+      "groupId": "42", "name": "iOS 스터디", "part": "IOS", "partDisplayName": "iOS",
+      "schools": [
+        {
+          "schoolId": "5", "schoolName": "한성대", "logoImageId": null,
+          "totalStudyGroupCount": 1, "totalMemberCount": 10
+        }
+      ],
+      "createdAt": "2026-06-01T09:00:00.000Z", "memberCount": 2,
+      "mentors": [
+        {
+          "challengerId": "1", "memberId": "10", "name": "멘토",
+          "profileImageUrl": null, "bestWorkbookPoint": 0
+        }
+      ],
+      "members": [
+        {
+          "challengerId": "2", "memberId": "20", "name": "챌린저",
+          "profileImageUrl": null, "bestWorkbookPoint": 5
+        }
+      ]
+    }
+    """
+
+    /// 필터(memberId 일치 & challengerId 비어있지 않음) 검증을 포함한 멤버 프로필
+    static let memberProfileObject = """
+    {
+      "challengerRecords": [
+        { "challengerId": "C7", "memberId": "100", "gisu": 7, "gisuId": "70" },
+        { "challengerId": "C8", "memberId": "100", "gisu": 8, "gisuId": "80" },
+        { "challengerId": "", "memberId": "100", "gisu": 9, "gisuId": "90" },
+        { "challengerId": "CX", "memberId": "999", "gisu": 7, "gisuId": "70" }
+      ]
+    }
+    """
+
+    /// 적격 레코드가 없는 멤버 프로필 (memberId 불일치 / challengerId 공백)
+    static let memberProfileNoEligibleObject = """
+    {
+      "challengerRecords": [
+        { "challengerId": "", "memberId": "100", "gisu": 7, "gisuId": "70" },
+        { "challengerId": "CX", "memberId": "999", "gisu": 8, "gisuId": "80" }
+      ]
+    }
+    """
+
+    static func success(_ resultJSON: String) -> Data {
+        Data("""
+        { "success": true, "code": "200", "message": "성공", "result": \(resultJSON) }
+        """.utf8)
+    }
+
+    static func studyGroupsPage(
+        _ detailObjects: [String],
+        nextCursor: String?,
+        hasNext: Bool
+    ) -> String {
+        let cursorField = nextCursor.map { "\"\($0)\"" } ?? "null"
+        return """
+        {
+          "studyGroups": [\(detailObjects.joined(separator: ","))],
+          "nextCursor": \(cursorField),
+          "hasNext": \(hasNext)
+        }
+        """
+    }
+
+    static func failureBody(code: String?, message: String?) -> Data {
+        var fields: [String] = ["\"success\": false"]
+        if let code { fields.append("\"code\": \"\(code)\"") }
+        if let message { fields.append("\"message\": \"\(message)\"") }
+        return Data("{ \(fields.joined(separator: ", ")) }".utf8)
+    }
+}
+
+private typealias RepositoryPair = (StudyRepository, StubNetworkRequesting)
+
+private func makeRepository(
+    _ outcomes: [StubNetworkRequesting.Outcome],
+    context: StudyContextProviding = StubStudyContext()
+) -> RepositoryPair {
+    let stub = StubNetworkRequesting(outcomes)
+    let repository = StudyRepository(networkRequesting: stub, context: context)
+    return (repository, stub)
+}
+
+private func makeRepository(
+    _ outcome: StubNetworkRequesting.Outcome,
+    context: StudyContextProviding = StubStudyContext()
+) -> RepositoryPair {
+    makeRepository([outcome], context: context)
+}
+
+// MARK: - Suite: 커리큘럼 조회 계약
+
+@Suite("StudyRepository — 커리큘럼 조회 매핑 (도메인 규칙)")
+struct StudyRepositoryCurriculumTests {
+
+    @Test("fetchCurriculumProgress — 커리큘럼 엔드포인트를 호출하고 진행률로 매핑한다")
+    func fetchCurriculumProgressMapsSuccess() async throws {
+        let (sut, stub) = makeRepository(.success(Fixture.success(Fixture.curriculumObject)))
+
+        let progress = try await sut.fetchCurriculumProgress()
+
+        #expect(progress.partName == "iOS PART CURRICULUM")
+        #expect(progress.totalCount == 2)
+        #expect(progress.completedCount == 2)        // 모든 주차 종료 → 결정론적
+        #expect(progress.curriculumTitle == "iOS 커리큘럼")
+        #expect(stub.lastPath == "/api/v2/curriculums/overview")
+        #expect(stub.lastMethod == .get)
+    }
+
+    @Test("fetchCurriculumProgress — gisuId 가 없으면 네트워크 호출 없이 도메인 에러를 던진다")
+    func fetchCurriculumProgressThrowsWhenNoGeneration() async {
+        let (sut, stub) = makeRepository([], context: StubStudyContext(gisuId: nil))
+
+        await #expect(throws: DomainError.curriculumUnavailableForGeneration) {
+            try await sut.fetchCurriculumProgress()
+        }
+        #expect(stub.requestCount == 0)
+    }
+
+    @Test("fetchMissions — 주차를 미션 카드로 매핑하고 주차 오름차순으로 정렬한다")
+    func fetchMissionsMapsAndSorts() async throws {
+        let (sut, _) = makeRepository(.success(Fixture.success(Fixture.curriculumObject)))
+
+        let missions = try await sut.fetchMissions()
+
+        #expect(missions.map(\.week) == [1, 2])
+        #expect(missions.allSatisfy { $0.platform == "iOS" })
+    }
+
+    @Test("fetchWeeklyCurriculumOptions — 주차를 옵션으로 매핑하고 주차 오름차순으로 정렬한다")
+    func fetchWeeklyCurriculumOptionsMapsAndSorts() async throws {
+        let (sut, _) = makeRepository(.success(Fixture.success(Fixture.curriculumObject)))
+
+        let options = try await sut.fetchWeeklyCurriculumOptions()
+
+        #expect(options.map(\.weeklyCurriculumId) == ["w1", "w2"])
+        #expect(options.map(\.weekNo) == ["1", "2"])     // 도메인 모델은 weekNo: String
+    }
+
+    @Test("fetchCurriculumProgress — isSuccess:false 면 RepositoryError.serverError 를 던진다")
+    func fetchCurriculumProgressThrowsServerError() async {
+        let (sut, _) = makeRepository(
+            .success(Fixture.failureBody(code: "CUR404", message: "커리큘럼 없음"))
+        )
+
+        await #expect(throws: RepositoryError.serverError(code: "CUR404", message: "커리큘럼 없음")) {
+            try await sut.fetchCurriculumProgress()
+        }
+    }
+}
+
+// MARK: - Suite: 스터디 그룹 조회 계약
+
+@Suite("StudyRepository — 스터디 그룹 조회 매핑 (도메인 규칙)")
+struct StudyRepositoryGroupTests {
+
+    @Test("fetchStudyGroupDetailsPage — 페이지를 매핑하고 운영 그룹 엔드포인트를 호출한다")
+    func fetchStudyGroupDetailsPageMapsSuccess() async throws {
+        let pageJSON = Fixture.studyGroupsPage(
+            [Fixture.studyGroupDetailObject], nextCursor: "5", hasNext: true
+        )
+        let (sut, stub) = makeRepository(.success(Fixture.success(pageJSON)))
+
+        let page = try await sut.fetchStudyGroupDetailsPage(cursor: nil, size: 20)
+
+        #expect(page.content.count == 1)
+        #expect(page.content.first?.serverID == "42")
+        #expect(page.hasNext)
+        #expect(page.nextCursor == "5")
+        #expect(stub.lastPath == "/api/v1/study-groups/managed")
+        #expect(stub.lastMethod == .get)
+    }
+
+    @Test("fetchStudyGroupDetails — 다음 페이지가 없을 때까지 누적한다")
+    func fetchStudyGroupDetailsAccumulatesPages() async throws {
+        let page1 = Fixture.studyGroupsPage(
+            [Fixture.studyGroupDetailObject], nextCursor: "5", hasNext: true
+        )
+        let page2 = Fixture.studyGroupsPage(
+            [Fixture.studyGroupDetailObject], nextCursor: nil, hasNext: false
+        )
+        let (sut, stub) = makeRepository([
+            .success(Fixture.success(page1)),
+            .success(Fixture.success(page2))
+        ])
+
+        let details = try await sut.fetchStudyGroupDetails()
+
+        #expect(details.count == 2)
+        #expect(stub.requestCount == 2)
+    }
+
+    @Test("fetchStudyGroupDetails — hasNext 인데 커서가 없으면 무한 루프를 막고 중단한다")
+    func fetchStudyGroupDetailsStopsOnMissingCursor() async throws {
+        let page = Fixture.studyGroupsPage(
+            [Fixture.studyGroupDetailObject], nextCursor: nil, hasNext: true
+        )
+        let (sut, stub) = makeRepository(.success(Fixture.success(page)))
+
+        let details = try await sut.fetchStudyGroupDetails()
+
+        #expect(details.count == 1)
+        #expect(stub.requestCount == 1)        // 두 번째 페이지를 요청하지 않음
+    }
+
+    @Test("fetchStudyGroupDetail — 단일 상세를 매핑하고 groupId 를 path 에 보간한다")
+    func fetchStudyGroupDetailMapsSuccess() async throws {
+        let (sut, stub) = makeRepository(
+            .success(Fixture.success(Fixture.studyGroupDetailObject))
+        )
+
+        let info = try await sut.fetchStudyGroupDetail(groupId: "42")
+
+        #expect(info.serverID == "42")
+        #expect(info.mentors.count == 1)
+        #expect(info.members.count == 1)
+        #expect(stub.lastPath == "/api/v1/study-groups/42")
+    }
+}
+
+// MARK: - Suite: 챌린저 ID 해석 계약
+
+@Suite("StudyRepository — 챌린저 ID 해석 (도메인 규칙)")
+struct StudyRepositoryResolveChallengerTests {
+
+    @Test(
+        "resolveChallengerId — 기수/컨텍스트 폴백/첫 레코드 우선순위로 challengerId 를 해석한다",
+        arguments: [
+            (preferred: Optional(8), contextGisuId: Optional("70"), expected: "C8"),
+            (preferred: Optional<Int>.none, contextGisuId: Optional("80"), expected: "C8"),
+            (preferred: Optional<Int>.none, contextGisuId: Optional("70"), expected: "C7"),
+            (preferred: Optional<Int>.none, contextGisuId: Optional<String>.none, expected: "C7")
+        ]
+    )
+    func resolveChallengerIdAppliesPriority(
+        preferred: Int?,
+        contextGisuId: String?,
+        expected: String
+    ) async throws {
+        let (sut, _) = makeRepository(
+            .success(Fixture.success(Fixture.memberProfileObject)),
+            context: StubStudyContext(gisuId: contextGisuId)
+        )
+
+        let challengerId = try await sut.resolveChallengerId(
+            memberId: "100",
+            preferredGeneration: preferred
+        )
+
+        #expect(challengerId == expected)
+    }
+
+    @Test("resolveChallengerId — 적격 레코드가 없으면 nil 을 반환한다")
+    func resolveChallengerIdReturnsNilWhenNoEligibleRecord() async throws {
+        let (sut, stub) = makeRepository(
+            .success(Fixture.success(Fixture.memberProfileNoEligibleObject))
+        )
+
+        let challengerId = try await sut.resolveChallengerId(
+            memberId: "100",
+            preferredGeneration: nil
+        )
+
+        #expect(challengerId == nil)
+        #expect(stub.lastPath == "/api/v1/member/profile/100")
+    }
+}
+
+// MARK: - Suite: CRUD 스텁 계약
+
+@Suite("StudyRepository — CRUD/연결 스텁 (미구현 계약)")
+struct StudyRepositoryStubTests {
+
+    /// 8차에서 실구현될 CRUD/연결 메서드. 모두 동일하게 `unimplemented` 를 던지므로
+    /// 검증 본문이 같아 파라미터화한다.
+    private enum StubOperation: CaseIterable, CustomTestStringConvertible {
+        case create, update, delete
+        case addMember, removeMember, addMentor, removeMentor
+        case linkSchedule
+
+        var operationName: String {
+            switch self {
+            case .create: "createStudyGroup"
+            case .update: "updateStudyGroup"
+            case .delete: "deleteStudyGroup"
+            case .addMember: "addStudyGroupMember"
+            case .removeMember: "removeStudyGroupMember"
+            case .addMentor: "addStudyGroupMentor"
+            case .removeMentor: "removeStudyGroupMentor"
+            case .linkSchedule: "linkStudyGroupSchedule"
+            }
+        }
+
+        var testDescription: String { operationName }
+
+        func invoke(on sut: StudyRepository) async throws {
+            switch self {
+            case .create:
+                try await sut.createStudyGroup(
+                    gisuId: "1", name: "n", part: .front(type: .ios),
+                    memberIds: [], mentorIds: []
+                )
+            case .update:
+                try await sut.updateStudyGroup(groupId: "1", name: "n")
+            case .delete:
+                try await sut.deleteStudyGroup(groupId: "1")
+            case .addMember:
+                try await sut.addStudyGroupMember(groupId: "1", memberId: "2")
+            case .removeMember:
+                try await sut.removeStudyGroupMember(groupId: "1", memberId: "2")
+            case .addMentor:
+                try await sut.addStudyGroupMentor(groupId: "1", mentorId: "2")
+            case .removeMentor:
+                try await sut.removeStudyGroupMentor(groupId: "1", mentorId: "2")
+            case .linkSchedule:
+                try await sut.linkStudyGroupSchedule(
+                    scheduleId: "1", studyGroupId: "2", weeklyCurriculumId: "3"
+                )
+            }
+        }
+    }
+
+    @Test(
+        "CRUD/연결 스텁 8종 — 호출 시 unimplemented(operation:) 에러를 던진다",
+        arguments: StubOperation.allCases
+    )
+    private func crudStubsThrowUnimplemented(_ operation: StubOperation) async {
+        let (sut, stub) = makeRepository([])
+
+        await #expect(
+            throws: StudyRepositoryError.unimplemented(operation: operation.operationName)
+        ) {
+            try await operation.invoke(on: sut)
+        }
+        #expect(stub.requestCount == 0)        // 네트워크 호출 없이 즉시 실패
+    }
+}
+
+#endif


### PR DESCRIPTION
resolves #814

## ✨ PR 유형

♻️ [Refactor] — 레거시 `AppProduct/` → Tuist 모듈 `UMCApp/` 로 `StudyRepository` 이식

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="988" alt="스크린샷 2026-06-25 오전 6 28 29" src="https://github.com/user-attachments/assets/42095045-95fa-4d4e-81f6-b0a98b166fad" />

<img width="1512" height="988" alt="스크린샷 2026-06-25 오전 6 28 35" src="https://github.com/user-attachments/assets/621854a0-9b7b-447d-a3de-a1ff64329e43" />


## 🛠️ 작업내용

`StudyRepositoryProtocol` 전체를 채택한 구현체를 신규 작성했습니다. 조회 계열은 실구현,
운영진 CRUD·일정 연결은 라우터 case 가 아직 없어 미구현 스텁으로 두고 8차에서 실구현합니다.

- **조회 실구현 7종**
  - 커리큘럼 진행률 / 미션 / 주차 커리큘럼 옵션 (`getCurriculum` → `CurriculumDTO` 매핑)
  - 운영 스터디 그룹 목록(커서 페이지네이션) / 단건 상세
  - `resolveChallengerId` (멤버 프로필 → 기수/컨텍스트 폴백으로 challengerId 해석)
- **CRUD·연결 8종 스텁**: `StudyRepositoryError.unimplemented(operation:)` throw + 8차 TODO
- **`StudyContextProviding` 신규**: 커리큘럼 조회용 기수(gisuId)·파트(part)를 주입으로 소싱
  (운영 기본 구현은 UserDefaults 기반)
- **`MemberProfileDTO` 신규**: `resolveChallengerId` 전용, 서버 ID 전부 `String`
- **단위 테스트**: 조회 매핑·에러·페이지네이션·challengerId 4분기·CRUD 스텁 8종 (Swift Testing)

## 📋 추후 진행 상황

- 8차: 운영진 스터디 그룹 CRUD·일정 연결 8종 실구현 (라우터 case 추가 후 스텁 대체)
- 후속: 커리큘럼 미등록(`CURRICULUM-0001`) 전용 `DomainError` case 추가 검토

## 📌 리뷰 포인트

- **gisuId/part 소싱 설계**: `StudyContextProviding` 주입 (UserDefaults 직접 읽기 대신) —
  Data 레이어의 UserDefaults 결합을 어댑터 1곳으로 격리. 테스트는 Stub 주입.
- **그룹 목록 조회**: PR #883 에서 도입된 `MyStudyGroupsPageDTO`(풀 상세 임베드)를 직접 소비
  → 레거시의 목록→상세 N+1 조회를 제거. `fetchStudyGroupDetails` 커서 루프 종료/무한루프 가드 확인 요망.
- **서버 ID 정책**: 서버 응답 식별자는 전 레이어 `String`, 클라이언트 입력(`cursor`, `preferredGeneration`)만 `Int` 유지.
- **CRUD 스텁 계약**: 8종 모두 `unimplemented` throw — 8차 분리.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)