### PR TITLE
♻️ [Refactor] 멤버 조회 UseCase 2종 이식 (FetchMembersUseCase + FetchUserIdUseCase)

### DIFF
--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/CurrentUserIdProviding.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/CurrentUserIdProviding.swift
@@ -1,0 +1,20 @@
+//
+//  CurrentUserIdProviding.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+
+/// 현재 로그인된 사용자의 식별자 제공 seam
+///
+/// `FetchUserIdUseCase` 가 의존하는 단일 협력자입니다. "현재 사용자 식별자" 는 멤버 관리
+/// 데이터 접근과 책임이 다르므로 `MemberRepositoryProtocol` 과 분리된 별도 프로토콜로 둡니다.
+/// 구현체는 현재 로컬 세션 저장소를 읽지만(서버 왕복 없음), 향후 서버 기반 조회로 교체될 수
+/// 있도록 `async throws` 계약을 유지합니다.
+public protocol CurrentUserIdProviding {
+
+    /// 현재 로그인된 사용자의 식별자를 반환합니다.
+    func fetchCurrentUserId() async throws -> UserID
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/FetchMembersUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/FetchMembersUseCaseProtocol.swift
@@ -1,0 +1,78 @@
+//
+//  FetchMembersUseCaseProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 운영진 멤버 관리 도메인 진입점
+///
+/// 멤버 목록 조회(전체/페이지), 챌린저 상벌점 부여·삭제·이력 조회, 멤버 상세
+/// (기수 텍스트·기수별 상벌점 요약·출석 이력) 조회를 단일 facade 로 묶어 제공합니다.
+/// `MemberRepositoryProtocol` 의 계약을 그대로 노출하며, 모든 서버 식별자는 `String` 으로
+/// 통일됩니다.
+public protocol FetchMembersUseCaseProtocol {
+
+    // MARK: - 멤버 목록
+
+    /// 멤버 목록 전체 조회
+    func execute() async throws -> [MemberManagementItem]
+
+    /// 멤버 목록 페이지 단위 조회 (offset 기반)
+    ///
+    /// - Parameter page: 0-based 페이지 인덱스
+    func executePage(page: Int) async throws -> MemberPage
+
+    // MARK: - 상벌점 부여 / 삭제
+
+    /// 챌린저에게 포인트를 부여합니다.
+    ///
+    /// - Parameters:
+    ///   - challengerId: 대상 챌린저 식별자 (서버 응답)
+    ///   - pointType: 포인트 유형
+    ///   - pointValue: 배점 (`ChallengerPointType/isCustom` 인 경우 직접 입력)
+    ///   - description: 부여 사유
+    func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws
+
+    /// 챌린저 포인트를 삭제합니다.
+    ///
+    /// - Parameter challengerPointId: 삭제할 포인트 식별자 (서버 응답)
+    func deletePoint(challengerPointId: String) async throws
+
+    /// 특정 챌린저의 포인트 히스토리를 조회합니다.
+    ///
+    /// - Parameter challengerId: 조회 대상 챌린저 식별자 (서버 응답)
+    func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory]
+
+    // MARK: - 멤버 상세
+
+    /// 멤버 프로필에서 모든 활동 기수 텍스트를 조회합니다.
+    ///
+    /// - Parameter memberId: 조회 대상 멤버 식별자 (서버 응답)
+    func fetchAllGenerations(memberId: String) async throws -> String
+
+    /// 멤버의 기수별 상벌점 요약을 조회합니다.
+    ///
+    /// - Parameter memberId: 조회 대상 멤버 식별자 (서버 응답)
+    func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary]
+
+    /// 일정 출석 현황에서 특정 멤버의 출석 이력을 조회합니다.
+    ///
+    /// - Parameter memberId: 조회 대상 멤버 식별자 (서버 응답)
+    /// - Returns: 해당 멤버가 포함된 일정별 출석 기록. 결과 없으면 빈 배열 반환.
+    func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord]
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/FetchUserIdUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/FetchUserIdUseCaseProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  FetchUserIdUseCaseProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+
+/// 현재 사용자 식별자 조회 UseCase 진입점
+public protocol FetchUserIdUseCaseProtocol {
+
+    /// 현재 로그인된 사용자의 식별자를 조회합니다.
+    func execute() async throws -> UserID
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/FetchMembersUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/FetchMembersUseCase.swift
@@ -1,0 +1,76 @@
+//
+//  FetchMembersUseCase.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// `FetchMembersUseCaseProtocol` 의 기본 구현체
+///
+/// 모든 호출을 `MemberRepositoryProtocol` 에 위임하는 얇은 facade 입니다. 서버 식별자는
+/// 전 레이어 `String` 으로 통일되어 그대로 전달됩니다.
+public final class FetchMembersUseCase: FetchMembersUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: MemberRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: MemberRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute() async throws -> [MemberManagementItem] {
+        try await repository.fetchMembers()
+    }
+
+    public func executePage(page: Int) async throws -> MemberPage {
+        try await repository.fetchMembersPage(page: page)
+    }
+
+    public func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws {
+        try await repository.grantPoint(
+            challengerId: challengerId,
+            pointType: pointType,
+            pointValue: pointValue,
+            description: description
+        )
+    }
+
+    public func deletePoint(challengerPointId: String) async throws {
+        try await repository.deletePoint(challengerPointId: challengerPointId)
+    }
+
+    public func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory] {
+        try await repository.fetchPointHistory(challengerId: challengerId)
+    }
+
+    public func fetchAllGenerations(memberId: String) async throws -> String {
+        try await repository.fetchAllGenerations(memberId: memberId)
+    }
+
+    public func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary] {
+        try await repository.fetchGenerationPointSummaries(memberId: memberId)
+    }
+
+    public func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord] {
+        try await repository.fetchAttendanceRecords(memberId: memberId)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/FetchUserIdUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/FetchUserIdUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  FetchUserIdUseCase.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+
+/// `FetchUserIdUseCaseProtocol` 의 기본 구현체
+///
+/// 현재 사용자 식별자 조회를 `CurrentUserIdProviding` 에 위임하는 얇은 facade 입니다.
+public final class FetchUserIdUseCase: FetchUserIdUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let provider: CurrentUserIdProviding
+
+    // MARK: - Init
+
+    public init(provider: CurrentUserIdProviding) {
+        self.provider = provider
+    }
+
+    // MARK: - Function
+
+    public func execute() async throws -> UserID {
+        try await provider.fetchCurrentUserId()
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchMembersUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchMembersUseCaseTests.swift
@@ -1,0 +1,318 @@
+//
+//  FetchMembersUseCaseTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+#if DEBUG
+
+// MARK: - Helpers
+
+/// `memberID` 만 검증 대상이고, 나머지 필드는 init 충족용 임의 고정값입니다.
+private func makeMemberItem(memberID: String) -> MemberManagementItem {
+    MemberManagementItem(
+        memberID: memberID,
+        profile: nil,
+        name: "테스트멤버",
+        nickname: "닉네임",
+        generation: "9기",
+        school: "한성대학교",
+        position: "파트원",
+        part: .front(type: .ios),
+        penalty: 0,
+        badge: false,
+        managementTeam: .challenger,
+        attendanceRecords: [],
+        penaltyHistory: []
+    )
+}
+
+private func makeUseCase(
+    repository: MockMemberRepository = MockMemberRepository()
+) -> FetchMembersUseCase {
+    FetchMembersUseCase(repository: repository)
+}
+
+// MARK: - Mocks
+
+/// `MemberRepositoryProtocol` 의 모든 계약 메서드를 기록·제어하는 Mock.
+/// `error` 가 설정되면 모든 메서드가 해당 에러를 던져 위임 facade 의 전파 경로를 검증합니다.
+private final class MockMemberRepository: @unchecked Sendable, MemberRepositoryProtocol {
+
+    enum MockError: Error {
+        /// 에러 전파 경로 검증용 스텁 에러
+        case stubbed
+    }
+
+    /// 챌린저 포인트 부여 호출 1건을 기록하는 값 타입
+    struct GrantCall: Equatable {
+        let challengerId: String
+        let pointType: ChallengerPointType
+        let pointValue: Int
+        let description: String
+    }
+
+    // MARK: 반환값 스텁
+
+    var fetchMembersResult: [MemberManagementItem] = []
+    var fetchMembersPageResult = MemberPage(members: [], hasNext: false, currentPage: 0)
+    var fetchPointHistoryResult: [OperatorMemberPenaltyHistory] = []
+    var fetchAllGenerationsResult = ""
+    var fetchGenerationPointSummariesResult: [GenerationPointSummary] = []
+    var fetchAttendanceRecordsResult: [MemberAttendanceRecord] = []
+
+    /// 설정 시 모든 메서드가 이 에러를 던진다 (에러 전파 검증용)
+    var error: Error?
+
+    // MARK: 호출 기록
+
+    private(set) var fetchMembersCallCount = 0
+    private(set) var fetchMembersPageCalls: [Int] = []
+    private(set) var grantPointCalls: [GrantCall] = []
+    private(set) var deletePointCalls: [String] = []
+    private(set) var fetchPointHistoryCalls: [String] = []
+    private(set) var fetchAllGenerationsCalls: [String] = []
+    private(set) var fetchGenerationPointSummariesCalls: [String] = []
+    private(set) var fetchAttendanceRecordsCalls: [String] = []
+
+    // MARK: MemberRepositoryProtocol
+
+    func fetchMembers() async throws -> [MemberManagementItem] {
+        fetchMembersCallCount += 1
+        if let error { throw error }
+        return fetchMembersResult
+    }
+
+    func fetchMembersPage(page: Int) async throws -> MemberPage {
+        fetchMembersPageCalls.append(page)
+        if let error { throw error }
+        return fetchMembersPageResult
+    }
+
+    func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws {
+        grantPointCalls.append(
+            GrantCall(
+                challengerId: challengerId,
+                pointType: pointType,
+                pointValue: pointValue,
+                description: description
+            )
+        )
+        if let error { throw error }
+    }
+
+    func deletePoint(challengerPointId: String) async throws {
+        deletePointCalls.append(challengerPointId)
+        if let error { throw error }
+    }
+
+    func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory] {
+        fetchPointHistoryCalls.append(challengerId)
+        if let error { throw error }
+        return fetchPointHistoryResult
+    }
+
+    func fetchAllGenerations(memberId: String) async throws -> String {
+        fetchAllGenerationsCalls.append(memberId)
+        if let error { throw error }
+        return fetchAllGenerationsResult
+    }
+
+    func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary] {
+        fetchGenerationPointSummariesCalls.append(memberId)
+        if let error { throw error }
+        return fetchGenerationPointSummariesResult
+    }
+
+    func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord] {
+        fetchAttendanceRecordsCalls.append(memberId)
+        if let error { throw error }
+        return fetchAttendanceRecordsResult
+    }
+}
+
+// MARK: - 파라미터화 식별자
+
+/// memberId 단일 인자를 받는 상세 조회 3종
+private enum MemberDetailRead: CaseIterable, Sendable {
+    case allGenerations
+    case generationSummaries
+    case attendanceRecords
+}
+
+/// 에러 전파 검증 대상 — 위임 facade 의 모든 메서드
+private enum MemberMethod: CaseIterable, Sendable {
+    case fetchMembers
+    case fetchMembersPage
+    case grantPoint
+    case deletePoint
+    case fetchPointHistory
+    case fetchAllGenerations
+    case fetchGenerationPointSummaries
+    case fetchAttendanceRecords
+}
+
+private func callMethod(
+    _ method: MemberMethod,
+    on useCase: FetchMembersUseCase
+) async throws {
+    switch method {
+    case .fetchMembers:
+        _ = try await useCase.execute()
+    case .fetchMembersPage:
+        _ = try await useCase.executePage(page: 0)
+    case .grantPoint:
+        try await useCase.grantPoint(
+            challengerId: "C-1",
+            pointType: .bestWorkbook,
+            pointValue: 2,
+            description: ""
+        )
+    case .deletePoint:
+        try await useCase.deletePoint(challengerPointId: "P-1")
+    case .fetchPointHistory:
+        _ = try await useCase.fetchPointHistory(challengerId: "C-1")
+    case .fetchAllGenerations:
+        _ = try await useCase.fetchAllGenerations(memberId: "M-1")
+    case .fetchGenerationPointSummaries:
+        _ = try await useCase.fetchGenerationPointSummaries(memberId: "M-1")
+    case .fetchAttendanceRecords:
+        _ = try await useCase.fetchAttendanceRecords(memberId: "M-1")
+    }
+}
+
+// MARK: - 위임 계약
+
+@Suite("FetchMembersUseCase — 멤버 관리 위임 계약 (도메인 규칙)")
+struct FetchMembersUseCaseDelegationTests {
+
+    @Test("execute — fetchMembers 결과를 그대로 반환하고 1회 호출")
+    func executeReturnsRepositoryMembers() async throws {
+        let repository = MockMemberRepository()
+        repository.fetchMembersResult = [makeMemberItem(memberID: "M-1")]
+        let useCase = makeUseCase(repository: repository)
+
+        let result = try await useCase.execute()
+
+        #expect(result.map(\.memberID) == ["M-1"])
+        #expect(repository.fetchMembersCallCount == 1)
+    }
+
+    @Test("executePage — page 인자를 그대로 위임하고 Repository 페이지를 반환")
+    func executePageForwardsPageAndReturnsRepositoryPage() async throws {
+        let repository = MockMemberRepository()
+        repository.fetchMembersPageResult = MemberPage(
+            members: [],
+            hasNext: true,
+            currentPage: 3
+        )
+        let useCase = makeUseCase(repository: repository)
+
+        let page = try await useCase.executePage(page: 3)
+
+        #expect(repository.fetchMembersPageCalls == [3])
+        #expect(page.hasNext)
+    }
+
+    @Test("grantPoint — 4개 인자를 변형 없이 그대로 위임")
+    func grantPointForwardsAllArguments() async throws {
+        let repository = MockMemberRepository()
+        let useCase = makeUseCase(repository: repository)
+
+        try await useCase.grantPoint(
+            challengerId: "C-9",
+            pointType: .bestWorkbook,
+            pointValue: 2,
+            description: "우수 워크북"
+        )
+
+        let expected = MockMemberRepository.GrantCall(
+            challengerId: "C-9",
+            pointType: .bestWorkbook,
+            pointValue: 2,
+            description: "우수 워크북"
+        )
+        #expect(repository.grantPointCalls == [expected])
+    }
+
+    @Test("deletePoint — challengerPointId 를 그대로 위임")
+    func deletePointForwardsId() async throws {
+        let repository = MockMemberRepository()
+        let useCase = makeUseCase(repository: repository)
+
+        try await useCase.deletePoint(challengerPointId: "P-3")
+
+        #expect(repository.deletePointCalls == ["P-3"])
+    }
+
+    @Test("fetchPointHistory — challengerId 위임 + Repository 결과 반환")
+    func fetchPointHistoryForwardsIdAndReturns() async throws {
+        let repository = MockMemberRepository()
+        let useCase = makeUseCase(repository: repository)
+
+        _ = try await useCase.fetchPointHistory(challengerId: "C-7")
+
+        #expect(repository.fetchPointHistoryCalls == ["C-7"])
+    }
+
+    @Test(
+        "memberId 기반 상세 조회 3종이 memberId 를 그대로 위임",
+        arguments: MemberDetailRead.allCases
+    )
+    fileprivate func detailReadsForwardMemberId(method: MemberDetailRead) async throws {
+        let repository = MockMemberRepository()
+        let useCase = makeUseCase(repository: repository)
+        let memberId = "M-42"
+
+        switch method {
+        case .allGenerations:
+            _ = try await useCase.fetchAllGenerations(memberId: memberId)
+            #expect(repository.fetchAllGenerationsCalls == [memberId])
+        case .generationSummaries:
+            _ = try await useCase.fetchGenerationPointSummaries(memberId: memberId)
+            #expect(repository.fetchGenerationPointSummariesCalls == [memberId])
+        case .attendanceRecords:
+            _ = try await useCase.fetchAttendanceRecords(memberId: memberId)
+            #expect(repository.fetchAttendanceRecordsCalls == [memberId])
+        }
+    }
+}
+
+// MARK: - 에러 전파
+
+@Suite("FetchMembersUseCase — Repository 에러 전파 (도메인 규칙)")
+struct FetchMembersUseCaseErrorTests {
+
+    @Test(
+        "모든 메서드가 Repository 에러를 그대로 전파",
+        arguments: MemberMethod.allCases
+    )
+    fileprivate func propagatesRepositoryError(method: MemberMethod) async {
+        let repository = MockMemberRepository()
+        repository.error = MockMemberRepository.MockError.stubbed
+        let useCase = makeUseCase(repository: repository)
+
+        await #expect(throws: MockMemberRepository.MockError.stubbed) {
+            try await callMethod(method, on: useCase)
+        }
+    }
+}
+
+#endif

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchUserIdUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchUserIdUseCaseTests.swift
@@ -1,0 +1,72 @@
+//
+//  FetchUserIdUseCaseTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 6/26/26.
+//
+
+import Foundation
+import Testing
+@testable import ActivityDomain
+
+#if DEBUG
+
+// MARK: - Helpers
+
+private func makeUseCase(
+    provider: MockCurrentUserIdProvider = MockCurrentUserIdProvider()
+) -> FetchUserIdUseCase {
+    FetchUserIdUseCase(provider: provider)
+}
+
+// MARK: - Mocks
+
+/// `CurrentUserIdProviding` 의 단일 메서드를 제어하는 Mock.
+private final class MockCurrentUserIdProvider: @unchecked Sendable, CurrentUserIdProviding {
+
+    enum MockError: Error {
+        /// 에러 전파 경로 검증용 스텁 에러
+        case stubbed
+    }
+
+    var result = UserID(value: "0")
+    var error: Error?
+    private(set) var callCount = 0
+
+    func fetchCurrentUserId() async throws -> UserID {
+        callCount += 1
+        if let error { throw error }
+        return result
+    }
+}
+
+// MARK: - 위임 계약
+
+@Suite("FetchUserIdUseCase — 현재 사용자 식별자 위임 (도메인 규칙)")
+struct FetchUserIdUseCaseTests {
+
+    @Test("execute — provider 의 UserID 를 그대로 반환하고 1회 호출")
+    func executeReturnsProviderUserId() async throws {
+        let provider = MockCurrentUserIdProvider()
+        provider.result = UserID(value: "42")
+        let useCase = makeUseCase(provider: provider)
+
+        let userId = try await useCase.execute()
+
+        #expect(userId == UserID(value: "42"))
+        #expect(provider.callCount == 1)
+    }
+
+    @Test("execute — provider 에러를 그대로 전파")
+    func executePropagatesProviderError() async {
+        let provider = MockCurrentUserIdProvider()
+        provider.error = MockCurrentUserIdProvider.MockError.stubbed
+        let useCase = makeUseCase(provider: provider)
+
+        await #expect(throws: MockCurrentUserIdProvider.MockError.stubbed) {
+            _ = try await useCase.execute()
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
resolves #892

## ✨ PR 유형
♻️ [Refactor] — 레거시 `AppProduct/` → `UMCApp/`(Tuist) `ActivityDomain` 모듈 이식

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="989" alt="스크린샷 2026-06-29 오전 12 06 40" src="https://github.com/user-attachments/assets/d0b4fbf3-fd26-44e0-8347-ea805bb0f707" />
<img width="1512" height="989" alt="스크린샷 2026-06-29 오전 12 06 49" src="https://github.com/user-attachments/assets/e4d63780-8346-48f3-a514-822b0903836c" />


## 🛠️ 작업내용
멤버 관리 도메인의 조회 UseCase 2종을 `ActivityDomain` 모듈로 이식했습니다.
- **FetchMembersUseCase** — `MemberRepositoryProtocol`(#888) 단독 의존. 멤버 목록(전체/페이지) + 챌린저 상벌점 부여·삭제·이력 + 멤버 상세를 8-메서드 facade로 위임. 서버 식별자 전부 `String` 통일(레거시 `Int` → `String`).
- **FetchUserIdUseCase** — 현재 사용자 식별자 조회. 전용 `CurrentUserIdProviding` 인터페이스에 의존.
- 두 UseCase 모두 Swift Testing 단위 테스트(Mock 계약 검증, `#if DEBUG` 가드) 작성.

## 📋 추후 진행 상황
- `MemberListViewModel` / `OperatorMemberDetailSheetViewModel` 이식 (본 PR이 선행 기반).
- `CurrentUserIdProviding` Data 구현 시 `AppStorageKey.memberIdString()`(String) 사용 권장.
- (후속 정규화) `FetchMembersUseCase`가 조회 + 상벌점 mutation을 함께 노출 → read/write 분리 또는 `MemberManagementUseCase` 개명 검토.

## 📌 리뷰 포인트
- **책임 정규화 결정 (핵심)**: 이슈는 `FetchUserIdUseCase`가 `MemberRepositoryProtocol`에 의존한다고 전제했으나, 실제 레거시는 `ActivityRepositoryProtocol.fetchCurrentUserId()`(로컬 세션 read)에 의존. 멤버관리 repository에 current-user-id를 얹는 건 책임 불일치라, 머지된 #888 protocol 미수정 + 전용 `CurrentUserIdProviding` 분리. → 적절성 리뷰 부탁.
- `…/Domain/Sources/UseCases/` — facade 위임 정확성 / `String` ID 통일.
- `…/Domain/Sources/Interfaces/CurrentUserIdProviding.swift` — seam 위치 + `async throws` 계약.
- `…/Domain/Tests/UseCases/` — Mock 계약, 에러 전파 형제 대칭(파라미터화), `#if DEBUG` 범위.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
