### PR TITLE
📄 Docs: README 간소화 및 상세·CLAUDE.md 문서 Wiki 이관 (#922)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,9 @@ UMC(University MakeUs Challenge) 동아리 운영을 하나의 앱으로 통합�
 
 ## 🛠️ 기술 스택
 
-| 구분 | 사용 기술 |
-|------|-----------|
-| 언어 | Swift 6.3 |
-| UI | SwiftUI · iOS 26 Liquid Glass |
-| 아키텍처 | Feature-based Modular + Clean Architecture + Observation |
-| 상태 관리 | `@Observable` · `Loadable` |
-| 네트워크 | Moya 15 |
-| 이미지 | Kingfisher 8 |
-| 저장소 | SwiftData (+ CloudKit 폴백) |
-| 모듈 · 빌드 | Tuist (mise로 버전 고정) |
-| 최소 사양 | iOS 26.0+ · Xcode 26.2 |
+<div align="center">
+<img src="https://github.com/user-attachments/assets/40c891f7-9e6c-4f02-990c-a2e5f2891c2a" width="100%" alt="기술 스택">
+</div>
 
 ## 🏢 iOS 팀 조직도
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ UMC(University MakeUs Challenge) 동아리 운영을 하나의 앱으로 통합�
 <img src="https://github.com/user-attachments/assets/04b68ba4-27ab-4c0c-9f72-9a2c4c6e3f9e" width="800" alt="iOS 1기 조직도">
 </div>
 
-### 🥈 2기 · 진행 예정
+### 🥈 2기 · 진행 중
 
 <div align="center">
 <img src="https://github.com/user-attachments/assets/de36bd93-9c6d-44cd-bbd1-2843103e878f" width="800" alt="iOS 2기 조직도">
@@ -72,6 +72,7 @@ UMC(University MakeUs Challenge) 동아리 운영을 하나의 앱으로 통합�
 | 🧱 모듈 구조 (Tuist) | [Module Structure](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Module-Structure) |
 | ⚙️ 빌드 & 실행 | [Build & Run](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Build-and-Run) |
 | 🔀 Git 워크플로우 | [Git Workflow](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Git-Workflow) |
+| 🛰️ API 커버리지 (Stella) | [Stella](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Stella) |
 
 > 신규 합류자는 [Wiki Home](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki) → **빌드 & 실행** 순서로 시작하세요.
 

--- a/README.md
+++ b/README.md
@@ -1,216 +1,93 @@
-# UMC PRODUCT TEAM iOS
+<div align="center">
 
-> UMC Product Team이 제작하는 동아리 운영 관리 iOS 애플리케이션입니다.
+# UMC PRODUCT TEAM · iOS
 
+**"Focus on Growth, We Handle the Ops"**
+
+UMC(University MakeUs Challenge) 동아리 운영을 하나의 앱으로 통합하는 iOS 클라이언트
+
+[![Release](https://img.shields.io/github/v/release/UMC-PRODUCT/umc-product-iOS?label=release&color=blue)](https://github.com/UMC-PRODUCT/umc-product-iOS/releases)
 [![Swift](https://img.shields.io/badge/Swift-6.3-orange.svg)]()
-[![Xcode](https://img.shields.io/badge/Xcode-26.2-blue.svg)]()
-[![iOS](https://img.shields.io/badge/iOS-26.0+-blue.svg)]()
-[![Architecture](https://img.shields.io/badge/Architecture-Feature+Modular+Clean-green.svg)]()
+[![Xcode](https://img.shields.io/badge/Xcode-26.2-1575F9.svg)]()
+[![iOS](https://img.shields.io/badge/iOS-26.0+-black.svg)]()
+[![Architecture](https://img.shields.io/badge/Architecture-Clean%20%2B%20Modular-2ea44f.svg)]()
+
+</div>
 
 ---
 
-## 📌 문서 목적
+## 📖 소개
 
-이 README는 다음을 동시에 관리합니다.
+디스코드·구글 시트·노션으로 흩어진 동아리 운영 도구를 **하나의 앱으로 통합**하여,
+부원이 운영 잡무 대신 성장에 집중할 수 있는 환경을 제공합니다.
 
-- 공통 운영 정보(아키텍처, 개발 환경, 규칙)
-- 기수별 정보(팀원, 기간, 신규 기능, 변경 사항)
+**Killer Features**
 
-기수가 늘어나도 아래 "기수 운영 보드"와 "기수별 상세"만 추가하면 누적 관리가 가능합니다.
+- 🔔 **The Ping** — 공지 수신 확인 추적 및 미확인자 재알림
+- 📱 **Mobile-First Admin** — 출석·경고·공지 운영을 모바일에서 처리
+- 📍 **GPS 스마트 출석** — 위치 기반 자동 출석
 
-## 📚 목차
+## 🛠️ 기술 스택
 
-- [기수 운영 보드](#-기수-운영-보드)
-- [공통 정보](#-공통-정보)
-- [기수별 상세](#-기수별-상세)
-- [새 기수 추가 템플릿](#-새-기수-추가-템플릿)
-- [참고 문서](#-참고-문서)
+| 구분 | 사용 기술 |
+|------|-----------|
+| 언어 | Swift 6.3 |
+| UI | SwiftUI · iOS 26 Liquid Glass |
+| 아키텍처 | Feature-based Modular + Clean Architecture + Observation |
+| 상태 관리 | `@Observable` · `Loadable` |
+| 네트워크 | Moya 15 |
+| 이미지 | Kingfisher 8 |
+| 저장소 | SwiftData (+ CloudKit 폴백) |
+| 모듈 · 빌드 | Tuist (mise로 버전 고정) |
+| 최소 사양 | iOS 26.0+ · Xcode 26.2 |
 
-## 🗂️ 기수 운영 보드
+## 👬 팀원 소개
 
-| 기수 | 기간 | 상태 | 리드 | 상세 |
-|------|------|------|------|------|
-| 1기 | 2025.12.27 - 2026.02.20 | 완료 | 리버/이재원 | [1기 상세](#-1기-20251227---20260220) |
-| 2기 | YYYY.MM.DD - YYYY.MM.DD | 예정 | 제옹/정의찬 | [2기 상세](#-2기-yyyyMMdd---yyyyMMdd) |
-| N기 | YYYY.MM.DD - YYYY.MM.DD | 진행/예정 | TBD | 아래 템플릿으로 추가 |
+### 🥇 1기 · 2025.12.27 – 2026.02.20
 
-## 🧩 공통 정보
+| 리버 / 이재원 | 제옹 / 정의찬 | 마티 / 김미주 | 소피 / 이예지 |
+|:---:|:---:|:---:|:---:|
+| <img src="https://github.com/user-attachments/assets/a4ddee14-419e-41da-a89a-e2c2fb23a03f" width="200"> | <img src="https://github.com/user-attachments/assets/00ba6ec3-d252-4e93-b467-b0d0ba654fb4" width="200"> | <img src="https://github.com/user-attachments/assets/7842f405-80c3-4394-8978-617c020f47d5" width="200"> | <img src="https://github.com/user-attachments/assets/1749df32-f292-4613-916d-b88cf2390cd2" width="200"> |
+| PL | iOS · PM | iOS | iOS |
+| [@jwon0523](https://github.com/jwon0523) | [@JEONG-J](https://github.com/JEONG-J) | [@alwn8918](https://github.com/alwn8918) | [@LeeYeJi546](https://github.com/LeeYeJi546) |
 
-### 소개
+### 🥈 2기 · 진행 예정
 
-> **"Focus on Growth, We Handle the Ops"**
-
-UMC(University MakeUs Challenge) 동아리 운영 관리 앱입니다.
-디스코드, 구글 시트, 노션으로 분산된 운영 도구를 하나의 앱으로 통합하여 운영 효율성을 높이고, 부원들이 성장에 집중할 수 있는 환경을 제공합니다.
-
-### 공통 기능 (기수 공통 유지 대상)
-
-- 공지사항 수신 확인 (The Ping)
-- Mobile-First Admin (출석/경고/공지 관리)
-- GPS 기반 스마트 출석
-- 커뮤니티 게시판
-
-### 요구사항
-
-- iOS 26.0+
-- Xcode 26.2
-- Swift 6.3
-
-### 시크릿 / Firebase 설정 안내
-
-- `Secrets.xcconfig`의 실제 키 값(`BASE_URL`, `KAKAO_KEY`)은 팀 내부 문서 기준으로 설정합니다.
-- `GoogleService-Info.plist`는 내부 가이드에 따라 발급/배치합니다.
-- 실제 키/설정 파일은 원격 저장소에 업로드하지 않습니다.
-
-### 아키텍처
-
-**Feature-based Modular + Clean Architecture + Observation**
-
-```text
-View <-> ViewModel(@Observable) -> UseCase(Protocol) -> Repository -> DataSource
-                               ^
-                 DIContainer가 Protocol 구현체 주입
-```
-
-| 계층 | 역할 | 의존 방향 |
-|------|------|-----------|
-| Presentation | View, ViewModel | -> Domain |
-| Domain | UseCase, Model, Interface | <- Data(구현) |
-| Data | Repository, Router, DTO | Domain Protocol 구현 |
-
-### 프로젝트 구조
-
-```text
-AppProduct/AppProduct/
-├── App/
-├── Core/
-│   ├── Alert/
-│   ├── Common/
-│   │   ├── DesignSystem/
-│   │   ├── Error/
-│   │   └── UIComponents/
-│   ├── DIContainer/
-│   ├── Manager/
-│   ├── Navigation/
-│   ├── NetworkAdapter/
-│   └── Services/
-└── Features/
-    ├── Activity/
-    ├── Auth/
-    ├── Community/
-    ├── Home/
-    ├── MyPage/
-    ├── Notice/
-    ├── Splash/
-    └── Tab/
-```
-
-### 테스트
-
-```bash
-xcodebuild -project AppProduct/AppProduct.xcodeproj \
-  -scheme AppProduct \
-  test
-```
-
-- 인증 연동 테스트에는 루트 `.test-config.json`이 필요합니다.
-- 샘플은 `AppProduct/AppProductTests/AuhTest/EmailVerificationTests.swift`를 참고합니다.
-
-### Git / PR 규칙
-
-- `main`/`develop` 직접 푸시 금지, 기능 브랜치에서 PR
-- 커밋 제목 형식: `type: 작업 내용`
-- PR 본문 최소 항목: 작업 내용 / 변경 이유 / 리뷰 포인트 / 추후 작업
-- UI 변경 시 스크린샷/영상 첨부
-- 최소 1명 Approve 후 `Squash and Merge`
-
-## 🚀 기수별 상세
-
-### 🥇 1기 (2025.12.27 - 2026.02.20)
-
-#### 팀 구성
-
-| 리버/이재원 | 제옹/정의찬 | 마티/김미주 | 소피/이예지 |
-|:------:|:------:|:------:|:------:|
-| <img src="https://github.com/user-attachments/assets/a4ddee14-419e-41da-a89a-e2c2fb23a03f" width="300" height="250"> | <img src="https://github.com/user-attachments/assets/00ba6ec3-d252-4e93-b467-b0d0ba654fb4" width="300" height="250"> | <img src="https://github.com/user-attachments/assets/7842f405-80c3-4394-8978-617c020f47d5" width="300" height="250"> | <img src="https://github.com/user-attachments/assets/1749df32-f292-4613-916d-b88cf2390cd2" width="300" height="250"> |
-| PL | iOS, PM | iOS | iOS |
-| [리버](https://github.com/jwon0523) | [제옹](https://github.com/JEONG-J) | [마티](https://github.com/alwn8918) | [소피](https://github.com/LeeYeJi546) |
-
-#### 1기 신규/강화 기능
-
-- The Ping 공지 미확인자 추적 및 재알림 UX 고도화
-- Mobile-First Admin 운영 플로우 정착
-- GPS 기반 스마트 출석 흐름 통합
-- 알림 히스토리 SwiftData 저장 및 CloudKit 폴백 구조 적용
-
-#### 1기 비고
-
-- 디자인 시스템에서 iOS 26 Liquid Glass 가이드라인 반영
-- CoreML 기반 알림 분류 테스트 리소스 운영
-
-### 🥈 2기 (YYYY.MM.DD - YYYY.MM.DD)
-
-#### 팀 구성
-
-| 제옹/정의찬 | 리버/이재원 | 소피/이예지 | 원/김동민 | 도도/김도연 |
-|:------:|:------:|:------:|:------:|:------:|
-| <img src="https://github.com/user-attachments/assets/00ba6ec3-d252-4e93-b467-b0d0ba654fb4" width="300" height="250"> | <img src="https://github.com/user-attachments/assets/a4ddee14-419e-41da-a89a-e2c2fb23a03f" width="300" height="250"> | <img src="https://github.com/user-attachments/assets/1749df32-f292-4613-916d-b88cf2390cd2" width="300" height="250"> | _사진 추후 추가_ | _사진 추후 추가_ |
+| 제옹 / 정의찬 | 리버 / 이재원 | 소피 / 이예지 | 원 / 김동민 | 도도 / 김도연 |
+|:---:|:---:|:---:|:---:|:---:|
+| <img src="https://github.com/user-attachments/assets/00ba6ec3-d252-4e93-b467-b0d0ba654fb4" width="200"> | <img src="https://github.com/user-attachments/assets/a4ddee14-419e-41da-a89a-e2c2fb23a03f" width="200"> | <img src="https://github.com/user-attachments/assets/1749df32-f292-4613-916d-b88cf2390cd2" width="200"> | _사진 추후 추가_ | _사진 추후 추가_ |
 | PL | iOS | iOS | iOS | iOS |
-| [제옹](https://github.com/JEONG-J) | [리버](https://github.com/jwon0523) | [소피](https://github.com/LeeYeJi546) | _추후 추가_ | _추후 추가_ |
+| [@JEONG-J](https://github.com/JEONG-J) | [@jwon0523](https://github.com/jwon0523) | [@LeeYeJi546](https://github.com/LeeYeJi546) | _추후 추가_ | _추후 추가_ |
 
-#### 2기 신규/강화 기능
+> 기수별 신규 기능·운영 기록은 [기수 & 릴리스 히스토리](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Release-History)에서 누적 관리합니다.
 
-- [신규] 기능 A
-- [개선] 기능 B
-- [실험] 기능 C
+## 📚 개발 문서 (Wiki)
 
-#### 2기 비고
+아키텍처·코딩 컨벤션·빌드 방법 등 상세 가이드는 모두 **[Wiki](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki)** 로 이관했습니다.
 
-- 운영/기술 의사결정 요약
-- 다음 기수로 넘길 TODO
+| 주제 | 문서 |
+|------|------|
+| 🏗️ 아키텍처 | [Architecture](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Architecture) |
+| 📐 절대 규칙 & 코딩 컨벤션 | [Coding Conventions](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Coding-Conventions) |
+| ⚠️ 에러 처리 | [Error Handling](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Error-Handling) |
+| 🌐 네트워크 & DTO 디코딩 | [Networking](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Networking) |
+| 🎨 디자인 시스템 | [Design System](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Design-System) |
+| 🧱 모듈 구조 (Tuist) | [Module Structure](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Module-Structure) |
+| ⚙️ 빌드 & 실행 | [Build & Run](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Build-and-Run) |
+| 🔀 Git 워크플로우 | [Git Workflow](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Git-Workflow) |
 
-## 🧱 새 기수 추가 템플릿
+> 신규 합류자는 [Wiki Home](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki) → **빌드 & 실행** 순서로 시작하세요.
 
-아래 블록을 복사해서 `기수별 상세` 섹션 하단에 이어서 추가하세요.
+## 🔑 시크릿 설정
 
-```md
-### 🥈 N기 (YYYY.MM.DD - YYYY.MM.DD)
+- `Secrets.xcconfig`(`BASE_URL`, `KAKAO_KEY`)와 `GoogleService-Info.plist`는 **팀 내부 채널**에서 수령합니다.
+- 실제 키·설정 파일은 원격 저장소에 커밋하지 않습니다.
+- 상세 절차: [Build & Run › 시크릿 설정](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Build-and-Run)
 
-#### 팀 구성
+---
 
-| 이름/실명 | 이름/실명 | 이름/실명 |
-|:------:|:------:|:------:|
-| 역할 | 역할 | 역할 |
-| [GitHub](https://github.com/) | [GitHub](https://github.com/) | [GitHub](https://github.com/) |
+<div align="center">
 
-#### N기 신규/강화 기능
+**Made with ❤️ by UMC Product Team · iOS**
 
-- [신규] 기능 A
-- [개선] 기능 B
-- [실험] 기능 C
-
-#### N기 비고
-
-- 운영/기술 의사결정 요약
-- 다음 기수로 넘길 TODO
-```
-
-그리고 "기수 운영 보드"에 해당 기수 행을 1줄 추가합니다.
-
-## 📎 참고 문서
-
-- `README.md`
-- `CLAUDE.md`
-- `.github/pull_request_template.md`
-- `AppProduct/Documentation.docc/Resources/NETWORK_API_GUIDE.md`
-- `AppProduct/Documentation.docc/Resources/SECRET_CIDCD_GUIDE.md`
-- `AppProduct/Documentation.docc/Resources/NOTICE_CLASSIFIER_GUIDE.md`
-- `AppProduct/Documentation.docc/Resources/SCHEDULE_CLASSIFIER_GUIDE.md`
-- `AppProduct/Documentation.docc/Resources/NOTICE_EDITOR_ROLE_TARGET_GUIDE.md`
-- `AppProduct/Documentation.docc/Resources/NOTICE_TAB_MENU_SCHEME.md`
-
-## 🛠️ 트러블슈팅 메모
-
-- `SwiftData CloudKit init failed` 로그는 CloudKit 실패 후 로컬 폴백 상황일 수 있습니다.
-- 시뮬레이터에서는 APNS 토큰 미설정으로 FCM 토큰 발급이 제한될 수 있습니다.
-- Preview에서 ModelContainer 오류가 발생하면 in-memory 컨테이너 주입 여부를 확인하세요.
+</div>

--- a/README.md
+++ b/README.md
@@ -43,11 +43,16 @@ UMC(University MakeUs Challenge) 동아리 운영을 하나의 앱으로 통합�
 
 ## 🏢 iOS 팀 조직도
 
+### 🥇 1기 · 2025.12.27 – 2026.02.20
+
 <div align="center">
+<img src="https://github.com/user-attachments/assets/04b68ba4-27ab-4c0c-9f72-9a2c4c6e3f9e" width="800" alt="iOS 1기 조직도">
+</div>
 
-<!-- TODO(#922): 조직도 이미지 URL 확정 시 아래 자리에 <img> 삽입 -->
-> 🏢 **iOS 팀 조직도 이미지 추가 예정** — URL 확정 시 이 자리에 삽입됩니다.
+### 🥈 2기 · 진행 예정
 
+<div align="center">
+<img src="https://github.com/user-attachments/assets/de36bd93-9c6d-44cd-bbd1-2843103e878f" width="800" alt="iOS 2기 조직도">
 </div>
 
 > 기수별 팀원 구성(사진·역할·GitHub)은 [Wiki › Team](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Team)에서,

--- a/README.md
+++ b/README.md
@@ -41,25 +41,17 @@ UMC(University MakeUs Challenge) 동아리 운영을 하나의 앱으로 통합�
 | 모듈 · 빌드 | Tuist (mise로 버전 고정) |
 | 최소 사양 | iOS 26.0+ · Xcode 26.2 |
 
-## 👬 팀원 소개
+## 🏢 iOS 팀 조직도
 
-### 🥇 1기 · 2025.12.27 – 2026.02.20
+<div align="center">
 
-| 리버 / 이재원 | 제옹 / 정의찬 | 마티 / 김미주 | 소피 / 이예지 |
-|:---:|:---:|:---:|:---:|
-| <img src="https://github.com/user-attachments/assets/a4ddee14-419e-41da-a89a-e2c2fb23a03f" width="200"> | <img src="https://github.com/user-attachments/assets/00ba6ec3-d252-4e93-b467-b0d0ba654fb4" width="200"> | <img src="https://github.com/user-attachments/assets/7842f405-80c3-4394-8978-617c020f47d5" width="200"> | <img src="https://github.com/user-attachments/assets/1749df32-f292-4613-916d-b88cf2390cd2" width="200"> |
-| PL | iOS · PM | iOS | iOS |
-| [@jwon0523](https://github.com/jwon0523) | [@JEONG-J](https://github.com/JEONG-J) | [@alwn8918](https://github.com/alwn8918) | [@LeeYeJi546](https://github.com/LeeYeJi546) |
+<!-- TODO(#922): 조직도 이미지 URL 확정 시 아래 자리에 <img> 삽입 -->
+> 🏢 **iOS 팀 조직도 이미지 추가 예정** — URL 확정 시 이 자리에 삽입됩니다.
 
-### 🥈 2기 · 진행 예정
+</div>
 
-| 제옹 / 정의찬 | 리버 / 이재원 | 소피 / 이예지 | 원 / 김동민 | 도도 / 김도연 |
-|:---:|:---:|:---:|:---:|:---:|
-| <img src="https://github.com/user-attachments/assets/00ba6ec3-d252-4e93-b467-b0d0ba654fb4" width="200"> | <img src="https://github.com/user-attachments/assets/a4ddee14-419e-41da-a89a-e2c2fb23a03f" width="200"> | <img src="https://github.com/user-attachments/assets/1749df32-f292-4613-916d-b88cf2390cd2" width="200"> | _사진 추후 추가_ | _사진 추후 추가_ |
-| PL | iOS | iOS | iOS | iOS |
-| [@JEONG-J](https://github.com/JEONG-J) | [@jwon0523](https://github.com/jwon0523) | [@LeeYeJi546](https://github.com/LeeYeJi546) | _추후 추가_ | _추후 추가_ |
-
-> 기수별 신규 기능·운영 기록은 [기수 & 릴리스 히스토리](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Release-History)에서 누적 관리합니다.
+> 기수별 팀원 구성(사진·역할·GitHub)은 [Wiki › Team](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Team)에서,
+> 신규 기능·운영 기록은 [Wiki › Release History](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Release-History)에서 확인하세요.
 
 ## 📚 개발 문서 (Wiki)
 


### PR DESCRIPTION
## 📌 작업 내용

비대해진 README를 정리하고 상세 가이드(아키텍처·빌드·CLAUDE.md 규칙 등)는 **GitHub [Wiki](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki)** 로 이관했습니다. README 팀 섹션은 인물별 사진 표 대신 **iOS 팀 조직도** 중심으로 전환하고, 팀원 상세는 Wiki로 옮겼습니다.

## ✅ 완료 조건 (#922)

- [x] README 간소화 (상세 내용 Wiki 이관, 팀 섹션을 조직도 중심으로 전환)
- [x] 기존 README의 상세 내용(개요·아키텍처·구조·테스트·트러블슈팅)을 Wiki로 이관
- [x] CLAUDE.md 관련 설명(절대 규칙·코딩 컨벤션·에러 처리)을 사람용 Wiki 문서로 정리
- [x] 팀원 소개(1기/2기 사진·역할·GitHub)를 Wiki `Team` 페이지로 이관
- [x] README → Wiki 링크 추가
- [x] Wiki Home·_Sidebar·_Footer 네비게이션 구성

## 🏢 README 팀 섹션

- `👬 팀원 소개`(인물 사진 표) → **`🏢 iOS 팀 조직도`** 섹션으로 전환
- 조직도 이미지 자리는 placeholder로 잡아둠 — **이미지 URL 확정 시 삽입 예정** `TODO(#922)`
- 인물 상세는 [Wiki › Team](https://github.com/UMC-PRODUCT/umc-product-iOS/wiki/Team)으로 링크

## 📚 Wiki 페이지 (별도 레포, 이미 반영됨)

`Home` · `_Sidebar` · `_Footer` + `Architecture` · `Coding-Conventions` · `Error-Handling` · `Networking` · `Design-System` · `Module-Structure` · `Build-and-Run` · `Git-Workflow` · **`Team`** · `Release-History`

→ https://github.com/UMC-PRODUCT/umc-product-iOS/wiki

## 🔧 추후 작업

- **조직도 이미지 URL 삽입** (placeholder 교체) — 머지 전/후 반영
- 2기 팀원 사진/GitHub 링크 확정 시 Wiki `Team` 갱신

Closes #922