### PR TITLE
♻️ [Refactor] ChallengerStudyViewModel 이식

### DIFF
--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerStudyViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerStudyViewModel.swift
@@ -39,17 +39,28 @@ final class ChallengerStudyViewModel {
 
     // MARK: - Action
 
-    /// 커리큘럼 진행 현황 로드
+    /// 커리큘럼 진행 현황을 조회합니다.
     ///
-    /// 성공 시 `.loaded`, 이미 래핑된 `AppError` 는 그대로, 그 외 계층 에러는 대응
-    /// `AppError` 로 매핑해 `.failed` 로 전이합니다. 모든 에러는 화면 내 인라인 표시용
-    /// `Loadable.failed` 로 흐릅니다.
+    /// 이미 로딩 중이면 중복 호출을 무시합니다. `.task` 가 취소되면 던져지는 에러는
+    /// 실패가 아니므로 이전 상태로 복원해 허위 에러 카드가 뜨지 않게 합니다. 에러 분기:
+    /// - `CancellationError` / `NSURLErrorCancelled` → 이전 상태 복원
+    /// - `AppError` → 그대로 `.failed` (이미 래핑됨)
+    /// - `DomainError` / `NetworkError` / `RepositoryError` → 대응 `AppError` 로 매핑
+    /// - 그 외 → `.failed(.unknown(message:))`
     func fetchCurriculum() async {
+        if curriculumState.isLoading { return }
+
+        let previousState = curriculumState
         curriculumState = .loading
 
         do {
             let progress = try await fetchCurriculumUseCase.execute()
             curriculumState = .loaded(progress)
+        } catch is CancellationError {
+            curriculumState = previousState
+        } catch let error as NSError
+            where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+            curriculumState = previousState
         } catch let error as AppError {
             curriculumState = .failed(error)
         } catch let error as DomainError {

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerStudyViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerStudyViewModel.swift
@@ -1,0 +1,78 @@
+//
+//  ChallengerStudyViewModel.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import ActivityDomain
+import Foundation
+import UMCFoundation
+
+/// 챌린저(일반 참여자) 모드의 스터디/활동 섹션 ViewModel
+///
+/// `FetchCurriculumUseCaseProtocol` 을 통해 커리큘럼 진행 현황을 조회해
+/// `ChallengerStudyView` 커리큘럼 섹션의 상태 소스로 사용됩니다.
+///
+/// - Note: 레거시는 `Loadable<CurriculumData>`(진행률 + 주차별 미션 카드)를 보유했으나,
+///   주차별 미션 상세(`CurriculumData`)는 정의 위치 미확정으로 #749 에서 동결되어
+///   본 진입점은 진행률(`CurriculumProgressModel`)만 보유합니다. 미션 카드 로딩과
+///   스터디 제출 현황(#586)·커리큘럼 과제 제출(#587)은 백엔드 결선 후 후행 이슈에서
+///   추가됩니다 (하단 TODO 참고).
+@MainActor
+@Observable
+final class ChallengerStudyViewModel {
+
+    // MARK: - Property
+
+    private let fetchCurriculumUseCase: FetchCurriculumUseCaseProtocol
+
+    // MARK: - State
+
+    private(set) var curriculumState: Loadable<CurriculumProgressModel> = .idle
+
+    // MARK: - Init
+
+    init(fetchCurriculumUseCase: FetchCurriculumUseCaseProtocol) {
+        self.fetchCurriculumUseCase = fetchCurriculumUseCase
+    }
+
+    // MARK: - Action
+
+    /// 커리큘럼 진행 현황 로드
+    ///
+    /// 성공 시 `.loaded`, 이미 래핑된 `AppError` 는 그대로, 그 외 계층 에러는 대응
+    /// `AppError` 로 매핑해 `.failed` 로 전이합니다. 모든 에러는 화면 내 인라인 표시용
+    /// `Loadable.failed` 로 흐릅니다.
+    func fetchCurriculum() async {
+        curriculumState = .loading
+
+        do {
+            let progress = try await fetchCurriculumUseCase.execute()
+            curriculumState = .loaded(progress)
+        } catch let error as AppError {
+            curriculumState = .failed(error)
+        } catch let error as DomainError {
+            curriculumState = .failed(.domain(error))
+        } catch let error as NetworkError {
+            curriculumState = .failed(.network(error))
+        } catch let error as RepositoryError {
+            curriculumState = .failed(.repository(error))
+        } catch {
+            curriculumState = .failed(
+                .unknown(message: error.localizedDescription)
+            )
+        }
+    }
+
+    // MARK: - 미션/제출 현황 (백엔드 후행)
+
+    // TODO: 주차별 미션 카드 결선 - [26.06.26] 이재원
+    //  — 레거시 `CurriculumData`(진행률 + 미션 카드)가 의존하던 `fetchCurriculumData(weekNo:)`
+    //    는 `CurriculumData` 정의 위치 미확정으로 #749 에서 동결됨. 정의 확정 후 미션 카드
+    //    Loadable 상태와 주차 선택 로딩을 복원한다.
+    // TODO: 스터디 제출 현황 조회(#586) 결선 - [26.06.26] 이재원
+    //  — 백엔드 제출 현황 API 미제공으로 비활성화.
+    // TODO: 커리큘럼 과제 제출(#587) 결선 - [26.06.26] 이재원
+    //  — 백엔드 과제 제출 API 미제공으로 비활성화.
+}

--- a/UMCApp/Features/Activity/Presentation/Tests/ChallengerStudyViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/ChallengerStudyViewModelTests.swift
@@ -32,14 +32,14 @@ private func makeProgress(
 
 @MainActor
 private func makeViewModel(
-    useCase: MockFetchCurriculumUseCase
+    useCase: any FetchCurriculumUseCaseProtocol
 ) -> ChallengerStudyViewModel {
     ChallengerStudyViewModel(fetchCurriculumUseCase: useCase)
 }
 
 // MARK: - Mocks
 
-/// 결정론적 메시지를 갖는 비분류 에러 — `.unknown` 폴백 매핑 검증용.
+/// `.unknown` 폴백 매핑 검증용 비분류 에러. 결정론적 메시지를 갖는다.
 private enum TestError: Error, LocalizedError {
     case unclassified
     var errorDescription: String? { "테스트 알 수 없는 오류" }
@@ -54,6 +54,26 @@ private final class MockFetchCurriculumUseCase: @unchecked Sendable,
     func execute() async throws -> CurriculumProgressModel {
         executeCallCount += 1
         return try result.get()
+    }
+}
+
+/// 재진입 가드 검증용. `execute()` 가 지정 시간만큼 suspend 해 로딩 상태를 유지한다.
+private final class SlowMockFetchCurriculumUseCase: @unchecked Sendable,
+    FetchCurriculumUseCaseProtocol {
+
+    private let progress: CurriculumProgressModel
+    private let delayNanoseconds: UInt64
+    private(set) var executeCallCount = 0
+
+    init(progress: CurriculumProgressModel, delayNanoseconds: UInt64) {
+        self.progress = progress
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func execute() async throws -> CurriculumProgressModel {
+        executeCallCount += 1
+        try? await Task.sleep(nanoseconds: delayNanoseconds)
+        return progress
     }
 }
 
@@ -103,6 +123,25 @@ private enum ErrorMappingCase: CaseIterable {
     }
 }
 
+// MARK: - 취소 에러 케이스
+
+/// `.failed` 가 아니라 이전 상태로 복원돼야 하는 두 취소 경로.
+///
+/// `CancellationError` / `NSURLErrorCancelled` 분기를 대칭 검증한다.
+private enum CancellationCase: CaseIterable {
+    case swiftCancellation
+    case urlCancellation
+
+    var thrown: Error {
+        switch self {
+        case .swiftCancellation:
+            return CancellationError()
+        case .urlCancellation:
+            return NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil)
+        }
+    }
+}
+
 // MARK: - 커리큘럼 조회
 
 // Suite 전체 @MainActor — SUT(ChallengerStudyViewModel)가 @MainActor 격리이므로 필요.
@@ -141,6 +180,51 @@ struct ChallengerStudyViewModelTests {
         await viewModel.fetchCurriculum()
 
         #expect(viewModel.curriculumState == .failed(errorCase.expected))
+    }
+
+    // 파라미터 타입 `CancellationCase` 가 file-private 이라 메서드도 fileprivate 로 맞춘다.
+    @Test(
+        "취소 에러 발생 시 이전 상태로 롤백 (허위 .failed(.unknown) 노출 방지)",
+        arguments: CancellationCase.allCases
+    )
+    fileprivate func cancellationRollsBackToPreviousState(
+        cancellationCase: CancellationCase
+    ) async {
+        let previous = makeProgress(curriculumTitle: "이전 주차")
+        let useCase = MockFetchCurriculumUseCase()
+        useCase.result = .success(previous)
+        let viewModel = makeViewModel(useCase: useCase)
+
+        // 1차 로드로 직전 상태를 .loaded 로 만든다.
+        await viewModel.fetchCurriculum()
+        #expect(viewModel.curriculumState == .loaded(previous))
+
+        // 2차 요청이 취소되면 .failed 가 아니라 직전 .loaded 로 복원돼야 한다.
+        useCase.result = .failure(cancellationCase.thrown)
+        await viewModel.fetchCurriculum()
+
+        #expect(viewModel.curriculumState == .loaded(previous))
+    }
+
+    @Test("로딩 중 중복 호출은 무시 (execute 1회만 호출 — 취소 롤백 stuck-loading 방지)")
+    func duplicateFetchWhileLoadingIsIgnored() async {
+        let expected = makeProgress()
+        let useCase = SlowMockFetchCurriculumUseCase(
+            progress: expected,
+            delayNanoseconds: 100_000_000  // 0.1s 지연으로 로딩 상태 유지
+        )
+        let viewModel = makeViewModel(useCase: useCase)
+
+        let first = Task { await viewModel.fetchCurriculum() }
+        // 첫 호출이 .loading 을 세팅할 때까지 양보한다.
+        await Task.yield()
+
+        // 로딩 중 2차 호출은 재진입 가드로 즉시 return 된다.
+        await viewModel.fetchCurriculum()
+        await first.value
+
+        #expect(useCase.executeCallCount == 1)
+        #expect(viewModel.curriculumState == .loaded(expected))
     }
 }
 

--- a/UMCApp/Features/Activity/Presentation/Tests/ChallengerStudyViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/ChallengerStudyViewModelTests.swift
@@ -1,0 +1,147 @@
+//
+//  ChallengerStudyViewModelTests.swift
+//  ActivityPresentationTests
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+import Testing
+import ActivityDomain
+import UMCFoundation
+@testable import ActivityPresentation
+
+// 이 테스트 파일은 전부 #if DEBUG 전용 Mock 에 의존하므로 본문 전체를 가드한다.
+#if DEBUG
+
+// MARK: - Helpers
+
+private func makeProgress(
+    partName: String = "iOS",
+    curriculumTitle: String = "1주차 OT",
+    completedCount: Int = 2,
+    totalCount: Int = 8
+) -> CurriculumProgressModel {
+    CurriculumProgressModel(
+        partName: partName,
+        curriculumTitle: curriculumTitle,
+        completedCount: completedCount,
+        totalCount: totalCount
+    )
+}
+
+@MainActor
+private func makeViewModel(
+    useCase: MockFetchCurriculumUseCase
+) -> ChallengerStudyViewModel {
+    ChallengerStudyViewModel(fetchCurriculumUseCase: useCase)
+}
+
+// MARK: - Mocks
+
+/// 결정론적 메시지를 갖는 비분류 에러 — `.unknown` 폴백 매핑 검증용.
+private enum TestError: Error, LocalizedError {
+    case unclassified
+    var errorDescription: String? { "테스트 알 수 없는 오류" }
+}
+
+private final class MockFetchCurriculumUseCase: @unchecked Sendable,
+    FetchCurriculumUseCaseProtocol {
+
+    var result: Result<CurriculumProgressModel, Error> = .success(makeProgress())
+    private(set) var executeCallCount = 0
+
+    func execute() async throws -> CurriculumProgressModel {
+        executeCallCount += 1
+        return try result.get()
+    }
+}
+
+// MARK: - 에러 매핑 케이스
+
+/// UseCase 가 던진 에러 타입별 → ViewModel 이 매핑해야 할 `AppError` 짝.
+///
+/// 형제 catch 분기(AppError 패스스루 / Domain / Network / Repository / unknown)를
+/// 빠짐없이 대칭 검증하기 위한 파라미터 집합입니다.
+private enum ErrorMappingCase: CaseIterable {
+    case appErrorPassthrough
+    case domain
+    case network
+    case repository
+    case unknownFallback
+
+    var thrown: Error {
+        switch self {
+        case .appErrorPassthrough:
+            return AppError.repository(.decodingError(detail: "이미 래핑됨"))
+        case .domain:
+            return DomainError.curriculumUnavailableForGeneration
+        case .network:
+            return NetworkError.unauthorized
+        case .repository:
+            return RepositoryError.serverError(code: "STUDY-500", message: "서버 오류")
+        case .unknownFallback:
+            return TestError.unclassified
+        }
+    }
+
+    /// 매핑 후 기대되는 `AppError`. 패스스루는 final catch 폴백(`.unknown`)과 결과가
+    /// 달라 조기 `catch as AppError` 분기가 실제로 동작했음을 구분한다.
+    var expected: AppError {
+        switch self {
+        case .appErrorPassthrough:
+            return .repository(.decodingError(detail: "이미 래핑됨"))
+        case .domain:
+            return .domain(.curriculumUnavailableForGeneration)
+        case .network:
+            return .network(.unauthorized)
+        case .repository:
+            return .repository(.serverError(code: "STUDY-500", message: "서버 오류"))
+        case .unknownFallback:
+            return .unknown(message: "테스트 알 수 없는 오류")
+        }
+    }
+}
+
+// MARK: - 커리큘럼 조회
+
+// Suite 전체 @MainActor — SUT(ChallengerStudyViewModel)가 @MainActor 격리이므로 필요.
+@MainActor
+@Suite("ChallengerStudyViewModel — 커리큘럼 조회 (도메인 규칙)")
+struct ChallengerStudyViewModelTests {
+
+    @Test("정상 — execute 위임 + .loaded 전이 + 1회 호출")
+    func fetchCurriculumLoadsProgress() async {
+        let expected = makeProgress(
+            partName: "Spring",
+            curriculumTitle: "3주차 세션",
+            completedCount: 5,
+            totalCount: 10
+        )
+        let useCase = MockFetchCurriculumUseCase()
+        useCase.result = .success(expected)
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchCurriculum()
+
+        #expect(useCase.executeCallCount == 1)
+        #expect(viewModel.curriculumState == .loaded(expected))
+    }
+
+    // 파라미터 타입 `ErrorMappingCase` 가 file-private 이라 메서드도 fileprivate 로 맞춘다.
+    @Test(
+        "에러 타입별 → 대응 AppError 로 매핑된 .failed 전이",
+        arguments: ErrorMappingCase.allCases
+    )
+    fileprivate func fetchCurriculumMapsErrorToFailed(errorCase: ErrorMappingCase) async {
+        let useCase = MockFetchCurriculumUseCase()
+        useCase.result = .failure(errorCase.thrown)
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchCurriculum()
+
+        #expect(viewModel.curriculumState == .failed(errorCase.expected))
+    }
+}
+
+#endif


### PR DESCRIPTION
resolves #891

## ✨ PR 유형

♻️ [Refactor] — 레거시 `ChallengerStudyViewModel` 을 `ActivityPresentation`(Tuist) 모듈로 이식

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="989" alt="스크린샷 2026-06-27 오후 11 50 12" src="https://github.com/user-attachments/assets/17531f19-0adc-4bad-8b06-92faa580164d" />

<img width="1512" height="989" alt="스크린샷 2026-06-27 오후 11 50 20" src="https://github.com/user-attachments/assets/afc68ec1-eb77-4991-b094-28e4ce5d64d6" />


## 🛠️ 작업내용

- 레거시 `ChallengerStudyViewModel`(커리큘럼 조회 단일 책임)을 `ActivityPresentation` 모듈로 이식
- 상태를 `Loadable<CurriculumProgressModel>` 로 보유 — 신규 `FetchCurriculumUseCaseProtocol.execute()` 가 진행률만 반환(레거시 `CurriculumData`·미션은 #749 에서 정의 위치 미확정으로 동결)
- `@Observable` + `FetchCurriculumUseCaseProtocol` 단일 의존, 5단 에러 매핑(AppError 패스스루 → Domain → Network → Repository → unknown)
- 미션 카드 상세·스터디 제출 현황(#586)·커리큘럼 과제 제출(#587)은 백엔드 후행으로 형식 준수 TODO 비활성화
- Swift Testing 단위 테스트 추가 — 정상 로드 1건 + 에러 매핑 5케이스 `arguments:` 파라미터화

## 📋 추후 진행 상황

- `ChallengerStudyView` 이식 (본 ViewModel 이 선행 기반)
- `CurriculumData`/주차별 미션 정의 위치 확정 후 미션 카드 로딩 결선
- 백엔드 API 결선 후 스터디 제출 현황(#586)·과제 제출(#587) 활성화

## 📌 리뷰 포인트

- **상태 타입 결정**: `Loadable<CurriculumProgressModel>`(레거시 `CurriculumData` 진행률+미션 대신) — 미션이 #749 에서 동결된 점을 반영한 선택이 적절한지
- **에러 매핑 사다리**: 이미 래핑된 `AppError` 패스스루 → `Domain`/`Network`/`Repository` → `unknown` 폴백 순서·누락 여부
- **테스트**: 에러 매핑 5케이스 파라미터화, `appErrorPassthrough` 케이스가 `unknown` 폴백과 결과로 구분되는지(조기 `catch as AppError` 동작 검증)
- **의존성**: ViewModel 이 `FetchCurriculumUseCaseProtocol` 에만 의존(Repository 직접 의존·미사용 주입 없음)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
