### PR TITLE
🍀 ETC: iOS·watchOS 배포 대상 26.4 상향 및 앱 버전 3.0.0 설정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ cd UMCApp && make test      # 테스트
 cd UMCApp && make doctor    # 환경 진단
 ```
 
-- Tuist 버전은 `UMCApp/mise.toml`(`4.155.0`)로 고정 · Deployment Target iOS 26.3
+- Tuist 버전은 `UMCApp/mise.toml`(`4.155.0`)로 고정 · Deployment Target iOS 26.4
 - 상세: `docs/claude/build-and-modules.md`, `UMCApp/MAKEFILE_GUIDE.md`
 
 ## 상세 레퍼런스 (필요 시 Read)

--- a/UMCApp/Core/Foundation/Project.swift
+++ b/UMCApp/Core/Foundation/Project.swift
@@ -5,7 +5,7 @@ let project = coreProject(
     name: "UMCFoundation",
     bundleIdSuffix: "foundation",
     destinations: [.iPhone, .appleWatch],
-    deploymentTargets: .multiplatform(iOS: "26.3", watchOS: "26.3"),
+    deploymentTargets: .multiplatform(iOS: "26.4", watchOS: "26.4"),
     includesTests: true
 )
 

--- a/UMCApp/Core/NearbyExchange/Project.swift
+++ b/UMCApp/Core/NearbyExchange/Project.swift
@@ -10,7 +10,7 @@ let project = Project(
             destinations: .iOS,
             product: .staticFramework,
             bundleId: "dev.umc.core.nearbyexchange",
-            deploymentTargets: .iOS("26.3"),
+            deploymentTargets: .iOS("26.4"),
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),

--- a/UMCApp/Core/WatchConnectivity/Project.swift
+++ b/UMCApp/Core/WatchConnectivity/Project.swift
@@ -5,7 +5,7 @@ let project = coreProject(
     name: "CoreWatchConnectivity",
     bundleIdSuffix: "watchconnectivity",
     destinations: [.iPhone, .appleWatch],
-    deploymentTargets: .multiplatform(iOS: "26.3", watchOS: "26.3"),
+    deploymentTargets: .multiplatform(iOS: "26.4", watchOS: "26.4"),
     dependencies: [
         .sdk(name: "WatchConnectivity", type: .framework, status: .required),
     ]

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -4,7 +4,7 @@ import ProjectDescriptionHelpers
 let project = featureProject(
     name: "Activity",
     domainDestinations: [.iPhone, .appleWatch],
-    domainDeploymentTargets: .multiplatform(iOS: "26.3", watchOS: "26.3"),
+    domainDeploymentTargets: .multiplatform(iOS: "26.4", watchOS: "26.4"),
     presentationExtraDependencies: [
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
     ],

--- a/UMCApp/Project.swift
+++ b/UMCApp/Project.swift
@@ -10,9 +10,10 @@ let project = Project(
             destinations: .iOS,
             product: .app,
             bundleId: "dev.tuist.UMCApp",
-            deploymentTargets: .iOS("26.3"),
+            deploymentTargets: .iOS("26.4"),
             infoPlist: .extendingDefault(
                 with: [
+                    "CFBundleShortVersionString": "$(MARKETING_VERSION)",
                     "UILaunchScreen": [
                         "UIColorName": "",
                         "UIImageName": "",
@@ -67,7 +68,7 @@ let project = Project(
             destinations: .iOS,
             product: .unitTests,
             bundleId: "dev.tuist.UMCAppTests",
-            deploymentTargets: .iOS("26.3"),
+            deploymentTargets: .iOS("26.4"),
             infoPlist: .default,
             buildableFolders: [
                 "UMCApp/Tests",

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Core.swift
@@ -11,7 +11,7 @@ private let bundleIdBase = "dev.umc.core"
 ///   - name: 타겟 이름 (예: "CoreNetwork", "UMCFoundation")
 ///   - bundleIdSuffix: bundleId 접미사 (예: "network", "foundation")
 ///   - destinations: 지원 플랫폼 (기본값: `.iOS`)
-///   - deploymentTargets: 배포 대상 (기본값: iOS 26.3)
+///   - deploymentTargets: 배포 대상 (기본값: iOS 26.4)
 ///   - dependencies: 메인 타겟 의존성 목록
 ///   - includesTests: `true`이면 `Tests/**` 소스를 사용하는 unitTests 타겟을 함께 생성
 ///   - testDependencies: 테스트 타겟에 추가로 주입할 의존성 (메인 타겟은 자동 포함)
@@ -20,7 +20,7 @@ public func coreProject(
     name: String,
     bundleIdSuffix: String,
     destinations: Destinations = .iOS,
-    deploymentTargets: DeploymentTargets = .iOS("26.3"),
+    deploymentTargets: DeploymentTargets = .iOS("26.4"),
     dependencies: [TargetDependency] = [],
     resources: ResourceFileElements? = nil,
     additionalSettings: SettingsDictionary = [:],

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+Feature.swift
@@ -15,7 +15,7 @@ private let bundleIdBase = "dev.umc.feature"
 /// - Parameters:
 ///   - name: Feature 이름 (예: "Auth", "Home"). 타겟명 및 bundleId 생성에 사용됩니다.
 ///   - domainDestinations: Domain 타겟의 지원 플랫폼 (기본값: `.iOS`). watchOS 공유가 필요한 경우 `[.iPhone, .appleWatch]`로 지정.
-///   - domainDeploymentTargets: Domain 타겟의 배포 대상 (기본값: iOS 26.3). watchOS 공유 시 `.multiplatform(iOS:watchOS:)` 로 지정.
+///   - domainDeploymentTargets: Domain 타겟의 배포 대상 (기본값: iOS 26.4). watchOS 공유 시 `.multiplatform(iOS:watchOS:)` 로 지정.
 ///   - domainExtraDependencies: Domain 타겟에 추가할 의존성
 ///   - dataExtraDependencies: Data 타겟에 추가할 의존성
 ///   - presentationExtraDependencies: Presentation 타겟에 추가할 의존성
@@ -28,7 +28,7 @@ private let bundleIdBase = "dev.umc.feature"
 public func featureProject(
     name: String,
     domainDestinations: Destinations = .iOS,
-    domainDeploymentTargets: DeploymentTargets = .iOS("26.3"),
+    domainDeploymentTargets: DeploymentTargets = .iOS("26.4"),
     domainExtraDependencies: [TargetDependency] = [],
     dataExtraDependencies: [TargetDependency] = [],
     presentationExtraDependencies: [TargetDependency] = [],
@@ -58,7 +58,7 @@ public func featureProject(
             destinations: .iOS,
             product: .staticFramework,
             bundleId: "\(bundleIdBase).\(nameLowered).data",
-            deploymentTargets: .iOS("26.3"),
+            deploymentTargets: .iOS("26.4"),
             sources: ["Data/Sources/**"],
             dependencies: [
                 .target(name: "\(name)Domain"),
@@ -71,7 +71,7 @@ public func featureProject(
             destinations: .iOS,
             product: .staticFramework,
             bundleId: "\(bundleIdBase).\(nameLowered).presentation",
-            deploymentTargets: .iOS("26.3"),
+            deploymentTargets: .iOS("26.4"),
             sources: ["Presentation/Sources/**"],
             dependencies: [
                 .target(name: "\(name)Domain"),
@@ -103,7 +103,7 @@ public func featureProject(
                 destinations: .iOS,
                 product: .unitTests,
                 bundleId: "\(bundleIdBase).\(nameLowered).data.tests",
-                deploymentTargets: .iOS("26.3"),
+                deploymentTargets: .iOS("26.4"),
                 sources: ["Data/Tests/**"],
                 dependencies: [.target(name: "\(name)Data")] + dataTestDependencies
             )
@@ -117,7 +117,7 @@ public func featureProject(
                 destinations: .iOS,
                 product: .unitTests,
                 bundleId: "\(bundleIdBase).\(nameLowered).presentation.tests",
-                deploymentTargets: .iOS("26.3"),
+                deploymentTargets: .iOS("26.4"),
                 sources: ["Presentation/Tests/**"],
                 dependencies: [.target(name: "\(name)Presentation")] + presentationTestDependencies
             )

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WatchApp.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WatchApp.swift
@@ -27,9 +27,10 @@ public func watchAppProject(
                 destinations: [.appleWatch],
                 product: .app,
                 bundleId: bundleId,
-                deploymentTargets: .watchOS("26.3"),
+                deploymentTargets: .watchOS("26.4"),
                 infoPlist: .extendingDefault(
                     with: [
+                        "CFBundleShortVersionString": .string("$(MARKETING_VERSION)"),
                         "WKCompanionAppBundleIdentifier": .string(companionBundleId),
                         "UISupportedInterfaceOrientations": .array([
                             .string("UIInterfaceOrientationPortrait"),

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WidgetExtension.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Project+WidgetExtension.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
-private let deploymentTargets: DeploymentTargets = .iOS("26.3")
+private let deploymentTargets: DeploymentTargets = .iOS("26.4")
 private let destinations: Destinations = .iOS
 
 /// Widget Extension 타겟용 Project 생성 헬퍼
@@ -31,6 +31,7 @@ public func widgetExtensionProject(
                 deploymentTargets: deploymentTargets,
                 infoPlist: .extendingDefault(
                     with: [
+                        "CFBundleShortVersionString": "$(MARKETING_VERSION)",
                         "NSExtension": [
                             "NSExtensionPointIdentifier": "com.apple.widgetkit-extension",
                         ],

--- a/UMCApp/Tuist/ProjectDescriptionHelpers/Settings+Recommended.swift
+++ b/UMCApp/Tuist/ProjectDescriptionHelpers/Settings+Recommended.swift
@@ -12,12 +12,14 @@ import ProjectDescription
 /// - `ENABLE_MODULE_VERIFIER`: Clang 모듈 헤더 검증
 /// - `ENABLE_USER_SCRIPT_SANDBOXING`: Run Script Phase 샌드박스
 /// - `LOCALIZED_STRING_SWIFTUI_SUPPORT` / `STRING_CATALOG_GENERATE_SYMBOLS`: String Catalog 심볼 생성
+/// - `MARKETING_VERSION`: 앱 마케팅 버전(이슈 #948). 앱-노출 타겟의 CFBundleShortVersionString이 이 값을 참조한다.
 public let recommendedSettings: SettingsDictionary = [
     "ENABLE_MODULE_VERIFIER": "YES",
     "MODULE_VERIFIER_SUPPORTED_LANGUAGES": "objective-c objective-c++",
     "MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS": "gnu17 gnu++20",
     "ENABLE_USER_SCRIPT_SANDBOXING": "YES",
     "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+    "MARKETING_VERSION": "3.0.0",
 ]
 
 /// 프로젝트 전역에 권장 빌드 설정을 적용한 Settings

--- a/docs/claude/build-and-modules.md
+++ b/docs/claude/build-and-modules.md
@@ -154,7 +154,7 @@ featureProject(
 ### 주요 설정
 
 - **Tuist 버전**: `UMCApp/mise.toml` 고정 (`4.155.0`)
-- **Deployment Target**: iOS 26.3 (`Project.swift` 기준, 전체 타겟 공통)
+- **Deployment Target**: iOS 26.4 (`Project.swift` 기준, 전체 타겟 공통)
 - **Product Type**: 모든 모듈 `.staticFramework`
 - **Bundle ID**: Core → `dev.umc.core.*` / Feature → `dev.umc.feature.*.*`
 - **Workspace**: glob(`Core/*`, `Features/*`) + `UMCAppWidget`, `UMCWatchApp` 명시 포함


### PR DESCRIPTION
## ✨ PR 유형

- `chore` — 빌드/프로젝트 설정 (앱 버전·배포 대상 상향)

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (빌드 설정 변경만).

## 🛠️ 작업내용

- **앱스토어 앱 버전(MARKETING_VERSION) `3.0.0` 설정**
  - 전역 `recommendedSettings`에 `MARKETING_VERSION`을 단일 정의(단일 진실원천)
  - 앱-노출 3개 타겟(메인 앱 / Watch / Widget)의 `CFBundleShortVersionString`이 `$(MARKETING_VERSION)`을 참조하도록 연결 → 앱스토어/설정 앱에 3.0.0 노출
- **iOS·watchOS 배포 대상 `26.3` → `26.4` 상향** (전 타겟·모듈, `.multiplatform` 포함)
- 문서 표기 갱신: `CLAUDE.md`, `docs/claude/build-and-modules.md`의 Deployment Target
- `AppProduct/`(레거시)는 미수정 (절대 규칙 #9)

### 검증

- `make generate` + `make build` (iPhone 17 Pro, Debug) → **BUILD SUCCEEDED**
- 빌드된 `UMCApp.app/Info.plist`: `CFBundleShortVersionString = 3.0.0`
- 생성된 `.pbxproj`: `IPHONEOS_DEPLOYMENT_TARGET = 26.4`, `WATCHOS_DEPLOYMENT_TARGET = 26.4`, `MARKETING_VERSION = 3.0.0` (전 타겟)
- 잔여 `26.3` 참조 0건

## 📋 추후 진행 상황

- 3.0.0 릴리즈/태깅 시점에 `CLAUDE.md`의 `현재 버전: 2.2.0` 표기 갱신 (릴리즈 태그가 아직 `v2.2.0`이라 이번 범위에서 제외)

## 📌 리뷰 포인트

- `MARKETING_VERSION`(앱 버전, `3.0.0`)과 배포 대상(`26.4`)은 서로 다른 개념 — 값이 각각 올바르게 들어갔는지
- watchOS 배포 대상도 26.4로 함께 상향한 점
- 앱 버전을 `recommendedSettings` 한 곳에서만 정의하고 타겟이 `$(MARKETING_VERSION)`로 참조하는 구조가 적절한지

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

Closes #948
