### PR TITLE
♻️ [Refactor] generationOrganizations roles backfill 픽스처 보강 — 레거시 병합 동등성 검증

### DIFF
--- a/UMCApp/Features/Auth/Data/Tests/MemberMeResponseDTOTests.swift
+++ b/UMCApp/Features/Auth/Data/Tests/MemberMeResponseDTOTests.swift
@@ -189,4 +189,81 @@ struct MemberMeResponseDTOTests {
         // challengerRecords의 schoolId가 "0"이라 무효 처리되고, roles의 organizationId(900)로 보강된다.
         #expect(generationOrganization.schoolId == "900")
     }
+
+    @Test("challengerRecords가 없는 기수도 roles의 조직 정보만으로 generationOrganizations 항목을 만든다")
+    func buildsGenerationOrganizationsFromRolesOnlyGeneration() throws {
+        let json = """
+        {
+            "id": 1,
+            "name": "A",
+            "nickname": "a",
+            "roles": [
+                {
+                    "gisu": "12", "roleType": "CHAPTER_PRESIDENT",
+                    "organizationType": "CHAPTER", "organizationId": "310"
+                },
+                {
+                    "gisu": "0", "roleType": "CHALLENGER",
+                    "organizationType": "CHAPTER", "organizationId": "999"
+                }
+            ],
+            "challengerRecords": [
+                {
+                    "gisu": "11", "challengerId": "1", "gisuId": "1",
+                    "chapterId": "300", "chapterName": "서울",
+                    "part": "IOS", "schoolId": "900", "schoolName": "한국대학교"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let dto = try JSONDecoder().decode(MemberMeResponseDTO.self, from: json)
+        let profile = dto.toDomain()
+
+        // 기수 "0" 역할은 제외되고, 숫자 크기 순으로 정렬된다.
+        #expect(profile.generationOrganizations.map(\.gen) == ["11", "12"])
+
+        let rolesOnlyOrganization = try #require(
+            profile.generationOrganizations.first { $0.gen == "12" }
+        )
+        #expect(rolesOnlyOrganization.chapterId == "310")
+        #expect(rolesOnlyOrganization.chapterName == nil)
+        #expect(rolesOnlyOrganization.schoolId == nil)
+        #expect(rolesOnlyOrganization.schoolName == nil)
+    }
+
+    @Test("challengerRecords의 chapterId 누락을 같은 기수 chapter 역할의 organizationId로 backfill한다")
+    func backfillsMissingChapterIdFromChapterRole() throws {
+        let json = """
+        {
+            "id": 1,
+            "name": "A",
+            "nickname": "a",
+            "roles": [
+                {
+                    "gisu": "11", "roleType": "CHAPTER_PRESIDENT",
+                    "organizationType": "CHAPTER", "organizationId": "305"
+                }
+            ],
+            "challengerRecords": [
+                {
+                    "gisu": "11", "challengerId": "1", "gisuId": "1",
+                    "chapterId": null, "chapterName": null,
+                    "part": "IOS", "schoolId": "900", "schoolName": "한국대학교"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let dto = try JSONDecoder().decode(MemberMeResponseDTO.self, from: json)
+        let profile = dto.toDomain()
+
+        let generationOrganization = try #require(
+            profile.generationOrganizations.first { $0.gen == "11" }
+        )
+        #expect(generationOrganization.chapterId == "305")
+        // chapter 역할 backfill은 record의 학교 정보를 덮어쓰지 않고 보존한다.
+        #expect(generationOrganization.schoolId == "900")
+        #expect(generationOrganization.schoolName == "한국대학교")
+    }
 }


### PR DESCRIPTION
## ✨ PR 유형

Refactor — #960(generationOrganizations roles 기반 backfill 이식)의 완료 조건 검증 및 픽스처 테스트 보강

Closes #960

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (테스트 코드만 추가)

## 🛠️ 작업내용

- **이슈 전제 재확인**: #960은 PR #957이 `generationOrganizations`를 records만으로 만드는 단순 버전으로 이식했다고 전제하나, 병합된 #957에는 이미 roles 기반 backfill 전체 버전(`MemberMeResponseDTO.buildGenerationOrganizations(records:roles:)`)이 포함되어 있음을 확인
- **레거시 의미 동등성 대조**: `AppProduct` `MyProfileDTO.buildGenerationOrganizations`와 라인 단위 비교 — 기수>0 필터, schoolId 0 무효화, organizationType(CHAPTER/SCHOOL)별 backfill, 기존 chapterName/schoolName 보존, 숫자 크기 정렬 모두 일치 (차이는 절대규칙 #2에 따른 서버 정수 String 통일뿐)
- **소비 체인 계약 확인**: `SyncProfileStorageUseCase`가 저장하는 `ProfileGenerationOrganization` JSON과 Notice의 `GenerationOrganizationContext` 디코딩 키(`gen`/`chapterId`/`chapterName`/`schoolId`/`schoolName`) 일치 확인
- **AC 픽스처 테스트 2건 추가** (`MemberMeResponseDTOTests`):
  - challengerRecords가 없는 기수를 roles 조직 정보만으로 구성 + 기수 "0" 역할 제외 + 숫자 정렬 검증
  - record의 chapterId 누락(null)을 같은 기수 CHAPTER 역할의 organizationId로 backfill하고 record의 학교 정보는 보존하는지 검증
- `make test SCHEME=AuthData` 통과 — 25개 스위트 68개 테스트 전건 성공

## 📋 추후 진행 상황

- Notice 기수/조직 필터가 `AppStorageKey.generationOrganizations`를 실제 소비하는 화면 이식 시 본 픽스처가 회귀 방어선으로 동작

## 📌 리뷰 포인트

- `UMCApp/Features/Auth/Data/Tests/MemberMeResponseDTOTests.swift` - 신규 픽스처 2건이 이슈 AC(records-누락/roles-보유 조합)를 충분히 커버하는지
- `UMCApp/Features/Auth/Data/Sources/DTOs/Response/MemberMeResponseDTO.swift` - (변경 없음, 검증 대상) 레거시 `buildGenerationOrganizations` 대비 의미 동등성 판단 근거

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
