### PR TITLE
♻️ Refactor: 에러 매핑 완성

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorHandler.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Handler/ErrorHandler.swift
@@ -202,14 +202,7 @@ public final class ErrorHandler {
     }
 
     private func convertURLError(_ error: URLError) -> NetworkError {
-        switch error.code {
-        case .notConnectedToInternet, .networkConnectionLost:
-            return .noNetwork
-        case .timedOut:
-            return .timeout
-        default:
-            return .requestFailed(statusCode: error.errorCode, data: nil)
-        }
+        .from(urlError: error)
     }
 
     private func describeGenerationError(_ error: LanguageModelSession.GenerationError) -> String {

--- a/UMCApp/Core/Foundation/Sources/Error/Types/NetworkError+Mapping.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/NetworkError+Mapping.swift
@@ -1,0 +1,85 @@
+//
+//  NetworkError+Mapping.swift
+//  UMCFoundation
+//
+//  HTTP 상태코드 / URLError 를 NetworkError 로 변환하는 단일 진실원 팩토리와,
+//  케이스 구조와 디커플링된 소비처용 헬퍼를 제공합니다.
+//
+
+import Foundation
+
+extension NetworkError {
+
+    // MARK: - Factory
+
+    /// HTTP 상태코드를 시맨틱 케이스로 매핑합니다. 알려지지 않은 코드는 `.requestFailed` 폴백.
+    ///
+    /// - Note: 401 은 `NetworkClient` 가 refresh 흐름에서 먼저 처리하므로 여기 도달하지 않습니다.
+    public static func from(statusCode: Int, data: Data?) -> NetworkError {
+        switch statusCode {
+        case 400:
+            return .badRequest(data: data)
+        case 403:
+            return .forbidden(data: data)
+        case 404:
+            return .notFound(data: data)
+        case 409:
+            return .conflict(data: data)
+        case 422:
+            return .unprocessable(data: data)
+        case 500...599:
+            return .serverError(statusCode: statusCode, data: data)
+        default:
+            return .requestFailed(statusCode: statusCode, data: data)
+        }
+    }
+
+    /// 전송 계층 URLError 를 흡수 케이스로 매핑합니다.
+    public static func from(urlError: URLError) -> NetworkError {
+        switch urlError.code {
+        case .notConnectedToInternet, .networkConnectionLost:
+            return .noNetwork
+        case .timedOut:
+            return .timeout
+        default:
+            return .transport(reason: urlError.localizedDescription)
+        }
+    }
+
+    // MARK: - Accessors
+
+    /// HTTP 상태를 표현하는 케이스면 상태코드를, 아니면 nil.
+    public var httpStatusCode: Int? {
+        switch self {
+        case .badRequest:
+            return 400
+        case .forbidden:
+            return 403
+        case .notFound:
+            return 404
+        case .conflict:
+            return 409
+        case .unprocessable:
+            return 422
+        case .serverError(let statusCode, _):
+            return statusCode
+        case .requestFailed(let statusCode, _):
+            return statusCode
+        default:
+            return nil
+        }
+    }
+
+    /// 서버 응답 본문을 실은 케이스면 그 데이터를, 아니면 nil.
+    public var responseBody: Data? {
+        switch self {
+        case .badRequest(let data), .forbidden(let data), .notFound(let data),
+             .conflict(let data), .unprocessable(let data):
+            return data
+        case .serverError(_, let data), .requestFailed(_, let data):
+            return data
+        default:
+            return nil
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Error/Types/NetworkError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/NetworkError.swift
@@ -103,6 +103,27 @@ public enum NetworkError: Error, Sendable, Equatable {
     /// - 해결 방법: 네트워크 상태 확인 후 재시도
     case timeout
 
+    /// 400 Bad Request — 요청 형식/파라미터 오류
+    case badRequest(data: Data?)
+
+    /// 403 Forbidden — 권한 없음
+    case forbidden(data: Data?)
+
+    /// 404 Not Found — 리소스 없음
+    case notFound(data: Data?)
+
+    /// 409 Conflict — 상태 충돌(중복 등)
+    case conflict(data: Data?)
+
+    /// 422 Unprocessable Content — 검증 실패
+    case unprocessable(data: Data?)
+
+    /// 5xx — 서버 내부 오류(공통)
+    case serverError(statusCode: Int, data: Data?)
+
+    /// 분류 불가 전송 계층 오류(URLError 중 noNetwork/timeout 외)
+    case transport(reason: String)
+
     // MARK: - Equatable
 
     /// Equatable 비교 구현
@@ -126,6 +147,20 @@ public enum NetworkError: Error, Sendable, Equatable {
             return true
         case (.timeout, .timeout):
             return true
+        case (.badRequest, .badRequest):
+            return true
+        case (.forbidden, .forbidden):
+            return true
+        case (.notFound, .notFound):
+            return true
+        case (.conflict, .conflict):
+            return true
+        case (.unprocessable, .unprocessable):
+            return true
+        case (.serverError(let lCode, _), .serverError(let rCode, _)):
+            return lCode == rCode  // Data는 비교 제외
+        case (.transport(let lReason), .transport(let rReason)):
+            return lReason == rReason
         default:
             return false
         }
@@ -156,6 +191,20 @@ extension NetworkError: LocalizedError {
             return "네트워크 연결이 없습니다."
         case .timeout:
             return "요청 시간이 초과되었습니다."
+        case .badRequest:
+            return "잘못된 요청입니다. (400)"
+        case .forbidden:
+            return "권한이 없습니다. (403)"
+        case .notFound:
+            return "리소스를 찾을 수 없습니다. (404)"
+        case .conflict:
+            return "요청이 충돌했습니다. (409)"
+        case .unprocessable:
+            return "요청을 처리할 수 없습니다. (422)"
+        case .serverError(let statusCode, _):
+            return "서버 오류 status: \(statusCode)"
+        case .transport(let reason):
+            return "전송 오류: \(reason)"
         }
     }
 
@@ -186,6 +235,17 @@ extension NetworkError: LocalizedError {
             return "인터넷 연결을 확인해주세요."
         case .timeout:
             return "서버 응답이 늦어지고 있어요. 잠시 후 다시 시도해주세요."
+        case .badRequest(let data), .notFound(let data),
+             .conflict(let data), .unprocessable(let data):
+            return Self.parseServerMessage(from: data)
+                ?? "요청을 처리할 수 없습니다. 다시 시도해주세요."
+        case .forbidden(let data):
+            return Self.parseServerMessage(from: data) ?? "접근 권한이 없습니다."
+        case .serverError(_, let data):
+            return Self.parseServerMessage(from: data)
+                ?? "서버에 일시적인 오류가 발생했습니다."
+        case .transport:
+            return "네트워크 연결이 원활하지 않습니다."
         }
     }
 
@@ -218,6 +278,10 @@ extension NetworkError: LocalizedError {
             return .warning
         case .noNetwork, .timeout:
             return .warning
+        case .serverError:
+            return .critical
+        case .badRequest, .forbidden, .notFound, .conflict, .unprocessable, .transport:
+            return .warning
         }
     }
 
@@ -239,6 +303,10 @@ extension NetworkError: LocalizedError {
             return true  // 네트워크 연결 재시도 가능
         case .noNetwork, .timeout:
             return true
+        case .serverError, .transport:
+            return true
+        case .badRequest, .forbidden, .notFound, .conflict, .unprocessable:
+            return false
         }
     }
 }

--- a/UMCApp/Core/Foundation/Tests/ErrorHandlerURLErrorTests.swift
+++ b/UMCApp/Core/Foundation/Tests/ErrorHandlerURLErrorTests.swift
@@ -1,0 +1,35 @@
+//
+//  ErrorHandlerURLErrorTests.swift
+//  UMCFoundationTests
+//
+//  ErrorHandler 가 URLError 를 단일 팩토리 경유로 NetworkError 에 매핑하는지 검증.
+//
+
+import Foundation
+import Testing
+@testable import UMCFoundation
+
+@MainActor
+@Suite("ErrorHandler — URLError 변환")
+struct ErrorHandlerURLErrorTests {
+
+    @Test("notConnectedToInternet 는 .network(.noNetwork) 로 변환된다")
+    func mapsNoNetwork() {
+        let handler = ErrorHandler()
+        handler.handle(URLError(.notConnectedToInternet),
+                       context: .init(feature: "Test", action: "t"))
+        #expect(handler.currentError?.error == .network(.noNetwork))
+    }
+
+    @Test("분류 불가 URLError 는 .network(.transport) 로 변환된다")
+    func mapsTransport() {
+        let handler = ErrorHandler()
+        handler.handle(URLError(.cannotFindHost),
+                       context: .init(feature: "Test", action: "t"))
+        if case .network(.transport) = handler.currentError?.error {
+            // 통과
+        } else {
+            Issue.record("cannotFindHost 는 .network(.transport) 여야 한다")
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Tests/NetworkErrorMappingTests.swift
+++ b/UMCApp/Core/Foundation/Tests/NetworkErrorMappingTests.swift
@@ -1,0 +1,56 @@
+//
+//  NetworkErrorMappingTests.swift
+//  UMCFoundationTests
+//
+//  HTTP 상태코드 → 시맨틱 케이스, URLError → 흡수 케이스, 헬퍼를 검증.
+//
+
+import Foundation
+import Testing
+@testable import UMCFoundation
+
+@Suite("NetworkError 매핑 — 상태코드/URLError/헬퍼")
+struct NetworkErrorMappingTests {
+
+    // MARK: - 상태코드 매핑
+
+    @Test("알려진 4xx/5xx 는 시맨틱 케이스로, 그 외는 requestFailed 폴백으로 매핑된다")
+    func statusCodeMapping() {
+        #expect(NetworkError.from(statusCode: 400, data: nil) == .badRequest(data: nil))
+        #expect(NetworkError.from(statusCode: 403, data: nil) == .forbidden(data: nil))
+        #expect(NetworkError.from(statusCode: 404, data: nil) == .notFound(data: nil))
+        #expect(NetworkError.from(statusCode: 409, data: nil) == .conflict(data: nil))
+        #expect(NetworkError.from(statusCode: 422, data: nil) == .unprocessable(data: nil))
+        #expect(NetworkError.from(statusCode: 500, data: nil) == .serverError(statusCode: 500, data: nil))
+        #expect(NetworkError.from(statusCode: 503, data: nil) == .serverError(statusCode: 503, data: nil))
+        #expect(NetworkError.from(statusCode: 418, data: nil) == .requestFailed(statusCode: 418, data: nil))
+    }
+
+    // MARK: - URLError 흡수
+
+    @Test("URLError 는 noNetwork/timeout/transport 로 흡수된다")
+    func urlErrorMapping() {
+        #expect(NetworkError.from(urlError: URLError(.notConnectedToInternet)) == .noNetwork)
+        #expect(NetworkError.from(urlError: URLError(.networkConnectionLost)) == .noNetwork)
+        #expect(NetworkError.from(urlError: URLError(.timedOut)) == .timeout)
+
+        if case .transport = NetworkError.from(urlError: URLError(.cannotFindHost)) {
+            // 통과
+        } else {
+            Issue.record("분류 불가 URLError 는 .transport 여야 한다")
+        }
+    }
+
+    // MARK: - 헬퍼
+
+    @Test("httpStatusCode/responseBody 헬퍼가 케이스 구조와 무관하게 값을 노출한다")
+    func helpers() {
+        let body = Data("payload".utf8)
+        #expect(NetworkError.conflict(data: body).httpStatusCode == 409)
+        #expect(NetworkError.conflict(data: body).responseBody == body)
+        #expect(NetworkError.serverError(statusCode: 502, data: body).httpStatusCode == 502)
+        #expect(NetworkError.requestFailed(statusCode: 410, data: body).httpStatusCode == 410)
+        #expect(NetworkError.timeout.httpStatusCode == nil)
+        #expect(NetworkError.noNetwork.responseBody == nil)
+    }
+}

--- a/UMCApp/Core/Network/Sources/Client/MoyaNetworkAdapter.swift
+++ b/UMCApp/Core/Network/Sources/Client/MoyaNetworkAdapter.swift
@@ -24,12 +24,14 @@ public struct MoyaNetworkAdapter {
 
     private let networkClient: NetworkClient
     private let baseURL: URL
+    private let session: URLSession
 
     // MARK: - Init
 
-    public init(networkClient: NetworkClient, baseURL: URL) {
+    public init(networkClient: NetworkClient, baseURL: URL, session: URLSession = .shared) {
         self.networkClient = networkClient
         self.baseURL = baseURL
+        self.session = session
     }
 
     // MARK: - Public API
@@ -69,17 +71,20 @@ public struct MoyaNetworkAdapter {
         NetworkVerboseLogger.logRequest(urlRequest, authRequired: false, requestID: requestID)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: urlRequest)
+            let data: Data
+            let response: URLResponse
+            do {
+                (data, response) = try await session.data(for: urlRequest)
+            } catch let urlError as URLError where urlError.code != .cancelled {
+                throw NetworkError.from(urlError: urlError)
+            }
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw NetworkError.invalidResponse
             }
 
             guard (200...299).contains(httpResponse.statusCode) else {
-                throw NetworkError.requestFailed(
-                    statusCode: httpResponse.statusCode,
-                    data: data
-                )
+                throw NetworkError.requestFailed(statusCode: httpResponse.statusCode, data: data)
             }
 
             let moyaResponse = Response(
@@ -300,9 +305,9 @@ private enum NetworkVerboseLogger {
         print("  url: \(url)")
         printSection("error", String(describing: error))
 
-        if case let NetworkError.requestFailed(statusCode, data) = error {
+        if let networkError = error as? NetworkError, let statusCode = networkError.httpStatusCode {
             print("  status: \(statusCode)")
-            if let data, !data.isEmpty {
+            if let data = networkError.responseBody, !data.isEmpty {
                 printSection("error body", formattedBody(from: data, shortenLongStrings: true))
             } else {
                 printSection("error body", "(empty)")

--- a/UMCApp/Core/Network/Sources/Client/NetworkClient.swift
+++ b/UMCApp/Core/Network/Sources/Client/NetworkClient.swift
@@ -103,7 +103,13 @@ extension NetworkClient {
         }
 
         // 2. 네트워크 요청 실행
-        let (data, response) = try await session.data(for: authenticatedRequest)
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: authenticatedRequest)
+        } catch let urlError as URLError where urlError.code != .cancelled {
+            throw NetworkError.from(urlError: urlError)
+        }
 
         // 3. HTTPURLResponse로 형변환
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -150,6 +156,8 @@ extension NetworkClient {
                     refreshToken: tokenPair.refreshToken
                 )
                 return tokenPair
+            } catch let networkError as NetworkError {
+                throw networkError  // 전송 계층 에러(noNetwork/timeout 등)는 그대로 전파
             } catch {
                 throw NetworkError.tokenRefreshFailed(reason: error.localizedDescription)
             }

--- a/UMCApp/Core/Network/Sources/Client/TokenRefreshServiceImpl.swift
+++ b/UMCApp/Core/Network/Sources/Client/TokenRefreshServiceImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UMCFoundation
 
 /// TokenRefreshService 프로토콜의 실제 구현체입니다.
 ///
@@ -58,7 +59,13 @@ struct TokenRefreshServiceImpl: TokenRefreshService {
         )
 
         // 3. 네트워크 요청 실행
-        let (data, response) = try await session.data(for: request)
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch let urlError as URLError where urlError.code != .cancelled {
+            throw NetworkError.from(urlError: urlError)
+        }
 
         // 4. HTTPURLResponse 형변환
         guard let httpResponse = response as? HTTPURLResponse else {

--- a/UMCApp/Core/Network/Sources/Storage/StorageRepository.swift
+++ b/UMCApp/Core/Network/Sources/Storage/StorageRepository.swift
@@ -16,15 +16,18 @@ public final class StorageRepository: StorageRepositoryProtocol, @unchecked Send
     // MARK: - Property
 
     private let adapter: MoyaNetworkAdapter
+    private let session: URLSession
     private let decoder: JSONDecoder
 
     // MARK: - Init
 
     public init(
         adapter: MoyaNetworkAdapter,
+        session: URLSession = .shared,
         decoder: JSONDecoder = JSONDecoder()
     ) {
         self.adapter = adapter
+        self.session = session
         self.decoder = decoder
     }
 
@@ -81,7 +84,12 @@ public final class StorageRepository: StorageRepositoryProtocol, @unchecked Send
             request.setValue(contentType ?? "application/octet-stream", forHTTPHeaderField: "Content-Type")
         }
 
-        let (_, response) = try await URLSession.shared.upload(for: request, from: data)
+        let response: URLResponse
+        do {
+            (_, response) = try await session.upload(for: request, from: data)
+        } catch let urlError as URLError where urlError.code != .cancelled {
+            throw NetworkError.from(urlError: urlError)
+        }
         guard let httpResponse = response as? HTTPURLResponse else {
             throw NetworkError.invalidResponse
         }

--- a/UMCApp/Core/Network/Tests/MoyaNetworkAdapterTests.swift
+++ b/UMCApp/Core/Network/Tests/MoyaNetworkAdapterTests.swift
@@ -1,0 +1,45 @@
+//
+//  MoyaNetworkAdapterTests.swift
+//  CoreNetworkTests
+//
+//  requestWithoutAuth 의 상태코드 매핑 및 URLError 흡수를 검증.
+//
+
+import Foundation
+import Testing
+import Moya
+import UMCFoundation
+@testable import CoreNetwork
+
+@MainActor
+@Suite("MoyaNetworkAdapter — requestWithoutAuth", .serialized)
+struct MoyaNetworkAdapterTests {
+
+    private let baseURL = URL(string: "https://api.umc.test")!
+
+    private func makeAdapter() -> MoyaNetworkAdapter {
+        StubURLProtocol.reset()
+        let store = MockTokenStore()
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = NetworkClient(session: makeStubSession(), tokenStore: store, refreshService: refresh)
+        return MoyaNetworkAdapter(networkClient: client, baseURL: baseURL, session: makeStubSession())
+    }
+
+    @Test("연결 없음 URLError 는 NetworkError.noNetwork 로 흡수된다")
+    func absorbsNoNetwork() async {
+        let adapter = makeAdapter()
+        StubURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+
+        await #expect(throws: NetworkError.noNetwork) {
+            _ = try await adapter.requestWithoutAuth(StubTarget())
+        }
+    }
+}
+
+private struct StubTarget: TargetType {
+    var baseURL: URL { URL(string: "https://api.umc.test")! }
+    var path: String { "/api/v1/auth/login" }
+    var method: Moya.Method { .post }
+    var task: Moya.Task { .requestPlain }
+    var headers: [String: String]? { nil }
+}

--- a/UMCApp/Core/Network/Tests/NetworkClientTests.swift
+++ b/UMCApp/Core/Network/Tests/NetworkClientTests.swift
@@ -153,6 +153,19 @@ struct NetworkClientTests {
         }
     }
 
+    @Test("refresh 중 발생한 NetworkError(noNetwork)는 tokenRefreshFailed 로 감싸지 않고 그대로 전파된다")
+    func refreshPassthroughNetworkError() async {
+        let store = MockTokenStore(accessToken: "OLD", refreshToken: "REFRESH")
+        let refresh = MockTokenRefreshService(behavior: .failureError(.noNetwork))
+        let client = makeClient(store: store, refresh: refresh)
+
+        StubURLProtocol.handler = { _ in (Data(), 401, nil) }
+
+        await #expect(throws: NetworkError.noNetwork) {
+            _ = try await client.request(URLRequest(url: self.testURL))
+        }
+    }
+
     @Test("리프레시 토큰이 없으면 NetworkError.noRefreshToken을 throw한다")
     func noRefreshTokenError() async {
         let store = MockTokenStore(accessToken: "OLD", refreshToken: nil)
@@ -253,6 +266,45 @@ struct NetworkClientTests {
         StubURLProtocol.handler = { _ in (Data(), 500, nil) }
 
         await #expect(throws: NetworkError.requestFailed(statusCode: 500, data: nil)) {
+            _ = try await client.request(URLRequest(url: self.testURL))
+        }
+    }
+
+    @Test("연결 없음 URLError 는 NetworkError.noNetwork 로 흡수된다")
+    func absorbsNoNetwork() async {
+        let store = MockTokenStore(accessToken: "A", refreshToken: "R")
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = makeClient(store: store, refresh: refresh)
+
+        StubURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+
+        await #expect(throws: NetworkError.noNetwork) {
+            _ = try await client.request(URLRequest(url: self.testURL))
+        }
+    }
+
+    @Test("타임아웃 URLError 는 NetworkError.timeout 로 흡수된다")
+    func absorbsTimeout() async {
+        let store = MockTokenStore(accessToken: "A", refreshToken: "R")
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = makeClient(store: store, refresh: refresh)
+
+        StubURLProtocol.handler = { _ in throw URLError(.timedOut) }
+
+        await #expect(throws: NetworkError.timeout) {
+            _ = try await client.request(URLRequest(url: self.testURL))
+        }
+    }
+
+    @Test("요청 취소(URLError.cancelled)는 흡수하지 않고 URLError 그대로 전파한다")
+    func doesNotAbsorbCancellation() async {
+        let store = MockTokenStore(accessToken: "A", refreshToken: "R")
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = makeClient(store: store, refresh: refresh)
+
+        StubURLProtocol.handler = { _ in throw URLError(.cancelled) }
+
+        await #expect(throws: URLError.self) {
             _ = try await client.request(URLRequest(url: self.testURL))
         }
     }

--- a/UMCApp/Core/Network/Tests/StorageRepositoryTests.swift
+++ b/UMCApp/Core/Network/Tests/StorageRepositoryTests.swift
@@ -1,0 +1,38 @@
+//
+//  StorageRepositoryTests.swift
+//  CoreNetworkTests
+//
+//  외부 스토리지 업로드(uploadFile)의 상태코드 매핑 및 URLError 흡수 검증.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import CoreNetwork
+
+@MainActor
+@Suite("StorageRepository — uploadFile", .serialized)
+struct StorageRepositoryTests {
+
+    private let uploadURL = "https://storage.umc.test/upload/abc"
+
+    private func makeRepository() -> StorageRepository {
+        StubURLProtocol.reset()
+        let store = MockTokenStore()
+        let refresh = MockTokenRefreshService(behavior: .success(TokenPair(accessToken: "A", refreshToken: "R")))
+        let client = NetworkClient(session: makeStubSession(), tokenStore: store, refreshService: refresh)
+        let adapter = MoyaNetworkAdapter(networkClient: client, baseURL: URL(string: "https://api.umc.test")!)
+        return StorageRepository(adapter: adapter, session: makeStubSession())
+    }
+
+    @Test("업로드 중 연결 없음은 NetworkError.noNetwork 로 흡수된다")
+    func absorbsNoNetwork() async {
+        let repo = makeRepository()
+        StubURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+
+        await #expect(throws: NetworkError.noNetwork) {
+            try await repo.uploadFile(to: uploadURL, data: Data("x".utf8),
+                                      method: "PUT", headers: nil, contentType: "image/png")
+        }
+    }
+}

--- a/UMCApp/Core/Network/Tests/Support/MockTokenStore.swift
+++ b/UMCApp/Core/Network/Tests/Support/MockTokenStore.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UMCFoundation
 @testable import CoreNetwork
 
 /// 메모리 기반 Mock TokenStore — Keychain을 거치지 않고 동작 확인용
@@ -45,6 +46,8 @@ actor MockTokenRefreshService: TokenRefreshService {
         case failure(MockRefreshError)
         /// 호출 시 sleep 후 success — single-flight 테스트에 사용
         case delayedSuccess(TokenPair, nanoseconds: UInt64)
+        /// NetworkError 를 던짐 — NetworkClient passthrough 검증용
+        case failureError(NetworkError)
     }
 
     private var behavior: Behavior
@@ -71,6 +74,8 @@ actor MockTokenRefreshService: TokenRefreshService {
         case .delayedSuccess(let pair, let nanoseconds):
             try? await Task.sleep(nanoseconds: nanoseconds)
             return pair
+        case .failureError(let error):
+            throw error
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형
♻️ [Refactor] — 네트워크 에러 매핑 기반 작업. 전송 계층 `URLError` 흡수 + `NetworkError` 시맨틱 매핑 레이어 신설. (HTTP 상태코드 emission 배선·소비처 마이그레이션은 후속 이슈)

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1067" height="85" alt="image" src="https://github.com/user-attachments/assets/72bf1ef2-7b04-4717-af79-76a9af127198" />

## 🛠️ 작업내용
### 전송 계층 URLError 흡수 (라이브)
- `NetworkClient` / `MoyaNetworkAdapter.requestWithoutAuth` / `TokenRefreshServiceImpl` / `StorageRepository` 4곳에서 `URLSession`이 던지는 `URLError`를 네트워크 레이어에서 `NetworkError`로 흡수
  - `.notConnectedToInternet` / `.networkConnectionLost` → `.noNetwork`
  - `.timedOut` → `.timeout`
  - 그 외 → `.transport(reason:)`
  - **취소(`URLError.cancelled`)는 흡수하지 않고 그대로 전파** — 기존 `NSURLErrorCancelled` 취소 감지 로직 보존
- `ErrorHandler.convertURLError`를 `NetworkError.from(urlError:)` 팩토리에 위임(단일 진실원) — 기존에 `errorCode`를 HTTP status로 오용하던 버그 교정
- **refresh passthrough**: 토큰 갱신 경로에서 발생한 `NetworkError`(`.noNetwork` 등)를 `.tokenRefreshFailed`로 감싸지 않고 그대로 전파 → 오프라인 시 "세션 만료" 대신 정확한 안내

### NetworkError 매핑 레이어 (세팅 — 정의·단위테스트 완료, emission 미배선)
- `NetworkError` 시맨틱 케이스 추가: `badRequest` / `forbidden` / `notFound` / `conflict` / `unprocessable` / `serverError` / `transport`
- 매핑 팩토리 `from(statusCode:)` / `from(urlError:)` + 접근 헬퍼 `httpStatusCode` / `responseBody`
- HTTP 상태코드는 현행대로 `requestFailed`로 emission 유지 → **소비처(Repository/ViewModel) 0 변경**

### 테스트 (Swift Testing)
- NetworkError 매핑/헬퍼, ErrorHandler URLError 변환, NetworkClient 흡수·**취소 전파**·refresh passthrough, Moya/Storage 흡수
- UMCFoundation 49 · CoreNetwork 44 · ActivityData 169 통과 · 전체 앱 BUILD SUCCEEDED

## 📋 추후 진행 상황
#719 작업진행예정

## 📌 리뷰 포인트
- **취소 전파 가드 (핵심)**: 흡수 catch에 `where urlError.code != .cancelled` — `NoticeViewModel+Fetch` / `MyPageViewModel`의 `NSURLErrorCancelled` 취소 감지가 깨지지 않도록 `.cancelled`는 흡수 대상에서 제외
- **401 refresh 흐름 무영향**: URLError catch가 `session.data` 호출만 감싸고, 401 판정·refresh·재시도 로직은 catch 밖에 위치 → 흡수가 refresh 흐름을 삼키지 않음
- **세팅 vs 배선 분리**: 시맨틱 상태코드 케이스는 정의·테스트만 하고 emission은 `requestFailed` 유지 → 이번 PR은 소비처 변경 0. 상태코드 배선은 후속 이슈로 분리
- **매핑 단일 진실원**: `from(...)` 팩토리를 `UMCFoundation`의 `NetworkError`에 두어 `CoreNetwork`·`ErrorHandler`가 공유(중복 제거)



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
