### PR TITLE
🍀 [Chore] tuist-ci(UMCApp) 워크플로우에 Discord 빌드 결과 알림 job 추가

### DIFF
--- a/.github/workflows/tuist-ci.yml
+++ b/.github/workflows/tuist-ci.yml
@@ -77,3 +77,70 @@ jobs:
 
       - name: Build & Test (make test)
         run: make test
+
+  notify:
+    name: Notify Discord
+    needs: build-test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      DISCORD_MENTION_ROLE_ID: ${{ secrets.DISCORD_MENTION_ROLE_ID }}
+      BUILD_RESULT: ${{ needs.build-test.result }}
+      REPOSITORY: ${{ github.repository }}
+      REF_NAME: ${{ github.ref_name }}
+      ACTOR: ${{ github.actor }}
+      COMMIT_SHA: ${{ github.sha }}
+      WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+
+    steps:
+      - name: Send build result to Discord
+        run: |
+          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+            echo "DISCORD_WEBHOOK_URL is not configured. Skipping Discord notification."
+            exit 0
+          fi
+
+          python3 - << 'PY' > payload.json
+          import json
+          import os
+
+          build_result = os.environ["BUILD_RESULT"]
+          short_sha = os.environ["COMMIT_SHA"][:7]
+          pr_url = os.environ.get("PR_URL") or "N/A"
+          mention_role_id = os.environ.get("DISCORD_MENTION_ROLE_ID", "").strip()
+
+          if build_result == "success":
+              status_text = "SUCCESS ✅"
+              color = 5763719  # green
+              mention = ""
+          else:
+              status_text = "FAILED ❌"
+              color = 15548997  # red
+              mention = f"<@&{mention_role_id}>" if mention_role_id else "@here"
+
+          payload = {
+              "content": mention,
+              "embeds": [
+                  {
+                      "title": "UMCApp (Tuist) CI Build Result",
+                      "url": os.environ["WORKFLOW_URL"],
+                      "color": color,
+                      "fields": [
+                          {"name": "Build Status", "value": status_text, "inline": True},
+                          {"name": "Branch", "value": os.environ["REF_NAME"], "inline": True},
+                          {"name": "Commit", "value": f"`{short_sha}` by {os.environ['ACTOR']}", "inline": True},
+                          {"name": "PR", "value": pr_url, "inline": False},
+                      ],
+                      "footer": {"text": os.environ["REPOSITORY"]},
+                  }
+              ],
+          }
+
+          print(json.dumps(payload))
+          PY
+
+          curl -sS -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data @payload.json


### PR DESCRIPTION
## ✨ PR 유형

- 🍀 ETC / chore — CI 워크플로우 개선

Closes #940

## 🛠️ 작업내용

`#908`(PR `#939`)에서 추가된 활성 코드베이스 CI(`tuist-ci.yml`)에는 빌드/테스트 결과를 알리는 Discord 알림 단계가 없어, **모든 develop push/PR에서 도는 활성 CI(UMCApp)** 가 깨져도 팀이 실시간으로 인지하지 못하는 사각지대가 있었습니다. 기존 `ios.yml` 의 `notify` job 을 미러링해 알림 job 을 추가했습니다.

- `notify` job 추가 — `needs: build-test`, `if: ${{ always() }}`, `runs-on: ubuntu-latest`
- 기존 `ios.yml` 의 `notify` job 로직 미러링 — 동일 시크릿(`DISCORD_WEBHOOK_URL` / `DISCORD_MENTION_ROLE_ID`) 사용
- `BUILD_RESULT` 를 `needs.build-test.result` 로 연결
- Discord 임베드 제목을 **`UMCApp (Tuist) CI Build Result`** 로 구분 (iOS CI 알림과 혼동 방지)
- 성공 시 조용히 / 실패 시 role 멘션(`DISCORD_MENTION_ROLE_ID` 미설정 시 `@here`) — 기존 동작 유지
- `DISCORD_WEBHOOK_URL` 미설정 시 알림 step skip 처리(기존 로직) 유지

## 🔑 필요한 GitHub Secrets

| Secret | 상태 | 용도 |
|--------|------|------|
| `DISCORD_WEBHOOK_URL` | ✅ 이미 등록됨 (repo secret) | 알림 전송 대상 웹훅. **미설정 시 알림 step 이 skip** 되어 CI 는 정상 통과 |
| `DISCORD_MENTION_ROLE_ID` | ⚠️ repo secret 미등록 (org secret 여부는 확인 불가) | 실패 시 멘션할 Discord role ID. **없어도 동작** — 실패 알림이 `@here` 로 폴백. 특정 role 멘션이 필요하면 등록 필요 |

> 두 시크릿 모두 기존 `ios.yml` 이 이미 참조하던 것과 동일합니다. 신규로 강제되는 시크릿은 없습니다.

## 📌 리뷰 포인트

- `tuist-ci.yml` 상단 `permissions: contents: read` 는 `notify` job 에 영향 없음 (외부 Discord POST 만 수행, GitHub 토큰 권한 불필요)
- `payload` 생성 로직·색상·필드 구성은 `ios.yml` 과 동일하게 유지 (제목만 상이)

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
- [ ] PR 실행에서 성공/실패 케이스로 알림이 실제 전송되는지 확인 (이 PR 의 CI 실행으로 검증)