### PR TITLE
♻️ [Refactor] OperatorStudyManagementViewModel 이식

### DIFF
--- a/UMCApp/Features/Activity/Data/Sources/DTOs/MyStudyGroupsQuery.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/MyStudyGroupsQuery.swift
@@ -9,10 +9,11 @@ import Foundation
 
 /// `GET /api/v1/study-groups/managed` 페이지네이션 쿼리 파라미터.
 ///
-/// `cursor` 는 첫 페이지에서 `nil`. `cursor`/`size` 는 페이지네이션 정수이며
-/// 서버 식별자가 아니므로 `Int` 를 유지합니다.
+/// `cursor` 는 첫 페이지에서 `nil`. 서버 `nextCursor` 는 불투명(opaque) 토큰이라
+/// 숫자가 아닐 수 있으므로(`"cursor-2"` 등) 받은 값을 그대로 echo 하도록 `String` 으로 보냅니다.
+/// `size` 만 페이지 크기 정수입니다.
 struct MyStudyGroupsQuery {
-    let cursor: Int?
+    let cursor: String?
     let size: Int
 
     /// Moya `URLEncoding.queryString` 직렬화용 파라미터 사전.

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
@@ -100,7 +100,7 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
 
     public func fetchStudyGroupDetails() async throws -> [StudyGroupInfo] {
         var allDetails: [StudyGroupInfo] = []
-        var cursor: Int?
+        var cursor: String?
         var hasNext = true
 
         while hasNext {
@@ -111,7 +111,7 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
             allDetails.append(contentsOf: page.content)
 
             hasNext = page.hasNext
-            cursor = page.nextCursor.flatMap(Int.init)
+            cursor = page.nextCursor
             // 다음 페이지가 있다고 했으나 커서가 없으면 무한 루프 방지를 위해 중단한다.
             if hasNext && cursor == nil {
                 break
@@ -122,7 +122,7 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
     }
 
     public func fetchStudyGroupDetailsPage(
-        cursor: Int?,
+        cursor: String?,
         size: Int
     ) async throws -> StudyGroupDetailsPage {
         let response = try await networkRequesting.request(
@@ -150,7 +150,7 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
 
     public func resolveChallengerId(
         memberId: String,
-        preferredGeneration: Int?
+        preferredGeneration: String?
     ) async throws -> String? {
         let response = try await networkRequesting.request(
             StudyRouter.getMemberProfile(memberId: memberId)
@@ -165,8 +165,9 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
             $0.memberId == memberId && !$0.challengerId.isEmpty
         }
 
-        if let preferredGeneration, preferredGeneration > 0,
-           let matched = records.first(where: { $0.gisu == preferredGeneration }) {
+        // 기수는 String 으로 전달받아 숫자 비교 연산 시점에만 Int 로 변환한다.
+        if let preferredGisu = preferredGeneration.flatMap(Int.init), preferredGisu > 0,
+           let matched = records.first(where: { $0.gisu == preferredGisu }) {
             return matched.challengerId
         }
 

--- a/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
@@ -37,6 +37,8 @@ private final class StubNetworkRequesting: NetworkRequesting, @unchecked Sendabl
     private var outcomes: [Outcome]
     private(set) var requestedPaths: [String] = []
     private(set) var requestedMethods: [Moya.Method] = []
+    /// 각 요청의 `cursor` 쿼리 파라미터 (없으면 `nil`). 페이지네이션 echo 검증용.
+    private(set) var requestedCursors: [String?] = []
 
     var requestCount: Int { requestedPaths.count }
     var lastPath: String? { requestedPaths.last }
@@ -49,6 +51,7 @@ private final class StubNetworkRequesting: NetworkRequesting, @unchecked Sendabl
     func request<T: TargetType>(_ target: T) async throws -> Response {
         requestedPaths.append(target.path)
         requestedMethods.append(target.method)
+        requestedCursors.append(Self.cursor(from: target.task))
         guard !outcomes.isEmpty else {
             throw StubError.noOutcomeQueued
         }
@@ -58,6 +61,13 @@ private final class StubNetworkRequesting: NetworkRequesting, @unchecked Sendabl
         case .failure(let error):
             throw error
         }
+    }
+
+    private static func cursor(from task: Moya.Task) -> String? {
+        if case let .requestParameters(parameters, _) = task {
+            return parameters["cursor"] as? String
+        }
+        return nil
     }
 }
 
@@ -306,6 +316,25 @@ struct StudyRepositoryGroupTests {
         #expect(stub.requestCount == 1)        // 두 번째 페이지를 요청하지 않음
     }
 
+    @Test("fetchStudyGroupDetails — 불투명 nextCursor 를 다음 페이지 요청 커서로 그대로 echo 한다")
+    func fetchStudyGroupDetailsEchoesOpaqueCursor() async throws {
+        let page1 = Fixture.studyGroupsPage(
+            [Fixture.studyGroupDetailObject], nextCursor: "cursor-2", hasNext: true
+        )
+        let page2 = Fixture.studyGroupsPage(
+            [Fixture.studyGroupDetailObject], nextCursor: nil, hasNext: false
+        )
+        let (sut, stub) = makeRepository([
+            .success(Fixture.success(page1)),
+            .success(Fixture.success(page2))
+        ])
+
+        _ = try await sut.fetchStudyGroupDetails()
+
+        // 1페이지는 커서 없음, 2페이지는 불투명 토큰을 숫자 변환 없이 그대로 전달.
+        #expect(stub.requestedCursors == [nil, "cursor-2"])
+    }
+
     @Test("fetchStudyGroupDetail — 단일 상세를 매핑하고 groupId 를 path 에 보간한다")
     func fetchStudyGroupDetailMapsSuccess() async throws {
         let (sut, stub) = makeRepository(
@@ -329,14 +358,14 @@ struct StudyRepositoryResolveChallengerTests {
     @Test(
         "resolveChallengerId — 기수/컨텍스트 폴백/첫 레코드 우선순위로 challengerId 를 해석한다",
         arguments: [
-            (preferred: Optional(8), contextGisuId: Optional("70"), expected: "C8"),
-            (preferred: Optional<Int>.none, contextGisuId: Optional("80"), expected: "C8"),
-            (preferred: Optional<Int>.none, contextGisuId: Optional("70"), expected: "C7"),
-            (preferred: Optional<Int>.none, contextGisuId: Optional<String>.none, expected: "C7")
+            (preferred: Optional("8"), contextGisuId: Optional("70"), expected: "C8"),
+            (preferred: Optional<String>.none, contextGisuId: Optional("80"), expected: "C8"),
+            (preferred: Optional<String>.none, contextGisuId: Optional("70"), expected: "C7"),
+            (preferred: Optional<String>.none, contextGisuId: Optional<String>.none, expected: "C7")
         ]
     )
     func resolveChallengerIdAppliesPriority(
-        preferred: Int?,
+        preferred: String?,
         contextGisuId: String?,
         expected: String
     ) async throws {

--- a/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRouterTests.swift
@@ -54,7 +54,7 @@ struct StudyRouterTests {
             StudyRouter.getCurriculum(
                 query: CurriculumOverviewQuery(gisuId: "7", part: "BE", weekNo: nil)
             ),
-            StudyRouter.getMyStudyGroups(query: MyStudyGroupsQuery(cursor: 10, size: 20)),
+            StudyRouter.getMyStudyGroups(query: MyStudyGroupsQuery(cursor: "10", size: 20)),
             StudyRouter.getStudyGroupDetail(groupId: "42"),
             StudyRouter.getMemberProfile(memberId: "99")
         ]
@@ -86,7 +86,7 @@ struct StudyRouterTests {
     func getMyStudyGroupsTaskEncodesQueryString() throws {
         // Given
         let router = StudyRouter.getMyStudyGroups(
-            query: MyStudyGroupsQuery(cursor: 10, size: 20)
+            query: MyStudyGroupsQuery(cursor: "10", size: 20)
         )
 
         // When
@@ -94,7 +94,7 @@ struct StudyRouterTests {
 
         // Then
         #expect(extracted.parameters["size"] as? Int == 20)
-        #expect(extracted.parameters["cursor"] as? Int == 10)
+        #expect(extracted.parameters["cursor"] as? String == "10")
         #expect((extracted.encoding as? URLEncoding)?.destination == .queryString)
     }
 
@@ -172,15 +172,27 @@ struct StudyRouterTests {
     @Test("MyStudyGroupsQuery 는 cursor 가 있으면 파라미터에 포함한다")
     func myStudyGroupsQueryIncludesCursorWhenPresent() {
         // Given
-        let query = MyStudyGroupsQuery(cursor: 15, size: 20)
+        let query = MyStudyGroupsQuery(cursor: "15", size: 20)
 
         // When
         let parameters = query.toParameters
 
         // Then
         #expect(parameters.count == 2)
-        #expect(parameters["cursor"] as? Int == 15)
+        #expect(parameters["cursor"] as? String == "15")
         #expect(parameters["size"] as? Int == 20)
+    }
+
+    @Test("MyStudyGroupsQuery 는 불투명 커서 토큰을 변형 없이 파라미터로 전달한다")
+    func myStudyGroupsQueryForwardsOpaqueCursor() {
+        // Given — 서버 nextCursor 는 숫자가 아닐 수 있다(불투명 토큰).
+        let query = MyStudyGroupsQuery(cursor: "cursor-2", size: 20)
+
+        // When
+        let parameters = query.toParameters
+
+        // Then
+        #expect(parameters["cursor"] as? String == "cursor-2")
     }
 
     @Test("MyStudyGroupsQuery 는 cursor 가 nil 이면 파라미터에서 제외한다")

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/StudyRepositoryProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/StudyRepositoryProtocol.swift
@@ -35,10 +35,11 @@ public protocol StudyRepositoryProtocol {
     /// 스터디 그룹 상세 목록 페이지 조회
     ///
     /// - Parameters:
-    ///   - cursor: 페이지 커서 (첫 페이지는 `nil`)
+    ///   - cursor: 페이지 커서 (첫 페이지는 `nil`). 서버가 내려준 불투명(opaque) 토큰을
+    ///     그대로 echo 하므로 `String` 으로 전달한다 (숫자로 강제 변환 금지).
     ///   - size: 페이지 크기
     func fetchStudyGroupDetailsPage(
-        cursor: Int?,
+        cursor: String?,
         size: Int
     ) async throws -> StudyGroupDetailsPage
 
@@ -53,11 +54,12 @@ public protocol StudyRepositoryProtocol {
     ///
     /// - Parameters:
     ///   - memberId: 멤버 ID (서버 응답)
-    ///   - preferredGeneration: 우선 조회할 기수 (클라이언트 입력, 없으면 최신 레코드 기준)
+    ///   - preferredGeneration: 우선 조회할 기수 (클라이언트 입력, 없으면 최신 레코드 기준).
+    ///     전 레이어 `String` 통일 — 숫자 기수 비교는 구현체가 연산 시점에 `Int` 로 변환한다.
     /// - Returns: 조회된 챌린저 ID — 서버 응답이므로 `String?`
     func resolveChallengerId(
         memberId: String,
-        preferredGeneration: Int?
+        preferredGeneration: String?
     ) async throws -> String?
 
     // MARK: - 운영진 스터디 그룹 CRUD

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/OperatorStudyManagementUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/OperatorStudyManagementUseCase.swift
@@ -1,0 +1,93 @@
+//
+//  OperatorStudyManagementUseCase.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/27/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// `OperatorStudyManagementUseCaseProtocol` 의 기본 구현체
+///
+/// 운영진 스터디 관리 액션을 모두 `StudyRepositoryProtocol` 에 그대로 위임합니다.
+/// 커서·기수를 포함한 모든 식별자를 `String` 으로 전달하며(전 레이어 `String` 통일),
+/// `Int` 변환은 Repository 가 실제 비교/직렬화하는 연산 시점에만 수행합니다.
+public final class OperatorStudyManagementUseCase: OperatorStudyManagementUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: StudyRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: StudyRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - 조회 / 페이지네이션
+
+    public func fetchStudyGroupDetailsPage(
+        cursor: String?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage {
+        try await repository.fetchStudyGroupDetailsPage(
+            cursor: cursor,
+            size: size
+        )
+    }
+
+    public func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: String?
+    ) async throws -> String? {
+        try await repository.resolveChallengerId(
+            memberId: memberId,
+            preferredGeneration: preferredGeneration
+        )
+    }
+
+    // MARK: - 그룹 CRUD
+
+    public func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws {
+        try await repository.createStudyGroup(
+            gisuId: gisuId,
+            name: name,
+            part: part,
+            memberIds: memberIds,
+            mentorIds: mentorIds
+        )
+    }
+
+    public func updateStudyGroup(groupId: String, name: String) async throws {
+        try await repository.updateStudyGroup(groupId: groupId, name: name)
+    }
+
+    public func deleteStudyGroup(groupId: String) async throws {
+        try await repository.deleteStudyGroup(groupId: groupId)
+    }
+
+    // MARK: - 멤버 / 멘토
+
+    public func addStudyGroupMember(groupId: String, memberId: String) async throws {
+        try await repository.addStudyGroupMember(groupId: groupId, memberId: memberId)
+    }
+
+    public func removeStudyGroupMember(groupId: String, memberId: String) async throws {
+        try await repository.removeStudyGroupMember(groupId: groupId, memberId: memberId)
+    }
+
+    public func addStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        try await repository.addStudyGroupMentor(groupId: groupId, mentorId: mentorId)
+    }
+
+    public func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        try await repository.removeStudyGroupMentor(groupId: groupId, mentorId: mentorId)
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/OperatorStudyManagementUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/OperatorStudyManagementUseCaseProtocol.swift
@@ -1,0 +1,81 @@
+//
+//  OperatorStudyManagementUseCaseProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/27/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 운영진 스터디 그룹 관리 도메인 진입점
+///
+/// 운영진 스터디 관리 화면이 수행하는 그룹 CRUD(생성/수정/삭제) · 멤버·멘토 추가/제거 ·
+/// 상세 목록 페이지네이션 · 챌린저 ID 해석을 단일 Protocol 로 노출합니다.
+/// 모든 액션을 ``StudyRepositoryProtocol`` 에 위임하므로 Presentation 은 Repository 를
+/// 직접 알 필요 없이 본 UseCase 에만 의존합니다 (`OperatorAttendanceUseCaseProtocol` 과 동형).
+///
+/// - Note: 단일 그룹의 멤버 목록 조회는 책임이 다른 `FetchStudyMembersUseCaseProtocol` 이
+///   담당합니다. 페이지 커서/기수는 서버 응답이므로 전 레이어를 `String` 으로 통일하며,
+///   `Int` 변환은 Repository 가 실제 숫자 비교를 수행하는 연산 시점에만 일어납니다.
+public protocol OperatorStudyManagementUseCaseProtocol {
+
+    // MARK: - 조회 / 페이지네이션
+
+    /// 스터디 그룹 상세 목록 페이지 조회
+    ///
+    /// - Parameters:
+    ///   - cursor: 페이지 커서 (첫 페이지는 `nil`, 서버 응답 `String`)
+    ///   - size: 페이지 크기
+    func fetchStudyGroupDetailsPage(
+        cursor: String?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage
+
+    /// 멤버 ID 로 챌린저 ID 조회
+    ///
+    /// - Parameters:
+    ///   - memberId: 멤버 ID (서버 응답 `String`)
+    ///   - preferredGeneration: 우선 조회할 기수 (서버 응답 `String`, 없으면 최신 레코드 기준)
+    /// - Returns: 조회된 챌린저 ID — 서버 응답이므로 `String?`
+    func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: String?
+    ) async throws -> String?
+
+    // MARK: - 그룹 CRUD
+
+    /// 스터디 그룹 생성
+    ///
+    /// - Parameters:
+    ///   - gisuId: 기수 ID (서버 응답 `String`)
+    ///   - memberIds: 멤버 ID 목록 (서버 응답 `String`)
+    ///   - mentorIds: 멘토 ID 목록 (서버 응답 `String`)
+    func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws
+
+    /// 스터디 그룹 정보 수정 (이름만 수정 가능)
+    func updateStudyGroup(groupId: String, name: String) async throws
+
+    /// 스터디 그룹 삭제
+    func deleteStudyGroup(groupId: String) async throws
+
+    // MARK: - 멤버 / 멘토
+
+    /// 스터디 그룹에 스터디원 추가
+    func addStudyGroupMember(groupId: String, memberId: String) async throws
+
+    /// 스터디 그룹에서 스터디원 제거
+    func removeStudyGroupMember(groupId: String, memberId: String) async throws
+
+    /// 스터디 그룹에 담당 파트장(멘토) 추가
+    func addStudyGroupMentor(groupId: String, mentorId: String) async throws
+
+    /// 스터디 그룹에서 담당 파트장(멘토) 제거
+    func removeStudyGroupMentor(groupId: String, mentorId: String) async throws
+}

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchCurriculumUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchCurriculumUseCaseTests.swift
@@ -76,7 +76,7 @@ private final class MockStudyRepository: @unchecked Sendable, StudyRepositoryPro
     }
 
     func fetchStudyGroupDetailsPage(
-        cursor: Int?,
+        cursor: String?,
         size: Int
     ) async throws -> StudyGroupDetailsPage {
         fatalError("fetchStudyGroupDetailsPage 는 FetchCurriculumUseCase 계약 밖입니다.")
@@ -88,7 +88,7 @@ private final class MockStudyRepository: @unchecked Sendable, StudyRepositoryPro
 
     func resolveChallengerId(
         memberId: String,
-        preferredGeneration: Int?
+        preferredGeneration: String?
     ) async throws -> String? {
         fatalError("resolveChallengerId 는 FetchCurriculumUseCase 계약 밖입니다.")
     }

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchStudyMembersUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchStudyMembersUseCaseTests.swift
@@ -96,7 +96,7 @@ private final class MockStudyRepository: @unchecked Sendable, StudyRepositoryPro
     }
 
     func fetchStudyGroupDetailsPage(
-        cursor: Int?,
+        cursor: String?,
         size: Int
     ) async throws -> StudyGroupDetailsPage {
         throw MockError.unimplemented
@@ -104,7 +104,7 @@ private final class MockStudyRepository: @unchecked Sendable, StudyRepositoryPro
 
     func resolveChallengerId(
         memberId: String,
-        preferredGeneration: Int?
+        preferredGeneration: String?
     ) async throws -> String? {
         throw MockError.unimplemented
     }

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/OperatorStudyManagementUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/OperatorStudyManagementUseCaseTests.swift
@@ -1,0 +1,303 @@
+//
+//  OperatorStudyManagementUseCaseTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 6/27/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+#if DEBUG
+
+// MARK: - Helpers
+
+private func makeUseCase(
+    repository: MockStudyRepository = MockStudyRepository()
+) -> OperatorStudyManagementUseCase {
+    OperatorStudyManagementUseCase(repository: repository)
+}
+
+// MARK: - Mocks
+
+/// 운영진 스터디 관리 UseCase 가 사용하는 9개 메서드를 기록/제어하는 포커스드 Mock.
+/// 본 UseCase 가 호출하지 않는 계약 메서드는 호출 시 `unimplemented` 로 즉시 실패시킵니다.
+private final class MockStudyRepository: @unchecked Sendable, StudyRepositoryProtocol {
+
+    enum MockError: Error {
+        /// 본 UseCase 가 호출하면 안 되는 계약 메서드를 건드렸음을 알리는 표식
+        case unimplemented
+        /// 에러 전파 경로 검증용 스텁 에러
+        case stubbed
+    }
+
+    /// update/delete/멤버·멘토 추가·제거의 위임 인자를 한 형태로 기록.
+    struct Mutation: Equatable {
+        let kind: String
+        let groupId: String
+        let id: String
+    }
+
+    // MARK: 기록 / 제어
+
+    var fetchPageResult = StudyGroupDetailsPage(content: [], hasNext: false, nextCursor: nil)
+    var resolveResult: String? = "C-1"
+    var errorToThrow: Error?
+
+    private(set) var fetchPageCalls: [(cursor: String?, size: Int)] = []
+    private(set) var resolveCalls: [(memberId: String, preferredGeneration: String?)] = []
+    private(set) var createCalls: [(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    )] = []
+    private(set) var mutationCalls: [Mutation] = []
+
+    // MARK: 본 UseCase 가 사용하는 메서드
+
+    func fetchStudyGroupDetailsPage(
+        cursor: String?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage {
+        if let errorToThrow { throw errorToThrow }
+        fetchPageCalls.append((cursor, size))
+        return fetchPageResult
+    }
+
+    func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: String?
+    ) async throws -> String? {
+        if let errorToThrow { throw errorToThrow }
+        resolveCalls.append((memberId, preferredGeneration))
+        return resolveResult
+    }
+
+    func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws {
+        if let errorToThrow { throw errorToThrow }
+        createCalls.append((gisuId, name, part, memberIds, mentorIds))
+    }
+
+    func updateStudyGroup(groupId: String, name: String) async throws {
+        if let errorToThrow { throw errorToThrow }
+        mutationCalls.append(Mutation(kind: "update", groupId: groupId, id: name))
+    }
+
+    func deleteStudyGroup(groupId: String) async throws {
+        if let errorToThrow { throw errorToThrow }
+        mutationCalls.append(Mutation(kind: "delete", groupId: groupId, id: ""))
+    }
+
+    func addStudyGroupMember(groupId: String, memberId: String) async throws {
+        if let errorToThrow { throw errorToThrow }
+        mutationCalls.append(Mutation(kind: "addMember", groupId: groupId, id: memberId))
+    }
+
+    func removeStudyGroupMember(groupId: String, memberId: String) async throws {
+        if let errorToThrow { throw errorToThrow }
+        mutationCalls.append(Mutation(kind: "removeMember", groupId: groupId, id: memberId))
+    }
+
+    func addStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        if let errorToThrow { throw errorToThrow }
+        mutationCalls.append(Mutation(kind: "addMentor", groupId: groupId, id: mentorId))
+    }
+
+    func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        if let errorToThrow { throw errorToThrow }
+        mutationCalls.append(Mutation(kind: "removeMentor", groupId: groupId, id: mentorId))
+    }
+
+    // MARK: 본 UseCase 미사용 — 호출 시 unimplemented
+
+    func fetchCurriculumProgress() async throws -> CurriculumProgressModel {
+        throw MockError.unimplemented
+    }
+
+    func fetchMissions() async throws -> [MissionCardModel] {
+        throw MockError.unimplemented
+    }
+
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption] {
+        throw MockError.unimplemented
+    }
+
+    func fetchStudyGroupDetails() async throws -> [StudyGroupInfo] {
+        throw MockError.unimplemented
+    }
+
+    func fetchStudyGroupDetail(groupId: String) async throws -> StudyGroupInfo {
+        throw MockError.unimplemented
+    }
+
+    func linkStudyGroupSchedule(
+        scheduleId: String,
+        studyGroupId: String,
+        weeklyCurriculumId: String
+    ) async throws {
+        throw MockError.unimplemented
+    }
+}
+
+// MARK: - 위임 메서드 디스패치
+
+/// 9개 위임 메서드를 파라미터화해 에러 전파/변경 위임을 형제 대칭으로 검증하기 위한 디스패처.
+private enum DelegatingMethod: CaseIterable {
+    case fetchPage, resolve, create
+    case update, delete, addMember, removeMember, addMentor, removeMentor
+
+    /// update/delete/멤버·멘토 변경처럼 `Mutation` 으로 기록되는 케이스만 추림.
+    static let mutationCases: [DelegatingMethod] = [
+        .update, .delete, .addMember, .removeMember, .addMentor, .removeMentor
+    ]
+
+    func invoke(_ useCase: OperatorStudyManagementUseCase) async throws {
+        switch self {
+        case .fetchPage:
+            _ = try await useCase.fetchStudyGroupDetailsPage(cursor: "1", size: 20)
+        case .resolve:
+            _ = try await useCase.resolveChallengerId(memberId: "M-1", preferredGeneration: "11")
+        case .create:
+            try await useCase.createStudyGroup(
+                gisuId: "11",
+                name: "n",
+                part: .front(type: .ios),
+                memberIds: [],
+                mentorIds: []
+            )
+        case .update:
+            try await useCase.updateStudyGroup(groupId: "G-1", name: "새 이름")
+        case .delete:
+            try await useCase.deleteStudyGroup(groupId: "G-1")
+        case .addMember:
+            try await useCase.addStudyGroupMember(groupId: "G-1", memberId: "M-1")
+        case .removeMember:
+            try await useCase.removeStudyGroupMember(groupId: "G-1", memberId: "M-1")
+        case .addMentor:
+            try await useCase.addStudyGroupMentor(groupId: "G-1", mentorId: "M-9")
+        case .removeMentor:
+            try await useCase.removeStudyGroupMentor(groupId: "G-1", mentorId: "M-9")
+        }
+    }
+
+    /// `mutationCases` 가 기대하는 기록값.
+    var expectedMutation: MockStudyRepository.Mutation? {
+        switch self {
+        case .update: return .init(kind: "update", groupId: "G-1", id: "새 이름")
+        case .delete: return .init(kind: "delete", groupId: "G-1", id: "")
+        case .addMember: return .init(kind: "addMember", groupId: "G-1", id: "M-1")
+        case .removeMember: return .init(kind: "removeMember", groupId: "G-1", id: "M-1")
+        case .addMentor: return .init(kind: "addMentor", groupId: "G-1", id: "M-9")
+        case .removeMentor: return .init(kind: "removeMentor", groupId: "G-1", id: "M-9")
+        case .fetchPage, .resolve, .create: return nil
+        }
+    }
+}
+
+// MARK: - 페이지 커서 / 기수 변환
+
+@Suite("OperatorStudyManagementUseCase — Repository 위임 (도메인 규칙)")
+struct OperatorStudyManagementUseCaseTests {
+
+    @Test(
+        "페이지 커서 — 불투명 토큰 포함 String 을 변형 없이 Repository 로 위임",
+        arguments: [
+            String?.none,
+            "42",
+            // 불투명 토큰: 숫자로 강제 변환하면 nil 로 유실돼 페이지네이션이 깨진다.
+            "cursor-2"
+        ]
+    )
+    func fetchPageForwardsCursorVerbatim(cursor: String?) async throws {
+        let repository = MockStudyRepository()
+        let useCase = makeUseCase(repository: repository)
+
+        _ = try await useCase.fetchStudyGroupDetailsPage(cursor: cursor, size: 20)
+
+        let call = try #require(repository.fetchPageCalls.first)
+        #expect(call.cursor == cursor)
+        #expect(call.size == 20)
+    }
+
+    @Test(
+        "챌린저 ID 조회 — String 기수를 변형 없이 위임 + memberId 그대로 위임",
+        arguments: [String?.none, "11"]
+    )
+    func resolveForwardsGenerationVerbatim(generation: String?) async throws {
+        let repository = MockStudyRepository()
+        let useCase = makeUseCase(repository: repository)
+
+        _ = try await useCase.resolveChallengerId(
+            memberId: "M-1",
+            preferredGeneration: generation
+        )
+
+        let call = try #require(repository.resolveCalls.first)
+        #expect(call.memberId == "M-1")
+        #expect(call.preferredGeneration == generation)
+    }
+
+    // MARK: - 생성 / 변경 위임
+
+    @Test("그룹 생성 — 인자를 변형 없이 Repository 에 위임")
+    func createForwardsArguments() async throws {
+        let repository = MockStudyRepository()
+        let useCase = makeUseCase(repository: repository)
+
+        try await useCase.createStudyGroup(
+            gisuId: "11",
+            name: "iOS 스터디",
+            part: .front(type: .ios),
+            memberIds: ["1", "2"],
+            mentorIds: ["9"]
+        )
+
+        let call = try #require(repository.createCalls.first)
+        #expect(call.gisuId == "11")
+        #expect(call.name == "iOS 스터디")
+        #expect(call.part == .front(type: .ios))
+        #expect(call.memberIds == ["1", "2"])
+        #expect(call.mentorIds == ["9"])
+    }
+
+    @Test(
+        "그룹 수정/삭제 · 멤버/멘토 추가·제거 — groupId/식별자를 그대로 위임",
+        arguments: DelegatingMethod.mutationCases
+    )
+    private func mutationForwardsIdentifiers(method: DelegatingMethod) async throws {
+        let repository = MockStudyRepository()
+        let useCase = makeUseCase(repository: repository)
+
+        try await method.invoke(useCase)
+
+        #expect(repository.mutationCalls == [method.expectedMutation].compactMap { $0 })
+    }
+
+    // MARK: - 에러 전파 (형제 대칭)
+
+    @Test(
+        "Repository 에러는 모든 위임 메서드에서 그대로 전파",
+        arguments: DelegatingMethod.allCases
+    )
+    private func propagatesRepositoryError(method: DelegatingMethod) async {
+        let repository = MockStudyRepository()
+        repository.errorToThrow = MockStudyRepository.MockError.stubbed
+        let useCase = makeUseCase(repository: repository)
+
+        await #expect(throws: MockStudyRepository.MockError.stubbed) {
+            try await method.invoke(useCase)
+        }
+    }
+}
+
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
@@ -680,18 +680,41 @@ final class OperatorStudyManagementViewModel {
     }
 
     private func refreshStudyGroupManagementDataInBackground() {
+        // 새로고침 전에 사용자가 스크롤로 로드해 둔 항목 수(로드 윈도우)를 기억한다.
+        // 낙관적 placeholder(`new_`)는 아직 서버에 없으므로 목표 길이 계산에서 제외한다.
+        let targetCount = max(
+            studyGroupDetails.filter { isPersistedServerGroup($0.serverID) }.count,
+            Constants.groupManagementPageSize
+        )
+
         Task { [weak self] in
             guard let self else { return }
 
             do {
-                let firstPage = try await self.useCase.fetchStudyGroupDetailsPage(
-                    cursor: nil,
-                    size: Constants.groupManagementPageSize
-                )
-                self.studyGroupDetails = firstPage.content
-                self.studyGroupDetailsNextCursor = firstPage.nextCursor
-                self.studyGroupDetailsHasNext = firstPage.hasNext
-                self.studyGroupDetailsState = .loaded(firstPage.content)
+                // 첫 페이지만 덮어써 뒤쪽 페이지를 잘라내던 문제를 방지한다.
+                // 첫 페이지부터 다시 페이지네이션해 기존 로드 윈도우 길이를 복원한다.
+                var restored: [StudyGroupInfo] = []
+                var seenServerIDs = Set<String>()
+                var cursor: String?
+                var hasNext = true
+
+                repeat {
+                    let page = try await self.useCase.fetchStudyGroupDetailsPage(
+                        cursor: cursor,
+                        size: Constants.groupManagementPageSize
+                    )
+                    for group in page.content {
+                        guard seenServerIDs.insert(group.serverID).inserted else { continue }
+                        restored.append(group)
+                    }
+                    cursor = page.nextCursor
+                    hasNext = page.hasNext
+                } while hasNext && restored.count < targetCount
+
+                self.studyGroupDetails = restored
+                self.studyGroupDetailsNextCursor = cursor
+                self.studyGroupDetailsHasNext = hasNext
+                self.studyGroupDetailsState = .loaded(restored)
             } catch {
                 // 생성 자체는 성공했으나 목록 재동기화에 실패한 경우.
                 // 낙관적 `new_` placeholder 가 남아 관리(수정/삭제)가 막히므로,

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
@@ -1,0 +1,888 @@
+//
+//  OperatorStudyManagementViewModel.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 6/27/26.
+//
+
+import ActivityDomain
+import CoreDomain
+import Foundation
+import UMCFoundation
+
+/// 운영진 스터디 관리 화면의 상태를 관리하는 ViewModel
+///
+/// 스터디 그룹 CRUD(생성/수정/삭제) 및 멘토·멤버 변경을 처리합니다.
+/// 모든 액션은 `OperatorStudyManagementUseCaseProtocol` 에만 의존하며(Repository 직접 의존 금지),
+/// 서버 식별자는 전 레이어 `String` 으로 통일합니다.
+@MainActor
+@Observable
+final class OperatorStudyManagementViewModel {
+
+    // MARK: - Property
+
+    private enum Constants {
+        static let groupManagementPageSize = 20
+        /// 낙관적 삽입으로 만든 로컬 placeholder 그룹의 serverID 접두사.
+        /// 서버 호출 대상이 아님을 구분하는 표식 — 백그라운드 새로고침으로 곧 교체됩니다.
+        static let localGroupIDPrefix = "new_"
+    }
+
+    private let errorHandler: ErrorHandler
+    private let useCase: OperatorStudyManagementUseCaseProtocol
+
+    /// 현재 사용자 기수 ID 제공자 (서버 응답 `String`) — 테스트에서 주입 가능.
+    private let gisuIdProvider: () -> String?
+
+    /// 스터디 그룹 관리 로딩 상태
+    private(set) var studyGroupDetailsState: Loadable<[StudyGroupInfo]> = .idle
+
+    /// 스터디 그룹 관리 상태
+    private(set) var studyGroupDetails: [StudyGroupInfo] = []
+
+    /// 스터디 그룹 목록 추가 페이지 로딩 여부
+    private(set) var isLoadingMoreStudyGroupDetails = false
+
+    /// 편집 중인 그룹 (시트 표시용)
+    var editingGroup: StudyGroupInfo?
+
+    /// 편집 시트 이름 입력 상태
+    var editingName: String = ""
+
+    /// 멤버 추가 대상 그룹 (시트 표시용)
+    var addMemberGroup: StudyGroupInfo?
+
+    /// 멤버 변경 API 호출 대상 그룹 (시트 dismiss 이후 사용)
+    private var memberUpdateTargetGroup: StudyGroupInfo?
+
+    /// 시트에서 선택된 챌린저 목록
+    var selectedChallengers: [ChallengerInfo] = []
+
+    /// 멘토 추가 대상 그룹 (시트 표시용)
+    var addMentorGroup: StudyGroupInfo?
+
+    /// 멘토 변경 API 호출 대상 그룹 (시트 dismiss 이후 사용)
+    private var mentorUpdateTargetGroup: StudyGroupInfo?
+
+    /// 멘토 시트에서 선택된 챌린저 목록
+    var selectedMentors: [ChallengerInfo] = []
+
+    /// 확인 다이얼로그
+    var alertPrompt: AlertPrompt?
+
+    /// 스터디 그룹 상세 목록 다음 페이지 커서 (서버 응답 `String`)
+    private var studyGroupDetailsNextCursor: String?
+
+    /// 스터디 그룹 상세 목록 다음 페이지 존재 여부
+    private var studyGroupDetailsHasNext = false
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - errorHandler: 전역 에러 핸들러
+    ///   - useCase: 운영진 스터디 관리 UseCase
+    ///   - gisuIdProvider: 현재 기수 ID 제공자 (기본값: `AppStorageKey.gisuId` 저장값)
+    init(
+        errorHandler: ErrorHandler,
+        useCase: OperatorStudyManagementUseCaseProtocol,
+        gisuIdProvider: @escaping () -> String? = {
+            OperatorStudyManagementViewModel.storedGisuId()
+        }
+    ) {
+        self.errorHandler = errorHandler
+        self.useCase = useCase
+        self.gisuIdProvider = gisuIdProvider
+    }
+
+    // MARK: - Function (조회 / 페이지네이션)
+
+    /// 스터디 그룹 관리 탭 진입 시 그룹 목록 및 상세 조회
+    func fetchGroupManagementData() async {
+        studyGroupDetailsState = .loading
+        isLoadingMoreStudyGroupDetails = false
+        studyGroupDetailsNextCursor = nil
+        studyGroupDetailsHasNext = false
+
+        do {
+            let firstPage = try await useCase.fetchStudyGroupDetailsPage(
+                cursor: nil,
+                size: Constants.groupManagementPageSize
+            )
+            studyGroupDetails = firstPage.content
+            studyGroupDetailsNextCursor = firstPage.nextCursor
+            studyGroupDetailsHasNext = firstPage.hasNext
+            studyGroupDetailsState = .loaded(studyGroupDetails)
+        } catch let error as AppError {
+            studyGroupDetailsState = .failed(error)
+        } catch let error as DomainError {
+            studyGroupDetailsState = .failed(.domain(error))
+        } catch let error as NetworkError {
+            studyGroupDetailsState = .failed(.network(error))
+        } catch let error as RepositoryError {
+            studyGroupDetailsState = .failed(.repository(error))
+        } catch {
+            studyGroupDetailsState = .failed(.unknown(
+                message: "스터디 그룹 관리 데이터를 불러오지 못했습니다."
+            ))
+        }
+    }
+
+    /// 스터디 그룹 관리 목록 마지막 카드 도달 시 다음 페이지를 로드합니다.
+    /// - Parameter currentGroupID: 현재 표시된 카드의 로컬 식별자
+    func loadMoreGroupManagementDataIfNeeded(currentGroupID: UUID) async {
+        guard case .loaded = studyGroupDetailsState else { return }
+        guard studyGroupDetails.last?.id == currentGroupID else { return }
+        guard studyGroupDetailsHasNext else { return }
+        guard !isLoadingMoreStudyGroupDetails else { return }
+
+        isLoadingMoreStudyGroupDetails = true
+        defer { isLoadingMoreStudyGroupDetails = false }
+
+        do {
+            let nextPage = try await useCase.fetchStudyGroupDetailsPage(
+                cursor: studyGroupDetailsNextCursor,
+                size: Constants.groupManagementPageSize
+            )
+
+            let existingServerIDs = Set(studyGroupDetails.map(\.serverID))
+            let newGroups = nextPage.content.filter {
+                !existingServerIDs.contains($0.serverID)
+            }
+            if !newGroups.isEmpty {
+                studyGroupDetails.append(contentsOf: newGroups)
+                studyGroupDetailsState = .loaded(studyGroupDetails)
+            }
+
+            studyGroupDetailsNextCursor = nextPage.nextCursor
+            studyGroupDetailsHasNext = nextPage.hasNext
+        } catch let error as DomainError {
+            presentAlert(title: "불러오지 못했어요", message: error.userMessage)
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "fetchMoreStudyGroupManagement"
+            ))
+        }
+    }
+
+    // MARK: - Function (멤버 / 멘토 변경)
+
+    /// Sheet dismiss 시 호출 — 변경된 스터디원 목록을 서버에 반영
+    func applySelectedChallengers() async {
+        guard let targetGroup = memberUpdateTargetGroup,
+              let index = studyGroupDetails.firstIndex(
+                  where: { $0.id == targetGroup.id }
+              )
+        else {
+            resetMemberSelection()
+            return
+        }
+
+        guard isPersistedServerGroup(targetGroup.serverID) else {
+            presentAlert(title: "변경 실패", message: "유효하지 않은 그룹 ID입니다.")
+            resetMemberSelection()
+            return
+        }
+        let serverGroupId = targetGroup.serverID
+
+        let currentChallengerIDs = Set(
+            studyGroupDetails[index].members
+                .compactMap(\.challengerID)
+                .filter(Self.isUsableID)
+        )
+        let resolvedChallengerIDs = await resolveChallengerIDs(from: selectedChallengers)
+        let unresolvedCount = selectedChallengers.count - resolvedChallengerIDs.count
+        guard unresolvedCount == 0 else {
+            presentAlert(
+                title: "변경 실패",
+                message: "선택한 멤버의 챌린저 ID를 확인하지 못했습니다. 다시 시도해 주세요."
+            )
+            resetMemberSelection()
+            return
+        }
+        let updatedChallengerIDs = Set(
+            selectedChallengers
+                .compactMap { resolvedChallengerIDs[$0.selectionKey] }
+                .filter(Self.isUsableID)
+        )
+
+        if currentChallengerIDs == updatedChallengerIDs {
+            resetMemberSelection()
+            return
+        }
+
+        let toAdd = updatedChallengerIDs.subtracting(currentChallengerIDs)
+        let toRemove = currentChallengerIDs.subtracting(updatedChallengerIDs)
+
+        let failures = await applyMembershipChanges(
+            groupId: serverGroupId,
+            toAdd: toAdd,
+            toRemove: toRemove,
+            add: useCase.addStudyGroupMember,
+            remove: useCase.removeStudyGroupMember,
+            addFailureMessage: "멤버 추가 실패",
+            removeFailureMessage: "멤버 제거 실패"
+        )
+
+        if failures.isEmpty {
+            studyGroupDetails[index].members = selectedChallengers.map {
+                studyGroupMember(from: $0, resolvedChallengerIDs: resolvedChallengerIDs)
+            }
+        } else {
+            presentAlert(
+                title: "일부 변경 실패",
+                message: failures.joined(separator: "\n")
+            )
+            refreshStudyGroupManagementDataInBackground()
+        }
+
+        resetMemberSelection()
+    }
+
+    /// 멘토 시트 dismiss 시 호출 — 변경된 멘토 목록을 서버에 반영
+    func applySelectedMentors() async {
+        guard let targetGroup = mentorUpdateTargetGroup,
+              let index = studyGroupDetails.firstIndex(
+                  where: { $0.id == targetGroup.id }
+              )
+        else {
+            resetMentorSelection()
+            return
+        }
+
+        guard isPersistedServerGroup(targetGroup.serverID) else {
+            presentAlert(title: "변경 실패", message: "유효하지 않은 그룹 ID입니다.")
+            resetMentorSelection()
+            return
+        }
+        let serverGroupId = targetGroup.serverID
+
+        guard !selectedMentors.isEmpty else {
+            presentAlert(title: "변경 실패", message: "최소 1명의 멘토가 필요합니다.")
+            resetMentorSelection()
+            return
+        }
+
+        let currentChallengerIDs = Set(
+            studyGroupDetails[index].mentors
+                .compactMap(\.challengerID)
+                .filter(Self.isUsableID)
+        )
+        let resolvedChallengerIDs = await resolveChallengerIDs(from: selectedMentors)
+        let unresolvedCount = selectedMentors.count - resolvedChallengerIDs.count
+        guard unresolvedCount == 0 else {
+            presentAlert(
+                title: "변경 실패",
+                message: "선택한 멘토의 챌린저 ID를 확인하지 못했습니다. 다시 시도해 주세요."
+            )
+            resetMentorSelection()
+            return
+        }
+        let updatedChallengerIDs = Set(
+            selectedMentors
+                .compactMap { resolvedChallengerIDs[$0.selectionKey] }
+                .filter(Self.isUsableID)
+        )
+
+        if currentChallengerIDs == updatedChallengerIDs {
+            resetMentorSelection()
+            return
+        }
+
+        let toAdd = updatedChallengerIDs.subtracting(currentChallengerIDs)
+        let toRemove = currentChallengerIDs.subtracting(updatedChallengerIDs)
+
+        let failures = await applyMembershipChanges(
+            groupId: serverGroupId,
+            toAdd: toAdd,
+            toRemove: toRemove,
+            add: useCase.addStudyGroupMentor,
+            remove: useCase.removeStudyGroupMentor,
+            addFailureMessage: "멘토 추가 실패",
+            removeFailureMessage: "멘토 제거 실패"
+        )
+
+        if failures.isEmpty {
+            studyGroupDetails[index].mentors = selectedMentors.map {
+                studyGroupMember(
+                    from: $0,
+                    resolvedChallengerIDs: resolvedChallengerIDs,
+                    role: .leader
+                )
+            }
+        } else {
+            presentAlert(
+                title: "일부 변경 실패",
+                message: failures.joined(separator: "\n")
+            )
+            refreshStudyGroupManagementDataInBackground()
+        }
+
+        resetMentorSelection()
+    }
+
+    /// 멤버 단건 삭제 (chip context menu)
+    func removeMember(_ member: StudyGroupMember, from group: StudyGroupInfo) async {
+        guard isPersistedServerGroup(group.serverID),
+              let challengerId = member.challengerID, Self.isUsableID(challengerId),
+              let index = studyGroupDetails.firstIndex(where: { $0.id == group.id })
+        else {
+            presentAlert(title: "삭제 실패", message: "유효하지 않은 식별자입니다.")
+            return
+        }
+
+        do {
+            try await useCase.removeStudyGroupMember(
+                groupId: group.serverID,
+                memberId: challengerId
+            )
+            studyGroupDetails[index].members.removeAll { $0.id == member.id }
+        } catch let error as DomainError {
+            presentAlert(title: "삭제 실패", message: error.userMessage)
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "removeStudyGroupMember"
+            ))
+        }
+    }
+
+    /// 멘토 단건 삭제 (chip context menu)
+    ///
+    /// 마지막 멘토 삭제는 차단합니다.
+    func removeMentor(_ mentor: StudyGroupMember, from group: StudyGroupInfo) async {
+        guard let index = studyGroupDetails.firstIndex(where: { $0.id == group.id }) else {
+            return
+        }
+
+        guard studyGroupDetails[index].mentors.count > 1 else {
+            presentAlert(title: "삭제 불가", message: "최소 1명의 멘토는 유지되어야 합니다.")
+            return
+        }
+
+        guard isPersistedServerGroup(group.serverID),
+              let challengerId = mentor.challengerID, Self.isUsableID(challengerId)
+        else {
+            presentAlert(title: "삭제 실패", message: "유효하지 않은 식별자입니다.")
+            return
+        }
+
+        do {
+            try await useCase.removeStudyGroupMentor(
+                groupId: group.serverID,
+                mentorId: challengerId
+            )
+            studyGroupDetails[index].mentors.removeAll { $0.id == mentor.id }
+        } catch let error as DomainError {
+            presentAlert(title: "삭제 실패", message: error.userMessage)
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "removeStudyGroupMentor"
+            ))
+        }
+    }
+
+    // MARK: - Function (그룹 CRUD)
+
+    /// 그룹 이름 수정 적용
+    /// - Parameters:
+    ///   - groupID: 수정할 그룹 ID
+    ///   - name: 새 그룹명
+    func updateGroup(groupID: UUID, name: String) async -> Bool {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            presentAlert(title: "수정 실패", message: "그룹 이름을 입력해 주세요.")
+            return false
+        }
+
+        guard let oldGroup = studyGroupDetails.first(where: { $0.id == groupID }) else {
+            presentAlert(title: "수정 실패", message: "그룹 정보를 찾을 수 없습니다.")
+            return false
+        }
+
+        guard isPersistedServerGroup(oldGroup.serverID) else {
+            presentAlert(title: "수정 실패", message: "유효한 그룹 식별자가 아닙니다.")
+            return false
+        }
+
+        do {
+            try await useCase.updateStudyGroup(
+                groupId: oldGroup.serverID,
+                name: trimmedName
+            )
+        } catch let error as DomainError {
+            presentAlert(title: "수정 실패", message: error.userMessage)
+            return false
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "updateStudyGroup"
+            ))
+            return false
+        }
+
+        guard let index = studyGroupDetails.firstIndex(where: { $0.id == groupID }) else {
+            presentAlert(title: "수정 실패", message: "그룹이 삭제되어 수정할 수 없습니다.")
+            return false
+        }
+
+        let old = studyGroupDetails[index]
+        studyGroupDetails[index] = StudyGroupInfo(
+            id: old.id,
+            serverID: old.serverID,
+            name: trimmedName,
+            part: old.part,
+            createdDate: old.createdDate,
+            mentors: old.mentors,
+            members: old.members
+        )
+        return true
+    }
+
+    /// 새 스터디 그룹 생성 (ChallengerInfo → StudyGroupMember 변환)
+    /// - Parameters:
+    ///   - name: 그룹명
+    ///   - part: 파트
+    ///   - mentors: 담당 파트장(멘토) 목록 (1명 이상)
+    ///   - members: 스터디원 목록
+    func createGroup(
+        name: String,
+        part: UMCPartType,
+        mentors: [ChallengerInfo],
+        members: [ChallengerInfo]
+    ) async -> Bool {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            presentAlert(title: "그룹 생성 실패", message: "그룹 이름을 입력해 주세요.")
+            return false
+        }
+
+        guard !mentors.isEmpty else {
+            presentAlert(
+                title: "그룹 생성 실패",
+                message: "최소 1명의 담당 파트장(멘토)이 필요합니다."
+            )
+            return false
+        }
+
+        guard let gisuId = gisuIdProvider(), Self.isUsableID(gisuId) else {
+            presentAlert(
+                title: "그룹 생성 실패",
+                message: "현재 기수 정보를 확인할 수 없습니다."
+            )
+            return false
+        }
+
+        let resolvedChallengerIDs = await resolveChallengerIDs(from: mentors + members)
+
+        let unresolvedMentor = mentors.contains {
+            resolvedChallengerIDs[$0.selectionKey] == nil
+        }
+        guard !unresolvedMentor else {
+            presentAlert(
+                title: "그룹 생성 실패",
+                message: "선택한 멘토의 챌린저 ID를 확인하지 못했습니다. 다시 시도해 주세요."
+            )
+            return false
+        }
+
+        let unresolvedMemberExists = members.contains {
+            resolvedChallengerIDs[$0.selectionKey] == nil
+        }
+        guard !unresolvedMemberExists else {
+            presentAlert(
+                title: "그룹 생성 실패",
+                message: "초대한 멤버의 챌린저 ID를 확인하지 못했습니다. 다시 시도해 주세요."
+            )
+            return false
+        }
+
+        let mentorIds = mentors.compactMap { resolvedChallengerIDs[$0.selectionKey] }
+        let memberIds = members
+            .compactMap { resolvedChallengerIDs[$0.selectionKey] }
+            .filter { !mentorIds.contains($0) }
+
+        do {
+            try await useCase.createStudyGroup(
+                gisuId: gisuId,
+                name: trimmedName,
+                part: part,
+                memberIds: memberIds,
+                mentorIds: mentorIds
+            )
+            appendCreatedGroupToLocalState(
+                name: trimmedName,
+                part: part,
+                mentors: mentors,
+                members: members,
+                resolvedChallengerIDs: resolvedChallengerIDs
+            )
+            refreshStudyGroupManagementDataInBackground()
+
+            return true
+        } catch let error as DomainError {
+            presentAlert(title: "그룹 생성 실패", message: error.userMessage)
+            return false
+        } catch let error as NetworkError {
+            if presentStudyGroupCreateAlert(from: error) {
+                return false
+            }
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "createStudyGroup"
+            ))
+            return false
+        } catch let error as RepositoryError {
+            if presentStudyGroupCreateAlert(from: error) {
+                return false
+            }
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "createStudyGroup"
+            ))
+            return false
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "createStudyGroup"
+            ))
+            return false
+        }
+    }
+
+    /// 그룹 삭제 API 호출
+    func deleteGroup(_ group: StudyGroupInfo) async {
+        guard isPersistedServerGroup(group.serverID) else {
+            presentAlert(title: "삭제 실패", message: "유효하지 않은 그룹 ID입니다.")
+            return
+        }
+
+        do {
+            try await useCase.deleteStudyGroup(groupId: group.serverID)
+            removeGroupFromLocalState(group.serverID)
+        } catch let error as DomainError {
+            presentAlert(title: "삭제 실패", message: error.userMessage)
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "deleteStudyGroup"
+            ))
+        }
+    }
+
+    // MARK: - Function (시트 표시)
+
+    /// 그룹 편집 시트 표시
+    func showEditSheet(for group: StudyGroupInfo) {
+        editingName = group.name
+        editingGroup = group
+    }
+
+    /// 멤버 추가 시트 표시
+    func showAddMemberSheet(for group: StudyGroupInfo) {
+        memberUpdateTargetGroup = group
+        selectedChallengers = group.members.map { challengerInfo(from: $0, part: group.part) }
+        addMemberGroup = group
+    }
+
+    /// 멘토 추가 시트 표시
+    func showAddMentorSheet(for group: StudyGroupInfo) {
+        mentorUpdateTargetGroup = group
+        selectedMentors = group.mentors.map { challengerInfo(from: $0, part: group.part) }
+        addMentorGroup = group
+    }
+
+    // MARK: - Private (챌린저 ID 해석)
+
+    private func resolveChallengerIDs(
+        from challengers: [ChallengerInfo]
+    ) async -> [String: String] {
+        var resolved: [String: String] = [:]
+        for challenger in challengers {
+            if let id = await resolveChallengerID(for: challenger) {
+                resolved[challenger.selectionKey] = id
+            }
+        }
+        return resolved
+    }
+
+    private func resolveChallengerID(for challenger: ChallengerInfo) async -> String? {
+        // memberId 와 다른 명시적 챌린저 ID 가 있으면 그대로 사용
+        let hasDistinctChallengerID = Self.isUsableID(challenger.challengerId)
+            && challenger.challengerId != challenger.memberId
+        if hasDistinctChallengerID {
+            return challenger.challengerId
+        }
+
+        do {
+            if let resolvedID = try await useCase.resolveChallengerId(
+                memberId: challenger.memberId,
+                preferredGeneration: challenger.gen.isEmpty ? nil : challenger.gen
+            ), Self.isUsableID(resolvedID) {
+                return resolvedID
+            }
+        } catch {
+            // 해석 실패는 무시하고 폴백으로 진행
+        }
+
+        // memberId 가 유효하지 않으면 challengerId 폴백
+        if !Self.isUsableID(challenger.memberId), Self.isUsableID(challenger.challengerId) {
+            return challenger.challengerId
+        }
+
+        return nil
+    }
+
+    // MARK: - Private (로컬 상태 반영)
+
+    private func appendCreatedGroupToLocalState(
+        name: String,
+        part: UMCPartType,
+        mentors: [ChallengerInfo],
+        members: [ChallengerInfo],
+        resolvedChallengerIDs: [String: String]
+    ) {
+        let localServerID = "\(Constants.localGroupIDPrefix)\(UUID().uuidString)"
+        let mentorMembers: [StudyGroupMember] = mentors.map { mentor in
+            studyGroupMember(
+                from: mentor,
+                resolvedChallengerIDs: resolvedChallengerIDs,
+                role: .leader
+            )
+        }
+        let mentorMemberIds = Set(mentors.map(\.memberId))
+        let localGroup = StudyGroupInfo(
+            serverID: localServerID,
+            name: name,
+            part: part,
+            createdDate: Date(),
+            mentors: mentorMembers,
+            members: members.compactMap { challenger in
+                guard !mentorMemberIds.contains(challenger.memberId) else { return nil }
+                return studyGroupMember(
+                    from: challenger,
+                    resolvedChallengerIDs: resolvedChallengerIDs
+                )
+            }
+        )
+
+        switch studyGroupDetailsState {
+        case .loaded:
+            studyGroupDetails.insert(localGroup, at: 0)
+            studyGroupDetailsState = .loaded(studyGroupDetails)
+        case .idle:
+            studyGroupDetails = [localGroup]
+            studyGroupDetailsState = .loaded(studyGroupDetails)
+        case .loading, .failed:
+            break
+        }
+    }
+
+    private func refreshStudyGroupManagementDataInBackground() {
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let firstPage = try await self.useCase.fetchStudyGroupDetailsPage(
+                    cursor: nil,
+                    size: Constants.groupManagementPageSize
+                )
+                self.studyGroupDetails = firstPage.content
+                self.studyGroupDetailsNextCursor = firstPage.nextCursor
+                self.studyGroupDetailsHasNext = firstPage.hasNext
+                self.studyGroupDetailsState = .loaded(firstPage.content)
+            } catch {
+                // 생성 자체는 성공했으나 목록 재동기화에 실패한 경우.
+                // 낙관적 `new_` placeholder 가 남아 관리(수정/삭제)가 막히므로,
+                // 실패를 삼키지 않고 사용자에게 노출해 수동 새로고침을 유도한다.
+                self.errorHandler.handle(error, context: ErrorContext(
+                    feature: "Activity",
+                    action: "refreshStudyGroupManagementAfterCreate"
+                ))
+            }
+        }
+    }
+
+    /// 삭제 성공 후 로컬 상태에서 그룹 삭제 반영
+    private func removeGroupFromLocalState(_ serverID: String) {
+        studyGroupDetails.removeAll { $0.serverID == serverID }
+        studyGroupDetailsState = .loaded(studyGroupDetails)
+    }
+
+    // MARK: - Private (그룹 생성 실패 메시지)
+
+    private func presentStudyGroupCreateAlert(from error: NetworkError) -> Bool {
+        guard case .requestFailed(let statusCode, let data) = error else {
+            return false
+        }
+
+        let message = studyGroupCreateFailureMessage(statusCode: statusCode, data: data)
+            ?? decodeServerMessage(from: data)
+
+        guard let message else { return false }
+
+        presentAlert(title: "그룹 생성 실패", message: message)
+        return true
+    }
+
+    private func presentStudyGroupCreateAlert(from error: RepositoryError) -> Bool {
+        guard case .serverError(_, let message) = error,
+              let message,
+              !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+
+        presentAlert(title: "그룹 생성 실패", message: message)
+        return true
+    }
+
+    private func studyGroupCreateFailureMessage(
+        statusCode: Int,
+        data: Data?
+    ) -> String? {
+        guard statusCode == 403 else { return nil }
+
+        let payload = decodeServerErrorPayload(from: data)
+        let errorCode = payload?.code?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        // 권한 안내 메시지는 `AUTHORIZATION-0002` 한 코드에만 적용한다.
+        // 다른 403 코드는 nil 을 반환해 호출부가 서버 메시지 fallback 으로 처리하게 한다.
+        guard errorCode == "AUTHORIZATION-0002" else {
+            return nil
+        }
+
+        return """
+        현재 계정 권한으로는 스터디 그룹을 생성할 수 없습니다.
+        서버 권한 수정 전까지 총괄 계정에서는 생성이 제한될 수 있습니다.
+        """
+    }
+
+    private func decodeServerMessage(from data: Data?) -> String? {
+        let payload = decodeServerErrorPayload(from: data)
+        let message = payload?.message ?? payload?.result ?? payload?.error
+        let trimmed = message?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func decodeServerErrorPayload(from data: Data?) -> ServerErrorPayload? {
+        guard let data,
+              let payload = try? JSONDecoder().decode(ServerErrorPayload.self, from: data) else {
+            return nil
+        }
+        return payload
+    }
+
+    private struct ServerErrorPayload: Decodable {
+        let code: String?
+        let message: String?
+        let result: String?
+        let error: String?
+    }
+
+    // MARK: - Private (Helper)
+
+    /// 멤버/멘토 추가·제거를 순차 적용하고 실패 메시지를 모읍니다.
+    /// `add`/`remove` 는 대상 UseCase 메서드(`(groupId, challengerId)`)이며,
+    /// 실패 시 도메인 메시지 또는 기본 메시지를 누적해 반환합니다.
+    private func applyMembershipChanges(
+        groupId: String,
+        toAdd: Set<String>,
+        toRemove: Set<String>,
+        add: (String, String) async throws -> Void,
+        remove: (String, String) async throws -> Void,
+        addFailureMessage: String,
+        removeFailureMessage: String
+    ) async -> [String] {
+        var failures: [String] = []
+        for challengerId in toAdd {
+            do {
+                try await add(groupId, challengerId)
+            } catch let error as DomainError {
+                failures.append(error.userMessage)
+            } catch {
+                failures.append(addFailureMessage)
+            }
+        }
+        for challengerId in toRemove {
+            do {
+                try await remove(groupId, challengerId)
+            } catch let error as DomainError {
+                failures.append(error.userMessage)
+            } catch {
+                failures.append(removeFailureMessage)
+            }
+        }
+        return failures
+    }
+
+    /// 유효한 서버 식별자(비어있지 않고 `"0"` 이 아님) 여부.
+    /// 레거시 `Int > 0` 판정을 `String` 세계로 옮긴 것 — `"0"`/빈 문자열은 미해석 ID 로 간주.
+    private static func isUsableID(_ id: String) -> Bool {
+        !id.isEmpty && id != "0"
+    }
+
+    /// 서버에 실재하는 그룹인지 — 낙관적 삽입 placeholder 는 서버 호출 대상이 아님.
+    private func isPersistedServerGroup(_ serverID: String) -> Bool {
+        !serverID.isEmpty && !serverID.hasPrefix(Constants.localGroupIDPrefix)
+    }
+
+    private func presentAlert(title: String, message: String) {
+        alertPrompt = AlertPrompt(
+            title: title,
+            message: message,
+            positiveBtnTitle: "확인"
+        )
+    }
+
+    private func resetMemberSelection() {
+        selectedChallengers = []
+        memberUpdateTargetGroup = nil
+    }
+
+    private func resetMentorSelection() {
+        selectedMentors = []
+        mentorUpdateTargetGroup = nil
+    }
+
+    private func challengerInfo(
+        from member: StudyGroupMember,
+        part: UMCPartType
+    ) -> ChallengerInfo {
+        ChallengerInfo(
+            memberId: member.memberID ?? member.serverID,
+            challengerId: member.challengerID ?? member.memberID ?? member.serverID,
+            gen: "",
+            name: member.name,
+            nickname: member.nickname ?? member.name,
+            schoolName: member.university,
+            profileImage: member.profileImageURL,
+            part: part
+        )
+    }
+
+    private func studyGroupMember(
+        from challenger: ChallengerInfo,
+        resolvedChallengerIDs: [String: String],
+        role: StudyGroupMember.MemberRole = .member
+    ) -> StudyGroupMember {
+        StudyGroupMember(
+            serverID: challenger.memberId,
+            challengerID: resolvedChallengerIDs[challenger.selectionKey],
+            memberID: challenger.memberId,
+            name: challenger.name,
+            nickname: challenger.nickname,
+            university: challenger.schoolName,
+            profileImageURL: challenger.profileImage,
+            role: role
+        )
+    }
+
+    private nonisolated static func storedGisuId(_ defaults: UserDefaults = .standard) -> String? {
+        if let value = defaults.string(forKey: AppStorageKey.gisuId), !value.isEmpty {
+            return value
+        }
+        let legacyInt = defaults.integer(forKey: AppStorageKey.gisuId)
+        return legacyInt > 0 ? String(legacyInt) : nil
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
@@ -717,7 +717,13 @@ final class OperatorStudyManagementViewModel {
             return false
         }
 
-        let message = studyGroupCreateFailureMessage(statusCode: statusCode, data: data)
+        // 로컬 Alert 로 소화하는 대상은 403(권한) 에러뿐이다.
+        // 그 외 상태코드(401 세션 만료·404·409·5xx 등)는 서버 응답 본문에 message 필드가
+        // 있더라도 여기서 처리하지 않고 false 를 반환해, 호출부가 errorHandler(로깅/세션 처리)로
+        // 흘려보내도록 한다.
+        guard statusCode == 403 else { return false }
+
+        let message = authorizationFailureMessage(from: data)
             ?? decodeServerMessage(from: data)
 
         guard let message else { return false }
@@ -737,17 +743,15 @@ final class OperatorStudyManagementViewModel {
         return true
     }
 
-    private func studyGroupCreateFailureMessage(
-        statusCode: Int,
-        data: Data?
-    ) -> String? {
-        guard statusCode == 403 else { return nil }
-
+    /// 403 그룹 생성 실패 중 `AUTHORIZATION-0002` 코드에 대한 권한 안내 메시지.
+    ///
+    /// 호출부(`presentStudyGroupCreateAlert(from:)`)가 이미 `statusCode == 403` 을 보장하므로
+    /// 여기서는 에러 코드만 판별한다. 다른 403 코드는 nil 을 반환해, 호출부가 서버 메시지
+    /// fallback(`decodeServerMessage`)으로 처리하게 한다.
+    private func authorizationFailureMessage(from data: Data?) -> String? {
         let payload = decodeServerErrorPayload(from: data)
         let errorCode = payload?.code?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-        // 권한 안내 메시지는 `AUTHORIZATION-0002` 한 코드에만 적용한다.
-        // 다른 403 코드는 nil 을 반환해 호출부가 서버 메시지 fallback 으로 처리하게 한다.
         guard errorCode == "AUTHORIZATION-0002" else {
             return nil
         }

--- a/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
@@ -90,6 +90,21 @@ private func makeViewModel(
     )
 }
 
+/// 백그라운드 새로고침처럼 fire-and-forget `Task` 가 완료될 때까지 조건을 폴링한다.
+/// mock 은 실제 I/O 지연이 없어 몇 번의 yield 로 끝난다. `maxYields` 는 무한 루프 방지 상한.
+@MainActor
+private func drainUntil(
+    _ viewModel: OperatorStudyManagementViewModel,
+    maxYields: Int = 10_000,
+    _ condition: (OperatorStudyManagementViewModel) -> Bool
+) async {
+    var yields = 0
+    while !condition(viewModel), yields < maxYields {
+        await Task.yield()
+        yields += 1
+    }
+}
+
 private struct DummyError: Error {}
 
 // MARK: - Mock
@@ -258,6 +273,45 @@ struct OperatorStudyManagementViewModelLoadTests {
         await viewModel.loadMoreGroupManagementDataIfNeeded(currentGroupID: UUID())
 
         #expect(useCase.fetchPageCalls.count == 1)
+    }
+
+    @Test("생성 후 백그라운드 새로고침 — 로드된 페이지 윈도우를 복원해 첫 페이지로 잘리지 않는다")
+    func refreshRestoresLoadedPageWindowAfterCreate() async throws {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let page1 = (1...20).map { makeGroup(serverID: "G-\($0)") }
+        let page2 = (21...40).map { makeGroup(serverID: "G-\($0)") }
+        // 페이지 소비 순서: [최초 조회][loadMore][새로고침 1p][새로고침 2p]
+        useCase.pageResults = [
+            makePage(content: page1, hasNext: true, nextCursor: "c1"),
+            makePage(content: page2, hasNext: false),
+            makePage(content: page1, hasNext: true, nextCursor: "c1"),
+            makePage(content: page2, hasNext: false)
+        ]
+        let viewModel = makeViewModel(useCase: useCase, gisuId: "11")
+
+        // 사용자가 2페이지(40개)까지 스크롤한 상태 재현
+        await viewModel.fetchGroupManagementData()
+        let lastCard = try #require(viewModel.studyGroupDetails.last)
+        await viewModel.loadMoreGroupManagementDataIfNeeded(currentGroupID: lastCard.id)
+        #expect(viewModel.studyGroupDetails.count == 40)
+
+        // 그룹 생성 → 백그라운드 새로고침 트리거
+        let created = await viewModel.createGroup(
+            name: "새 스터디",
+            part: .front(type: .ios),
+            mentors: [makeChallenger(memberId: "9", challengerId: "909")],
+            members: []
+        )
+        #expect(created == true)
+
+        // 새로고침 Task 가 placeholder 를 서버 데이터로 교체할 때까지 대기
+        await drainUntil(viewModel) { vm in
+            !vm.studyGroupDetails.contains { $0.serverID.hasPrefix("new_") }
+        }
+
+        // 첫 페이지(20)로 잘리지 않고 로드 윈도우(40)가 복원돼야 한다.
+        #expect(viewModel.studyGroupDetails.count == 40)
+        #expect(viewModel.studyGroupDetails.map(\.serverID).contains("G-40"))
     }
 }
 

--- a/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
@@ -1,0 +1,612 @@
+//
+//  OperatorStudyManagementViewModelTests.swift
+//  ActivityPresentationTests
+//
+//  Created by jaewon Lee on 6/27/26.
+//
+
+import Foundation
+import Testing
+import ActivityDomain
+import CoreDomain
+import UMCFoundation
+@testable import ActivityPresentation
+
+#if DEBUG
+
+// MARK: - Helpers
+
+private func makeMember(
+    serverID: String,
+    memberID: String? = nil,
+    challengerID: String? = nil,
+    name: String = "챌린저",
+    role: StudyGroupMember.MemberRole = .member
+) -> StudyGroupMember {
+    StudyGroupMember(
+        serverID: serverID,
+        challengerID: challengerID,
+        memberID: memberID ?? serverID,
+        name: name,
+        university: "한성대학교",
+        role: role
+    )
+}
+
+private func makeGroup(
+    serverID: String = "G-1",
+    name: String = "iOS 스터디",
+    part: UMCPartType = .front(type: .ios),
+    mentors: [StudyGroupMember] = [],
+    members: [StudyGroupMember] = []
+) -> StudyGroupInfo {
+    StudyGroupInfo(
+        serverID: serverID,
+        name: name,
+        part: part,
+        createdDate: Date(timeIntervalSince1970: 1_000),
+        mentors: mentors,
+        members: members
+    )
+}
+
+private func makeChallenger(
+    memberId: String,
+    challengerId: String? = nil,
+    gen: String = "",
+    name: String = "챌린저",
+    part: UMCPartType = .front(type: .ios)
+) -> ChallengerInfo {
+    ChallengerInfo(
+        memberId: memberId,
+        challengerId: challengerId,
+        gen: gen,
+        name: name,
+        nickname: name,
+        schoolName: "한성대학교",
+        profileImage: nil,
+        part: part
+    )
+}
+
+private func makePage(
+    content: [StudyGroupInfo],
+    hasNext: Bool = false,
+    nextCursor: String? = nil
+) -> StudyGroupDetailsPage {
+    StudyGroupDetailsPage(content: content, hasNext: hasNext, nextCursor: nextCursor)
+}
+
+@MainActor
+private func makeViewModel(
+    useCase: MockOperatorStudyManagementUseCase,
+    errorHandler: ErrorHandler = ErrorHandler(),
+    gisuId: String? = "11"
+) -> OperatorStudyManagementViewModel {
+    OperatorStudyManagementViewModel(
+        errorHandler: errorHandler,
+        useCase: useCase,
+        gisuIdProvider: { gisuId }
+    )
+}
+
+private struct DummyError: Error {}
+
+// MARK: - Mock
+
+private final class MockOperatorStudyManagementUseCase: @unchecked Sendable,
+    OperatorStudyManagementUseCaseProtocol {
+
+    // 페이지: 호출 순서대로 소비. 모두 소비되면 빈 페이지 반환.
+    var pageResults: [StudyGroupDetailsPage] = []
+    var pageError: Error?
+    private var pageIndex = 0
+    private(set) var fetchPageCalls: [(cursor: String?, size: Int)] = []
+
+    // resolve: memberId → challengerId (없으면 resolveDefault)
+    var resolveMap: [String: String?] = [:]
+    var resolveDefault: String?
+    var resolveError: Error?
+    private(set) var resolveCalls: [(memberId: String, preferredGeneration: String?)] = []
+
+    var createError: Error?
+    private(set) var createCalls: [(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    )] = []
+
+    var updateError: Error?
+    private(set) var updateCalls: [(groupId: String, name: String)] = []
+
+    var deleteError: Error?
+    private(set) var deleteCalls: [String] = []
+
+    var addMemberError: Error?
+    private(set) var addMemberCalls: [(groupId: String, memberId: String)] = []
+    var removeMemberError: Error?
+    private(set) var removeMemberCalls: [(groupId: String, memberId: String)] = []
+    var addMentorError: Error?
+    private(set) var addMentorCalls: [(groupId: String, mentorId: String)] = []
+    var removeMentorError: Error?
+    private(set) var removeMentorCalls: [(groupId: String, mentorId: String)] = []
+
+    func fetchStudyGroupDetailsPage(
+        cursor: String?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage {
+        if let pageError { throw pageError }
+        fetchPageCalls.append((cursor, size))
+        defer { pageIndex += 1 }
+        return pageIndex < pageResults.count
+            ? pageResults[pageIndex]
+            : makePage(content: [])
+    }
+
+    func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: String?
+    ) async throws -> String? {
+        if let resolveError { throw resolveError }
+        resolveCalls.append((memberId, preferredGeneration))
+        if let mapped = resolveMap[memberId] { return mapped }
+        return resolveDefault
+    }
+
+    func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws {
+        if let createError { throw createError }
+        createCalls.append((gisuId, name, part, memberIds, mentorIds))
+    }
+
+    func updateStudyGroup(groupId: String, name: String) async throws {
+        if let updateError { throw updateError }
+        updateCalls.append((groupId, name))
+    }
+
+    func deleteStudyGroup(groupId: String) async throws {
+        if let deleteError { throw deleteError }
+        deleteCalls.append(groupId)
+    }
+
+    func addStudyGroupMember(groupId: String, memberId: String) async throws {
+        if let addMemberError { throw addMemberError }
+        addMemberCalls.append((groupId, memberId))
+    }
+
+    func removeStudyGroupMember(groupId: String, memberId: String) async throws {
+        if let removeMemberError { throw removeMemberError }
+        removeMemberCalls.append((groupId, memberId))
+    }
+
+    func addStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        if let addMentorError { throw addMentorError }
+        addMentorCalls.append((groupId, mentorId))
+    }
+
+    func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        if let removeMentorError { throw removeMentorError }
+        removeMentorCalls.append((groupId, mentorId))
+    }
+}
+
+// MARK: - 그룹 목록 로딩 / 페이지네이션
+
+@MainActor
+@Suite("OperatorStudyManagementViewModel — 그룹 목록 로딩 (도메인 규칙)")
+struct OperatorStudyManagementViewModelLoadTests {
+
+    @Test("최초 조회 성공 → loaded 전이 + 커서/다음 페이지 상태 반영")
+    func fetchSucceedsAndStoresCursor() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let group = makeGroup(serverID: "G-1")
+        useCase.pageResults = [makePage(content: [group], hasNext: true, nextCursor: "10")]
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchGroupManagementData()
+
+        #expect(viewModel.studyGroupDetails.map(\.serverID) == ["G-1"])
+        #expect(viewModel.studyGroupDetailsState == .loaded([group]))
+    }
+
+    @Test("최초 조회 실패(DomainError) → failed(.domain) 전이")
+    func fetchFailsWithDomainError() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        useCase.pageError = DomainError.custom(message: "실패")
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchGroupManagementData()
+
+        #expect(viewModel.studyGroupDetailsState == .failed(.domain(.custom(message: "실패"))))
+    }
+
+    @Test("다음 페이지 — 마지막 카드 도달 시 커서로 추가 로드 + serverID 중복 제거")
+    func loadMoreAppendsDedupedByServerID() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let g1 = makeGroup(serverID: "G-1")
+        let g2 = makeGroup(serverID: "G-2", name: "Web 스터디")
+        useCase.pageResults = [
+            makePage(content: [g1], hasNext: true, nextCursor: "10"),
+            // 2페이지가 g1(중복) + g2 를 반환해도 g2 만 추가돼야 함
+            makePage(content: [g1, g2], hasNext: false, nextCursor: nil)
+        ]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        await viewModel.loadMoreGroupManagementDataIfNeeded(currentGroupID: g1.id)
+
+        #expect(viewModel.studyGroupDetails.map(\.serverID) == ["G-1", "G-2"])
+        #expect(useCase.fetchPageCalls.count == 2)
+        #expect(useCase.fetchPageCalls.last?.cursor == "10")
+    }
+
+    @Test("다음 페이지 — 마지막 카드가 아니면 추가 로드 안 함")
+    func loadMoreSkipsWhenNotLastCard() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let g1 = makeGroup(serverID: "G-1")
+        useCase.pageResults = [makePage(content: [g1], hasNext: true, nextCursor: "10")]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        await viewModel.loadMoreGroupManagementDataIfNeeded(currentGroupID: UUID())
+
+        #expect(useCase.fetchPageCalls.count == 1)
+    }
+}
+
+// MARK: - 그룹 생성
+
+@MainActor
+@Suite("OperatorStudyManagementViewModel — 그룹 생성 (도메인 규칙)")
+struct OperatorStudyManagementViewModelCreateTests {
+
+    @Test(
+        "입력 검증 실패 → 생성 미요청 + Alert",
+        arguments: [
+            (name: "", hasMentor: true, gisuId: "11"),
+            (name: "iOS", hasMentor: false, gisuId: "11"),
+            (name: "iOS", hasMentor: true, gisuId: nil)
+        ]
+    )
+    func createRejectsInvalidInput(
+        name: String,
+        hasMentor: Bool,
+        gisuId: String?
+    ) async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let viewModel = makeViewModel(useCase: useCase, gisuId: gisuId)
+        let mentors = hasMentor ? [makeChallenger(memberId: "9", challengerId: "909")] : []
+
+        let created = await viewModel.createGroup(
+            name: name,
+            part: .front(type: .ios),
+            mentors: mentors,
+            members: []
+        )
+
+        #expect(created == false)
+        #expect(useCase.createCalls.isEmpty)
+        #expect(viewModel.alertPrompt != nil)
+    }
+
+    @Test("생성 성공 → 멘토와 중복된 멤버는 memberIds 에서 제외 + 낙관적 삽입")
+    func createSucceedsAndSplitsMentorMemberIds() async throws {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let viewModel = makeViewModel(useCase: useCase, gisuId: "11")
+        let mentor = makeChallenger(memberId: "9", challengerId: "909")
+        let memberA = makeChallenger(memberId: "1", challengerId: "101")
+        let mentorClone = makeChallenger(memberId: "9", challengerId: "909")
+
+        let created = await viewModel.createGroup(
+            name: "iOS 스터디",
+            part: .front(type: .ios),
+            mentors: [mentor],
+            members: [memberA, mentorClone]
+        )
+
+        #expect(created == true)
+        let call = try #require(useCase.createCalls.first)
+        #expect(call.gisuId == "11")
+        #expect(call.mentorIds == ["909"])
+        #expect(call.memberIds == ["101"])  // 909(멘토)는 제외
+        // 낙관적 삽입: 백그라운드 새로고침 전 상태를 즉시 검증
+        #expect(viewModel.studyGroupDetails.first?.name == "iOS 스터디")
+    }
+
+    @Test("생성 — challengerId 가 memberId 와 같으면 resolve 로 해석")
+    func createResolvesChallengerIdWhenNotDistinct() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        useCase.resolveMap = ["5": "505"]
+        let viewModel = makeViewModel(useCase: useCase, gisuId: "11")
+        // challengerId == memberId → 구분 불가 → resolve 위임
+        let mentor = makeChallenger(memberId: "5", challengerId: "5")
+
+        let created = await viewModel.createGroup(
+            name: "iOS 스터디",
+            part: .front(type: .ios),
+            mentors: [mentor],
+            members: []
+        )
+
+        #expect(created == true)
+        #expect(useCase.resolveCalls.map(\.memberId) == ["5"])
+        #expect(useCase.createCalls.first?.mentorIds == ["505"])
+    }
+
+    @Test("생성 403(AUTHORIZATION) → 권한 안내 Alert + 실패 반환")
+    func createPresentsPermissionAlertOn403() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let body = Data(#"{"code":"AUTHORIZATION-0002"}"#.utf8)
+        useCase.createError = NetworkError.requestFailed(statusCode: 403, data: body)
+        let viewModel = makeViewModel(useCase: useCase, gisuId: "11")
+
+        let created = await viewModel.createGroup(
+            name: "iOS 스터디",
+            part: .front(type: .ios),
+            mentors: [makeChallenger(memberId: "9", challengerId: "909")],
+            members: []
+        )
+
+        #expect(created == false)
+        #expect(viewModel.alertPrompt?.title == "그룹 생성 실패")
+        #expect(viewModel.alertPrompt?.message.hasPrefix("현재 계정 권한으로는") == true)
+    }
+
+    @Test("생성 403 — AUTHORIZATION-0002 가 아닌 코드는 권한 템플릿이 아니라 서버 메시지를 보여준다")
+    func createShowsServerMessageForOther403() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let body = Data(#"{"code":"STUDY-403","message":"이미 존재하는 그룹입니다."}"#.utf8)
+        useCase.createError = NetworkError.requestFailed(statusCode: 403, data: body)
+        let viewModel = makeViewModel(useCase: useCase, gisuId: "11")
+
+        let created = await viewModel.createGroup(
+            name: "iOS 스터디",
+            part: .front(type: .ios),
+            mentors: [makeChallenger(memberId: "9", challengerId: "909")],
+            members: []
+        )
+
+        #expect(created == false)
+        #expect(viewModel.alertPrompt?.message == "이미 존재하는 그룹입니다.")
+        #expect(viewModel.alertPrompt?.message.hasPrefix("현재 계정 권한으로는") == false)
+    }
+}
+
+// MARK: - 그룹 수정 / 삭제
+
+@MainActor
+@Suite("OperatorStudyManagementViewModel — 그룹 수정/삭제 (도메인 규칙)")
+struct OperatorStudyManagementViewModelEditTests {
+
+    @Test("이름 수정 성공 → UseCase 위임 + 로컬 이름 갱신")
+    func updateSucceedsAndUpdatesLocalName() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let group = makeGroup(serverID: "G-1", name: "옛 이름")
+        useCase.pageResults = [makePage(content: [group])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        let updated = await viewModel.updateGroup(groupID: group.id, name: "새 이름")
+
+        #expect(updated == true)
+        #expect(useCase.updateCalls.first?.groupId == "G-1")
+        #expect(viewModel.studyGroupDetails.first?.name == "새 이름")
+    }
+
+    @Test("이름 수정 — 빈 이름은 거부")
+    func updateRejectsEmptyName() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let group = makeGroup(serverID: "G-1")
+        useCase.pageResults = [makePage(content: [group])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        let updated = await viewModel.updateGroup(groupID: group.id, name: "   ")
+
+        #expect(updated == false)
+        #expect(useCase.updateCalls.isEmpty)
+        #expect(viewModel.alertPrompt != nil)
+    }
+
+    @Test("이름 수정 — 낙관적 placeholder 그룹은 서버 호출 차단")
+    func updateRejectsLocalPlaceholderGroup() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let placeholder = makeGroup(serverID: "new_LOCAL")
+        useCase.pageResults = [makePage(content: [placeholder])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        let updated = await viewModel.updateGroup(groupID: placeholder.id, name: "새 이름")
+
+        #expect(updated == false)
+        #expect(useCase.updateCalls.isEmpty)
+    }
+
+    @Test("삭제 성공 → UseCase 위임 + 로컬 목록에서 제거")
+    func deleteSucceedsAndRemovesLocally() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let group = makeGroup(serverID: "G-1")
+        useCase.pageResults = [makePage(content: [group])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        await viewModel.deleteGroup(group)
+
+        #expect(useCase.deleteCalls == ["G-1"])
+        #expect(viewModel.studyGroupDetails.isEmpty)
+    }
+
+    @Test("삭제 — 낙관적 placeholder 그룹은 서버 호출 차단 + Alert")
+    func deleteRejectsLocalPlaceholderGroup() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.deleteGroup(makeGroup(serverID: "new_LOCAL"))
+
+        #expect(useCase.deleteCalls.isEmpty)
+        #expect(viewModel.alertPrompt != nil)
+    }
+}
+
+// MARK: - 멤버 / 멘토 변경
+
+@MainActor
+@Suite("OperatorStudyManagementViewModel — 멤버/멘토 변경 (도메인 규칙)")
+struct OperatorStudyManagementViewModelMembershipTests {
+
+    @Test("멤버 적용 — 추가/제거 diff 만 서버 호출 + 로컬 반영")
+    func applySelectedChallengersSendsOnlyDiff() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let memberA = makeMember(serverID: "1", memberID: "1", challengerID: "101")
+        let memberB = makeMember(serverID: "2", memberID: "2", challengerID: "102")
+        let group = makeGroup(serverID: "G-1", members: [memberA, memberB])
+        useCase.pageResults = [makePage(content: [group])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        viewModel.showAddMemberSheet(for: group)
+        // B 제거, C 추가
+        viewModel.selectedChallengers = [
+            makeChallenger(memberId: "1", challengerId: "101"),
+            makeChallenger(memberId: "3", challengerId: "103")
+        ]
+
+        await viewModel.applySelectedChallengers()
+
+        #expect(useCase.addMemberCalls.map(\.memberId) == ["103"])
+        #expect(useCase.removeMemberCalls.map(\.memberId) == ["102"])
+        #expect(viewModel.studyGroupDetails.first?.members.map(\.memberID) == ["1", "3"])
+    }
+
+    @Test("멤버 적용 — 변경 없음이면 서버 호출 안 함")
+    func applySelectedChallengersSkipsWhenUnchanged() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let memberA = makeMember(serverID: "1", memberID: "1", challengerID: "101")
+        let group = makeGroup(serverID: "G-1", members: [memberA])
+        useCase.pageResults = [makePage(content: [group])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        viewModel.showAddMemberSheet(for: group)
+        // 선택을 그대로 유지 (변경 없음)
+        await viewModel.applySelectedChallengers()
+
+        #expect(useCase.addMemberCalls.isEmpty)
+        #expect(useCase.removeMemberCalls.isEmpty)
+    }
+
+    @Test("멘토 적용 — 추가/제거 diff 만 서버 호출 + 로컬 반영")
+    func applySelectedMentorsSendsOnlyDiff() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let mentorA = makeMember(serverID: "9", memberID: "9", challengerID: "909", role: .leader)
+        let mentorB = makeMember(serverID: "8", memberID: "8", challengerID: "808", role: .leader)
+        let group = makeGroup(serverID: "G-1", mentors: [mentorA, mentorB])
+        useCase.pageResults = [makePage(content: [group])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        viewModel.showAddMentorSheet(for: group)
+        // B(808) 제거, C(707) 추가
+        viewModel.selectedMentors = [
+            makeChallenger(memberId: "9", challengerId: "909"),
+            makeChallenger(memberId: "7", challengerId: "707")
+        ]
+
+        await viewModel.applySelectedMentors()
+
+        #expect(useCase.addMentorCalls.map(\.mentorId) == ["707"])
+        #expect(useCase.removeMentorCalls.map(\.mentorId) == ["808"])
+        #expect(viewModel.studyGroupDetails.first?.mentors.map(\.memberID) == ["9", "7"])
+    }
+
+    @Test("멘토 단건 삭제 — 마지막 멘토는 차단")
+    func removeMentorBlocksLastOne() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let onlyMentor = makeMember(serverID: "9", challengerID: "909", role: .leader)
+        let group = makeGroup(serverID: "G-1", mentors: [onlyMentor])
+        useCase.pageResults = [makePage(content: [group])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        await viewModel.removeMentor(onlyMentor, from: group)
+
+        #expect(useCase.removeMentorCalls.isEmpty)
+        #expect(viewModel.alertPrompt?.title == "삭제 불가")
+        #expect(viewModel.studyGroupDetails.first?.mentors.count == 1)
+    }
+
+    @Test("멘토 단건 삭제 — 2명 이상이면 제거 위임 + 로컬 반영")
+    func removeMentorSucceedsWhenMoreThanOne() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let mentorA = makeMember(serverID: "9", challengerID: "909", role: .leader)
+        let mentorB = makeMember(serverID: "8", challengerID: "808", role: .leader)
+        let group = makeGroup(serverID: "G-1", mentors: [mentorA, mentorB])
+        useCase.pageResults = [makePage(content: [group])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        await viewModel.removeMentor(mentorA, from: group)
+
+        #expect(useCase.removeMentorCalls.map(\.mentorId) == ["909"])
+        #expect(viewModel.studyGroupDetails.first?.mentors.map(\.serverID) == ["8"])
+    }
+
+    @Test("멤버 단건 삭제 — 제거 위임 + 로컬 반영")
+    func removeMemberSucceeds() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let memberA = makeMember(serverID: "1", challengerID: "101")
+        let group = makeGroup(serverID: "G-1", members: [memberA])
+        useCase.pageResults = [makePage(content: [group])]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchGroupManagementData()
+
+        await viewModel.removeMember(memberA, from: group)
+
+        #expect(useCase.removeMemberCalls.map(\.memberId) == ["101"])
+        #expect(viewModel.studyGroupDetails.first?.members.isEmpty == true)
+    }
+}
+
+// MARK: - 시트 표시
+
+@MainActor
+@Suite("OperatorStudyManagementViewModel — 시트 표시 (도메인 규칙)")
+struct OperatorStudyManagementViewModelSheetTests {
+
+    @Test("편집 시트 — 현재 이름을 입력 상태로 시드")
+    func showEditSheetSeedsName() {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+        let group = makeGroup(serverID: "G-1", name: "iOS 스터디")
+
+        viewModel.showEditSheet(for: group)
+
+        #expect(viewModel.editingName == "iOS 스터디")
+        #expect(viewModel.editingGroup?.id == group.id)
+    }
+
+    @Test("멤버 추가 시트 — 기존 멤버를 선택 목록으로 변환")
+    func showAddMemberSheetBuildsSelection() {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+        let members = [
+            makeMember(serverID: "1", memberID: "1", challengerID: "101"),
+            makeMember(serverID: "2", memberID: "2", challengerID: "102")
+        ]
+        let group = makeGroup(serverID: "G-1", members: members)
+
+        viewModel.showAddMemberSheet(for: group)
+
+        #expect(viewModel.selectedChallengers.map(\.memberId) == ["1", "2"])
+        #expect(viewModel.addMemberGroup?.id == group.id)
+    }
+}
+
+#endif

--- a/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
@@ -377,6 +377,29 @@ struct OperatorStudyManagementViewModelCreateTests {
         #expect(viewModel.alertPrompt?.message == "이미 존재하는 그룹입니다.")
         #expect(viewModel.alertPrompt?.message.hasPrefix("현재 계정 권한으로는") == false)
     }
+
+    @Test(
+        "생성 비-403 에러 — 서버 메시지 body 가 있어도 로컬 Alert 로 소화하지 않고 errorHandler 로 전파",
+        arguments: [401, 404, 409, 500]
+    )
+    func createDoesNotSwallowNon403ServerMessage(statusCode: Int) async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        let body = Data(#"{"message":"서버가 내려준 실패 메시지"}"#.utf8)
+        useCase.createError = NetworkError.requestFailed(statusCode: statusCode, data: body)
+        let viewModel = makeViewModel(useCase: useCase, gisuId: "11")
+
+        let created = await viewModel.createGroup(
+            name: "iOS 스터디",
+            part: .front(type: .ios),
+            mentors: [makeChallenger(memberId: "9", challengerId: "909")],
+            members: []
+        )
+
+        #expect(created == false)
+        // 비-403 은 로컬 Alert(권한/서버 메시지)로 소화되지 않아야 한다 → alertPrompt 는 nil,
+        // 에러는 errorHandler 경로로 흘러간다.
+        #expect(viewModel.alertPrompt == nil)
+    }
 }
 
 // MARK: - 그룹 수정 / 삭제

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -7,6 +7,8 @@ let project = featureProject(
     domainDeploymentTargets: .multiplatform(iOS: "26.4", watchOS: "26.4"),
     presentationExtraDependencies: [
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
+        // OperatorStudyManagementViewModel 이 멤버/멘토 선택 입력 타입(ChallengerInfo)을 사용.
+        .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
     ],
     includesDomainTests: true,
     includesDataTests: true,
@@ -17,5 +19,9 @@ let project = featureProject(
         .target(name: "ActivityDomain"),
         .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
     ],
-    includesPresentationTests: true
+    includesPresentationTests: true,
+    presentationTestDependencies: [
+        // VM 테스트가 ChallengerInfo 를 직접 생성하므로 명시 주입.
+        .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
+    ]
 )


### PR DESCRIPTION
resolves #889

## ✨ PR 유형

♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="984" alt="스크린샷 2026-07-10 오후 1 17 47" src="https://github.com/user-attachments/assets/11d12483-3fbb-4918-8293-7880db60f4df" />

<img width="1512" height="984" alt="스크린샷 2026-07-10 오후 1 17 56" src="https://github.com/user-attachments/assets/aa03c01a-b017-48cb-b7f9-8143b1e1c794" />

## 🛠️ 작업내용

레거시 `AppProduct/` 의 `OperatorStudyManagementViewModel` 을 `UMCApp/` Activity 모듈로 이식했습니다.

- **VM 이식** — `@MainActor @Observable`, `OperatorStudyManagementUseCaseProtocol` 에만 의존(Repository 직접 의존 없음). 그룹 CRUD·멤버/멘토 변경·낙관적 삽입·403 권한 안내 포함.
- **신규 UseCase 레이어** — `OperatorStudyManagementUseCase(Protocol)` 를 신설해 `StudyRepository` CRUD 에 위임(기존 `OperatorAttendanceUseCase` 선례와 동형).
- **페이지 커서 전 레이어 `String` 통일** — 서버 `nextCursor` 가 숫자가 아닌 불투명 토큰(`"cursor-2"` 등)일 수 있어 `Int` 변환 시 유실되던 문제를 수정. `StudyRepositoryProtocol`·`StudyRepository`·`MyStudyGroupsQuery` 의 커서/기수를 `String` 으로 통일하고, `Int` 변환은 실제 숫자 비교 연산 시점에만 수행.
- 서버 식별자는 전 레이어 `String`, 단위 테스트는 Swift Testing 으로 작성.

## 📋 추후 진행 상황

- `OperatorStudyManagementViewModel` 책임 분리(선택자/변경자 헬퍼 추출) 리팩터링
- 생성 후 background refresh 실패 경로의 회귀 테스트 보강

## 📌 리뷰 포인트

- `OperatorStudyManagementUseCase` 위임 계층 분리가 적절한지 (기존 `OperatorAttendanceUseCase` 대비)
- 커서 `String` 통일 — `StudyRepository` 내부 페이지네이션 루프와 `MyStudyGroupsQuery` 직렬화가 불투명 토큰을 그대로 보존하는지
- 낙관적 삽입 placeholder(`new_` 접두사) 기반 서버 호출 차단 로직의 분기 일관성(수정/삭제/멤버·멘토 변경)
- 403 / `AUTHORIZATION-0002` 권한 안내 분기와 그 외 403 코드의 서버 메시지 fallback

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
