### PR TITLE
✨ [Feat] 비밀번호 재설정(ResetPassword) 이식 — 이메일 인증 재사용 (Auth 슬라이스 5)

### DIFF
--- a/UMCApp/Core/UIComponents/Sources/Utilities/NavigationModifier.swift
+++ b/UMCApp/Core/UIComponents/Sources/Utilities/NavigationModifier.swift
@@ -45,6 +45,7 @@ public struct NavigationModifier: ViewModifier {
         case detailSchedule = "일정 상세"
         case studyScheduleRegistration = "스터디 일정 등록"
         case communityPostEdit = "게시글 수정"
+        case resetPassword = "비밀번호 재설정"
     }
 
     public func body(content: Content) -> some View {

--- a/UMCApp/Features/Auth/Data/Sources/DTOs/Request/ResetPasswordRequestDTO.swift
+++ b/UMCApp/Features/Auth/Data/Sources/DTOs/Request/ResetPasswordRequestDTO.swift
@@ -1,0 +1,14 @@
+/// 비밀번호 재설정 요청 DTO
+///
+/// `PATCH /api/v1/auth/password/reset`
+public struct ResetPasswordRequestDTO: Encodable {
+    /// 이메일 인증 완료 토큰(`PASSWORD_RESET` 목적)
+    public let emailVerificationToken: String
+    /// 새로 설정할 평문 비밀번호
+    public let newPassword: String
+
+    public init(emailVerificationToken: String, newPassword: String) {
+        self.emailVerificationToken = emailVerificationToken
+        self.newPassword = newPassword
+    }
+}

--- a/UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift
+++ b/UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift
@@ -397,6 +397,29 @@ extension AuthRepository: AuthRegistrationRepositoryProtocol {
             throw RepositoryError.decodingError(detail: "\(decodingError)")
         }
     }
+
+    // MARK: - Reset Password
+
+    public func resetPassword(emailVerificationToken: String, newPassword: String) async throws {
+        let response = try await adapter.requestWithoutAuth(
+            AuthRouter.resetPassword(
+                body: ResetPasswordRequestDTO(
+                    emailVerificationToken: emailVerificationToken,
+                    newPassword: newPassword
+                )
+            )
+        )
+
+        do {
+            let apiResponse = try JSONDecoder().decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let decodingError as DecodingError {
+            throw RepositoryError.decodingError(detail: "\(decodingError)")
+        }
+    }
 }
 
 // MARK: - Helpers (Email Verification Error Mapping)

--- a/UMCApp/Features/Auth/Data/Sources/Router/AuthRouter.swift
+++ b/UMCApp/Features/Auth/Data/Sources/Router/AuthRouter.swift
@@ -41,6 +41,8 @@ public enum AuthRouter: BaseTargetType {
     case registerCredential(body: RegisterCredentialRequestDTO)
     /// 기존 챌린저 코드 등록
     case registerExistingChallenger(body: RegisterExistingChallengerRequestDTO)
+    /// 비밀번호 재설정
+    case resetPassword(body: ResetPasswordRequestDTO)
 
     // MARK: - Path
 
@@ -74,6 +76,8 @@ public enum AuthRouter: BaseTargetType {
             return "/api/v1/auth/credentials"
         case .registerExistingChallenger:
             return "/api/v1/challenger-record/member"
+        case .resetPassword:
+            return "/api/v1/auth/password/reset"
         }
     }
 
@@ -87,6 +91,8 @@ public enum AuthRouter: BaseTargetType {
              .sendEmailVerification, .resendEmailVerification, .verifyEmailCode,
              .register, .registerByEmail, .registerCredential, .registerExistingChallenger:
             return .post
+        case .resetPassword:
+            return .patch
         }
     }
 
@@ -122,6 +128,8 @@ public enum AuthRouter: BaseTargetType {
         case .registerCredential(let body):
             return .requestJSONEncodable(body)
         case .registerExistingChallenger(let body):
+            return .requestJSONEncodable(body)
+        case .resetPassword(let body):
             return .requestJSONEncodable(body)
         }
     }

--- a/UMCApp/Features/Auth/Data/Tests/AuthRouterTests.swift
+++ b/UMCApp/Features/Auth/Data/Tests/AuthRouterTests.swift
@@ -219,6 +219,50 @@ struct AuthRouterRequestDTOEncodingTests {
     }
 }
 
+// MARK: - Suite: 비밀번호 재설정(ResetPassword) 케이스 계약
+
+@Suite("AuthRouter — 비밀번호 재설정(ResetPassword) 케이스 계약")
+struct AuthRouterResetPasswordTests {
+
+    @Test("resetPassword — path는 /api/v1/auth/password/reset, method는 .patch")
+    func resetPasswordPathMethod() {
+        let router = AuthRouter.resetPassword(
+            body: ResetPasswordRequestDTO(
+                emailVerificationToken: "email-token",
+                newPassword: "newPassword123"
+            )
+        )
+        #expect(router.path == "/api/v1/auth/password/reset")
+        #expect(router.method == .patch)
+    }
+
+    @Test("resetPassword — task는 .requestJSONEncodable")
+    func resetPasswordTask() {
+        let router = AuthRouter.resetPassword(
+            body: ResetPasswordRequestDTO(
+                emailVerificationToken: "email-token",
+                newPassword: "newPassword123"
+            )
+        )
+        guard case .requestJSONEncodable = router.task else {
+            Issue.record("task가 .requestJSONEncodable 이어야 함 — 실제: \(router.task)")
+            return
+        }
+    }
+
+    @Test("ResetPasswordRequestDTO — { emailVerificationToken, newPassword } 로 인코딩")
+    func resetPasswordRequestDTOEncoding() throws {
+        let dto = ResetPasswordRequestDTO(
+            emailVerificationToken: "email-token",
+            newPassword: "newPassword123"
+        )
+        let json = try encodeToJSON(dto)
+        #expect(json["emailVerificationToken"] as? String == "email-token")
+        #expect(json["newPassword"] as? String == "newPassword123")
+        #expect(json.keys.count == 2)
+    }
+}
+
 // MARK: - Test Helpers
 
 private func makeRegisterRequestDTO(profileImageId: String? = "img-1") -> RegisterRequestDTO {

--- a/UMCApp/Features/Auth/Domain/Sources/Interfaces/AuthRegistrationRepositoryProtocol.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/Interfaces/AuthRegistrationRepositoryProtocol.swift
@@ -92,4 +92,10 @@ public protocol AuthRegistrationRepositoryProtocol: Sendable {
     /// 운영진이 발급한 6자리 코드로 기존 챌린저 기록을 등록한다.
     /// - Parameter code: 운영진 발급 코드
     func registerExistingChallenger(code: String) async throws
+
+    /// 이메일 인증을 완료한 뒤 비밀번호를 재설정한다.
+    /// - Parameters:
+    ///   - emailVerificationToken: 이메일 인증 완료 토큰(`PASSWORD_RESET` 목적)
+    ///   - newPassword: 새로 설정할 평문 비밀번호
+    func resetPassword(emailVerificationToken: String, newPassword: String) async throws
 }

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/ResetPasswordUseCase.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/ResetPasswordUseCase.swift
@@ -1,0 +1,22 @@
+/// 비밀번호 재설정 UseCase 구현체
+public final class ResetPasswordUseCase: ResetPasswordUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: AuthRegistrationRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: AuthRegistrationRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(emailVerificationToken: String, newPassword: String) async throws {
+        try await repository.resetPassword(
+            emailVerificationToken: emailVerificationToken,
+            newPassword: newPassword
+        )
+    }
+}

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/ResetPasswordUseCaseProtocol.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/ResetPasswordUseCaseProtocol.swift
@@ -1,0 +1,8 @@
+/// 비밀번호 재설정 UseCase 인터페이스
+public protocol ResetPasswordUseCaseProtocol {
+    /// 이메일 인증 완료 토큰으로 비밀번호를 재설정한다.
+    /// - Parameters:
+    ///   - emailVerificationToken: 이메일 인증 완료 토큰(`PASSWORD_RESET` 목적)
+    ///   - newPassword: 새로 설정할 평문 비밀번호
+    func execute(emailVerificationToken: String, newPassword: String) async throws
+}

--- a/UMCApp/Features/Auth/Domain/Tests/Support/MockAuthRegistrationRepository.swift
+++ b/UMCApp/Features/Auth/Domain/Tests/Support/MockAuthRegistrationRepository.swift
@@ -183,4 +183,20 @@ final class MockAuthRegistrationRepository:
             throw registerExistingChallengerError
         }
     }
+
+    // MARK: - resetPassword
+
+    var resetPasswordError: Error?
+    private(set) var resetPasswordCallCount = 0
+    private(set) var resetPasswordReceivedEmailVerificationToken: String?
+    private(set) var resetPasswordReceivedNewPassword: String?
+
+    func resetPassword(emailVerificationToken: String, newPassword: String) async throws {
+        resetPasswordCallCount += 1
+        resetPasswordReceivedEmailVerificationToken = emailVerificationToken
+        resetPasswordReceivedNewPassword = newPassword
+        if let resetPasswordError {
+            throw resetPasswordError
+        }
+    }
 }

--- a/UMCApp/Features/Auth/Domain/Tests/UseCases/ResetPasswordUseCaseTests.swift
+++ b/UMCApp/Features/Auth/Domain/Tests/UseCases/ResetPasswordUseCaseTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import AuthDomain
+
+@Suite("ResetPasswordUseCase — Repository 위임 검증")
+struct ResetPasswordUseCaseTests {
+
+    @Test("execute() 호출 시 repository.resetPassword()에 파라미터를 그대로 전달한다")
+    func executeDelegatesToRepository() async throws {
+        let repository = MockAuthRegistrationRepository()
+        let useCase = ResetPasswordUseCase(repository: repository)
+
+        try await useCase.execute(
+            emailVerificationToken: "email-verification-token",
+            newPassword: "newPassword123"
+        )
+
+        #expect(repository.resetPasswordCallCount == 1)
+        #expect(repository.resetPasswordReceivedEmailVerificationToken == "email-verification-token")
+        #expect(repository.resetPasswordReceivedNewPassword == "newPassword123")
+    }
+
+    @Test("repository.resetPassword()가 에러를 던지면 그대로 전파한다")
+    func executePropagatesError() async {
+        let repository = MockAuthRegistrationRepository()
+        repository.resetPasswordError = AuthTestError.boom
+        let useCase = ResetPasswordUseCase(repository: repository)
+
+        await #expect(throws: AuthTestError.boom) {
+            try await useCase.execute(
+                emailVerificationToken: "email-verification-token",
+                newPassword: "newPassword123"
+            )
+        }
+    }
+}

--- a/UMCApp/Features/Auth/Domain/Tests/UseCases/ResetPasswordUseCaseTests.swift
+++ b/UMCApp/Features/Auth/Domain/Tests/UseCases/ResetPasswordUseCaseTests.swift
@@ -10,12 +10,12 @@ struct ResetPasswordUseCaseTests {
         let useCase = ResetPasswordUseCase(repository: repository)
 
         try await useCase.execute(
-            emailVerificationToken: "email-verification-token",
+            emailVerificationToken: "email-token",
             newPassword: "newPassword123"
         )
 
         #expect(repository.resetPasswordCallCount == 1)
-        #expect(repository.resetPasswordReceivedEmailVerificationToken == "email-verification-token")
+        #expect(repository.resetPasswordReceivedEmailVerificationToken == "email-token")
         #expect(repository.resetPasswordReceivedNewPassword == "newPassword123")
     }
 
@@ -27,7 +27,7 @@ struct ResetPasswordUseCaseTests {
 
         await #expect(throws: AuthTestError.boom) {
             try await useCase.execute(
-                emailVerificationToken: "email-verification-token",
+                emailVerificationToken: "email-token",
                 newPassword: "newPassword123"
             )
         }

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/EmailVerificationFlow.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/EmailVerificationFlow.swift
@@ -1,0 +1,133 @@
+import AuthDomain
+import CoreDI
+import Foundation
+
+/// 이메일 인증(발송 → 검증 → 재전송) 흐름을 캡슐화한 컴포지션 객체.
+///
+/// `SignUpByIdPwViewModel`과 `ResetPasswordViewModel`이 동일한 이메일 인증 상태·재진입 가드·
+/// 이메일 변경 감지 로직을 복사-붙여넣기로 중복 보유하던 것을 이 타입으로 추출했다. 두 ViewModel은
+/// 이 객체를 프로퍼티로 보유하고 위임하며, `purpose`(가입/비밀번호 재설정)만 초기화 시점에 다르게
+/// 주입한다.
+///
+/// - Important: 부모 `@Observable` ViewModel에서 `var emailVerificationFlow: EmailVerificationFlow`로
+///   선언해야 한다(`let` 금지). `Binding`의 `subscript(dynamicMember:)`는 체인의 모든 단계가
+///   `WritableKeyPath`여야 동작하는데, `let` 프로퍼티는 `KeyPath`(읽기 전용)만 만들어
+///   `$viewModel.emailVerificationFlow.email` 같은 중첩 바인딩이 깨진다.
+@Observable
+final class EmailVerificationFlow {
+
+    // MARK: - Property
+
+    private let purpose: EmailVerificationPurpose
+    private let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
+    private let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
+    private let resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
+
+    /// 이메일 주소 — `FormEmailField`와 양방향 바인딩된다.
+    var email: String = ""
+
+    /// 이메일 인증 완료 여부 — `FormEmailField`와 양방향 바인딩된다.
+    var isEmailVerified: Bool = false
+
+    /// 이메일 인증 발송 후 발급되는 요청 식별자
+    private(set) var emailVerificationId: String?
+
+    /// 이메일 인증 코드 검증 완료 후 발급되는 토큰
+    private(set) var emailVerificationToken: String?
+
+    /// 이메일 변경 감지를 위한 마지막 스냅샷
+    private var lastEmailSnapshot: String = ""
+
+    /// `resetEmailVerification()` 완료 시점에 호출되는 확장 지점.
+    ///
+    /// 이 흐름을 보유한 ViewModel이 이메일 인증과 함께 리셋되어야 하는 자신만의 파생 상태
+    /// (예: `SignUpByIdPwViewModel`의 이메일 중복 확인 상태)를 가지고 있을 때 사용한다.
+    /// 별도 파생 상태가 없는 경우(`ResetPasswordViewModel`)는 설정하지 않아도 된다.
+    @ObservationIgnored var onReset: (@MainActor () -> Void)?
+
+    @ObservationIgnored private var isRequestingEmailVerification = false
+    @ObservationIgnored private var isVerifyingEmailCode = false
+    @ObservationIgnored private var isResendingEmailVerification = false
+
+    // MARK: - Init
+
+    init(
+        purpose: EmailVerificationPurpose,
+        sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+        verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
+        resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
+    ) {
+        self.purpose = purpose
+        self.sendEmailVerificationUseCase = sendEmailVerificationUseCase
+        self.verifyEmailCodeUseCase = verifyEmailCodeUseCase
+        self.resendEmailVerificationUseCase = resendEmailVerificationUseCase
+    }
+
+    // MARK: - Function
+
+    /// 이메일 인증번호 발송 요청.
+    ///
+    /// `FormEmailField`가 bare `Task {}`로 호출하므로 중복 탭에 대비해 재진입을 막는다.
+    @MainActor
+    func requestEmailVerification() async throws {
+        guard !isRequestingEmailVerification else { return }
+        isRequestingEmailVerification = true
+        defer { isRequestingEmailVerification = false }
+
+        let id = try await sendEmailVerificationUseCase.execute(email: email, purpose: purpose)
+        emailVerificationId = id
+    }
+
+    /// 이메일 인증번호 검증.
+    ///
+    /// - Returns: 검증이 실제로 수행되어 `isEmailVerified`가 갱신됐으면 `true`, 재진입 가드나
+    ///   `emailVerificationId` 부재로 스킵됐으면 `false`. 호출자가 검증 성공 시에만 추가 동작
+    ///   (예: 이메일 중복 확인 예약)을 트리거할 수 있도록 반환하되, 별도 동작이 필요 없는
+    ///   호출자는 결과를 버려도 된다.
+    @discardableResult
+    @MainActor
+    func verifyEmailCode(_ code: String) async throws -> Bool {
+        guard !isVerifyingEmailCode else { return false }
+        guard let emailVerificationId else { return false }
+        isVerifyingEmailCode = true
+        defer { isVerifyingEmailCode = false }
+
+        let token = try await verifyEmailCodeUseCase.execute(
+            emailVerificationId: emailVerificationId,
+            verificationCode: code
+        )
+        emailVerificationToken = token
+        isEmailVerified = true
+        return true
+    }
+
+    /// 이메일 인증번호 재전송
+    @MainActor
+    func resendEmailVerification() async throws {
+        guard !isResendingEmailVerification else { return }
+        guard let emailVerificationId else { return }
+        isResendingEmailVerification = true
+        defer { isResendingEmailVerification = false }
+
+        try await resendEmailVerificationUseCase.execute(emailVerificationId: emailVerificationId)
+    }
+
+    /// 이메일 텍스트 변경 콜백 — 실제로 값이 바뀐 경우에만 인증 상태를 리셋한다.
+    @MainActor
+    func handleEmailChanged() {
+        guard email != lastEmailSnapshot else { return }
+        lastEmailSnapshot = email
+        resetEmailVerification()
+    }
+
+    /// 이메일 변경 시 이메일 인증 상태를 초기화하고 `onReset` 훅을 호출한다.
+    ///
+    /// 기존 인증번호/토큰은 이전 이메일 기준이므로 폐기되어야 한다.
+    @MainActor
+    func resetEmailVerification() {
+        isEmailVerified = false
+        emailVerificationId = nil
+        emailVerificationToken = nil
+        onReset?()
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/ResetPasswordViewModel.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/ResetPasswordViewModel.swift
@@ -1,0 +1,179 @@
+import AuthDomain
+import CoreDI
+import Foundation
+import UMCFoundation
+
+/// 비밀번호 재설정 화면의 상태 및 액션을 관리하는 ViewModel.
+///
+/// 절대규칙 #1에 따라 `@Observable`을 사용한다. 흐름: 이메일 인증(`PASSWORD_RESET` 목적) →
+/// 새 비밀번호 입력 → 재설정 요청. `SignUpByIdPwViewModel`과 이메일 인증 처리 패턴(재진입 방지,
+/// 이메일 변경 시 인증 상태 리셋)을 공유하며, 재설정 실패는 흐름 중단형 에러이므로
+/// `SignUpByIdPwViewModel.register()`와 동일하게 `ErrorHandler`로 처리한다.
+@Observable
+final class ResetPasswordViewModel {
+
+    // MARK: - Constant
+
+    private enum Constants {
+        static let minimumPasswordLength: Int = 8
+    }
+
+    // MARK: - Property
+
+    private let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
+    private let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
+    private let resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
+    private let resetPasswordUseCase: ResetPasswordUseCaseProtocol
+    private let errorHandler: ErrorHandler
+
+    /// 이메일 주소
+    var email: String = ""
+
+    /// 새 비밀번호
+    var newPassword: String = ""
+
+    /// 새 비밀번호 확인
+    var newPasswordConfirm: String = ""
+
+    /// 이메일 인증 완료 여부 — `FormEmailField`와 양방향 바인딩된다.
+    var isEmailVerified: Bool = false
+
+    /// 이메일 인증 발송 후 발급되는 요청 식별자
+    private(set) var emailVerificationId: String?
+
+    /// 이메일 인증 코드 검증 완료 후 발급되는 토큰
+    private(set) var emailVerificationToken: String?
+
+    /// 비밀번호 재설정 진행 상태
+    private(set) var resetPasswordState: Loadable<Bool> = .idle
+
+    /// 이메일 변경 감지를 위한 마지막 스냅샷
+    private var lastEmailSnapshot: String = ""
+
+    @ObservationIgnored private var isRequestingEmailVerification = false
+    @ObservationIgnored private var isVerifyingEmailCode = false
+    @ObservationIgnored private var isResendingEmailVerification = false
+
+    // MARK: - Init
+
+    init(container: DIContainer, errorHandler: ErrorHandler) {
+        self.sendEmailVerificationUseCase = container.resolve(
+            SendEmailVerificationUseCaseProtocol.self
+        )
+        self.verifyEmailCodeUseCase = container.resolve(VerifyEmailCodeUseCaseProtocol.self)
+        self.resendEmailVerificationUseCase = container.resolve(
+            ResendEmailVerificationUseCaseProtocol.self
+        )
+        self.resetPasswordUseCase = container.resolve(ResetPasswordUseCaseProtocol.self)
+        self.errorHandler = errorHandler
+    }
+
+    // MARK: - Computed Property
+
+    /// 새 비밀번호 최소 길이(8자) 충족 여부
+    var isPasswordValid: Bool {
+        newPassword.count >= Constants.minimumPasswordLength
+    }
+
+    /// 새 비밀번호 확인 일치 여부
+    var isPasswordConfirmed: Bool {
+        !newPasswordConfirm.isEmpty && newPassword == newPasswordConfirm
+    }
+
+    /// 재설정 제출 가능 여부
+    var canSubmit: Bool {
+        isEmailVerified &&
+        emailVerificationToken != nil &&
+        isPasswordValid &&
+        isPasswordConfirmed
+    }
+
+    // MARK: - Function (Email Verification)
+
+    /// 이메일 인증번호 발송 요청 (`purpose: .passwordReset`).
+    ///
+    /// `FormEmailField`가 bare `Task {}`로 호출하므로 중복 탭에 대비해 재진입을 막는다.
+    @MainActor
+    func requestEmailVerification() async throws {
+        guard !isRequestingEmailVerification else { return }
+        isRequestingEmailVerification = true
+        defer { isRequestingEmailVerification = false }
+
+        let id = try await sendEmailVerificationUseCase.execute(
+            email: email,
+            purpose: .passwordReset
+        )
+        emailVerificationId = id
+    }
+
+    /// 이메일 인증번호 검증
+    @MainActor
+    func verifyEmailCode(_ code: String) async throws {
+        guard !isVerifyingEmailCode else { return }
+        guard let emailVerificationId else { return }
+        isVerifyingEmailCode = true
+        defer { isVerifyingEmailCode = false }
+
+        let token = try await verifyEmailCodeUseCase.execute(
+            emailVerificationId: emailVerificationId,
+            verificationCode: code
+        )
+        emailVerificationToken = token
+        isEmailVerified = true
+    }
+
+    /// 이메일 인증번호 재전송
+    @MainActor
+    func resendEmailVerification() async throws {
+        guard !isResendingEmailVerification else { return }
+        guard let emailVerificationId else { return }
+        isResendingEmailVerification = true
+        defer { isResendingEmailVerification = false }
+
+        try await resendEmailVerificationUseCase.execute(emailVerificationId: emailVerificationId)
+    }
+
+    /// 이메일 텍스트 변경 콜백 — 실제로 값이 바뀐 경우에만 인증 상태를 리셋한다.
+    @MainActor
+    func handleEmailChanged() {
+        guard email != lastEmailSnapshot else { return }
+        lastEmailSnapshot = email
+        resetEmailVerification()
+    }
+
+    /// 이메일 변경 시 이메일 인증 상태를 초기화한다.
+    ///
+    /// 기존 인증번호/토큰은 이전 이메일 기준이므로 폐기되어야 한다.
+    @MainActor
+    func resetEmailVerification() {
+        isEmailVerified = false
+        emailVerificationId = nil
+        emailVerificationToken = nil
+    }
+
+    // MARK: - Function (Reset Password)
+
+    /// 비밀번호 재설정 실행
+    @MainActor
+    func resetPassword() async {
+        guard !resetPasswordState.isLoading else { return }
+        guard canSubmit, let emailVerificationToken else { return }
+
+        resetPasswordState = .loading
+
+        do {
+            try await resetPasswordUseCase.execute(
+                emailVerificationToken: emailVerificationToken,
+                newPassword: newPassword
+            )
+            resetPasswordState = .loaded(true)
+        } catch {
+            resetPasswordState = .idle
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Auth",
+                action: "resetPassword",
+                retryAction: { [weak self] in await self?.resetPassword() }
+            ))
+        }
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/ResetPasswordViewModel.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/ResetPasswordViewModel.swift
@@ -6,9 +6,9 @@ import UMCFoundation
 /// 비밀번호 재설정 화면의 상태 및 액션을 관리하는 ViewModel.
 ///
 /// 절대규칙 #1에 따라 `@Observable`을 사용한다. 흐름: 이메일 인증(`PASSWORD_RESET` 목적) →
-/// 새 비밀번호 입력 → 재설정 요청. `SignUpByIdPwViewModel`과 이메일 인증 처리 패턴(재진입 방지,
-/// 이메일 변경 시 인증 상태 리셋)을 공유하며, 재설정 실패는 흐름 중단형 에러이므로
-/// `SignUpByIdPwViewModel.register()`와 동일하게 `ErrorHandler`로 처리한다.
+/// 새 비밀번호 입력 → 재설정 요청. 이메일 인증 처리(재진입 방지, 이메일 변경 시 인증 상태 리셋)는
+/// `SignUpByIdPwViewModel`과 공유하는 `EmailVerificationFlow`에 위임하며, 재설정 실패는
+/// 흐름 중단형 에러이므로 `SignUpByIdPwViewModel.register()`와 동일하게 `ErrorHandler`로 처리한다.
 @Observable
 final class ResetPasswordViewModel {
 
@@ -20,14 +20,11 @@ final class ResetPasswordViewModel {
 
     // MARK: - Property
 
-    private let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
-    private let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
-    private let resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
     private let resetPasswordUseCase: ResetPasswordUseCaseProtocol
     private let errorHandler: ErrorHandler
 
-    /// 이메일 주소
-    var email: String = ""
+    /// 이메일 인증(발송·검증·재전송) 상태와 액션 — `EmailVerificationFlow`에 위임한다.
+    var emailVerificationFlow: EmailVerificationFlow
 
     /// 새 비밀번호
     var newPassword: String = ""
@@ -35,37 +32,24 @@ final class ResetPasswordViewModel {
     /// 새 비밀번호 확인
     var newPasswordConfirm: String = ""
 
-    /// 이메일 인증 완료 여부 — `FormEmailField`와 양방향 바인딩된다.
-    var isEmailVerified: Bool = false
-
-    /// 이메일 인증 발송 후 발급되는 요청 식별자
-    private(set) var emailVerificationId: String?
-
-    /// 이메일 인증 코드 검증 완료 후 발급되는 토큰
-    private(set) var emailVerificationToken: String?
-
     /// 비밀번호 재설정 진행 상태
     private(set) var resetPasswordState: Loadable<Bool> = .idle
-
-    /// 이메일 변경 감지를 위한 마지막 스냅샷
-    private var lastEmailSnapshot: String = ""
-
-    @ObservationIgnored private var isRequestingEmailVerification = false
-    @ObservationIgnored private var isVerifyingEmailCode = false
-    @ObservationIgnored private var isResendingEmailVerification = false
 
     // MARK: - Init
 
     init(container: DIContainer, errorHandler: ErrorHandler) {
-        self.sendEmailVerificationUseCase = container.resolve(
-            SendEmailVerificationUseCaseProtocol.self
-        )
-        self.verifyEmailCodeUseCase = container.resolve(VerifyEmailCodeUseCaseProtocol.self)
-        self.resendEmailVerificationUseCase = container.resolve(
-            ResendEmailVerificationUseCaseProtocol.self
-        )
         self.resetPasswordUseCase = container.resolve(ResetPasswordUseCaseProtocol.self)
         self.errorHandler = errorHandler
+        self.emailVerificationFlow = EmailVerificationFlow(
+            purpose: .passwordReset,
+            sendEmailVerificationUseCase: container.resolve(
+                SendEmailVerificationUseCaseProtocol.self
+            ),
+            verifyEmailCodeUseCase: container.resolve(VerifyEmailCodeUseCaseProtocol.self),
+            resendEmailVerificationUseCase: container.resolve(
+                ResendEmailVerificationUseCaseProtocol.self
+            )
+        )
     }
 
     // MARK: - Computed Property
@@ -82,73 +66,10 @@ final class ResetPasswordViewModel {
 
     /// 재설정 제출 가능 여부
     var canSubmit: Bool {
-        isEmailVerified &&
-        emailVerificationToken != nil &&
+        emailVerificationFlow.isEmailVerified &&
+        emailVerificationFlow.emailVerificationToken != nil &&
         isPasswordValid &&
         isPasswordConfirmed
-    }
-
-    // MARK: - Function (Email Verification)
-
-    /// 이메일 인증번호 발송 요청 (`purpose: .passwordReset`).
-    ///
-    /// `FormEmailField`가 bare `Task {}`로 호출하므로 중복 탭에 대비해 재진입을 막는다.
-    @MainActor
-    func requestEmailVerification() async throws {
-        guard !isRequestingEmailVerification else { return }
-        isRequestingEmailVerification = true
-        defer { isRequestingEmailVerification = false }
-
-        let id = try await sendEmailVerificationUseCase.execute(
-            email: email,
-            purpose: .passwordReset
-        )
-        emailVerificationId = id
-    }
-
-    /// 이메일 인증번호 검증
-    @MainActor
-    func verifyEmailCode(_ code: String) async throws {
-        guard !isVerifyingEmailCode else { return }
-        guard let emailVerificationId else { return }
-        isVerifyingEmailCode = true
-        defer { isVerifyingEmailCode = false }
-
-        let token = try await verifyEmailCodeUseCase.execute(
-            emailVerificationId: emailVerificationId,
-            verificationCode: code
-        )
-        emailVerificationToken = token
-        isEmailVerified = true
-    }
-
-    /// 이메일 인증번호 재전송
-    @MainActor
-    func resendEmailVerification() async throws {
-        guard !isResendingEmailVerification else { return }
-        guard let emailVerificationId else { return }
-        isResendingEmailVerification = true
-        defer { isResendingEmailVerification = false }
-
-        try await resendEmailVerificationUseCase.execute(emailVerificationId: emailVerificationId)
-    }
-
-    /// 이메일 텍스트 변경 콜백 — 실제로 값이 바뀐 경우에만 인증 상태를 리셋한다.
-    @MainActor
-    func handleEmailChanged() {
-        guard email != lastEmailSnapshot else { return }
-        lastEmailSnapshot = email
-        resetEmailVerification()
-    }
-
-    /// 이메일 변경 시 이메일 인증 상태를 초기화한다.
-    ///
-    /// 기존 인증번호/토큰은 이전 이메일 기준이므로 폐기되어야 한다.
-    @MainActor
-    func resetEmailVerification() {
-        isEmailVerified = false
-        emailVerificationId = nil
-        emailVerificationToken = nil
     }
 
     // MARK: - Function (Reset Password)
@@ -157,7 +78,10 @@ final class ResetPasswordViewModel {
     @MainActor
     func resetPassword() async {
         guard !resetPasswordState.isLoading else { return }
-        guard canSubmit, let emailVerificationToken else { return }
+        guard canSubmit,
+              let emailVerificationToken = emailVerificationFlow.emailVerificationToken else {
+            return
+        }
 
         resetPasswordState = .loading
 

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/SignUpByIdPwViewModel.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/SignUpByIdPwViewModel.swift
@@ -20,22 +20,19 @@ final class SignUpByIdPwViewModel {
     // MARK: - Property
 
     private let fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
-    private let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
-    private let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
-    private let resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
     private let checkEmailAvailabilityUseCase: CheckEmailAvailabilityUseCaseProtocol
     private let registerByEmailUseCase: RegisterByEmailUseCaseProtocol
     private let fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol
     private let errorHandler: ErrorHandler
+
+    /// 이메일 인증(발송·검증·재전송) 상태와 액션 — `EmailVerificationFlow`에 위임한다.
+    var emailVerificationFlow: EmailVerificationFlow
 
     /// 사용자 실명
     var name: String = ""
 
     /// 사용자 닉네임
     var nickname: String = ""
-
-    /// 이메일 주소
-    var email: String = ""
 
     /// 비밀번호
     var password: String = ""
@@ -55,15 +52,6 @@ final class SignUpByIdPwViewModel {
     /// 약관 목록 로딩 상태 (서비스·개인정보 2종, marketing 미노출)
     private(set) var termsState: Loadable<[Terms]> = .idle
 
-    /// 이메일 인증 완료 여부 — `FormEmailField`와 양방향 바인딩된다.
-    var isEmailVerified: Bool = false
-
-    /// 이메일 인증 발송 후 발급되는 요청 식별자
-    private(set) var emailVerificationId: String?
-
-    /// 이메일 인증 코드 검증 완료 후 발급되는 토큰
-    private(set) var emailVerificationToken: String?
-
     /// 마지막으로 검증에 성공한 인증 코드
     private(set) var verificationCode: String = ""
 
@@ -79,30 +67,31 @@ final class SignUpByIdPwViewModel {
     /// `showMain()`/`showLogin()` 분기를 결정한다.
     private(set) var isApprovedAfterRegister = false
 
-    private var lastEmailSnapshot: String = ""
-
-    @ObservationIgnored private var isRequestingEmailVerification = false
-    @ObservationIgnored private var isVerifyingEmailCode = false
-    @ObservationIgnored private var isResendingEmailVerification = false
     @ObservationIgnored private var emailAvailabilityTask: Task<Void, Never>?
 
     // MARK: - Init
 
     init(container: DIContainer, errorHandler: ErrorHandler) {
         self.fetchSignUpDataUseCase = container.resolve(FetchSignUpDataUseCaseProtocol.self)
-        self.sendEmailVerificationUseCase = container.resolve(
-            SendEmailVerificationUseCaseProtocol.self
-        )
-        self.verifyEmailCodeUseCase = container.resolve(VerifyEmailCodeUseCaseProtocol.self)
-        self.resendEmailVerificationUseCase = container.resolve(
-            ResendEmailVerificationUseCaseProtocol.self
-        )
         self.checkEmailAvailabilityUseCase = container.resolve(
             CheckEmailAvailabilityUseCaseProtocol.self
         )
         self.registerByEmailUseCase = container.resolve(RegisterByEmailUseCaseProtocol.self)
         self.fetchMyProfileUseCase = container.resolve(FetchMyProfileUseCaseProtocol.self)
         self.errorHandler = errorHandler
+        self.emailVerificationFlow = EmailVerificationFlow(
+            purpose: .register,
+            sendEmailVerificationUseCase: container.resolve(
+                SendEmailVerificationUseCaseProtocol.self
+            ),
+            verifyEmailCodeUseCase: container.resolve(VerifyEmailCodeUseCaseProtocol.self),
+            resendEmailVerificationUseCase: container.resolve(
+                ResendEmailVerificationUseCaseProtocol.self
+            )
+        )
+        self.emailVerificationFlow.onReset = { [weak self] in
+            self?.resetEmailAvailability()
+        }
     }
 
     // MARK: - Computed Property
@@ -129,11 +118,11 @@ final class SignUpByIdPwViewModel {
     var canSubmit: Bool {
         !name.isEmpty &&
         !nickname.isEmpty &&
-        !email.isEmpty &&
+        !emailVerificationFlow.email.isEmpty &&
         isPasswordValid &&
         isPasswordConfirmed &&
         selectedSchool != nil &&
-        isEmailVerified &&
+        emailVerificationFlow.isEmailVerified &&
         isEmailAvailable &&
         mandatoryTermsAgreed
     }
@@ -184,69 +173,15 @@ final class SignUpByIdPwViewModel {
 
     // MARK: - Function (Email Verification)
 
-    /// 이메일 인증번호 발송 요청.
-    ///
-    /// `FormEmailField`가 bare `Task {}`로 호출하므로 중복 탭에 대비해 재진입을 막는다.
-    @MainActor
-    func requestEmailVerification() async throws {
-        guard !isRequestingEmailVerification else { return }
-        isRequestingEmailVerification = true
-        defer { isRequestingEmailVerification = false }
-
-        let id = try await sendEmailVerificationUseCase.execute(email: email, purpose: .register)
-        emailVerificationId = id
-    }
-
     /// 이메일 인증번호 검증. 성공 시 이메일 중복 확인을 이어서 예약한다.
+    ///
+    /// 공통 흐름(`EmailVerificationFlow`)에 위임하되, 검증이 실제로 완료된 경우에만 이 화면
+    /// 전용 파생 동작(이메일 중복 확인 예약)을 수행한다.
     @MainActor
     func verifyEmailCode(_ code: String) async throws {
-        guard !isVerifyingEmailCode else { return }
-        guard let emailVerificationId else { return }
-        isVerifyingEmailCode = true
-        defer { isVerifyingEmailCode = false }
-
-        let token = try await verifyEmailCodeUseCase.execute(
-            emailVerificationId: emailVerificationId,
-            verificationCode: code
-        )
-        emailVerificationToken = token
+        guard try await emailVerificationFlow.verifyEmailCode(code) else { return }
         verificationCode = code
-        isEmailVerified = true
-
         scheduleEmailAvailabilityCheck()
-    }
-
-    /// 이메일 인증번호 재전송
-    @MainActor
-    func resendEmailVerification() async throws {
-        guard !isResendingEmailVerification else { return }
-        guard let emailVerificationId else { return }
-        isResendingEmailVerification = true
-        defer { isResendingEmailVerification = false }
-
-        try await resendEmailVerificationUseCase.execute(emailVerificationId: emailVerificationId)
-    }
-
-    /// 이메일 텍스트 변경 콜백 — 실제로 값이 바뀐 경우에만 인증 상태를 리셋한다.
-    @MainActor
-    func handleEmailChanged() {
-        guard email != lastEmailSnapshot else { return }
-        lastEmailSnapshot = email
-        resetEmailVerification()
-    }
-
-    /// 이메일 변경 시 이메일 인증/중복 확인 상태를 초기화한다.
-    ///
-    /// 기존 인증번호/토큰은 이전 이메일 기준이므로 폐기되어야 한다.
-    @MainActor
-    func resetEmailVerification() {
-        isEmailVerified = false
-        emailVerificationId = nil
-        emailVerificationToken = nil
-        verificationCode = ""
-        emailAvailabilityTask?.cancel()
-        emailAvailabilityTask = nil
-        emailAvailabilityState = .idle
     }
 
     // MARK: - Function (Terms)
@@ -271,7 +206,7 @@ final class SignUpByIdPwViewModel {
     @MainActor
     private func scheduleEmailAvailabilityCheck() {
         emailAvailabilityTask?.cancel()
-        let targetEmail = email
+        let targetEmail = emailVerificationFlow.email
         emailAvailabilityTask = Task { [weak self] in
             try? await Task.sleep(
                 for: .milliseconds(Constants.emailAvailabilityDebounceMilliseconds)
@@ -295,6 +230,17 @@ final class SignUpByIdPwViewModel {
         }
     }
 
+    /// 이메일 인증 상태가 리셋될 때(이메일 변경) 이메일 중복 확인 관련 파생 상태도 초기화한다.
+    ///
+    /// `EmailVerificationFlow.onReset` 훅으로 연결된다.
+    @MainActor
+    private func resetEmailAvailability() {
+        verificationCode = ""
+        emailAvailabilityTask?.cancel()
+        emailAvailabilityTask = nil
+        emailAvailabilityState = .idle
+    }
+
     // MARK: - Function (Register)
 
     /// 회원가입 실행 — 성공 시 프로필을 재조회해 승인 여부를 확정한다.
@@ -303,7 +249,7 @@ final class SignUpByIdPwViewModel {
         guard !registerState.isLoading else { return }
         guard canSubmit,
               let selectedSchool,
-              let emailVerificationToken else {
+              let emailVerificationToken = emailVerificationFlow.emailVerificationToken else {
             return
         }
 

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/ResetPasswordView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/ResetPasswordView.swift
@@ -1,0 +1,132 @@
+import AuthDomain
+import CoreDesignSystem
+import CoreDI
+import SwiftUI
+import UMCFoundation
+
+/// 비밀번호 재설정 화면 — 이메일 인증(`PASSWORD_RESET` 목적) 후 새 비밀번호를 입력받아
+/// 재설정을 완료한다.
+///
+/// - Note: 프로덕션 네비게이션 배선은 이 Task(#947)의 범위가 아니다. 실제 진입 경로는
+///   ID/PW 로그인 화면(#943)이 이식된 뒤 그 화면에서 연결되며, 이 화면은 `#if DEBUG`
+///   진입점(`AppRootView`)을 통해서만 현재 리뷰/QA 가능하다.
+public struct ResetPasswordView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: ResetPasswordViewModel
+    @State private var alertPrompt: AlertPrompt?
+    @FocusState private var focusedField: SignUpFocusField?
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Constant
+
+    fileprivate enum Constants {
+        static let deliveryNotice: String = "메일이 도착하지 않으면 가입 여부를 확인해주세요."
+        static let submitTitle: String = "비밀번호 변경"
+        static let completedTitle: String = "비밀번호 변경 완료"
+        static let completedMessage: String = "변경된 비밀번호로 로그인해주세요."
+        static let confirmTitle: String = "확인"
+    }
+
+    // MARK: - Init
+
+    public init(container: DIContainer, errorHandler: ErrorHandler) {
+        _viewModel = State(initialValue: ResetPasswordViewModel(
+            container: container,
+            errorHandler: errorHandler
+        ))
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
+                    FormEmailField(
+                        title: "이메일",
+                        placeholder: "example@example.com",
+                        text: $viewModel.email,
+                        isVerified: $viewModel.isEmailVerified,
+                        onVerificationRequested: {
+                            try await viewModel.requestEmailVerification()
+                        },
+                        onVerificationComplete: { code in
+                            try await viewModel.verifyEmailCode(code)
+                        },
+                        onResend: {
+                            try await viewModel.resendEmailVerification()
+                        },
+                        submitLabel: .next,
+                        onSubmit: { focusedField = .password },
+                        onEmailChanged: { viewModel.handleEmailChanged() }
+                    )
+
+                    Text(Constants.deliveryNotice)
+                        .appFont(.footnote, color: .grey500)
+
+                    if viewModel.isEmailVerified {
+                        SignUpPasswordSection(
+                            password: $viewModel.newPassword,
+                            passwordConfirm: $viewModel.newPasswordConfirm,
+                            isPasswordValid: viewModel.isPasswordValid,
+                            isPasswordConfirmed: viewModel.isPasswordConfirmed,
+                            focusBinding: $focusedField,
+                            onConfirmSubmit: { focusedField = nil }
+                        )
+                    }
+                }
+                .safeAreaPadding(.vertical, DefaultConstant.defaultContentTopMargins)
+                .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .navigation(naviTitle: .resetPassword, displayMode: .inline)
+            .safeAreaInset(edge: .bottom) {
+                submitButton
+            }
+        }
+        .onChange(of: viewModel.resetPasswordState) { _, newState in
+            handleResetPasswordStateChange(newState)
+        }
+        .alertPrompt(item: $alertPrompt)
+    }
+
+    // MARK: - Subviews
+
+    private var submitButton: some View {
+        Button {
+            focusedField = nil
+            Task { await viewModel.resetPassword() }
+        } label: {
+            Group {
+                if viewModel.resetPasswordState.isLoading {
+                    ProgressView()
+                        .tint(.white)
+                } else {
+                    Text(Constants.submitTitle)
+                        .appFont(.subheadline, weight: .semibold, color: .white)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, DefaultConstant.defaultBtnPadding)
+        }
+        .buttonStyle(.glassProminent)
+        .tint(.indigo500)
+        .disabled(!viewModel.canSubmit || viewModel.resetPasswordState.isLoading)
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    // MARK: - Function
+
+    private func handleResetPasswordStateChange(_ newState: Loadable<Bool>) {
+        guard case .loaded = newState else { return }
+
+        alertPrompt = AlertPrompt(
+            title: Constants.completedTitle,
+            message: Constants.completedMessage,
+            positiveBtnTitle: Constants.confirmTitle,
+            positiveBtnAction: { dismiss() }
+        )
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/ResetPasswordView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/ResetPasswordView.swift
@@ -47,26 +47,26 @@ public struct ResetPasswordView: View {
                     FormEmailField(
                         title: "이메일",
                         placeholder: "example@example.com",
-                        text: $viewModel.email,
-                        isVerified: $viewModel.isEmailVerified,
+                        text: $viewModel.emailVerificationFlow.email,
+                        isVerified: $viewModel.emailVerificationFlow.isEmailVerified,
                         onVerificationRequested: {
-                            try await viewModel.requestEmailVerification()
+                            try await viewModel.emailVerificationFlow.requestEmailVerification()
                         },
                         onVerificationComplete: { code in
-                            try await viewModel.verifyEmailCode(code)
+                            try await viewModel.emailVerificationFlow.verifyEmailCode(code)
                         },
                         onResend: {
-                            try await viewModel.resendEmailVerification()
+                            try await viewModel.emailVerificationFlow.resendEmailVerification()
                         },
                         submitLabel: .next,
                         onSubmit: { focusedField = .password },
-                        onEmailChanged: { viewModel.handleEmailChanged() }
+                        onEmailChanged: { viewModel.emailVerificationFlow.handleEmailChanged() }
                     )
 
                     Text(Constants.deliveryNotice)
                         .appFont(.footnote, color: .grey500)
 
-                    if viewModel.isEmailVerified {
+                    if viewModel.emailVerificationFlow.isEmailVerified {
                         SignUpPasswordSection(
                             password: $viewModel.newPassword,
                             passwordConfirm: $viewModel.newPasswordConfirm,

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpByIdPwView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpByIdPwView.swift
@@ -70,24 +70,25 @@ public struct SignUpByIdPwView: View {
 
                     VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
                         SignUpEmailSection(
-                            email: $viewModel.email,
-                            isVerified: $viewModel.isEmailVerified,
+                            email: $viewModel.emailVerificationFlow.email,
+                            isVerified: $viewModel.emailVerificationFlow.isEmailVerified,
                             onVerificationRequested: {
-                                try await viewModel.requestEmailVerification()
+                                try await viewModel.emailVerificationFlow
+                                    .requestEmailVerification()
                             },
                             onVerificationComplete: { code in
                                 try await viewModel.verifyEmailCode(code)
                             },
                             onResend: {
-                                try await viewModel.resendEmailVerification()
+                                try await viewModel.emailVerificationFlow.resendEmailVerification()
                             },
                             onEmailChanged: {
-                                viewModel.handleEmailChanged()
+                                viewModel.emailVerificationFlow.handleEmailChanged()
                             },
                             showsVerifiedMessage: false
                         )
 
-                        if viewModel.isEmailVerified {
+                        if viewModel.emailVerificationFlow.isEmailVerified {
                             emailAvailabilityStatusRow
                         }
                     }

--- a/UMCApp/Features/Auth/Presentation/Tests/EmailVerificationFlowTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/EmailVerificationFlowTests.swift
@@ -1,0 +1,286 @@
+import Testing
+import Foundation
+import AuthDomain
+@testable import AuthPresentation
+
+@MainActor
+@Suite("EmailVerificationFlow — 발송/검증/재전송")
+struct EmailVerificationFlowRequestTests {
+
+    @Test("인증번호 발송 성공 시 emailVerificationId가 저장되고 purpose가 그대로 전달된다")
+    func requestEmailVerificationStoresIdAndPassesPurpose() async throws {
+        let sendUseCase = MockSendEmailVerificationUseCase()
+        sendUseCase.result = .success("verify-id-1")
+        let flow = makeFlow(purpose: .passwordReset, sendEmailVerificationUseCase: sendUseCase)
+        flow.email = "member@umc.dev"
+
+        try await flow.requestEmailVerification()
+
+        #expect(sendUseCase.callCount == 1)
+        #expect(sendUseCase.receivedEmail == "member@umc.dev")
+        #expect(sendUseCase.receivedPurpose == .passwordReset)
+        #expect(flow.emailVerificationId == "verify-id-1")
+    }
+
+    @Test("emailVerificationId가 없으면 verifyEmailCode는 false를 반환하고 아무 것도 검증하지 않는다")
+    func verifyEmailCodeWithoutIdReturnsFalse() async throws {
+        let verifyUseCase = MockVerifyEmailCodeUseCase()
+        let flow = makeFlow(verifyEmailCodeUseCase: verifyUseCase)
+
+        let didVerify = try await flow.verifyEmailCode("123456")
+
+        #expect(didVerify == false)
+        #expect(verifyUseCase.callCount == 0)
+        #expect(flow.isEmailVerified == false)
+    }
+
+    @Test("인증번호 검증 성공 시 true를 반환하고 토큰이 저장되며 isEmailVerified가 true가 된다")
+    func verifyEmailCodeSucceedsAfterRequest() async throws {
+        let sendUseCase = MockSendEmailVerificationUseCase()
+        sendUseCase.result = .success("verify-id-1")
+        let verifyUseCase = MockVerifyEmailCodeUseCase()
+        verifyUseCase.result = .success("verify-token-1")
+        let flow = makeFlow(
+            sendEmailVerificationUseCase: sendUseCase,
+            verifyEmailCodeUseCase: verifyUseCase
+        )
+        flow.email = "member@umc.dev"
+        try await flow.requestEmailVerification()
+
+        let didVerify = try await flow.verifyEmailCode("123456")
+
+        #expect(didVerify == true)
+        #expect(flow.isEmailVerified == true)
+        #expect(flow.emailVerificationToken == "verify-token-1")
+    }
+
+    @Test("emailVerificationId가 없으면 resendEmailVerification은 아무 것도 하지 않는다")
+    func resendWithoutIdNoOps() async throws {
+        let resendUseCase = MockResendEmailVerificationUseCase()
+        let flow = makeFlow(resendEmailVerificationUseCase: resendUseCase)
+
+        try await flow.resendEmailVerification()
+
+        #expect(resendUseCase.callCount == 0)
+    }
+
+    @Test("인증번호 발송 후 재전송하면 동일한 emailVerificationId로 재전송 UseCase가 호출된다")
+    func resendAfterRequestCallsUseCaseWithSameId() async throws {
+        let sendUseCase = MockSendEmailVerificationUseCase()
+        sendUseCase.result = .success("verify-id-1")
+        let resendUseCase = MockResendEmailVerificationUseCase()
+        resendUseCase.result = .success(())
+        let flow = makeFlow(
+            sendEmailVerificationUseCase: sendUseCase,
+            resendEmailVerificationUseCase: resendUseCase
+        )
+        flow.email = "member@umc.dev"
+        try await flow.requestEmailVerification()
+
+        try await flow.resendEmailVerification()
+
+        #expect(resendUseCase.callCount == 1)
+        #expect(resendUseCase.receivedEmailVerificationId == "verify-id-1")
+    }
+
+    @Test("발송 요청이 진행 중이면 재진입 호출은 API를 다시 호출하지 않는다")
+    func duplicateRequestWhileInFlightIsIgnored() async throws {
+        let slowUseCase = SlowSendEmailVerificationUseCase(delayNanoseconds: 50_000_000)
+        let flow = makeFlow(sendEmailVerificationUseCase: slowUseCase)
+        flow.email = "member@umc.dev"
+
+        let first = Task { try await flow.requestEmailVerification() }
+        await Task.yield()
+
+        try await flow.requestEmailVerification()
+        try await first.value
+
+        #expect(slowUseCase.callCount == 1)
+    }
+}
+
+@MainActor
+@Suite("EmailVerificationFlow — 이메일 변경 감지")
+struct EmailVerificationFlowEmailChangeTests {
+
+    @Test("이메일이 바뀌지 않았다면 재호출해도 인증 상태가 유지된다")
+    func handleEmailChangedNoOpsWhenEmailUnchanged() async throws {
+        let flow = try await makeVerifiedFlow()
+        // 최초 호출 시점엔 스냅샷이 아직 비어 있으므로(어떤 이메일과 비교해도 다름) 리셋된다.
+        flow.handleEmailChanged()
+        #expect(flow.isEmailVerified == false)
+
+        try await flow.requestEmailVerification()
+        try await flow.verifyEmailCode("123456")
+        #expect(flow.isEmailVerified == true)
+
+        // 이메일을 바꾸지 않고 재호출 — 스냅샷과 동일하므로 리셋되지 않아야 한다.
+        flow.handleEmailChanged()
+
+        #expect(flow.isEmailVerified == true)
+    }
+
+    @Test("이메일이 실제로 바뀌면 인증 상태가 초기화된다")
+    func handleEmailChangedResetsWhenEmailActuallyChanges() async throws {
+        let flow = try await makeVerifiedFlow()
+
+        flow.email = "changed@umc.dev"
+        flow.handleEmailChanged()
+
+        #expect(flow.isEmailVerified == false)
+        #expect(flow.emailVerificationId == nil)
+        #expect(flow.emailVerificationToken == nil)
+    }
+
+    @Test("이메일 변경으로 인한 리셋은 onReset 훅을 호출한다")
+    func handleEmailChangedInvokesOnResetHook() async throws {
+        let flow = try await makeVerifiedFlow()
+        var onResetCallCount = 0
+        flow.onReset = { onResetCallCount += 1 }
+
+        flow.email = "changed@umc.dev"
+        flow.handleEmailChanged()
+
+        #expect(onResetCallCount == 1)
+    }
+}
+
+@MainActor
+@Suite("EmailVerificationFlow — resetEmailVerification")
+struct EmailVerificationFlowResetTests {
+
+    @Test("resetEmailVerification은 인증 상태를 모두 초기화하고 onReset을 호출한다")
+    func resetClearsStateAndInvokesHook() async throws {
+        let flow = try await makeVerifiedFlow()
+        var onResetCallCount = 0
+        flow.onReset = { onResetCallCount += 1 }
+
+        flow.resetEmailVerification()
+
+        #expect(flow.isEmailVerified == false)
+        #expect(flow.emailVerificationId == nil)
+        #expect(flow.emailVerificationToken == nil)
+        #expect(onResetCallCount == 1)
+    }
+
+    @Test("onReset이 설정되지 않아도 resetEmailVerification은 안전하게 동작한다")
+    func resetWithoutHookDoesNotCrash() async throws {
+        let flow = try await makeVerifiedFlow()
+
+        flow.resetEmailVerification()
+
+        #expect(flow.isEmailVerified == false)
+    }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeFlow(
+    purpose: EmailVerificationPurpose = .register,
+    sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol? = nil,
+    verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol? = nil,
+    resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol? = nil
+) -> EmailVerificationFlow {
+    EmailVerificationFlow(
+        purpose: purpose,
+        sendEmailVerificationUseCase: sendEmailVerificationUseCase
+            ?? MockSendEmailVerificationUseCase(),
+        verifyEmailCodeUseCase: verifyEmailCodeUseCase ?? MockVerifyEmailCodeUseCase(),
+        resendEmailVerificationUseCase: resendEmailVerificationUseCase
+            ?? MockResendEmailVerificationUseCase()
+    )
+}
+
+/// 이메일 인증까지 완료한 상태의 플로우를 만든다.
+@MainActor
+private func makeVerifiedFlow(
+    email: String = "member@umc.dev"
+) async throws -> EmailVerificationFlow {
+    let sendUseCase = MockSendEmailVerificationUseCase()
+    sendUseCase.result = .success("verify-id-1")
+    let verifyUseCase = MockVerifyEmailCodeUseCase()
+    verifyUseCase.result = .success("verify-token-1")
+
+    let flow = makeFlow(
+        sendEmailVerificationUseCase: sendUseCase,
+        verifyEmailCodeUseCase: verifyUseCase
+    )
+    flow.email = email
+    try await flow.requestEmailVerification()
+    try await flow.verifyEmailCode("123456")
+
+    return flow
+}
+
+// MARK: - Mocks — UseCase
+
+private final class MockSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+    @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<String, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+    private(set) var receivedEmail: String?
+    private(set) var receivedPurpose: EmailVerificationPurpose?
+
+    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
+        callCount += 1
+        receivedEmail = email
+        receivedPurpose = purpose
+        return try result.get()
+    }
+}
+
+private final class MockVerifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
+    @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<String, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+
+    func execute(emailVerificationId: String, verificationCode: String) async throws -> String {
+        callCount += 1
+        return try result.get()
+    }
+}
+
+private final class MockResendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
+    @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<Void, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+    private(set) var receivedEmailVerificationId: String?
+
+    func execute(emailVerificationId: String) async throws {
+        callCount += 1
+        receivedEmailVerificationId = emailVerificationId
+        _ = try result.get()
+    }
+}
+
+/// 재진입 가드 검증을 위해 인위적인 지연을 주는 인증 발송 UseCase.
+private final class SlowSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+    @unchecked Sendable {
+    private let delayNanoseconds: UInt64
+    private let lock = NSLock()
+    private var _callCount = 0
+
+    var callCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _callCount
+    }
+
+    init(delayNanoseconds: UInt64) {
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
+        lock.lock()
+        _callCount += 1
+        lock.unlock()
+        try await Task.sleep(nanoseconds: delayNanoseconds)
+        return "verify-id-slow"
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Tests/ResetPasswordViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/ResetPasswordViewModelTests.swift
@@ -98,6 +98,16 @@ struct ResetPasswordViewModelCanSubmitTests {
         #expect(viewModel.canSubmit == false)
     }
 
+    @Test("비밀번호가 정확히 8자면 isPasswordValid가 true다 (경계값)")
+    func exactlyMinimumLengthPasswordIsValid() async throws {
+        let viewModel = try await makeVerifiedViewModel()
+        viewModel.newPassword = "exactly8"
+        viewModel.newPasswordConfirm = "exactly8"
+
+        #expect(viewModel.isPasswordValid == true)
+        #expect(viewModel.canSubmit == true)
+    }
+
     @Test("비밀번호 확인이 일치하지 않으면 canSubmit이 false다")
     func passwordMismatchBlocksSubmit() async throws {
         let viewModel = try await makeVerifiedViewModel()

--- a/UMCApp/Features/Auth/Presentation/Tests/ResetPasswordViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/ResetPasswordViewModelTests.swift
@@ -14,13 +14,13 @@ struct ResetPasswordViewModelEmailVerificationTests {
         let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
         sendEmailVerificationUseCase.result = .success("verify-id-1")
         let viewModel = makeViewModel(sendEmailVerificationUseCase: sendEmailVerificationUseCase)
-        viewModel.email = "member@umc.dev"
+        viewModel.emailVerificationFlow.email = "member@umc.dev"
 
-        try await viewModel.requestEmailVerification()
+        try await viewModel.emailVerificationFlow.requestEmailVerification()
 
         #expect(sendEmailVerificationUseCase.callCount == 1)
         #expect(sendEmailVerificationUseCase.receivedPurpose == .passwordReset)
-        #expect(viewModel.emailVerificationId == "verify-id-1")
+        #expect(viewModel.emailVerificationFlow.emailVerificationId == "verify-id-1")
     }
 
     @Test("인증코드 검증 성공 시 토큰이 저장되고 isEmailVerified가 true가 된다")
@@ -33,13 +33,13 @@ struct ResetPasswordViewModelEmailVerificationTests {
             sendEmailVerificationUseCase: sendEmailVerificationUseCase,
             verifyEmailCodeUseCase: verifyEmailCodeUseCase
         )
-        viewModel.email = "member@umc.dev"
-        try await viewModel.requestEmailVerification()
+        viewModel.emailVerificationFlow.email = "member@umc.dev"
+        try await viewModel.emailVerificationFlow.requestEmailVerification()
 
-        try await viewModel.verifyEmailCode("123456")
+        try await viewModel.emailVerificationFlow.verifyEmailCode("123456")
 
-        #expect(viewModel.isEmailVerified == true)
-        #expect(viewModel.emailVerificationToken == "verify-token-1")
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == true)
+        #expect(viewModel.emailVerificationFlow.emailVerificationToken == "verify-token-1")
     }
 
     @Test("이메일 변경 시 인증 상태가 초기화된다")
@@ -52,17 +52,17 @@ struct ResetPasswordViewModelEmailVerificationTests {
             sendEmailVerificationUseCase: sendEmailVerificationUseCase,
             verifyEmailCodeUseCase: verifyEmailCodeUseCase
         )
-        viewModel.email = "member@umc.dev"
-        try await viewModel.requestEmailVerification()
-        try await viewModel.verifyEmailCode("123456")
-        #expect(viewModel.isEmailVerified == true)
+        viewModel.emailVerificationFlow.email = "member@umc.dev"
+        try await viewModel.emailVerificationFlow.requestEmailVerification()
+        try await viewModel.emailVerificationFlow.verifyEmailCode("123456")
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == true)
 
-        viewModel.email = "changed@umc.dev"
-        viewModel.handleEmailChanged()
+        viewModel.emailVerificationFlow.email = "changed@umc.dev"
+        viewModel.emailVerificationFlow.handleEmailChanged()
 
-        #expect(viewModel.isEmailVerified == false)
-        #expect(viewModel.emailVerificationId == nil)
-        #expect(viewModel.emailVerificationToken == nil)
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == false)
+        #expect(viewModel.emailVerificationFlow.emailVerificationId == nil)
+        #expect(viewModel.emailVerificationFlow.emailVerificationToken == nil)
     }
 }
 
@@ -220,9 +220,9 @@ private func makeVerifiedViewModel(
         errorHandler: errorHandler
     )
 
-    viewModel.email = email
-    try await viewModel.requestEmailVerification()
-    try await viewModel.verifyEmailCode("123456")
+    viewModel.emailVerificationFlow.email = email
+    try await viewModel.emailVerificationFlow.requestEmailVerification()
+    try await viewModel.emailVerificationFlow.verifyEmailCode("123456")
 
     return viewModel
 }

--- a/UMCApp/Features/Auth/Presentation/Tests/ResetPasswordViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/ResetPasswordViewModelTests.swift
@@ -1,0 +1,277 @@
+import Testing
+import Foundation
+import CoreDI
+import AuthDomain
+import UMCFoundation
+@testable import AuthPresentation
+
+@MainActor
+@Suite("ResetPasswordViewModel — 이메일 인증")
+struct ResetPasswordViewModelEmailVerificationTests {
+
+    @Test("인증번호 발송 성공 시 emailVerificationId가 저장된다")
+    func requestEmailVerificationStoresId() async throws {
+        let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
+        sendEmailVerificationUseCase.result = .success("verify-id-1")
+        let viewModel = makeViewModel(sendEmailVerificationUseCase: sendEmailVerificationUseCase)
+        viewModel.email = "member@umc.dev"
+
+        try await viewModel.requestEmailVerification()
+
+        #expect(sendEmailVerificationUseCase.callCount == 1)
+        #expect(sendEmailVerificationUseCase.receivedPurpose == .passwordReset)
+        #expect(viewModel.emailVerificationId == "verify-id-1")
+    }
+
+    @Test("인증코드 검증 성공 시 토큰이 저장되고 isEmailVerified가 true가 된다")
+    func verifyEmailCodeMarksVerified() async throws {
+        let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
+        sendEmailVerificationUseCase.result = .success("verify-id-1")
+        let verifyEmailCodeUseCase = MockVerifyEmailCodeUseCase()
+        verifyEmailCodeUseCase.result = .success("verify-token-1")
+        let viewModel = makeViewModel(
+            sendEmailVerificationUseCase: sendEmailVerificationUseCase,
+            verifyEmailCodeUseCase: verifyEmailCodeUseCase
+        )
+        viewModel.email = "member@umc.dev"
+        try await viewModel.requestEmailVerification()
+
+        try await viewModel.verifyEmailCode("123456")
+
+        #expect(viewModel.isEmailVerified == true)
+        #expect(viewModel.emailVerificationToken == "verify-token-1")
+    }
+
+    @Test("이메일 변경 시 인증 상태가 초기화된다")
+    func emailChangeResetsVerificationState() async throws {
+        let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
+        sendEmailVerificationUseCase.result = .success("verify-id-1")
+        let verifyEmailCodeUseCase = MockVerifyEmailCodeUseCase()
+        verifyEmailCodeUseCase.result = .success("verify-token-1")
+        let viewModel = makeViewModel(
+            sendEmailVerificationUseCase: sendEmailVerificationUseCase,
+            verifyEmailCodeUseCase: verifyEmailCodeUseCase
+        )
+        viewModel.email = "member@umc.dev"
+        try await viewModel.requestEmailVerification()
+        try await viewModel.verifyEmailCode("123456")
+        #expect(viewModel.isEmailVerified == true)
+
+        viewModel.email = "changed@umc.dev"
+        viewModel.handleEmailChanged()
+
+        #expect(viewModel.isEmailVerified == false)
+        #expect(viewModel.emailVerificationId == nil)
+        #expect(viewModel.emailVerificationToken == nil)
+    }
+}
+
+@MainActor
+@Suite("ResetPasswordViewModel — canSubmit")
+struct ResetPasswordViewModelCanSubmitTests {
+
+    @Test("이메일 인증, 비밀번호 검증을 모두 충족하면 canSubmit이 true다")
+    func allConditionsSatisfiedMakesCanSubmitTrue() async throws {
+        let viewModel = try await makeVerifiedViewModel()
+        viewModel.newPassword = "newPassword1234"
+        viewModel.newPasswordConfirm = "newPassword1234"
+
+        #expect(viewModel.canSubmit == true)
+    }
+
+    @Test("이메일 인증 전이면 canSubmit이 false다")
+    func emailNotVerifiedBlocksSubmit() {
+        let viewModel = makeViewModel()
+        viewModel.newPassword = "newPassword1234"
+        viewModel.newPasswordConfirm = "newPassword1234"
+
+        #expect(viewModel.canSubmit == false)
+    }
+
+    @Test("비밀번호가 8자 미만이면 canSubmit이 false다")
+    func shortPasswordBlocksSubmit() async throws {
+        let viewModel = try await makeVerifiedViewModel()
+        viewModel.newPassword = "short"
+        viewModel.newPasswordConfirm = "short"
+
+        #expect(viewModel.isPasswordValid == false)
+        #expect(viewModel.canSubmit == false)
+    }
+
+    @Test("비밀번호 확인이 일치하지 않으면 canSubmit이 false다")
+    func passwordMismatchBlocksSubmit() async throws {
+        let viewModel = try await makeVerifiedViewModel()
+        viewModel.newPassword = "newPassword1234"
+        viewModel.newPasswordConfirm = "different-password"
+
+        #expect(viewModel.isPasswordConfirmed == false)
+        #expect(viewModel.canSubmit == false)
+    }
+}
+
+@MainActor
+@Suite("ResetPasswordViewModel — 비밀번호 재설정")
+struct ResetPasswordViewModelResetPasswordTests {
+
+    @Test("canSubmit이 false면 resetPassword()는 아무 것도 하지 않는다")
+    func resetPasswordNoOpsWhenCanSubmitFalse() async {
+        let resetPasswordUseCase = MockResetPasswordUseCase()
+        let viewModel = makeViewModel(resetPasswordUseCase: resetPasswordUseCase)
+
+        await viewModel.resetPassword()
+
+        #expect(resetPasswordUseCase.callCount == 0)
+        #expect(viewModel.resetPasswordState == .idle)
+    }
+
+    @Test("재설정 성공 → resetPasswordState.loaded(true)")
+    func resetPasswordSuccessSetsLoaded() async throws {
+        let resetPasswordUseCase = MockResetPasswordUseCase()
+        resetPasswordUseCase.result = .success(())
+        let viewModel = try await makeVerifiedViewModel(resetPasswordUseCase: resetPasswordUseCase)
+        viewModel.newPassword = "newPassword1234"
+        viewModel.newPasswordConfirm = "newPassword1234"
+
+        await viewModel.resetPassword()
+
+        #expect(viewModel.resetPasswordState == .loaded(true))
+        #expect(resetPasswordUseCase.callCount == 1)
+        #expect(resetPasswordUseCase.receivedEmailVerificationToken == "verify-token-1")
+        #expect(resetPasswordUseCase.receivedNewPassword == "newPassword1234")
+    }
+
+    @Test("재설정 실패 → resetPasswordState.idle 복귀 + ErrorHandler Alert 노출")
+    func resetPasswordFailureSetsIdleWithErrorAlert() async throws {
+        let resetPasswordUseCase = MockResetPasswordUseCase()
+        resetPasswordUseCase.result = .failure(DummyError())
+        let errorHandler = ErrorHandler()
+        let viewModel = try await makeVerifiedViewModel(
+            resetPasswordUseCase: resetPasswordUseCase,
+            errorHandler: errorHandler
+        )
+        viewModel.newPassword = "newPassword1234"
+        viewModel.newPasswordConfirm = "newPassword1234"
+
+        await viewModel.resetPassword()
+
+        #expect(viewModel.resetPasswordState == .idle)
+        #expect(errorHandler.currentError != nil)
+    }
+}
+
+// MARK: - Helpers
+
+private struct DummyError: Error {}
+
+@MainActor
+private func makeViewModel(
+    sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol? = nil,
+    verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol? = nil,
+    resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol? = nil,
+    resetPasswordUseCase: ResetPasswordUseCaseProtocol? = nil,
+    errorHandler: ErrorHandler? = nil
+) -> ResetPasswordViewModel {
+    let container = DIContainer()
+    container.register(SendEmailVerificationUseCaseProtocol.self) {
+        sendEmailVerificationUseCase ?? MockSendEmailVerificationUseCase()
+    }
+    container.register(VerifyEmailCodeUseCaseProtocol.self) {
+        verifyEmailCodeUseCase ?? MockVerifyEmailCodeUseCase()
+    }
+    container.register(ResendEmailVerificationUseCaseProtocol.self) {
+        resendEmailVerificationUseCase ?? MockResendEmailVerificationUseCase()
+    }
+    container.register(ResetPasswordUseCaseProtocol.self) {
+        resetPasswordUseCase ?? MockResetPasswordUseCase()
+    }
+
+    return ResetPasswordViewModel(
+        container: container,
+        errorHandler: errorHandler ?? ErrorHandler()
+    )
+}
+
+/// 이메일 인증까지 완료한 상태의 ViewModel을 만든다.
+@MainActor
+private func makeVerifiedViewModel(
+    resetPasswordUseCase: ResetPasswordUseCaseProtocol? = nil,
+    errorHandler: ErrorHandler? = nil,
+    email: String = "member@umc.dev"
+) async throws -> ResetPasswordViewModel {
+    let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
+    sendEmailVerificationUseCase.result = .success("verify-id-1")
+    let verifyEmailCodeUseCase = MockVerifyEmailCodeUseCase()
+    verifyEmailCodeUseCase.result = .success("verify-token-1")
+
+    let viewModel = makeViewModel(
+        sendEmailVerificationUseCase: sendEmailVerificationUseCase,
+        verifyEmailCodeUseCase: verifyEmailCodeUseCase,
+        resetPasswordUseCase: resetPasswordUseCase,
+        errorHandler: errorHandler
+    )
+
+    viewModel.email = email
+    try await viewModel.requestEmailVerification()
+    try await viewModel.verifyEmailCode("123456")
+
+    return viewModel
+}
+
+// MARK: - Mocks — UseCase
+
+private final class MockSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+    @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<String, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+    private(set) var receivedPurpose: EmailVerificationPurpose?
+
+    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
+        callCount += 1
+        receivedPurpose = purpose
+        return try result.get()
+    }
+}
+
+private final class MockVerifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
+    @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<String, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+
+    func execute(emailVerificationId: String, verificationCode: String) async throws -> String {
+        callCount += 1
+        return try result.get()
+    }
+}
+
+private final class MockResendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
+    @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<Void, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+
+    func execute(emailVerificationId: String) async throws {
+        callCount += 1
+        _ = try result.get()
+    }
+}
+
+private final class MockResetPasswordUseCase: ResetPasswordUseCaseProtocol, @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<Void, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+    private(set) var receivedEmailVerificationToken: String?
+    private(set) var receivedNewPassword: String?
+
+    func execute(emailVerificationToken: String, newPassword: String) async throws {
+        callCount += 1
+        receivedEmailVerificationToken = emailVerificationToken
+        receivedNewPassword = newPassword
+        _ = try result.get()
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Tests/SignUpByIdPwViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/SignUpByIdPwViewModelTests.swift
@@ -52,7 +52,7 @@ struct SignUpByIdPwViewModelEmailAvailabilityTests {
             verifyEmailCodeUseCase: verifyEmailCodeUseCase,
             checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase
         )
-        viewModel.email = "member@umc.dev"
+        viewModel.emailVerificationFlow.email = "member@umc.dev"
         try await requestVerification(on: viewModel)
 
         // 연속 재검증(예: 코드 재입력) — 매 호출마다 이전 debounce 예약이 취소된다.
@@ -79,12 +79,12 @@ struct SignUpByIdPwViewModelEmailAvailabilityTests {
             verifyEmailCodeUseCase: verifyEmailCodeUseCase,
             checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase
         )
-        viewModel.email = "first@umc.dev"
+        viewModel.emailVerificationFlow.email = "first@umc.dev"
         try await requestVerification(on: viewModel)
         try await viewModel.verifyEmailCode("111111")
 
-        viewModel.email = "second@umc.dev"
-        viewModel.handleEmailChanged()
+        viewModel.emailVerificationFlow.email = "second@umc.dev"
+        viewModel.emailVerificationFlow.handleEmailChanged()
         try await requestVerification(on: viewModel)
         try await viewModel.verifyEmailCode("222222")
 
@@ -104,8 +104,8 @@ struct SignUpByIdPwViewModelEmailAvailabilityTests {
         try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
         #expect(viewModel.emailAvailabilityState == .loaded(true))
 
-        viewModel.email = "changed@umc.dev"
-        viewModel.handleEmailChanged()
+        viewModel.emailVerificationFlow.email = "changed@umc.dev"
+        viewModel.emailVerificationFlow.handleEmailChanged()
 
         #expect(viewModel.emailAvailabilityState == .idle)
     }
@@ -366,7 +366,7 @@ private func requestVerification(
     on viewModel: SignUpByIdPwViewModel,
     code: String = "123456"
 ) async throws {
-    try await viewModel.requestEmailVerification()
+    try await viewModel.emailVerificationFlow.requestEmailVerification()
     try await viewModel.verifyEmailCode(code)
 }
 
@@ -411,7 +411,7 @@ private func makeVerifiedEmailViewModel(
         viewModel.termsAgreements["terms-privacy"] = true
     }
 
-    viewModel.email = email
+    viewModel.emailVerificationFlow.email = email
     try await requestVerification(on: viewModel)
 
     return viewModel
@@ -458,7 +458,7 @@ private func makeValidFormViewModel(
     viewModel.nickname = "길동이"
     viewModel.password = "password1234"
     viewModel.passwordConfirm = "password1234"
-    viewModel.email = "member@umc.dev"
+    viewModel.emailVerificationFlow.email = "member@umc.dev"
     viewModel.selectedSchool = School(id: "1", name: "테스트대학교")
 
     try await requestVerification(on: viewModel)

--- a/UMCApp/UMCApp/Sources/AppRootView.swift
+++ b/UMCApp/UMCApp/Sources/AppRootView.swift
@@ -17,6 +17,9 @@ struct AppRootView: View {
     @Environment(ErrorHandler.self) private var errorHandler
     #if DEBUG
     @State private var isDebugSignUpByIdPwPresented = false
+    // TODO: [#943] ID/PW 로그인 화면이 이식되면 그 화면의 "비밀번호 찾기" 링크로 대체하고
+    // 이 DEBUG 진입점은 제거한다.
+    @State private var isDebugResetPasswordPresented = false
     #endif
 
     // MARK: - Body
@@ -66,6 +69,9 @@ struct AppRootView: View {
         .fullScreenCover(isPresented: $isDebugSignUpByIdPwPresented) {
             SignUpByIdPwView(container: di, errorHandler: errorHandler)
         }
+        .fullScreenCover(isPresented: $isDebugResetPasswordPresented) {
+            ResetPasswordView(container: di, errorHandler: errorHandler)
+        }
         #endif
     }
 
@@ -93,14 +99,16 @@ struct AppRootView: View {
 
     /// 상태머신 강제 전환 확인용 디버그 컨트롤. 릴리스 빌드에는 포함되지 않는다.
     ///
-    /// - Note: 이메일(ID/PW) 가입 화면(`SignUpByIdPwView`)은 프로덕션 네비게이션 배선이
-    ///   아직 없다(Q1, 후속 이슈에서 연결). 그 전까지 QA/리뷰어용 임시 진입점만 제공한다.
+    /// - Note: 이메일(ID/PW) 가입 화면(`SignUpByIdPwView`)과 비밀번호 재설정 화면
+    ///   (`ResetPasswordView`)은 프로덕션 네비게이션 배선이 아직 없다(각각 Q1, #943 참고 —
+    ///   후속 이슈에서 연결). 그 전까지 QA/리뷰어용 임시 진입점만 제공한다.
     private var debugFlowSwitcher: some View {
         HStack(spacing: DefaultSpacing.spacing12) {
             Button("Bootstrap") { viewModel.showBootstrap() }
             Button("Login") { viewModel.showLogin() }
             Button("Main") { viewModel.showMain() }
             Button("SignUp(ID/PW)") { isDebugSignUpByIdPwPresented = true }
+            Button("Reset PW") { isDebugResetPasswordPresented = true }
         }
         .buttonStyle(.bordered)
         .padding(.bottom, DefaultConstant.defaultSafeBottom)

--- a/UMCApp/UMCApp/Sources/DIContainer+Auth.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Auth.swift
@@ -89,5 +89,13 @@ extension DIContainer {
                 repository: self.resolve(AuthRegistrationRepositoryProtocol.self)
             )
         }
+
+        // MARK: - 비밀번호 재설정(ResetPassword) 관련 UseCase (#947)
+
+        register(ResetPasswordUseCaseProtocol.self) {
+            ResetPasswordUseCase(
+                repository: self.resolve(AuthRegistrationRepositoryProtocol.self)
+            )
+        }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Feature — 레거시(AppProduct, v2.2.0 동결)의 비밀번호 재설정(ResetPassword) 플로우를 UMCApp(Tuist) Auth 피처로 이식. 이메일 인증 인프라(#944 이식분)를 재사용합니다.
close #947

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->
- 재설정 화면: 이메일 입력 → 인증코드 발송/검증 → 새 비밀번호 설정 → 완료 얼럿 후 닫기
- 현재 진입은 `#if DEBUG` 임시 배선(AppRootView) — #943(이메일 로그인) 이관 시 실제 "비밀번호 찾기" 링크로 대체 예정

## 🛠️ 작업내용

- **Domain**: `ResetPasswordUseCaseProtocol` + 구현체 신설, `AuthRegistrationRepositoryProtocol.resetPassword(emailVerificationToken:newPassword:)` 계약 추가, Mock 스텁 + UseCase 테스트
- **Data**: `AuthRouter`에 `.resetPassword` 케이스 추가 — 파라미터는 `ResetPasswordRequestDTO`(Body DTO)로 캡슐화(절대규칙 #6), `AuthRepository.resetPassword`는 비로그인 상태 플로우이므로 `requestWithoutAuth` 사용. 전용 Router 테스트 스위트(`AuthRouterResetPasswordTests`) 추가
- **Presentation**: `ResetPasswordViewModel(@Observable)` + `ResetPasswordView` 이식 — #944의 `SendEmailVerificationUseCase`/`VerifyEmailCodeUseCase`/`ResendEmailVerificationUseCase` 재사용, `FormEmailField`/`SignUpPasswordSection` 기존 컴포넌트 재사용, 완료 안내는 `AlertPrompt`
- **진입점(임시)**: 선행 이슈 #943(이메일 ID/PW 로그인 화면)이 미이식이라 `AppRootView`에 `#if DEBUG` fullScreenCover 임시 진입점 배선 + `// TODO: [#943]` 마커 — 릴리스 빌드에는 미포함
- **DI**: `DIContainer+Auth.swift`에 `ResetPasswordUseCaseProtocol` 등록
- **테스트**: UseCase/Router/ViewModel 테스트 + 비밀번호 8자 경계값 테스트 — `make generate && make test` 통과

### 후속 갭 해소 (추가 커밋 `c8d28cad`)

당초 "추후 진행 상황"으로 미뤄뒀던 이메일 인증 로직 중복을 이 PR에서 해소:

- **`EmailVerificationFlow` 공통 컴포넌트 추출**: `ResetPasswordViewModel`과 `SignUpByIdPwViewModel`에 복사-붙여넣기로 중복돼 있던 이메일 인증 상태/액션 전체(인증 ID/토큰, 재진입 가드, 발송/검증/재전송/이메일 변경 감지/리셋)를 `@Observable` 컴포지션 객체로 추출 — `purpose`(가입/재설정)는 init 주입, 파생 상태 정리는 `onReset: (@MainActor () -> Void)?` 훅으로 확장
- 두 ViewModel은 flow를 프로퍼티로 보유·위임 (SignUp 쪽은 이메일 중복확인 스케줄링만 얇은 래퍼 유지), View 바인딩 경로는 `viewModel.emailVerificationFlow.*`로 갱신
- **동작 불변** 확인: 기존 두 ViewModel 테스트 전부 새 구조로 갱신해 통과 + `EmailVerificationFlowTests` 전용 스위트 신규 추가 — AuthDomain 47 · AuthData 66 · AuthPresentation 86 · UMCApp 7 전부 성공

### 레거시와 의도적으로 다른 부분

- **재설정 실패 처리**: 레거시는 에러 타입별 인라인 `Loadable.failed` 매핑이지만, 이식본은 `.idle` 복귀 + `ErrorHandler`(흐름 중단형 전역 Alert) 위임 — 프로젝트 에러 처리 규약 및 #944 슬라이스(`SignUpByIdPwViewModel.register()`)와 동일 패턴으로 정합화

## 📋 추후 진행 상황

- #943(이메일 로그인) 이관 시 로그인 화면에 "비밀번호 찾기" 실링크 노출 + `AppRootView`의 DEBUG 임시 진입점 제거 (#943 스코프에서 처리)

## 📌 리뷰 포인트

- `UMCApp/Features/Auth/Presentation/Sources/ViewModels/EmailVerificationFlow.swift` - 추출된 공통 인증 플로우의 재진입 가드·`onReset` 훅 설계, `@Observable` 중첩 관측 경로
- `UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/ResetPasswordUseCase.swift` - Repository 계약과 토큰 전달 흐름
- `UMCApp/Features/Auth/Data/Sources/Router/AuthRouter.swift` - `.resetPassword` 엔드포인트 path/method/task가 레거시·서버 스펙과 일치하는지
- `UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift` - `requestWithoutAuth` 선택(비로그인 플로우)의 타당성
- `UMCApp/Features/Auth/Presentation/Sources/ViewModels/ResetPasswordViewModel.swift`, `SignUpByIdPwViewModel.swift` - flow 위임 후에도 화면별 정책(가입: 중복확인 스케줄링 / 재설정: canSubmit)이 기존과 동일한지
- `UMCApp/UMCApp/Sources/AppRootView.swift` - `#if DEBUG` 임시 진입점이 릴리스에 새지 않는지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)