### PR TITLE
♻️ [Refactor] UserSessionManager 완전 이식 — allRoles·Admin 모드 토글 복원

### DIFF
--- a/UMCApp/Core/Domain/Project.swift
+++ b/UMCApp/Core/Domain/Project.swift
@@ -6,5 +6,9 @@ let project = coreProject(
     bundleIdSuffix: "domain",
     dependencies: [
         .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+    ],
+    includesTests: true,
+    testDependencies: [
+        .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
     ]
 )

--- a/UMCApp/Core/Domain/Sources/Member/UserSessionManager.swift
+++ b/UMCApp/Core/Domain/Sources/Member/UserSessionManager.swift
@@ -1,16 +1,42 @@
 import Foundation
 import UMCFoundation
 
-/// 앱 전역에서 공유하는 현재 로그인 사용자의 최고 권한 역할 상태.
+/// Activity 화면의 모드
+public enum ActivityMode: String, CaseIterable, Sendable {
+    case challenger
+    case admin
+}
+
+/// 앱 전역에서 공유하는 현재 로그인 사용자의 세션·권한 상태.
 ///
 /// `SyncProfileStorageUseCase`가 프로필 동기화 시점에 갱신하며, Notice 등 권한 분기가
-/// 필요한 화면에서 관찰한다.
+/// 필요한 화면에서 관찰한다. Activity 화면의 Challenger/Admin 모드 전환 상태도 함께 관리한다
+/// (레거시 `AppProduct` `UserSessionManager` 의미 동등, #959).
 @Observable
 public final class UserSessionManager {
 
     // MARK: - Property
 
+    /// 현재 사용자의 최고 권한 역할 (서버에서 받아온 실제 권한)
     public private(set) var currentRole: ManagementTeam = .challenger
+
+    /// 사용자가 보유한 전체 역할 목록
+    public private(set) var allRoles: [ManagementTeam] = []
+
+    /// Admin 모드 활성화 여부
+    public private(set) var isAdminModeEnabled: Bool = false
+
+    // MARK: - Computed Property
+
+    /// Admin 모드 토글 가능 여부
+    public var canToggleAdminMode: Bool {
+        currentRole.canAccessAdminMode
+    }
+
+    /// 현재 활성화된 Activity 모드
+    public var currentActivityMode: ActivityMode {
+        isAdminModeEnabled ? .admin : .challenger
+    }
 
     // MARK: - Init
 
@@ -18,7 +44,31 @@ public final class UserSessionManager {
 
     // MARK: - Function
 
-    public func updateRole(_ role: ManagementTeam) {
+    /// Admin 모드 토글
+    public func toggleAdminMode() {
+        guard canToggleAdminMode else { return }
+        isAdminModeEnabled.toggle()
+    }
+
+    /// 사용자 역할 업데이트 (로그인/세션 복원 시 호출)
+    public func updateRole(_ role: ManagementTeam, allRoles: [ManagementTeam] = []) {
         currentRole = role
+        self.allRoles = allRoles.isEmpty ? [role] : allRoles
+        // Admin 모드 접근 불가 역할로 변경되면 Admin 모드 비활성화
+        if !role.canAccessAdminMode {
+            isAdminModeEnabled = false
+        }
+    }
+
+    /// 보유 역할 중 특정 권한이 있는지 확인
+    public func hasAnyRole(where predicate: (ManagementTeam) -> Bool) -> Bool {
+        allRoles.contains(where: predicate)
+    }
+
+    /// 세션 초기화 (로그아웃/탈퇴 시 호출)
+    public func reset() {
+        currentRole = .challenger
+        allRoles = []
+        isAdminModeEnabled = false
     }
 }

--- a/UMCApp/Core/Domain/Tests/UserSessionManagerTests.swift
+++ b/UMCApp/Core/Domain/Tests/UserSessionManagerTests.swift
@@ -1,0 +1,130 @@
+import Testing
+import UMCFoundation
+@testable import CoreDomain
+
+@Suite("UserSessionManager — 세션 역할·Admin 모드 상태")
+struct UserSessionManagerTests {
+
+    // MARK: - 초기 상태
+
+    @Test("초기 상태는 challenger 역할, 빈 역할 목록, Admin 모드 비활성이다")
+    func initialStateIsChallengerWithAdminModeDisabled() {
+        let manager = UserSessionManager()
+
+        #expect(manager.currentRole == .challenger)
+        #expect(manager.allRoles.isEmpty)
+        #expect(manager.isAdminModeEnabled == false)
+        #expect(manager.canToggleAdminMode == false)
+        #expect(manager.currentActivityMode == .challenger)
+    }
+
+    // MARK: - updateRole
+
+    @Test("allRoles 없이 updateRole하면 현재 역할 하나로 역할 목록을 채운다")
+    func updateRoleWithoutAllRolesFallsBackToSingleRole() {
+        let manager = UserSessionManager()
+
+        manager.updateRole(.schoolPresident)
+
+        #expect(manager.currentRole == .schoolPresident)
+        #expect(manager.allRoles == [.schoolPresident])
+    }
+
+    @Test("allRoles를 함께 전달하면 역할 목록을 그대로 저장한다")
+    func updateRoleStoresProvidedAllRoles() {
+        let manager = UserSessionManager()
+
+        manager.updateRole(
+            .chapterPresident,
+            allRoles: [.chapterPresident, .schoolPartLeader, .challenger]
+        )
+
+        #expect(manager.currentRole == .chapterPresident)
+        #expect(manager.allRoles == [.chapterPresident, .schoolPartLeader, .challenger])
+    }
+
+    @Test("Admin 모드 접근 불가 역할로 변경되면 Admin 모드가 비활성화된다")
+    func updateRoleToNonAdminRoleDisablesAdminMode() {
+        let manager = UserSessionManager()
+        manager.updateRole(.schoolPresident)
+        manager.toggleAdminMode()
+        #expect(manager.isAdminModeEnabled == true)
+
+        manager.updateRole(.challenger)
+
+        #expect(manager.isAdminModeEnabled == false)
+        #expect(manager.currentActivityMode == .challenger)
+    }
+
+    @Test("Admin 모드 접근 가능 역할로 변경되면 활성화된 Admin 모드를 유지한다")
+    func updateRoleToAdminCapableRoleKeepsAdminModeEnabled() {
+        let manager = UserSessionManager()
+        manager.updateRole(.schoolPresident)
+        manager.toggleAdminMode()
+
+        manager.updateRole(.chapterPresident)
+
+        #expect(manager.isAdminModeEnabled == true)
+        #expect(manager.currentActivityMode == .admin)
+    }
+
+    // MARK: - toggleAdminMode
+
+    @Test("Admin 모드 접근 불가 역할은 토글해도 Admin 모드가 켜지지 않는다")
+    func toggleAdminModeIsIgnoredForNonAdminRole() {
+        let manager = UserSessionManager()
+        manager.updateRole(.challenger)
+
+        manager.toggleAdminMode()
+
+        #expect(manager.isAdminModeEnabled == false)
+    }
+
+    @Test("Admin 모드 접근 가능 역할은 토글로 Admin 모드를 켜고 끌 수 있다")
+    func toggleAdminModeSwitchesModeForAdminCapableRole() {
+        let manager = UserSessionManager()
+        manager.updateRole(.schoolEtcAdmin)
+
+        manager.toggleAdminMode()
+        #expect(manager.isAdminModeEnabled == true)
+        #expect(manager.currentActivityMode == .admin)
+
+        manager.toggleAdminMode()
+        #expect(manager.isAdminModeEnabled == false)
+        #expect(manager.currentActivityMode == .challenger)
+    }
+
+    // MARK: - hasAnyRole
+
+    @Test("hasAnyRole은 보유 역할 목록 전체에서 조건을 검사한다")
+    func hasAnyRoleChecksAllRoles() {
+        let manager = UserSessionManager()
+        manager.updateRole(
+            .schoolPartLeader,
+            allRoles: [.schoolPartLeader, .challenger]
+        )
+
+        #expect(manager.hasAnyRole(where: { $0 == .challenger }))
+        #expect(manager.hasAnyRole(where: \.canAccessAdminMode))
+        #expect(manager.hasAnyRole(where: { $0 == .centralPresident }) == false)
+    }
+
+    // MARK: - reset
+
+    @Test("reset은 역할·역할 목록·Admin 모드를 초기 상태로 되돌린다")
+    func resetRestoresInitialState() {
+        let manager = UserSessionManager()
+        manager.updateRole(
+            .centralPresident,
+            allRoles: [.centralPresident, .schoolPresident]
+        )
+        manager.toggleAdminMode()
+
+        manager.reset()
+
+        #expect(manager.currentRole == .challenger)
+        #expect(manager.allRoles.isEmpty)
+        #expect(manager.isAdminModeEnabled == false)
+        #expect(manager.currentActivityMode == .challenger)
+    }
+}

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/SyncProfileStorageUseCase.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/SyncProfileStorageUseCase.swift
@@ -54,7 +54,7 @@ public final class SyncProfileStorageUseCase: SyncProfileStorageUseCaseProtocol 
         )
         userDefaults.set(profile.isApproved, forKey: AppStorageKey.canAutoLogin)
 
-        userSessionManager.updateRole(resolvedRole)
+        userSessionManager.updateRole(resolvedRole, allRoles: profile.roles.map(\.roleType))
     }
 
     // MARK: - Private Function

--- a/UMCApp/Features/Auth/Domain/Tests/UseCases/SyncProfileStorageUseCaseTests.swift
+++ b/UMCApp/Features/Auth/Domain/Tests/UseCases/SyncProfileStorageUseCaseTests.swift
@@ -231,8 +231,8 @@ struct SyncProfileStorageUseCaseTests {
         )
     }
 
-    @Test("실제 UserSessionManager의 currentRole을 해석된 역할로 갱신한다")
-    func updatesUserSessionManagerCurrentRole() {
+    @Test("실제 UserSessionManager의 currentRole과 allRoles를 해석된 역할로 갱신한다")
+    func updatesUserSessionManagerCurrentRoleAndAllRoles() {
         let userSessionManager = UserSessionManager()
         let useCase = SyncProfileStorageUseCase(
             userSessionManager: userSessionManager,
@@ -242,7 +242,7 @@ struct SyncProfileStorageUseCaseTests {
             memberId: "1",
             name: "A",
             nickname: "a",
-            generations: ["11"],
+            generations: ["10", "11"],
             roles: [
                 ProfileRole(
                     gisu: "11",
@@ -250,13 +250,36 @@ struct SyncProfileStorageUseCaseTests {
                     organizationType: .chapter,
                     organizationId: "500"
                 ),
+                ProfileRole(
+                    gisu: "10",
+                    roleType: .schoolPartLeader,
+                    organizationType: .school,
+                    organizationId: "700"
+                ),
             ]
         )
 
         #expect(userSessionManager.currentRole == .challenger)
+        #expect(userSessionManager.allRoles.isEmpty)
 
         useCase.execute(profile: profile)
 
         #expect(userSessionManager.currentRole == .chapterPresident)
+        #expect(userSessionManager.allRoles == [.chapterPresident, .schoolPartLeader])
+    }
+
+    @Test("역할이 없는 프로필은 UserSessionManager의 allRoles를 challenger 하나로 채운다")
+    func fillsAllRolesWithChallengerWhenProfileHasNoRoles() {
+        let userSessionManager = UserSessionManager()
+        let useCase = SyncProfileStorageUseCase(
+            userSessionManager: userSessionManager,
+            userDefaults: makeIsolatedUserDefaults()
+        )
+        let profile = Profile(memberId: "1", name: "A", nickname: "a", generations: ["11"])
+
+        useCase.execute(profile: profile)
+
+        #expect(userSessionManager.currentRole == .challenger)
+        #expect(userSessionManager.allRoles == [.challenger])
     }
 }

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/FailedVerificationUMCViewModel.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/FailedVerificationUMCViewModel.swift
@@ -1,5 +1,6 @@
 import AuthDomain
 import CoreDI
+import CoreDomain
 import CoreNetwork
 import Foundation
 import MyPageDomain
@@ -28,6 +29,7 @@ final class FailedVerificationUMCViewModel {
     private let fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol
     private let deleteMemberUseCase: DeleteMemberUseCaseProtocol
     private let syncProfileStorageUseCase: SyncProfileStorageUseCaseProtocol
+    private let userSessionManager: UserSessionManager
     private let networkClient: NetworkClient
     private let container: DIContainer
     private let errorHandler: ErrorHandler
@@ -65,6 +67,7 @@ final class FailedVerificationUMCViewModel {
         self.fetchMyProfileUseCase = container.resolve(FetchMyProfileUseCaseProtocol.self)
         self.deleteMemberUseCase = container.resolve(DeleteMemberUseCaseProtocol.self)
         self.syncProfileStorageUseCase = container.resolve(SyncProfileStorageUseCaseProtocol.self)
+        self.userSessionManager = container.resolve(UserSessionManager.self)
         self.networkClient = container.resolve(NetworkClient.self)
         self.container = container
         self.errorHandler = errorHandler
@@ -221,6 +224,7 @@ final class FailedVerificationUMCViewModel {
 
         do {
             try await networkClient.logout()
+            userSessionManager.reset()
             container.resetCache()
             destination = .login
         } catch {
@@ -242,6 +246,7 @@ final class FailedVerificationUMCViewModel {
             try await deleteMemberUseCase.execute()
             UserDefaults.standard.set(false, forKey: AppStorageKey.canAutoLogin)
             try await networkClient.logout()
+            userSessionManager.reset()
             container.resetCache()
             destination = .login
         } catch {

--- a/UMCApp/Features/Auth/Presentation/Tests/FailedVerificationUMCViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/FailedVerificationUMCViewModelTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import CoreDI
+import CoreDomain
 import CoreNetwork
 import AuthDomain
 import MyPageDomain
@@ -160,10 +161,14 @@ struct FailedVerificationUMCViewModelTests {
         #expect(viewModel.alertPrompt?.isPositiveBtnDestructive == true)
     }
 
-    @Test("로그아웃 확인 시 토큰을 정리하고 로그인 화면으로 이동한다")
+    @Test("로그아웃 확인 시 토큰을 정리하고 세션을 초기화한 뒤 로그인 화면으로 이동한다")
     func logoutConfirmClearsTokenAndNavigatesToLogin() async throws {
         let tokenStore = FakeTokenStore()
-        let viewModel = makeViewModel(tokenStore: tokenStore)
+        let sessionManager = makeAdminSessionManager()
+        let viewModel = makeViewModel(
+            tokenStore: tokenStore,
+            userSessionManager: sessionManager
+        )
 
         viewModel.presentLogoutPrompt()
         viewModel.alertPrompt?.positiveBtnAction?()
@@ -172,14 +177,22 @@ struct FailedVerificationUMCViewModelTests {
 
         #expect(viewModel.isLoggingOut == false)
         #expect(await tokenStore.clearCallCount == 1)
+        #expect(sessionManager.currentRole == .challenger)
+        #expect(sessionManager.allRoles.isEmpty)
+        #expect(sessionManager.isAdminModeEnabled == false)
     }
 
-    @Test("로그아웃 실패 시 ErrorHandler에 에러를 전달하고 화면을 전환하지 않는다")
+    @Test("로그아웃 실패 시 ErrorHandler에 에러를 전달하고 화면 전환과 세션 초기화를 하지 않는다")
     func logoutFailureReportsErrorWithoutNavigating() async throws {
         let tokenStore = FakeTokenStore()
         await tokenStore.setClearError(DummyError())
         let errorHandler = ErrorHandler()
-        let viewModel = makeViewModel(errorHandler: errorHandler, tokenStore: tokenStore)
+        let sessionManager = makeAdminSessionManager()
+        let viewModel = makeViewModel(
+            errorHandler: errorHandler,
+            tokenStore: tokenStore,
+            userSessionManager: sessionManager
+        )
 
         viewModel.presentLogoutPrompt()
         viewModel.alertPrompt?.positiveBtnAction?()
@@ -188,6 +201,7 @@ struct FailedVerificationUMCViewModelTests {
 
         #expect(viewModel.destination == nil)
         #expect(viewModel.isLoggingOut == false)
+        #expect(sessionManager.currentRole == .chapterPresident)
     }
 
     // MARK: - 회원 탈퇴
@@ -202,13 +216,15 @@ struct FailedVerificationUMCViewModelTests {
         #expect(viewModel.alertPrompt?.isPositiveBtnDestructive == true)
     }
 
-    @Test("회원 탈퇴 성공 시 로그아웃까지 수행하고 로그인 화면으로 이동한다")
+    @Test("회원 탈퇴 성공 시 로그아웃과 세션 초기화까지 수행하고 로그인 화면으로 이동한다")
     func deleteAccountSuccessLogsOutAndNavigatesToLogin() async throws {
         let deleteMemberUseCase = MockDeleteMemberUseCase()
         let tokenStore = FakeTokenStore()
+        let sessionManager = makeAdminSessionManager()
         let viewModel = makeViewModel(
             deleteMemberUseCase: deleteMemberUseCase,
-            tokenStore: tokenStore
+            tokenStore: tokenStore,
+            userSessionManager: sessionManager
         )
 
         viewModel.presentDeleteAccountPrompt()
@@ -219,18 +235,23 @@ struct FailedVerificationUMCViewModelTests {
         #expect(deleteMemberUseCase.callCount == 1)
         #expect(await tokenStore.clearCallCount == 1)
         #expect(viewModel.isDeletingAccount == false)
+        #expect(sessionManager.currentRole == .challenger)
+        #expect(sessionManager.allRoles.isEmpty)
+        #expect(sessionManager.isAdminModeEnabled == false)
     }
 
-    @Test("회원 탈퇴는 성공했지만 로그아웃(토큰 정리)이 실패하면 화면을 전환하지 않는다")
+    @Test("회원 탈퇴는 성공했지만 로그아웃(토큰 정리)이 실패하면 화면 전환과 세션 초기화를 하지 않는다")
     func deleteAccountSucceedsButLogoutFailsReportsErrorWithoutNavigating() async throws {
         let deleteMemberUseCase = MockDeleteMemberUseCase()
         let tokenStore = FakeTokenStore()
         await tokenStore.setClearError(DummyError())
         let errorHandler = ErrorHandler()
+        let sessionManager = makeAdminSessionManager()
         let viewModel = makeViewModel(
             errorHandler: errorHandler,
             deleteMemberUseCase: deleteMemberUseCase,
-            tokenStore: tokenStore
+            tokenStore: tokenStore,
+            userSessionManager: sessionManager
         )
 
         viewModel.presentDeleteAccountPrompt()
@@ -241,6 +262,7 @@ struct FailedVerificationUMCViewModelTests {
         #expect(deleteMemberUseCase.callCount == 1)
         #expect(viewModel.destination == nil)
         #expect(viewModel.isDeletingAccount == false)
+        #expect(sessionManager.currentRole == .chapterPresident)
     }
 
     @Test("회원 탈퇴 실패 시 로그아웃을 수행하지 않고 에러를 전달한다")
@@ -292,7 +314,8 @@ private func makeViewModel(
     fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol? = nil,
     deleteMemberUseCase: DeleteMemberUseCaseProtocol? = nil,
     tokenStore: FakeTokenStore? = nil,
-    syncProfileStorageUseCase: SyncProfileStorageUseCaseProtocol? = nil
+    syncProfileStorageUseCase: SyncProfileStorageUseCaseProtocol? = nil,
+    userSessionManager: UserSessionManager? = nil
 ) -> FailedVerificationUMCViewModel {
     let registerUseCase = registerExistingChallengerUseCase
         ?? MockRegisterExistingChallengerUseCase()
@@ -300,12 +323,14 @@ private func makeViewModel(
     let deleteUseCase = deleteMemberUseCase ?? MockDeleteMemberUseCase()
     let store = tokenStore ?? FakeTokenStore()
     let syncUseCase = syncProfileStorageUseCase ?? MockSyncProfileStorageUseCase()
+    let sessionManager = userSessionManager ?? UserSessionManager()
 
     let container = DIContainer()
     container.register(RegisterExistingChallengerUseCaseProtocol.self) { registerUseCase }
     container.register(FetchMyProfileUseCaseProtocol.self) { fetchUseCase }
     container.register(DeleteMemberUseCaseProtocol.self) { deleteUseCase }
     container.register(SyncProfileStorageUseCaseProtocol.self) { syncUseCase }
+    container.register(UserSessionManager.self) { sessionManager }
     container.register(NetworkClient.self) {
         NetworkClient(tokenStore: store, refreshService: FakeTokenRefreshService())
     }
@@ -314,6 +339,17 @@ private func makeViewModel(
         container: container,
         errorHandler: errorHandler ?? ErrorHandler()
     )
+}
+
+/// 로그아웃/탈퇴의 `reset()` 배선 검증용으로 관리자 역할이 세팅된 세션을 만든다.
+private func makeAdminSessionManager() -> UserSessionManager {
+    let sessionManager = UserSessionManager()
+    sessionManager.updateRole(
+        .chapterPresident,
+        allRoles: [.chapterPresident, .challenger]
+    )
+    sessionManager.toggleAdminMode()
+    return sessionManager
 }
 
 private func makeProfile(generations: [String]) -> Profile {

--- a/UMCApp/Features/Auth/Project.swift
+++ b/UMCApp/Features/Auth/Project.swift
@@ -10,6 +10,8 @@ let project = featureProject(
     presentationExtraDependencies: [
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
+        // 승인 대기 화면의 로그아웃/탈퇴가 전역 `UserSessionManager.reset()`(#959)을 호출한다.
+        .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
         // 승인 대기(#945) 화면의 회원 탈퇴 액션이 MyPageDomain의 UseCase를 직접 사용한다.
         .project(target: "MyPageDomain", path: .relativeToRoot("Features/MyPage")),
@@ -29,6 +31,8 @@ let project = featureProject(
     includesPresentationTests: true,
     presentationTestDependencies: [
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
+        // 로그아웃/탈퇴 시 `UserSessionManager.reset()` 배선(#959)을 실제 인스턴스로 검증한다.
+        .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
         .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
         // 승인 대기(#945) ViewModel 테스트에서 DeleteMemberUseCaseProtocol 목을 직접 구성한다.

--- a/UMCApp/UMCApp/Sources/AppRootView.swift
+++ b/UMCApp/UMCApp/Sources/AppRootView.swift
@@ -1,6 +1,7 @@
 import AuthPresentation
 import CoreDesignSystem
 import CoreDI
+import CoreDomain
 import CoreNetwork
 #if DEBUG
 import MaintenanceData
@@ -80,7 +81,8 @@ struct AppRootView: View {
 
     // MARK: - Function
 
-    /// 세션 만료 시 DI 캐시 초기화 → 로그인 화면 전환 → (비동기) 토큰 삭제를 수행한다.
+    /// 세션 만료 시 세션 역할 상태 초기화 → DI 캐시 초기화 → 로그인 화면 전환 →
+    /// (비동기) 토큰 삭제를 수행한다.
     ///
     /// - Note: `resetCache()`보다 먼저 `NetworkClient` 참조를 동기적으로 확보한다.
     ///   순서를 바꾸면 `Task` 내부의 `resolve`가 캐시 미스로 새 인스턴스를 생성해
@@ -90,6 +92,7 @@ struct AppRootView: View {
     ///   기다리지 않는다.
     private func handleAuthSessionExpired() {
         let networkClient = di.resolve(NetworkClient.self)
+        di.resolve(UserSessionManager.self).reset()
         di.resetCache()
         viewModel.logout()
         Task {


### PR DESCRIPTION
## ✨ PR 유형

Refactor — PR #957에서 축소판으로 승격했던 `UserSessionManager`(CoreDomain)에 레거시(AppProduct, v2.2.0 동결)의 나머지 세션·권한 기능 전체를 이식하고, 세션 종료 경로에 `reset()` 배선을 추가합니다.
close #959

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요 -->
- UI 변경 없음 — 전역 세션 상태 관리 로직만 변경 (관리자 모드 전환 UI 등 소비 화면 이식의 선행 조건)

## 🛠️ 작업내용

- **CoreDomain — `UserSessionManager` 완전 복원**: `allRoles`·`isAdminModeEnabled` 저장 프로퍼티, `canToggleAdminMode`·`currentActivityMode` 계산 프로퍼티, `toggleAdminMode()`·`hasAnyRole(where:)`·`reset()` 함수, `ActivityMode` enum 이식 — 레거시 의미 동등(`allRoles` 빈 값 → `[role]` 폴백, Admin 접근 불가 역할로 갱신 시 Admin 모드 자동 해제), `@Observable` 유지(절대규칙 #1), 모듈 간 노출 `public`(절대규칙 #4)
- **`SyncProfileStorageUseCase`**: `updateRole(_:allRoles:)` 호출로 전환 — 레거시 3개 호출부와 동일하게 `profile.roles.map(\.roleType)` 전달
- **`reset()` 배선(세션 종료 3경로)**: `FailedVerificationUMCViewModel`의 로그아웃/탈퇴 성공 경로(`container.resetCache()` 직전, 실패 시 미초기화) + `AppRootView.handleAuthSessionExpired()` 세션 만료 경로
- **Tuist**: CoreDomain에 테스트 타깃 신설(`includesTests: true`), AuthPresentation 본체·테스트 타깃에 CoreDomain 의존성 추가
- **테스트**: `UserSessionManagerTests` 신규 9건(토글 가드·폴백·Admin 모드 자동 해제/유지·reset), `SyncProfileStorageUseCaseTests`에 allRoles 전달·challenger 폴백 검증, `FailedVerificationUMCViewModelTests`에 로그아웃/탈퇴 시 세션 초기화(성공)·미초기화(실패) 검증 — `make generate && make test` 통과 (CoreDomain 9 · AuthDomain 48 · AuthPresentation 86 · UMCApp 7)

## 📋 추후 진행 상황

- 관리자 모드 전환 UI·역할 기반 게이트 화면(Activity `UmcTab` 등) 이식 시 `currentActivityMode`/`toggleAdminMode()` 소비 시작 — 그때까지 해당 API는 대기 상태
- 메인 셸(MyPage 등)에 로그아웃이 이식되면 동일하게 `reset()` 배선 적용

## 📌 리뷰 포인트

- `UMCApp/Core/Domain/Sources/Member/UserSessionManager.swift` - 레거시(`AppProduct/AppProduct/Core/Manager/User/UserSessionManager.swift`, 읽기 전용 참조)와의 의미 동등성 — 특히 `updateRole`의 `allRoles` 폴백과 Admin 모드 자동 해제 조건
- `UMCApp/Features/Auth/Presentation/Sources/ViewModels/FailedVerificationUMCViewModel.swift` - `reset()` 호출 위치(로그아웃/탈퇴 성공 시에만, `resetCache()` 직전) — 실패 시 세션 상태를 유지하는 게 맞는지
- `UMCApp/UMCApp/Sources/AppRootView.swift` - 세션 만료 경로에서 `resolve → reset → resetCache` 순서 (기존 NetworkClient 확보 순서 주석과 동일한 이유)
- `UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/SyncProfileStorageUseCase.swift` - `allRoles` 전달이 UserDefaults `memberRoles` 저장 값과 일관되는지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)