### PR TITLE
♻️ [Refactor] DIEnvironment 패스키 이전(#933)

### DIFF
--- a/UMCApp/Core/DI/Resources/DIEnvironmentKey.swift
+++ b/UMCApp/Core/DI/Resources/DIEnvironmentKey.swift
@@ -1,0 +1,8 @@
+//
+//  DIEnvironmentKey.swift
+//  CoreDI
+//
+//  Created by 김동민 on 7/4/26.
+//
+
+import Foundation

--- a/UMCApp/Core/DI/Resources/DIEnvironmentKey.swift
+++ b/UMCApp/Core/DI/Resources/DIEnvironmentKey.swift
@@ -6,3 +6,28 @@
 //
 
 import Foundation
+import SwiftUI
+
+
+/// ### View에서 사용
+/// ```swift
+/// struct LoginView: View {
+///     @Environment(\.di) private var container
+///
+///     var body: some View {
+///         Button("로그인") {
+///             let useCase = container.resolve(LoginUseCaseProtocol.self)
+///             useCase.execute()
+///         }
+///     }
+/// }
+public struct DIEnvironmentKey: EnvironmentKey {
+    public static let defaultValue: DIContainer = .init()
+}
+
+extension EnvironmentValues {
+    public var di: DIContainer {
+        get { self[DIEnvironmentKey.self] }
+        set { self[DIEnvironmentKey.self] = newValue }
+    }
+}

--- a/UMCApp/Core/DI/Sources/DIContainer.swift
+++ b/UMCApp/Core/DI/Sources/DIContainer.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftData
 import CoreNetwork
+import UMCFoundation
 
 // MARK: - DIContainer 사용 예시
 /// DIContainer는 의존성 주입(Dependency Injection)을 관리하는 컨테이너입니다.
@@ -193,4 +194,8 @@ extension DIContainer {
         return container
     }
 
+}
+
+extension DIContainer: Resolver {
+    
 }

--- a/UMCApp/Core/Foundation/Sources/DIContainer/DIEnvironmentKey.swift
+++ b/UMCApp/Core/Foundation/Sources/DIContainer/DIEnvironmentKey.swift
@@ -1,6 +1,6 @@
 //
 //  DIEnvironmentKey.swift
-//  CoreDI
+//  UMCFoundation
 //
 //  Created by 김동민 on 7/4/26.
 //
@@ -22,11 +22,11 @@ import SwiftUI
 ///     }
 /// }
 public struct DIEnvironmentKey: EnvironmentKey {
-    public static let defaultValue: DIContainer = .init()
+    public static let defaultValue: any Resolver = UnregisteredResolver()
 }
 
 extension EnvironmentValues {
-    public var di: DIContainer {
+    public var di: any Resolver {
         get { self[DIEnvironmentKey.self] }
         set { self[DIEnvironmentKey.self] = newValue }
     }

--- a/UMCApp/Core/Foundation/Sources/DIContainer/Resolver.swift
+++ b/UMCApp/Core/Foundation/Sources/DIContainer/Resolver.swift
@@ -18,8 +18,52 @@ import Foundation
 /// @Environment(\.di) private var di            // any Resolver
 /// let useCase = di.resolve(LoginUseCaseProtocol.self)
 /// ```
+///
+/// ### ViewModel — 생성자 주입
+///
+/// `ViewModel` 은 `@Environment` 를 쓸 수 없으므로 **생성자로** `any Resolver` 를 받는다.
+///
+/// ```swift
+/// import UMCFoundation
+/// import NoticeDomain
+/// // import CoreDI  ← 불필요
+///
+/// @Observable
+/// public final class NoticeViewModel {
+///
+///     // MARK: - Dependency
+///     private let container: any Resolver
+///
+///     // MARK: - Lifecycle
+///     public init(container: any Resolver, errorHandler: ErrorHandler) {
+///         self.container = container
+///         self.errorHandler = errorHandler
+///         self.noticeUseCase = container.resolve(NoticeUseCaseProtocol.self)
+///     }
+/// }
+/// ```
+///
+/// ### View — 루트에서 `\.di` 를 한 번 읽어 전달
+///
+/// 컨테이너의 소스는 `\.di` 다. **루트 View 가 한 번 읽어** 생성자 체인으로 흘려보낸다.
+///
+/// ```swift
+/// import SwiftUI
+/// import UMCFoundation
+/// import NoticePresentation
+///
+/// struct ContentView: View {
+///     @Environment(\.di) private var di        // any Resolver
+///     private let errorHandler = ErrorHandler()
+///
+///     var body: some View {
+///         NoticeView(container: di, errorHandler: errorHandler)
+///     }
+/// }
+/// ```
 public protocol Resolver {
 
+    
     /// 등록된 의존성을 조회한다.
     /// - Parameter type: 조회할 프로토콜/타입 (예: `LoginUseCaseProtocol.self`)
     /// - Returns: 등록된 타입의 인스턴스

--- a/UMCApp/Core/Foundation/Sources/DIContainer/Resolver.swift
+++ b/UMCApp/Core/Foundation/Sources/DIContainer/Resolver.swift
@@ -1,0 +1,45 @@
+//
+//  Resolver.swift
+//  UMCFoundation
+//
+//  Created by 김동민 on 7/4/26.
+//
+
+import Foundation
+
+// MARK: - Resolver
+
+/// DI 컨테이너의 조회(resolve) 능력만 노출하는 추상.
+///
+/// 피처 레이어는 이 프로토콜에만 의존하고, 구체 `DIContainer`(CoreDI)는 모른다.
+/// `DIContainer`가 CoreDI에서 이 프로토콜을 채택한다.
+///
+/// ```swift
+/// @Environment(\.di) private var di            // any Resolver
+/// let useCase = di.resolve(LoginUseCaseProtocol.self)
+/// ```
+public protocol Resolver {
+
+    /// 등록된 의존성을 조회한다.
+    /// - Parameter type: 조회할 프로토콜/타입 (예: `LoginUseCaseProtocol.self`)
+    /// - Returns: 등록된 타입의 인스턴스
+    /// - Warning: 미등록·미주입 시 `fatalError`.
+    func resolve<T>(_ type: T.Type) -> T
+}
+
+// MARK: - UnregisteredResolver
+
+/// `\.di`의 기본값 백킹 — 앱 루트에서 컨테이너가 주입되기 전 상태.
+///
+/// Foundation은 `DIContainer`(CoreDI)를 생성할 수 없어, 기본값 자리에 둘
+/// 로컬 conformer가 필요하다. 실제 앱은 루트에서
+/// `.environment(\.di, DIContainer.configured(...))`로 교체하므로,
+/// 이 타입의 `resolve`가 불렸다는 건 곧 주입 누락을 의미한다.
+public struct UnregisteredResolver: Resolver {
+    public func resolve<T>(_ type: T.Type) -> T {
+        fatalError(
+            "\\.di has no injected container. Inject "
+            + "DIContainer.configured(...) at the app root before resolving \(T.self)."
+        )
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/DIContainer/Resolver.swift
+++ b/UMCApp/Core/Foundation/Sources/DIContainer/Resolver.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os
 
 // MARK: - Resolver
 
@@ -62,14 +63,20 @@ import Foundation
 /// }
 /// ```
 public protocol Resolver {
-
+    
     
     /// 등록된 의존성을 조회한다.
     /// - Parameter type: 조회할 프로토콜/타입 (예: `LoginUseCaseProtocol.self`)
     /// - Returns: 등록된 타입의 인스턴스
     /// - Warning: 미등록·미주입 시 `fatalError`.
     func resolve<T>(_ type: T.Type) -> T
+    
 }
+
+private let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "UMCApp",
+    category: "DI"
+)
 
 // MARK: - UnregisteredResolver
 
@@ -81,9 +88,9 @@ public protocol Resolver {
 /// 이 타입의 `resolve`가 불렸다는 건 곧 주입 누락을 의미한다.
 public struct UnregisteredResolver: Resolver {
     public func resolve<T>(_ type: T.Type) -> T {
-        fatalError(
-            "\\.di has no injected container. Inject "
-            + "DIContainer.configured(...) at the app root before resolving \(T.self)."
-        )
+        let reason = "\\.di has no injected container. "
+                + "Inject DIContainer.configured(...) at the app root before resolving \(T.self)."
+            logger.fault("\(reason, privacy: .public)")   // Console(category: "DI")에 원인 기록
+            fatalError(reason)
     }
 }

--- a/UMCApp/UMCApp/Sources/UMCAppApp.swift
+++ b/UMCApp/UMCApp/Sources/UMCAppApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import CoreDesignSystem
+import CoreDI
 
 @main
 struct UMCAppApp: App {
@@ -11,6 +12,7 @@ struct UMCAppApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+//                .environment(\.di, DIContainer.configured(modelContext:))
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형
<!-- 어떤 변경 사항이 있나요?? -->
DIContainer 패스키 이전

## 🛠️ 작업내용
<!-- [ 작업한 내용을 작성해주세요 ] -->
DIEnvironmentKey 마이그레이션
사용 예시 문서작성 
DIContainer에서 Resolver 프로토콜을 만들어서 CoreDI 모듈을 import할 필요없이, resolve 사용 가능하도록 개선 -> DIContainer을 any resolver 타입으로 변경 필요

## 📋 추후 진행 상황
<!-- [ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
#803 진행

## 📌 리뷰 포인트
<!-- [ 어떤 부분을 잘 체크해야하는지 작성해주세요 ] -->
패스키 파일 의존성 방향 확인 필요


## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
+)추가로 앱 진입점에서 ModeContainer 만들어서 주입해주면됩니다.
