### PR TITLE
✨ [Feat] 루트 탭 셸 + 전역 PathStore (launch→home #0)

### DIFF
--- a/UMCApp/Features/Notice/Presentation/Sources/Navigation/NoticeNavigation.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Navigation/NoticeNavigation.swift
@@ -9,6 +9,15 @@ import SwiftUI
 import NoticeDomain
 
 // TODO: PathStore / NavigationDestination 교체
+//
+// #910에서 App 타깃(UMCApp/UMCApp/Sources/Navigation)에 전역 PathStore/NavigationDestination
+// 골격을 추가하고, 그 안에 이 파일과 동일한 형태의 `NavigationDestination.Notice` 케이스
+// (detail/staffNotice/editor)를 이미 이식해 두었다. 다만 `NoticePresentation`은 App 타깃을
+// import할 수 없으므로(Feature → App 의존 방향 금지) 이 로컬 타입을 지금 당장 지울 수는 없다.
+// Notice 탭을 `RootTabView`에 실연결하는 후속 이슈에서 다음 중 하나로 정리한다.
+//   (a) 이 로컬 타입을 유지한 채, 상위(App)가 콜백/클로저(예: AppFlow 패턴)로 연동한다.
+//   (b) 여러 Feature가 공유할 신규 Core 모듈(예: CoreNavigation)을 신설해 이 타입을 옮긴다.
+//       (신규 모듈 신설이므로 메인테이너 승인 필요)
 @Observable
 public final class PathStore {
     public var noticePath: [NavigationDestination] = []

--- a/UMCApp/UMCApp/Sources/AppRootView.swift
+++ b/UMCApp/UMCApp/Sources/AppRootView.swift
@@ -2,14 +2,13 @@ import AuthPresentation
 import CoreDesignSystem
 import CoreDI
 import CoreNetwork
-import HomePresentation
 import SwiftUI
 import UMCFoundation
 
 /// 앱 루트 화면.
 ///
 /// `AppFlowViewModel`의 상태에 따라 Bootstrap / Login / Main(탭 셸)을 스위칭한다.
-/// 탭 셸·실제 로그인 화면은 후속 이슈(#910, #912)에서 이 스위치의 각 분기를 교체한다.
+/// 실제 로그인 화면은 후속 이슈(#912)에서 이 스위치의 분기를 교체한다.
 struct AppRootView: View {
 
     // MARK: - Property
@@ -29,7 +28,7 @@ struct AppRootView: View {
                 AuthFeatureView()
 
             case .main:
-                HomeFeatureView()
+                RootTabView()
             }
         }
         .animation(.easeInOut(duration: DefaultConstant.animationTime), value: viewModel.state)

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationDestination.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationDestination.swift
@@ -1,0 +1,24 @@
+import NoticeDomain
+
+/// 탭 내부에서 push되는 화면 목적지를 타입 세이프하게 정의하는 전역 열거형.
+///
+/// Feature 그룹별로 nested enum을 두고, 아직 탭에 실연결되지 않은 Feature는 케이스를
+/// 추가하지 않는다. `AppFlowState`와 마찬가지로 각 Feature가 실제로 탭에 연결되는
+/// 후속 이슈에서 케이스가 점진적으로 채워지는 최소 골격이다.
+///
+/// - Note: `.notice`는 `NoticePresentation`이 자체적으로 들고 있던 로컬 스텁
+///   (`NoticeNavigation.swift`)의 목적지 구조를 그대로 옮겼다. 다만 `NoticePresentation`은
+///   App 타깃을 참조할 수 없어(Feature → App 의존 방향 금지) `NoticeView`/`NoticeDetailView`가
+///   이 타입을 직접 쓰도록 교체할 수는 없다. Notice 탭을 `RootTabView`에 실연결하는 후속
+///   이슈에서 (a) Notice가 로컬 타입을 유지한 채 콜백/클로저로 상위와 연동하거나,
+///   (b) 여러 Feature가 공유할 신규 Core 모듈을 신설해 이 타입을 옮기는 방안 중 하나를
+///   메인테이너 승인 하에 선택해야 한다.
+enum NavigationDestination: Hashable {
+    case notice(Notice)
+
+    enum Notice: Hashable {
+        case detail(detailItem: NoticeDetail)
+        case staffNotice
+        case editor(mode: NoticeEditorMode, selectedGisuId: String?)
+    }
+}

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
@@ -1,0 +1,47 @@
+import CoreDI
+import NoticePresentation
+import SwiftUI
+import UMCFoundation
+
+/// `NavigationDestination`을 받아 실제 목적지 화면으로 라우팅하는 뷰.
+///
+/// 각 탭의 `NavigationStack`이 `.navigationDestination(for: NavigationDestination.self)`에서
+/// 공통으로 사용한다.
+struct NavigationRoutingView: View {
+
+    // MARK: - Property
+
+    @Environment(\.di) private var di
+    @Environment(ErrorHandler.self) private var errorHandler
+    private let destination: NavigationDestination
+
+    // MARK: - Init
+
+    init(destination: NavigationDestination) {
+        self.destination = destination
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        switch destination {
+        case .notice(let route):
+            noticeView(route)
+        }
+    }
+}
+
+// MARK: - Notice Routing
+
+private extension NavigationRoutingView {
+    @ViewBuilder
+    func noticeView(_ route: NavigationDestination.Notice) -> some View {
+        switch route {
+        case .detail(let detailItem):
+            NoticeDetailView(container: di, errorHandler: errorHandler, model: detailItem)
+        case .staffNotice, .editor:
+            // StaffNoticeView / NoticeEditorView는 아직 NoticePresentation에 이식되지 않았다.
+            Text("아직 지원하지 않는 화면입니다")
+        }
+    }
+}

--- a/UMCApp/UMCApp/Sources/Navigation/PathStore.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/PathStore.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// 탭별 네비게이션 경로를 한 곳에서 관리하는 전역 Store.
+///
+/// 절대규칙 #1의 명시적 예외(앱 생명주기 전역 관리자)로 `@Observable`을 사용한다.
+/// `RootTabView`가 소유하며, 탭별 `NavigationStack`의 path 바인딩 소스로 쓰인다.
+@Observable
+final class PathStore {
+
+    // MARK: - Property
+
+    var homePath: [NavigationDestination] = []
+    var noticePath: [NavigationDestination] = []
+    var activityPath: [NavigationDestination] = []
+    var communityPath: [NavigationDestination] = []
+    var myPagePath: [NavigationDestination] = []
+
+    // MARK: - Init
+
+    init() {}
+}

--- a/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
+++ b/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
@@ -1,0 +1,100 @@
+import ActivityPresentation
+import CommunityPresentation
+import CoreDesignSystem
+import HomePresentation
+import MyPagePresentation
+import NoticePresentation
+import SwiftUI
+
+/// `.main` 상태의 루트 탭 셸.
+///
+/// Home/Notice/Activity/Community/MyPage 5개 탭을 탭별 독립 `NavigationStack`으로
+/// 구성한다. 최소 수직 슬라이스이므로 Home 탭만 실제 화면(`HomeFeatureView`)에 연결되고,
+/// 나머지 4탭은 각 Feature의 placeholder(`{Feature}FeatureView`)를 표시한다.
+struct RootTabView: View {
+
+    // MARK: - Property
+
+    @State private var selectedTab: TabCase = .home
+    @State private var pathStore = PathStore()
+
+    // MARK: - Body
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            ForEach(TabCase.allCases) { tab in
+                Tab(value: tab, role: tab.role) {
+                    tabRootView(tab)
+                } label: {
+                    tabLabel(tab)
+                }
+            }
+        }
+        .tabBarMinimizeBehavior(.onScrollDown)
+    }
+
+    // MARK: - Function
+
+    private func tabLabel(_ tab: TabCase) -> some View {
+        VStack(alignment: .center, spacing: DefaultSpacing.spacing8) {
+            Image(systemName: tab.systemImageName)
+                .renderingMode(.template)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+
+            Text(tab.title)
+                .appFont(.caption1, weight: .regular)
+        }
+    }
+
+    /// 탭 케이스에 따른 루트 뷰를 독립 `NavigationStack`으로 감싼다.
+    @ViewBuilder
+    private func tabRootView(_ tab: TabCase) -> some View {
+        NavigationStack(path: pathBinding(for: tab)) {
+            tabContent(tab)
+                .navigationDestination(for: NavigationDestination.self) { destination in
+                    NavigationRoutingView(destination: destination)
+                }
+        }
+    }
+
+    /// Home 탭만 실제 화면에 연결하고, 나머지는 각 Feature의 placeholder를 표시한다.
+    ///
+    /// - Note: Notice/MyPage는 이미 이식된 모듈이 있지만, 탭 실연결은 후속 이슈에서
+    ///   진행한다(#910 범위 밖).
+    @ViewBuilder
+    private func tabContent(_ tab: TabCase) -> some View {
+        switch tab {
+        case .home:
+            HomeFeatureView()
+        case .notice:
+            // TODO: NoticePresentation의 실제 NoticeView 연결 (Notice 탭 실연결 후속 이슈)
+            NoticeFeatureView()
+        case .activity:
+            // TODO: ActivityPresentation의 실제 ActivityView 연결 (Activity 탭 실연결 후속 이슈)
+            ActivityFeatureView()
+        case .community:
+            // TODO: CommunityPresentation의 실제 CommunityView 연결 (Community 탭 실연결 후속 이슈)
+            CommunityFeatureView()
+        case .mypage:
+            // TODO: MyPagePresentation의 실제 MyPageView 연결 (MyPage 탭 실연결 후속 이슈)
+            MyPageFeatureView()
+        }
+    }
+
+    /// 탭별 독립 `NavigationStack` path 바인딩을 `PathStore`에 위임한다.
+    private func pathBinding(for tab: TabCase) -> Binding<[NavigationDestination]> {
+        switch tab {
+        case .home:
+            Binding(get: { pathStore.homePath }, set: { pathStore.homePath = $0 })
+        case .notice:
+            Binding(get: { pathStore.noticePath }, set: { pathStore.noticePath = $0 })
+        case .activity:
+            Binding(get: { pathStore.activityPath }, set: { pathStore.activityPath = $0 })
+        case .community:
+            Binding(get: { pathStore.communityPath }, set: { pathStore.communityPath = $0 })
+        case .mypage:
+            Binding(get: { pathStore.myPagePath }, set: { pathStore.myPagePath = $0 })
+        }
+    }
+}

--- a/UMCApp/UMCApp/Sources/RootTab/TabCase.swift
+++ b/UMCApp/UMCApp/Sources/RootTab/TabCase.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// 루트 탭 셸이 표시하는 5개 탭.
+///
+/// 이번 이슈(#910)의 최소 수직 슬라이스에서는 `.home`만 실제 화면에 연결되고
+/// 나머지 탭은 placeholder(`{Feature}FeatureView`)를 표시한다.
+enum TabCase: CaseIterable, Identifiable, Hashable {
+    case home
+    case notice
+    case activity
+    case community
+    case mypage
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .home: "홈"
+        case .notice: "공지"
+        case .activity: "활동"
+        case .community: "커뮤니티"
+        case .mypage: "마이페이지"
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .home: "house"
+        case .notice: "list.bullet.clipboard"
+        case .activity: "folder.badge.person.crop"
+        case .community: "bubble.left.and.bubble.right"
+        case .mypage: "person.fill"
+        }
+    }
+
+    var role: TabRole? {
+        switch self {
+        case .mypage: .search
+        default: nil
+        }
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Feature — launch→home 수직 슬라이스 이식 Phase 0 (앱 셸 배선) 2단계

Closes #910

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 시뮬레이터 확인: 5탭(홈/공지/활동/커뮤니티/마이페이지 search role) + Home placeholder 진입 정상 -->

## 🛠️ 작업내용

- `TabCase`(Home/Notice/Activity/Community/MyPage 5탭) + `RootTabView` 추가 — 레거시 UmcTab과 타이틀/아이콘/role(.mypage=.search) 1:1 일치
- 탭별 독립 `NavigationStack` 구성 (탭마다 분리된 path 바인딩)
- 전역 `PathStore`(@Observable) / `NavigationDestination` / `NavigationRoutingView` 골격 추가 — tuist-file-mapping.md 기준 App 타깃 배치
- `AppRootView`의 `.main` 분기를 `RootTabView`로 교체
- Home 탭만 실제 진입점, 나머지 4탭 placeholder + TODO로 실연결 지점 명시
- Notice 로컬 PathStore 스텁은 Feature→App 의존 불가 제약으로 즉시 통합 대신 통합 경로(콜백 방식/신규 Core 모듈 방식)를 doc comment로 명시 — App 전역 `NavigationDestination.notice`는 실제 타입으로 선행 준비

## 📋 추후 진행 상황

- #913~#915 Home 탭 콘텐츠 (프로필 카드/캘린더/최근 공지)
- #912 딥링크 — PathStore 외부 접근 경로(DI/Environment 노출) 설계 필요 (현재 RootTabView 내부 캡슐화)
- UmcBottonAccessoryView(관리자 모드 토글)는 미이식 권한 로직 결합으로 스코프 제외 — 관리자 기능 이식 시 추적

## 📌 리뷰 포인트

- `UMCApp/UMCApp/Sources/RootTab/RootTabView.swift` - 탭별 독립 NavigationStack 구성
- `UMCApp/UMCApp/Sources/Navigation/PathStore.swift` - 탭별 path 분리 보유 구조
- `UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift` - Notice 라우팅 선행 배선
- `UMCApp/Features/Notice/Presentation/Sources/Navigation/NoticeNavigation.swift` - 통합 경로 문서화

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)