### PR TITLE
🔧 [Chore] UMCApp(Tuist) 빌드+테스트 CI 게이트 추가 및 AppProduct CI path 필터링

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,8 +3,14 @@ name: iOS CI
 on:
   push:
     branches: [ "develop" ]
+    paths:
+      - "AppProduct/**"
+      - ".github/workflows/ios.yml"
   pull_request:
     branches: [ "develop" ]
+    paths:
+      - "AppProduct/**"
+      - ".github/workflows/ios.yml"
 
 jobs:
   build:

--- a/.github/workflows/tuist-ci.yml
+++ b/.github/workflows/tuist-ci.yml
@@ -1,0 +1,79 @@
+name: Tuist CI
+
+# 활성 코드베이스 UMCApp(Tuist)의 컴파일/테스트 게이트.
+# 동결된 레거시 AppProduct 는 ios.yml 이 담당한다(AppProduct/** 변경 시에만 실행).
+# 빌드 진입점은 로컬과 동일하게 UMCApp/Makefile 을 사용한다(CLAUDE.md 규약).
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tuist-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & Test (UMCApp / Tuist)
+    runs-on: macos-26
+
+    defaults:
+      run:
+        working-directory: UMCApp
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode 26.4+
+        run: |
+          XCODE_PATH=$(ls -d /Applications/Xcode_26.4*.app 2>/dev/null | sort -V | tail -n 1)
+          if [ -z "$XCODE_PATH" ]; then
+            echo "❌ Xcode 26.4+ not found on runner. Available:"
+            ls -d /Applications/Xcode_*.app 2>/dev/null || true
+            exit 1
+          fi
+          echo "Selecting $XCODE_PATH"
+          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
+          xcodebuild -version
+
+      - name: Create Secrets.xcconfig placeholder
+        run: |
+          # 신규 클론에는 git-untracked Secrets.xcconfig 가 없다.
+          # Shared.xcconfig 의 `#include?` 는 optional 이라 없어도 빌드되지만,
+          # 로컬 개발과 동일한 상태를 만들기 위해 템플릿(플레이스홀더 값)을 복사한다.
+          if [ ! -f Secrets/Secrets.xcconfig ]; then
+            cp Secrets/Secrets.xcconfig.template Secrets/Secrets.xcconfig
+          fi
+
+      - name: Install mise & Tuist (from mise.toml)
+        uses: jdx/mise-action@v2
+        with:
+          working_directory: UMCApp
+          install: true
+          cache: true
+
+      - name: Cache SwiftPM / Tuist artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/tuist
+            ~/Library/Caches/org.swift.swiftpm
+            UMCApp/Tuist/.build
+          key: ${{ runner.os }}-tuist-${{ hashFiles('UMCApp/Tuist/Package.resolved', 'UMCApp/Tuist/Package.swift', 'UMCApp/mise.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-tuist-
+
+      - name: Install dependencies (tuist install)
+        run: make install
+
+      - name: Generate project (tuist generate --no-open)
+        run: make generate
+
+      - name: Build & Test (make test)
+        run: make test


### PR DESCRIPTION
## ✨ PR 유형

🔧 Chore / CI — 활성 코드베이스(UMCApp/Tuist)의 컴파일·테스트 게이트 추가 및 동결 레거시(AppProduct) CI path 필터링

## 🛠️ 작업내용

기존 CI는 **동결된 레거시 `AppProduct.xcodeproj`만 빌드**했고, 활발히 이식 중인 **`UMCApp/`(Tuist)에는 컴파일/테스트 게이트가 전무**했습니다. (실증: #865 에서 String 통일 피드백이 AppProduct 모델 2개까지 잘못 바꿔 iOS CI가 깨진 사례 — UMCApp 자체 빌드 깨짐은 어떤 CI도 잡지 못하는 상태였음.)

### 1. `.github/workflows/tuist-ci.yml` 신규 추가
- 트리거: `develop` push / PR
- `runs-on: macos-26`, `working-directory: UMCApp`
- **Xcode 26.4+ 선택** 단계 — `ios.yml` 로직 그대로 재사용
- **`jdx/mise-action@v2`** 로 `mise.toml` 의 Tuist `4.155.0` 설치 (`working_directory: UMCApp`)
- 로컬과 동일한 진입점인 **`UMCApp/Makefile`** 사용:
  `make install`(tuist install) → `make generate`(tuist generate --no-open) → **`make test`(빌드+테스트)**
- **`Secrets.xcconfig` 플레이스홀더** 생성 단계: 신규 클론에는 git-untracked `Secrets.xcconfig` 가 없으므로 템플릿을 복사. (`Secrets/Shared.xcconfig` 의 `#include?` 가 optional 이라 없어도 빌드되지만, 로컬 개발과 동일 상태를 보장하기 위한 방어적 단계)
- **SwiftPM/Tuist 산출물 캐시**(`actions/cache@v4`)로 빌드 시간 단축

### 2. `.github/workflows/ios.yml` — `paths` 필터 추가
- `AppProduct/**` 또는 `.github/workflows/ios.yml` 변경 시에만 동결 레거시 빌드 실행 → 불필요한 실행 제거

## 📌 리뷰 포인트

- **트리거 비대칭(의도적)**: 활성 게이트(`tuist-ci`)는 `develop` 의 **모든** push/PR 에서 안전망으로 동작하도록 `paths` 필터를 두지 않았고, 동결된 `ios.yml` 만 `AppProduct/**` 로 좁혔습니다. (러너 분(minutes) 절약을 위해 tuist-ci 에도 `paths`/`paths-ignore`(docs 등) 필터가 필요하면 후속으로 조정 가능)
- **시크릿 처리**: UMCApp 은 `GoogleService-Info.plist` 미참조(Firebase 없음), `Shared.xcconfig`(커밋됨)의 기본값 + optional `#include?` 로 시크릿 없이 빌드됩니다.
- **실검증**: 이 PR 자체가 신규 `tuist-ci` 워크플로우를 트리거하므로, 아래 Checks 초록불로 실제 동작을 확인합니다. (완료 조건의 "1회 빌드로 검증")

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

Resolves #908
