### PR TITLE
🐛 [Fix] MyPage deleteMember void 응답 디코딩 계약 수정(EmptyResult) 및 NetworkError 매핑 추가

### DIFF
--- a/UMCApp/Features/MyPage/Data/Sources/Repository/MyPageRepository.swift
+++ b/UMCApp/Features/MyPage/Data/Sources/Repository/MyPageRepository.swift
@@ -150,29 +150,41 @@ public final class MyPageRepository: MyPageRepositoryProtocol, @unchecked Sendab
                 )
             }
         )
-        
-        let response = try await adapter.request(
-            MyPageRouter.patchMemberProfileLinks(
-                request: request
+
+        do {
+            let response = try await adapter.request(
+                MyPageRouter.patchMemberProfileLinks(
+                    request: request
+                )
             )
-        )
-        
-        let apiResponse = try decoder.decode(
-            APIResponse<MyPageProfileResponseDTO>.self,
-            from: response.data
-        )
-        
-        return try apiResponse.unwrap().toProfileData()
+
+            let apiResponse = try decoder.decode(
+                APIResponse<MyPageProfileResponseDTO>.self,
+                from: response.data
+            )
+
+            return try apiResponse.unwrap().toProfileData()
+        } catch let error as NetworkError {
+            throw Self.parseServerError(from: error) ?? error
+        }
     }
     
     /// 회원 탈퇴 처리
+    ///
+    /// - Note: 백엔드(MEMBER-003)는 탈퇴 전 회원 정보 스냅샷을 `result`로 반환하지만
+    ///   클라이언트는 사용하지 않으므로 `EmptyResult`로 성공 여부만 검증합니다.
+    ///   (`EmptyResult`는 임의 JSON 객체·`result: null` 모두 흡수)
     public func deleteMember() async throws {
-        let response = try await adapter.request(MyPageRouter.deleteMember)
-        let apiResponse = try decoder.decode(
-            APIResponse<MyPageProfileResponseDTO>.self,
-            from: response.data
-        )
-        _ = try apiResponse.unwrap()
+        do {
+            let response = try await adapter.request(MyPageRouter.deleteMember)
+            let apiResponse = try decoder.decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let error as NetworkError {
+            throw Self.parseServerError(from: error) ?? error
+        }
     }
     
     // MARK: - Posts

--- a/UMCApp/Features/MyPage/Data/Tests/MyPageRepositoryTests.swift
+++ b/UMCApp/Features/MyPage/Data/Tests/MyPageRepositoryTests.swift
@@ -414,14 +414,26 @@ struct MyPageRepositoryAddRecordTests {
     }
 }
 
-// MARK: - Suite: 회원 탈퇴 (void 계약)
+// MARK: - Suite: 회원 탈퇴 (result 폐기 계약)
 
 @Suite("MyPageRepository — 회원 탈퇴")
 struct MyPageRepositoryDeleteTests {
 
-    @Test("deleteMember — 성공 시 throw 없이 완료하고 DELETE /member를 호출한다")
+    @Test("deleteMember — 실제 계약(result: 탈퇴 전 회원 스냅샷)에서 throw 없이 완료하고 DELETE /member를 호출한다")
     func deleteMemberSucceeds() async throws {
+        // 백엔드 MEMBER-003은 탈퇴 전 회원 정보 스냅샷을 result로 반환하지만 클라이언트는 폐기한다
         let (sut, stub) = makeRepository(.success(Fixture.success(Fixture.profileObject)))
+
+        try await sut.deleteMember()
+
+        #expect(stub.requestCount == 1)
+        #expect(stub.lastPath == "/api/v1/member")
+        #expect(stub.lastMethod == .delete)
+    }
+
+    @Test("deleteMember — result가 없는 표준 void 봉투도 성공으로 처리한다")
+    func deleteMemberSucceedsWithVoidResult() async throws {
+        let (sut, stub) = makeRepository(.success(Fixture.successVoid()))
 
         try await sut.deleteMember()
 
@@ -437,6 +449,27 @@ struct MyPageRepositoryDeleteTests {
         )
 
         await #expect(throws: RepositoryError.serverError(code: "M403", message: "권한이 없습니다.")) {
+            try await sut.deleteMember()
+        }
+    }
+
+    @Test("deleteMember — 서버 에러 본문(requestFailed)을 RepositoryError.serverError로 승격한다")
+    func deleteMemberMapsServerError() async {
+        let body = Fixture.failureBody(code: "M403", message: "권한이 없습니다.")
+        let (sut, _) = makeRepository(
+            .failure(NetworkError.requestFailed(statusCode: 403, data: body))
+        )
+
+        await #expect(throws: RepositoryError.serverError(code: "M403", message: "권한이 없습니다.")) {
+            try await sut.deleteMember()
+        }
+    }
+
+    @Test("deleteMember — 파싱 불가한 NetworkError는 원본 그대로 전파한다")
+    func deleteMemberPropagatesNonMappableError() async {
+        let (sut, _) = makeRepository(.failure(NetworkError.timeout))
+
+        await #expect(throws: NetworkError.timeout) {
             try await sut.deleteMember()
         }
     }
@@ -472,6 +505,29 @@ struct MyPageRepositoryUpdateLinksTests {
         #expect(byType["GITHUB"] == "https://github.com/me")           // trim 적용
         #expect(byType["LINKEDIN"] == "")                              // 미제공 → 빈 문자열
         #expect(byType["BLOG"] == "")
+    }
+
+    @Test("updateProfileLinks — 서버 에러 본문(requestFailed)을 RepositoryError.serverError로 승격한다")
+    func updateLinksMapsServerError() async {
+        let body = Fixture.failureBody(code: "M400", message: "잘못된 링크 형식입니다.")
+        let (sut, _) = makeRepository(
+            .failure(NetworkError.requestFailed(statusCode: 400, data: body))
+        )
+
+        await #expect(throws: RepositoryError.serverError(
+            code: "M400", message: "잘못된 링크 형식입니다."
+        )) {
+            _ = try await sut.updateProfileLinks([ProfileLink(type: .github, url: "x")])
+        }
+    }
+
+    @Test("updateProfileLinks — 파싱 불가한 NetworkError는 원본 그대로 전파한다")
+    func updateLinksPropagatesNonMappableError() async {
+        let (sut, _) = makeRepository(.failure(NetworkError.timeout))
+
+        await #expect(throws: NetworkError.timeout) {
+            _ = try await sut.updateProfileLinks([ProfileLink(type: .github, url: "x")])
+        }
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

Fix — MyPage `deleteMember()` void 응답 디코딩 계약 수정 및 NetworkError → RepositoryError 매핑 추가 (PR #935 리뷰 MEDIUM #2 후속)

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (Data 레이어 수정)

## 🛠️ 작업내용

- 백엔드 계약 확인(이슈 완료 조건 1): `umc-product-server`의 `MemberCommandController`(MEMBER-003, `DELETE /api/v1/member`)는 `ApiResponse<MemberInfoResponse>` 반환 — **result에 탈퇴 전 회원 정보 스냅샷**을 담으며(void 아님), 봉투 `{success, code, message, result}`에서 result는 `@JsonInclude(NON_NULL)`로 null이면 키 생략
- `deleteMember()`를 `APIResponse<EmptyResult>` + `validateSuccess()`로 교체 — 클라이언트는 result를 사용하지 않으므로 성공 여부만 검증. `EmptyResult`는 임의 JSON 객체·`result: null` 봉투를 모두 흡수해, 백엔드가 응답을 축소해도 "계정은 삭제됐는데 에러 표시"가 나는 위험 제거 (계약 근거는 문서 주석으로 명시)
- `deleteMember`/`updateProfileLinks`에 `addChallengerRecord`와 동일한 `parseServerError(from:)` 기반 `NetworkError → RepositoryError.serverError` 매핑 추가 (4xx/5xx 도메인 에러 변환)
- `MyPageRepositoryTests` 테스트 5건 추가: void 봉투 성공 경로, deleteMember/updateProfileLinks 각각의 서버 에러 본문 승격·비매핑 에러(timeout) 전파. 기존 `deleteMemberSucceeds`는 실제 계약(프로필 스냅샷) 픽스처임을 주석으로 명시하고 유지
- TDD 진행: 수정 전 신규 테스트 3건 실패 확인 → 수정 후 MyPageData 스킴 68개 테스트 전부 통과

## 📋 추후 진행 상황

- 없음 (이슈 #949 완료 조건 전건 반영)

## 📌 리뷰 포인트

- `UMCApp/Features/MyPage/Data/Sources/Repository/MyPageRepository.swift` - `deleteMember()`의 `EmptyResult` + `validateSuccess()` 전환과 두 메서드의 `parseServerError(from:)` 매핑이 `addChallengerRecord` 패턴과 일치하는지
- `UMCApp/Features/MyPage/Data/Tests/MyPageRepositoryTests.swift` - 스냅샷/void 두 성공 경로와 NetworkError 매핑·전파 테스트가 계약을 충분히 고정하는지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

Closes #949