### PR TITLE
♻️ [Refactor] StudyRouter CRUD case 확장 + StudyRepository CRUD 실구현

### DIFF
--- a/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupCreateRequestDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupCreateRequestDTO.swift
@@ -12,19 +12,19 @@ import Foundation
 /// `POST /api/v1/study-groups` body. 운영진이 새 스터디 그룹을 만들 때 기수·이름·파트와
 /// 함께 스터디원/멘토 식별자 목록을 전달합니다.
 ///
-/// - Note: 서버 식별자는 전 레이어 `String` 으로 통일하므로 `gisuId`·`memberIds`·`mentorIds`
-///   를 문자열로 직렬화합니다. 레거시는 정수로 전송했으나, 신규 모듈은 형제
-///   ``DecideAttendanceItemDTO`` 처럼 식별자를 문자열 와이어로 보냅니다. `part` 는
-///   ``UMCFoundation/UMCPartType`` 의 `apiValue` 문자열입니다.
+/// - Note: 서버가 이 엔드포인트의 식별자를 정수로 받으므로 `gisuId`·`memberIds`·`mentorIds`
+///   를 `Int`/`[Int]` 로 보냅니다. 응답의 정수는 `String` 으로 다루지만 요청 본문은 정수
+///   그대로 보내며, `String`→`Int` 변환은 ``StudyRepository`` 에서 이 DTO 를 만들 때 합니다.
+///   `part` 는 ``UMCFoundation/UMCPartType`` 의 `apiValue` 문자열입니다.
 struct StudyGroupCreateRequestDTO: Encodable, Sendable {
-    /// 기수 식별자 (서버 응답)
-    let gisuId: String
+    /// 기수 식별자
+    let gisuId: Int
     /// 그룹 이름
     let name: String
     /// 파트 API 값 (``UMCPartType/apiValue``)
     let part: String
-    /// 스터디원 챌린저 식별자 목록 (서버 응답)
-    let memberIds: [String]
-    /// 담당 파트장(멘토) 챌린저 식별자 목록 (서버 응답)
-    let mentorIds: [String]
+    /// 스터디원 챌린저 식별자 목록
+    let memberIds: [Int]
+    /// 담당 파트장(멘토) 챌린저 식별자 목록
+    let mentorIds: [Int]
 }

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupCreateRequestDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupCreateRequestDTO.swift
@@ -1,0 +1,30 @@
+//
+//  StudyGroupCreateRequestDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+
+/// 스터디 그룹 생성 요청 DTO
+///
+/// `POST /api/v1/study-groups` body. 운영진이 새 스터디 그룹을 만들 때 기수·이름·파트와
+/// 함께 스터디원/멘토 식별자 목록을 전달합니다.
+///
+/// - Note: 서버 식별자는 전 레이어 `String` 으로 통일하므로 `gisuId`·`memberIds`·`mentorIds`
+///   를 문자열로 직렬화합니다. 레거시는 정수로 전송했으나, 신규 모듈은 형제
+///   ``DecideAttendanceItemDTO`` 처럼 식별자를 문자열 와이어로 보냅니다. `part` 는
+///   ``UMCFoundation/UMCPartType`` 의 `apiValue` 문자열입니다.
+struct StudyGroupCreateRequestDTO: Encodable, Sendable {
+    /// 기수 식별자 (서버 응답)
+    let gisuId: String
+    /// 그룹 이름
+    let name: String
+    /// 파트 API 값 (``UMCPartType/apiValue``)
+    let part: String
+    /// 스터디원 챌린저 식별자 목록 (서버 응답)
+    let memberIds: [String]
+    /// 담당 파트장(멘토) 챌린저 식별자 목록 (서버 응답)
+    let mentorIds: [String]
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupScheduleCreateRequestDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupScheduleCreateRequestDTO.swift
@@ -1,0 +1,23 @@
+//
+//  StudyGroupScheduleCreateRequestDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+
+/// 스터디 그룹 일정 연결 요청 DTO
+///
+/// `POST /api/v1/study-groups/schedules` body. 1단계 일정 생성으로 받은 `scheduleId` 를
+/// 스터디 그룹·주차 커리큘럼에 연결합니다.
+///
+/// - Note: 모두 서버 응답 식별자이므로 전 레이어 `String` 으로 통일해 문자열로 직렬화합니다.
+struct StudyGroupScheduleCreateRequestDTO: Encodable, Sendable {
+    /// 연결할 일정 식별자 (1단계 생성 응답)
+    let scheduleId: String
+    /// 대상 스터디 그룹 식별자 (서버 응답)
+    let studyGroupId: String
+    /// 연결할 주차 커리큘럼 식별자 (서버 응답)
+    let weeklyCurriculumId: String
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupScheduleCreateRequestDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupScheduleCreateRequestDTO.swift
@@ -12,12 +12,14 @@ import Foundation
 /// `POST /api/v1/study-groups/schedules` body. 1단계 일정 생성으로 받은 `scheduleId` 를
 /// 스터디 그룹·주차 커리큘럼에 연결합니다.
 ///
-/// - Note: 모두 서버 응답 식별자이므로 전 레이어 `String` 으로 통일해 문자열로 직렬화합니다.
+/// - Note: 서버가 세 식별자를 정수로 받으므로 `Int` 로 보냅니다. 응답의 정수는 `String` 으로
+///   다루지만 요청 본문은 정수 그대로 보내며, `String`→`Int` 변환은 ``StudyRepository`` 에서
+///   이 DTO 를 만들 때 합니다.
 struct StudyGroupScheduleCreateRequestDTO: Encodable, Sendable {
     /// 연결할 일정 식별자 (1단계 생성 응답)
-    let scheduleId: String
-    /// 대상 스터디 그룹 식별자 (서버 응답)
-    let studyGroupId: String
-    /// 연결할 주차 커리큘럼 식별자 (서버 응답)
-    let weeklyCurriculumId: String
+    let scheduleId: Int
+    /// 대상 스터디 그룹 식별자
+    let studyGroupId: Int
+    /// 연결할 주차 커리큘럼 식별자
+    let weeklyCurriculumId: Int
 }

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupUpdateRequestDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupUpdateRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  StudyGroupUpdateRequestDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+
+/// 스터디 그룹 수정 요청 DTO
+///
+/// `PATCH /api/v1/study-groups/{groupId}` body — 이름만 수정 가능합니다.
+struct StudyGroupUpdateRequestDTO: Encodable, Sendable {
+    /// 변경할 그룹 이름
+    let name: String
+}

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
@@ -14,10 +14,10 @@ import Moya
 /// 스터디 Repository 구현체
 ///
 /// ``StudyRepositoryProtocol`` 전체를 채택한다. 조회 계열(커리큘럼/미션/주차 옵션, 운영진
-/// 스터디 그룹 조회, 챌린저 ID 해석)은 ``StudyRouter`` 조회 case 로 실구현하고, 운영진 스터디
-/// 그룹 CRUD·일정 연결은 라우터 case 가 아직 없어 미구현 에러를 던지는 스텁으로 둔다(8차에서
-/// 실구현). ``NetworkRequesting`` 으로 요청을 보낸 뒤 `APIResponse<DTO>` 를 디코딩하고
-/// `toDomain()` 으로 도메인 모델에 매핑한다.
+/// 스터디 그룹 조회, 챌린저 ID 해석)과 운영진 스터디 그룹 CRUD·일정 연결을 모두 ``StudyRouter``
+/// case 로 실구현한다. ``NetworkRequesting`` 으로 요청을 보낸 뒤 조회는 `APIResponse<DTO>` 를
+/// 디코딩해 `toDomain()` 으로 매핑하고, 결과 없는 변경(CRUD/연결)은 `APIResponse<EmptyResult>`
+/// 의 성공 여부만 검증한다.
 ///
 /// - Note: 서버 식별자는 전 레이어 `String` 으로 통일된다. 커리큘럼 조회에 필요한 현재
 ///   기수·담당 파트는 ``StudyContextProviding`` 에서 읽는다(신규 모듈에는 레거시
@@ -178,7 +178,7 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
         return records.first?.challengerId
     }
 
-    // MARK: - 운영진 스터디 그룹 CRUD (8차 실구현 — 미구현 스텁)
+    // MARK: - 운영진 스터디 그룹 CRUD / 일정 연결
 
     public func createStudyGroup(
         gisuId: String,
@@ -187,38 +187,54 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
         memberIds: [String],
         mentorIds: [String]
     ) async throws {
-        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
-        throw StudyRepositoryError.unimplemented(operation: "createStudyGroup")
+        try await performVoidRequest(
+            .createStudyGroup(
+                body: StudyGroupCreateRequestDTO(
+                    gisuId: gisuId,
+                    name: name,
+                    part: part.apiValue,
+                    memberIds: memberIds,
+                    mentorIds: mentorIds
+                )
+            )
+        )
     }
 
     public func updateStudyGroup(groupId: String, name: String) async throws {
-        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
-        throw StudyRepositoryError.unimplemented(operation: "updateStudyGroup")
+        try await performVoidRequest(
+            .updateStudyGroup(
+                groupId: groupId,
+                body: StudyGroupUpdateRequestDTO(name: name)
+            )
+        )
     }
 
     public func deleteStudyGroup(groupId: String) async throws {
-        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
-        throw StudyRepositoryError.unimplemented(operation: "deleteStudyGroup")
+        try await performVoidRequest(.deleteStudyGroup(groupId: groupId))
     }
 
     public func addStudyGroupMember(groupId: String, memberId: String) async throws {
-        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
-        throw StudyRepositoryError.unimplemented(operation: "addStudyGroupMember")
+        try await performVoidRequest(
+            .addStudyGroupMember(groupId: groupId, memberId: memberId)
+        )
     }
 
     public func removeStudyGroupMember(groupId: String, memberId: String) async throws {
-        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
-        throw StudyRepositoryError.unimplemented(operation: "removeStudyGroupMember")
+        try await performVoidRequest(
+            .removeStudyGroupMember(groupId: groupId, memberId: memberId)
+        )
     }
 
     public func addStudyGroupMentor(groupId: String, mentorId: String) async throws {
-        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
-        throw StudyRepositoryError.unimplemented(operation: "addStudyGroupMentor")
+        try await performVoidRequest(
+            .addStudyGroupMentor(groupId: groupId, mentorId: mentorId)
+        )
     }
 
     public func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {
-        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
-        throw StudyRepositoryError.unimplemented(operation: "removeStudyGroupMentor")
+        try await performVoidRequest(
+            .removeStudyGroupMentor(groupId: groupId, mentorId: mentorId)
+        )
     }
 
     public func linkStudyGroupSchedule(
@@ -226,8 +242,15 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
         studyGroupId: String,
         weeklyCurriculumId: String
     ) async throws {
-        // TODO: 8차 CRUD 구현 - [26.06.24] jaewon
-        throw StudyRepositoryError.unimplemented(operation: "linkStudyGroupSchedule")
+        try await performVoidRequest(
+            .linkStudyGroupSchedule(
+                body: StudyGroupScheduleCreateRequestDTO(
+                    scheduleId: scheduleId,
+                    studyGroupId: studyGroupId,
+                    weeklyCurriculumId: weeklyCurriculumId
+                )
+            )
+        )
     }
 }
 
@@ -262,16 +285,23 @@ private extension StudyRepository {
         )
         return (try apiResponse.unwrap(), part)
     }
-}
 
-// MARK: - StudyRepositoryError
-
-/// ``StudyRepository`` 의 미구현 스텁 메서드가 호출됐음을 알리는 에러.
-///
-/// 운영진 스터디 그룹 CRUD·일정 연결은 라우터 case 가 추가되는 8차에서 실구현된다.
-/// 그 전까지 호출되면 본 에러를 던져 "아직 미구현" 임을 명확히 한다.
-enum StudyRepositoryError: Error, Equatable {
-
-    /// 아직 구현되지 않은 운영진 스터디 CRUD/연결 작업 (`operation`: 메서드 이름)
-    case unimplemented(operation: String)
+    /// 결과 본문이 없는 변경(CRUD/연결) 요청의 공통 호출·검증.
+    ///
+    /// 비-2xx 는 네트워크 계층(``NetworkRequesting``)에서 이미 throw 되므로, 여기 도달한
+    /// `response` 는 2xx 다. DELETE 등 일부 엔드포인트는 본문 없이 2xx 만 반환하므로 빈 본문은
+    /// 성공으로 처리하고, 본문이 있으면 `APIResponse<EmptyResult>` 로 디코딩해 `isSuccess` 만
+    /// 검증한다. 실패 응답은 ``CoreNetwork/RepositoryError/serverError(code:message:)`` 로
+    /// 승격된다.
+    func performVoidRequest(_ target: StudyRouter) async throws {
+        let response = try await networkRequesting.request(target)
+        guard !response.data.isEmpty else {
+            return
+        }
+        let apiResponse = try decoder.decode(
+            APIResponse<EmptyResult>.self,
+            from: response.data
+        )
+        try apiResponse.validateSuccess()
+    }
 }

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
@@ -187,17 +187,14 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
         memberIds: [String],
         mentorIds: [String]
     ) async throws {
-        try await performVoidRequest(
-            .createStudyGroup(
-                body: StudyGroupCreateRequestDTO(
-                    gisuId: gisuId,
-                    name: name,
-                    part: part.apiValue,
-                    memberIds: memberIds,
-                    mentorIds: mentorIds
-                )
-            )
+        let body = StudyGroupCreateRequestDTO(
+            gisuId: try intIdentifier(gisuId, field: "gisuId"),
+            name: name,
+            part: part.apiValue,
+            memberIds: try intIdentifiers(memberIds, field: "memberIds"),
+            mentorIds: try intIdentifiers(mentorIds, field: "mentorIds")
         )
+        try await performVoidRequest(.createStudyGroup(body: body))
     }
 
     public func updateStudyGroup(groupId: String, name: String) async throws {
@@ -242,15 +239,14 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
         studyGroupId: String,
         weeklyCurriculumId: String
     ) async throws {
-        try await performVoidRequest(
-            .linkStudyGroupSchedule(
-                body: StudyGroupScheduleCreateRequestDTO(
-                    scheduleId: scheduleId,
-                    studyGroupId: studyGroupId,
-                    weeklyCurriculumId: weeklyCurriculumId
-                )
+        let body = StudyGroupScheduleCreateRequestDTO(
+            scheduleId: try intIdentifier(scheduleId, field: "scheduleId"),
+            studyGroupId: try intIdentifier(studyGroupId, field: "studyGroupId"),
+            weeklyCurriculumId: try intIdentifier(
+                weeklyCurriculumId, field: "weeklyCurriculumId"
             )
         )
+        try await performVoidRequest(.linkStudyGroupSchedule(body: body))
     }
 }
 
@@ -303,5 +299,24 @@ private extension StudyRepository {
             from: response.data
         )
         try apiResponse.validateSuccess()
+    }
+
+    /// 요청 본문에 담을 `String` 식별자를 `Int` 로 변환한다.
+    ///
+    /// 서버는 이 식별자들을 정수로 받는다. 값은 서버 응답(숫자 문자열)에서 오므로 보통 변환에
+    /// 성공하지만, 변환할 수 없는 값이면 잘못된 요청을 보내는 대신 곧바로 에러를 던진다.
+    /// 마땅한 전용 케이스가 없어 ``UMCFoundation/RepositoryError`` 의 `decodingError` 로 던진다.
+    func intIdentifier(_ value: String, field: String) throws -> Int {
+        guard let converted = Int(value) else {
+            throw RepositoryError.decodingError(
+                detail: "\(field) 식별자를 정수로 변환할 수 없습니다: \(value)"
+            )
+        }
+        return converted
+    }
+
+    /// ``intIdentifier(_:field:)`` 의 배열 버전. 하나라도 변환에 실패하면 던진다.
+    func intIdentifiers(_ values: [String], field: String) throws -> [Int] {
+        try values.map { try intIdentifier($0, field: field) }
     }
 }

--- a/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
@@ -10,13 +10,17 @@ import Moya
 import CoreNetwork
 internal import Alamofire
 
-/// Study(Activity) Feature 조회 API 라우터.
+/// Study(Activity) Feature API 라우터.
 ///
-/// 조회 계열 case 만 정의합니다. CRUD case(생성/수정/삭제/멤버·멘토/일정 연결)는
-/// 후속 작업에서 동일 enum 에 case 추가만으로 확장합니다.
+/// 조회 계열(커리큘럼/운영 스터디 그룹/멤버 프로필)과 운영진 스터디 그룹 CRUD·일정 연결을
+/// 단일 enum 으로 묶어 표현합니다. 멤버·포인트 계열 case 는 9차 멤버 Data 레이어에서 확장합니다.
 ///
-/// 연관값(Query DTO·식별자 String)이 모두 `Sendable` 이므로 라우터도 `Sendable`.
+/// 연관값(Query/Request DTO·식별자 String)이 모두 `Sendable` 이므로 라우터도 `Sendable`.
 /// 동시성 경계를 넘어 안전하게 전달되며, 테스트의 파라미터화(`@Test(arguments:)`)도 가능.
+///
+/// - Note: 스터디 그룹 엔드포인트는 레거시와 동일하게 `/api/v1/study-groups` 경로를 사용합니다
+///   (커리큘럼만 `/api/v2`). 쿼리는 Query DTO 의 `toParameters`, 바디는 Request DTO 로
+///   캡슐화하고 `task` 에 인라인 딕셔너리를 두지 않습니다.
 enum StudyRouter: Sendable {
     /// 커리큘럼 개요 조회 — `GET /api/v2/curriculums/overview`
     case getCurriculum(query: CurriculumOverviewQuery)
@@ -26,6 +30,25 @@ enum StudyRouter: Sendable {
     case getStudyGroupDetail(groupId: String)
     /// 멤버 프로필 조회 (resolveChallengerId 용) — `GET /api/v1/member/profile/{memberId}`
     case getMemberProfile(memberId: String)
+
+    // MARK: - 운영진 스터디 그룹 CRUD / 일정 연결
+
+    /// 스터디 그룹 생성 — `POST /api/v1/study-groups`
+    case createStudyGroup(body: StudyGroupCreateRequestDTO)
+    /// 스터디 그룹 수정(이름) — `PATCH /api/v1/study-groups/{groupId}`
+    case updateStudyGroup(groupId: String, body: StudyGroupUpdateRequestDTO)
+    /// 스터디 그룹 삭제 — `DELETE /api/v1/study-groups/{groupId}`
+    case deleteStudyGroup(groupId: String)
+    /// 스터디원 추가 — `PATCH /api/v1/study-groups/{groupId}/members/{memberId}`
+    case addStudyGroupMember(groupId: String, memberId: String)
+    /// 스터디원 제거 — `DELETE /api/v1/study-groups/{groupId}/members/{memberId}`
+    case removeStudyGroupMember(groupId: String, memberId: String)
+    /// 멘토(파트장) 추가 — `PATCH /api/v1/study-groups/{groupId}/mentors/{mentorId}`
+    case addStudyGroupMentor(groupId: String, mentorId: String)
+    /// 멘토(파트장) 제거 — `DELETE /api/v1/study-groups/{groupId}/mentors/{mentorId}`
+    case removeStudyGroupMentor(groupId: String, mentorId: String)
+    /// 일정-스터디 그룹 연결 — `POST /api/v1/study-groups/schedules`
+    case linkStudyGroupSchedule(body: StudyGroupScheduleCreateRequestDTO)
 }
 
 extension StudyRouter: BaseTargetType {
@@ -42,6 +65,20 @@ extension StudyRouter: BaseTargetType {
             return "/api/v1/study-groups/\(groupId)"
         case .getMemberProfile(let memberId):
             return "/api/v1/member/profile/\(memberId)"
+        case .createStudyGroup:
+            return "/api/v1/study-groups"
+        case .updateStudyGroup(let groupId, _):
+            return "/api/v1/study-groups/\(groupId)"
+        case .deleteStudyGroup(let groupId):
+            return "/api/v1/study-groups/\(groupId)"
+        case .addStudyGroupMember(let groupId, let memberId),
+             .removeStudyGroupMember(let groupId, let memberId):
+            return "/api/v1/study-groups/\(groupId)/members/\(memberId)"
+        case .addStudyGroupMentor(let groupId, let mentorId),
+             .removeStudyGroupMentor(let groupId, let mentorId):
+            return "/api/v1/study-groups/\(groupId)/mentors/\(mentorId)"
+        case .linkStudyGroupSchedule:
+            return "/api/v1/study-groups/schedules"
         }
     }
 
@@ -54,6 +91,17 @@ extension StudyRouter: BaseTargetType {
              .getStudyGroupDetail,
              .getMemberProfile:
             return .get
+        case .createStudyGroup,
+             .linkStudyGroupSchedule:
+            return .post
+        case .updateStudyGroup,
+             .addStudyGroupMember,
+             .addStudyGroupMentor:
+            return .patch
+        case .deleteStudyGroup,
+             .removeStudyGroupMember,
+             .removeStudyGroupMentor:
+            return .delete
         }
     }
 
@@ -71,7 +119,19 @@ extension StudyRouter: BaseTargetType {
                 parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
-        case .getStudyGroupDetail, .getMemberProfile:
+        case .createStudyGroup(let body):
+            return .requestJSONEncodable(body)
+        case .updateStudyGroup(_, let body):
+            return .requestJSONEncodable(body)
+        case .linkStudyGroupSchedule(let body):
+            return .requestJSONEncodable(body)
+        case .getStudyGroupDetail,
+             .getMemberProfile,
+             .deleteStudyGroup,
+             .addStudyGroupMember,
+             .removeStudyGroupMember,
+             .addStudyGroupMentor,
+             .removeStudyGroupMentor:
             return .requestPlain
         }
     }

--- a/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
@@ -369,14 +369,14 @@ struct StudyRepositoryResolveChallengerTests {
     }
 }
 
-// MARK: - Suite: CRUD 스텁 계약
+// MARK: - Suite: CRUD/연결 실행 계약
 
-@Suite("StudyRepository — CRUD/연결 스텁 (미구현 계약)")
-struct StudyRepositoryStubTests {
+@Suite("StudyRepository — CRUD/연결 실행 (도메인 규칙)")
+struct StudyRepositoryCRUDTests {
 
-    /// 8차에서 실구현될 CRUD/연결 메서드. 모두 동일하게 `unimplemented` 를 던지므로
-    /// 검증 본문이 같아 파라미터화한다.
-    private enum StubOperation: CaseIterable, CustomTestStringConvertible {
+    /// CRUD/연결 8종. 성공/실패 검증 본문이 동일하므로 파라미터화한다
+    /// (작업별로 path·method 만 다르며, 이를 케이스 메타데이터로 분리한다).
+    private enum Operation: CaseIterable, CustomTestStringConvertible {
         case create, update, delete
         case addMember, removeMember, addMentor, removeMentor
         case linkSchedule
@@ -394,6 +394,24 @@ struct StudyRepositoryStubTests {
             }
         }
 
+        var expectedPath: String {
+            switch self {
+            case .create: "/api/v1/study-groups"
+            case .update, .delete: "/api/v1/study-groups/1"
+            case .addMember, .removeMember: "/api/v1/study-groups/1/members/2"
+            case .addMentor, .removeMentor: "/api/v1/study-groups/1/mentors/2"
+            case .linkSchedule: "/api/v1/study-groups/schedules"
+            }
+        }
+
+        var expectedMethod: Moya.Method {
+            switch self {
+            case .create, .linkSchedule: .post
+            case .update, .addMember, .addMentor: .patch
+            case .delete, .removeMember, .removeMentor: .delete
+            }
+        }
+
         var testDescription: String { operationName }
 
         func invoke(on sut: StudyRepository) async throws {
@@ -401,7 +419,7 @@ struct StudyRepositoryStubTests {
             case .create:
                 try await sut.createStudyGroup(
                     gisuId: "1", name: "n", part: .front(type: .ios),
-                    memberIds: [], mentorIds: []
+                    memberIds: ["2"], mentorIds: ["3"]
                 )
             case .update:
                 try await sut.updateStudyGroup(groupId: "1", name: "n")
@@ -424,18 +442,48 @@ struct StudyRepositoryStubTests {
     }
 
     @Test(
-        "CRUD/연결 스텁 8종 — 호출 시 unimplemented(operation:) 에러를 던진다",
-        arguments: StubOperation.allCases
+        "CRUD/연결 8종 — 성공 응답 시 명세된 path·method 로 1회 호출한다",
+        arguments: Operation.allCases
     )
-    private func crudStubsThrowUnimplemented(_ operation: StubOperation) async {
-        let (sut, stub) = makeRepository([])
+    private func crudSucceedsWithExpectedEndpoint(_ operation: Operation) async throws {
+        let (sut, stub) = makeRepository(.success(Fixture.success("null")))
+
+        try await operation.invoke(on: sut)
+
+        #expect(stub.requestCount == 1)
+        #expect(stub.lastPath == operation.expectedPath)
+        #expect(stub.lastMethod == operation.expectedMethod)
+    }
+
+    @Test(
+        "CRUD/연결 8종 — 본문 없는 2xx 응답(빈 본문)도 성공으로 처리한다",
+        arguments: Operation.allCases
+    )
+    private func crudSucceedsOnEmptyBody(_ operation: Operation) async throws {
+        // DELETE 등은 본문 없이 2xx 만 반환할 수 있다. 빈 본문을 디코딩 시도하면 실패하므로
+        // 성공으로 처리해야 한다(레거시 CRUD 와 동일한 계약).
+        let (sut, stub) = makeRepository(.success(Data()))
+
+        try await operation.invoke(on: sut)
+
+        #expect(stub.requestCount == 1)
+        #expect(stub.lastPath == operation.expectedPath)
+    }
+
+    @Test(
+        "CRUD/연결 8종 — 실패(success:false) 응답 시 serverError 를 던진다",
+        arguments: Operation.allCases
+    )
+    private func crudThrowsServerErrorOnFailure(_ operation: Operation) async {
+        let (sut, _) = makeRepository(
+            .success(Fixture.failureBody(code: "STUDY403", message: "권한 없음"))
+        )
 
         await #expect(
-            throws: StudyRepositoryError.unimplemented(operation: operation.operationName)
+            throws: RepositoryError.serverError(code: "STUDY403", message: "권한 없음")
         ) {
             try await operation.invoke(on: sut)
         }
-        #expect(stub.requestCount == 0)        // 네트워크 호출 없이 즉시 실패
     }
 }
 

--- a/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
@@ -485,6 +485,21 @@ struct StudyRepositoryCRUDTests {
             try await operation.invoke(on: sut)
         }
     }
+
+    @Test("createStudyGroup — 식별자가 정수 문자열이 아니면 네트워크 호출 없이 던진다")
+    private func createStudyGroupThrowsBeforeNetworkOnNonNumericIdentifier() async {
+        // 서버는 ID 를 정수로 받으므로 Repository 가 요청을 만들 때 String→Int 로 변환한다.
+        // 변환할 수 없는 값이면 요청을 보내기 전에 에러를 던진다.
+        let (sut, stub) = makeRepository(.success(Fixture.success("null")))
+
+        await #expect(throws: RepositoryError.self) {
+            try await sut.createStudyGroup(
+                gisuId: "abc", name: "n", part: .front(type: .ios),
+                memberIds: ["2"], mentorIds: ["3"]
+            )
+        }
+        #expect(stub.requestCount == 0)
+    }
 }
 
 #endif

--- a/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
@@ -212,3 +212,207 @@ struct StudyRouterTests {
         #expect(parameters.count == 1)
     }
 }
+
+// MARK: - CRUD Helpers
+
+private func makeCreateBody() -> StudyGroupCreateRequestDTO {
+    StudyGroupCreateRequestDTO(
+        gisuId: "7",
+        name: "iOS 스터디",
+        part: "IOS",
+        memberIds: ["1", "2"],
+        mentorIds: ["3"]
+    )
+}
+
+private func makeScheduleBody() -> StudyGroupScheduleCreateRequestDTO {
+    StudyGroupScheduleCreateRequestDTO(
+        scheduleId: "10",
+        studyGroupId: "42",
+        weeklyCurriculumId: "5"
+    )
+}
+
+private func encodeToJSON(_ value: some Encodable) throws -> [String: Any] {
+    let data = try JSONEncoder().encode(value)
+    let obj = try JSONSerialization.jsonObject(with: data)
+    return try #require(obj as? [String: Any])
+}
+
+// MARK: - Suite: CRUD/연결 path·method 계약
+
+@Suite("StudyRouter — CRUD/연결 엔드포인트 매핑 (API 계약)")
+struct StudyRouterCRUDPathMethodTests {
+
+    // MARK: - Path
+
+    @Test("각 CRUD/연결 case 는 명세된 path 로 매핑된다")
+    func crudPathMapsEachCase() {
+        // Given
+        let create = StudyRouter.createStudyGroup(body: makeCreateBody())
+        let update = StudyRouter.updateStudyGroup(
+            groupId: "42", body: StudyGroupUpdateRequestDTO(name: "n")
+        )
+        let delete = StudyRouter.deleteStudyGroup(groupId: "42")
+        let addMember = StudyRouter.addStudyGroupMember(groupId: "42", memberId: "7")
+        let removeMember = StudyRouter.removeStudyGroupMember(groupId: "42", memberId: "7")
+        let addMentor = StudyRouter.addStudyGroupMentor(groupId: "42", mentorId: "9")
+        let removeMentor = StudyRouter.removeStudyGroupMentor(groupId: "42", mentorId: "9")
+        let link = StudyRouter.linkStudyGroupSchedule(body: makeScheduleBody())
+
+        // Then
+        #expect(create.path == "/api/v1/study-groups")
+        #expect(update.path == "/api/v1/study-groups/42")
+        #expect(delete.path == "/api/v1/study-groups/42")
+        #expect(addMember.path == "/api/v1/study-groups/42/members/7")
+        #expect(removeMember.path == "/api/v1/study-groups/42/members/7")
+        #expect(addMentor.path == "/api/v1/study-groups/42/mentors/9")
+        #expect(removeMentor.path == "/api/v1/study-groups/42/mentors/9")
+        #expect(link.path == "/api/v1/study-groups/schedules")
+    }
+
+    // MARK: - Method
+
+    @Test(
+        "POST case 의 HTTP method 는 POST 이다",
+        arguments: [
+            StudyRouter.createStudyGroup(body: makeCreateBody()),
+            StudyRouter.linkStudyGroupSchedule(body: makeScheduleBody())
+        ]
+    )
+    func methodIsPost(router: StudyRouter) {
+        #expect(router.method == .post)
+    }
+
+    @Test(
+        "PATCH case 의 HTTP method 는 PATCH 이다",
+        arguments: [
+            StudyRouter.updateStudyGroup(
+                groupId: "42", body: StudyGroupUpdateRequestDTO(name: "n")
+            ),
+            StudyRouter.addStudyGroupMember(groupId: "42", memberId: "7"),
+            StudyRouter.addStudyGroupMentor(groupId: "42", mentorId: "9")
+        ]
+    )
+    func methodIsPatch(router: StudyRouter) {
+        #expect(router.method == .patch)
+    }
+
+    @Test(
+        "DELETE case 의 HTTP method 는 DELETE 이다",
+        arguments: [
+            StudyRouter.deleteStudyGroup(groupId: "42"),
+            StudyRouter.removeStudyGroupMember(groupId: "42", memberId: "7"),
+            StudyRouter.removeStudyGroupMentor(groupId: "42", mentorId: "9")
+        ]
+    )
+    func methodIsDelete(router: StudyRouter) {
+        #expect(router.method == .delete)
+    }
+}
+
+// MARK: - Suite: CRUD/연결 task 형태 계약
+
+@Suite("StudyRouter — CRUD/연결 task 형태 계약")
+struct StudyRouterCRUDTaskTests {
+
+    @Test("createStudyGroup 의 task 는 requestJSONEncodable 이다")
+    func createStudyGroupTaskIsJSONEncodable() {
+        let router = StudyRouter.createStudyGroup(body: makeCreateBody())
+        if case .requestJSONEncodable = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestJSONEncodable 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    @Test("updateStudyGroup 의 task 는 requestJSONEncodable 이다")
+    func updateStudyGroupTaskIsJSONEncodable() {
+        let router = StudyRouter.updateStudyGroup(
+            groupId: "42", body: StudyGroupUpdateRequestDTO(name: "n")
+        )
+        if case .requestJSONEncodable = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestJSONEncodable 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    @Test("linkStudyGroupSchedule 의 task 는 requestJSONEncodable 이다")
+    func linkStudyGroupScheduleTaskIsJSONEncodable() {
+        let router = StudyRouter.linkStudyGroupSchedule(body: makeScheduleBody())
+        if case .requestJSONEncodable = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestJSONEncodable 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    @Test(
+        "결과 없는 변경(delete/멤버·멘토) case 의 task 는 requestPlain 이다",
+        arguments: [
+            StudyRouter.deleteStudyGroup(groupId: "42"),
+            StudyRouter.addStudyGroupMember(groupId: "42", memberId: "7"),
+            StudyRouter.removeStudyGroupMember(groupId: "42", memberId: "7"),
+            StudyRouter.addStudyGroupMentor(groupId: "42", mentorId: "9"),
+            StudyRouter.removeStudyGroupMentor(groupId: "42", mentorId: "9")
+        ]
+    )
+    func voidMutationTaskIsPlain(router: StudyRouter) {
+        if case .requestPlain = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestPlain 여야 함 — 실제: \(router.task)")
+        }
+    }
+}
+
+// MARK: - Suite: Request DTO JSON 인코딩 계약
+
+@Suite("StudyRouter — Request DTO JSON 인코딩 계약")
+struct StudyRouterRequestDTOEncodingTests {
+
+    @Test("StudyGroupCreateRequestDTO — 식별자를 문자열/문자열 배열로 직렬화한다 (정수 아님)")
+    func createDTOEncodesIdentifiersAsStrings() throws {
+        let dto = StudyGroupCreateRequestDTO(
+            gisuId: "7",
+            name: "iOS 스터디",
+            part: "IOS",
+            memberIds: ["1", "2"],
+            mentorIds: ["3"]
+        )
+        let json = try encodeToJSON(dto)
+
+        // 핵심 계약: 식별자는 String/[String] 이며 숫자가 아님
+        #expect(json["gisuId"] as? String == "7")
+        #expect(json["gisuId"] as? Int == nil)
+        #expect(json["memberIds"] as? [String] == ["1", "2"])
+        #expect(json["mentorIds"] as? [String] == ["3"])
+        #expect(json["name"] as? String == "iOS 스터디")
+        #expect(json["part"] as? String == "IOS")
+        #expect(json.keys.count == 5)
+    }
+
+    @Test("StudyGroupUpdateRequestDTO — name 키만 인코딩한다")
+    func updateDTOEncodesNameOnly() throws {
+        let dto = StudyGroupUpdateRequestDTO(name: "새 이름")
+        let json = try encodeToJSON(dto)
+        #expect(json["name"] as? String == "새 이름")
+        #expect(json.keys.count == 1)
+    }
+
+    @Test("StudyGroupScheduleCreateRequestDTO — 세 식별자를 문자열로 직렬화한다 (정수 아님)")
+    func scheduleDTOEncodesIdentifiersAsStrings() throws {
+        let dto = StudyGroupScheduleCreateRequestDTO(
+            scheduleId: "10",
+            studyGroupId: "42",
+            weeklyCurriculumId: "5"
+        )
+        let json = try encodeToJSON(dto)
+        #expect(json["scheduleId"] as? String == "10")
+        #expect(json["studyGroupId"] as? String == "42")
+        #expect(json["weeklyCurriculumId"] as? String == "5")
+        #expect(json["scheduleId"] as? Int == nil)
+        #expect(json.keys.count == 3)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
@@ -217,19 +217,19 @@ struct StudyRouterTests {
 
 private func makeCreateBody() -> StudyGroupCreateRequestDTO {
     StudyGroupCreateRequestDTO(
-        gisuId: "7",
+        gisuId: 7,
         name: "iOS 스터디",
         part: "IOS",
-        memberIds: ["1", "2"],
-        mentorIds: ["3"]
+        memberIds: [1, 2],
+        mentorIds: [3]
     )
 }
 
 private func makeScheduleBody() -> StudyGroupScheduleCreateRequestDTO {
     StudyGroupScheduleCreateRequestDTO(
-        scheduleId: "10",
-        studyGroupId: "42",
-        weeklyCurriculumId: "5"
+        scheduleId: 10,
+        studyGroupId: 42,
+        weeklyCurriculumId: 5
     )
 }
 
@@ -372,22 +372,22 @@ struct StudyRouterCRUDTaskTests {
 @Suite("StudyRouter — Request DTO JSON 인코딩 계약")
 struct StudyRouterRequestDTOEncodingTests {
 
-    @Test("StudyGroupCreateRequestDTO — 식별자를 문자열/문자열 배열로 직렬화한다 (정수 아님)")
-    func createDTOEncodesIdentifiersAsStrings() throws {
+    @Test("StudyGroupCreateRequestDTO — 식별자를 정수/정수 배열로 직렬화한다 (문자열 아님)")
+    func createDTOEncodesIdentifiersAsIntegers() throws {
         let dto = StudyGroupCreateRequestDTO(
-            gisuId: "7",
+            gisuId: 7,
             name: "iOS 스터디",
             part: "IOS",
-            memberIds: ["1", "2"],
-            mentorIds: ["3"]
+            memberIds: [1, 2],
+            mentorIds: [3]
         )
         let json = try encodeToJSON(dto)
 
-        // 핵심 계약: 식별자는 String/[String] 이며 숫자가 아님
-        #expect(json["gisuId"] as? String == "7")
-        #expect(json["gisuId"] as? Int == nil)
-        #expect(json["memberIds"] as? [String] == ["1", "2"])
-        #expect(json["mentorIds"] as? [String] == ["3"])
+        // 서버가 식별자를 정수로 받으므로 Int/[Int] 로 인코딩되어야 한다 (문자열 아님)
+        #expect(json["gisuId"] as? Int == 7)
+        #expect(json["gisuId"] as? String == nil)
+        #expect(json["memberIds"] as? [Int] == [1, 2])
+        #expect(json["mentorIds"] as? [Int] == [3])
         #expect(json["name"] as? String == "iOS 스터디")
         #expect(json["part"] as? String == "IOS")
         #expect(json.keys.count == 5)
@@ -401,18 +401,18 @@ struct StudyRouterRequestDTOEncodingTests {
         #expect(json.keys.count == 1)
     }
 
-    @Test("StudyGroupScheduleCreateRequestDTO — 세 식별자를 문자열로 직렬화한다 (정수 아님)")
-    func scheduleDTOEncodesIdentifiersAsStrings() throws {
+    @Test("StudyGroupScheduleCreateRequestDTO — 세 식별자를 정수로 직렬화한다 (문자열 아님)")
+    func scheduleDTOEncodesIdentifiersAsIntegers() throws {
         let dto = StudyGroupScheduleCreateRequestDTO(
-            scheduleId: "10",
-            studyGroupId: "42",
-            weeklyCurriculumId: "5"
+            scheduleId: 10,
+            studyGroupId: 42,
+            weeklyCurriculumId: 5
         )
         let json = try encodeToJSON(dto)
-        #expect(json["scheduleId"] as? String == "10")
-        #expect(json["studyGroupId"] as? String == "42")
-        #expect(json["weeklyCurriculumId"] as? String == "5")
-        #expect(json["scheduleId"] as? Int == nil)
+        #expect(json["scheduleId"] as? Int == 10)
+        #expect(json["studyGroupId"] as? Int == 42)
+        #expect(json["weeklyCurriculumId"] as? Int == 5)
+        #expect(json["scheduleId"] as? String == nil)
         #expect(json.keys.count == 3)
     }
 }


### PR DESCRIPTION
resolves #886

## ✨ PR 유형

♻️ [Refactor] — 레거시 `AppProduct/`의 스터디 그룹 CRUD를 신규 `UMCApp/`(Tuist) 모듈로 이식

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="1512" height="989" alt="스크린샷 2026-06-27 오후 11 25 43" src="https://github.com/user-attachments/assets/97fee975-0241-4756-80a5-3f100499d99c" />
<img width="1512" height="989" alt="스크린샷 2026-06-27 오후 11 25 55" src="https://github.com/user-attachments/assets/d71d94d5-1246-4323-bb76-2abd999523ca" />

## 🛠️ 작업내용

8차 계획의 스터디 그룹 Data 레이어 CRUD를 완성합니다. #814에서 스텁으로 남겨둔 CRUD를 실구현으로 전환했습니다.

- **Request DTO 3종 이식** — `StudyGroupCreateRequestDTO` / `StudyGroupUpdateRequestDTO` / `StudyGroupScheduleCreateRequestDTO`
- **StudyRouter CRUD case 8종 확장** — 생성·수정·삭제 + 스터디원/멘토 추가·제거 + 일정 연결 (path·method·task 대칭 처리, 라우터 인라인 딕셔너리 없음)
- **StudyRepository CRUD 실구현** — 스텁 8종 → 실구현, 결과 없는 변경은 `performVoidRequest` 헬퍼로 통합, 미구현 표식 `StudyRepositoryError` enum 제거
- **계약/단위 테스트** — Router(path/method/task) + Request DTO 인코딩 + Repository CRUD(성공/빈 본문/실패)

> 멤버·포인트 case와 "베스트 워크북"은 본 PR 범위 제외 (9차 멤버 Data 레이어).

## 📋 추후 진행 상황

- 9차: OperatorStudyManagement Presentation (본 Data 레이어가 선행 기반)
- 멤버·포인트 case 확장 (`searchChallengersOffset` 등)

## 📌 리뷰 포인트

핵심 의사결정 2가지를 중점적으로 봐주세요:

1. **식별자 String 와이어 포맷** — 레거시 Request DTO는 ID를 정수로 전송했으나, 서버 정수 전 레이어 String 통일 규칙 + 형제 `DecideAttendanceItemDTO`(participantMemberId를 String 직렬화) 선례를 따라 문자열로 직렬화했습니다. 생성/멤버/멘토/일정 엔드포인트가 문자열 ID를 수용하는지 서버 스펙 확인 부탁드립니다.
2. **경로 `/api/v1/study-groups`** — 레거시 및 기존 이식 case와 동일하게 v1 사용 (코드베이스에 `/api/v2/study-groups` 부재).

- `StudyRepository.swift` — `performVoidRequest`의 빈 본문(2xx) 성공 처리 (DELETE 등 본문 없는 응답 대비)
- `StudyRouter.swift` — CRUD case의 method/task 매핑 대칭성

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)