### PR TITLE
✨ [Feat] KakaoPlusManager 이식 — 승인 대기 화면 문의하기 인앱 카카오 채널 복원

### DIFF
--- a/UMCApp/Core/Network/Project.swift
+++ b/UMCApp/Core/Network/Project.swift
@@ -10,6 +10,7 @@ let project = coreProject(
         .external(name: "KakaoSDKAuth"),
         .external(name: "KakaoSDKCommon"),
         .external(name: "KakaoSDKUser"),
+        .external(name: "KakaoSDKTalk"),
         .external(name: "GoogleSignIn"),
         .sdk(name: "Security", type: .framework),
     ],

--- a/UMCApp/Core/Network/Sources/Auth/KakaoPlusManager.swift
+++ b/UMCApp/Core/Network/Sources/Auth/KakaoPlusManager.swift
@@ -1,0 +1,68 @@
+import Foundation
+import KakaoSDKTalk
+import UIKit
+import UMCFoundation
+
+/// 카카오톡 채널(플러스친구) 인앱 문의 채팅을 여는 매니저입니다.
+///
+/// 카카오톡 앱이 설치되어 있고 채널 채팅 딥링크가 가능하면 인앱 채팅방으로 바로
+/// 전환하고, 그렇지 않거나 SDK 호출이 실패하면 웹 채팅 URL로 폴백합니다.
+///
+/// - Important: `Info.plist`의 `LSApplicationQueriesSchemes`에 `kakaoplus` 스킴이
+///   등록되어 있어야 `TalkApi.isKakaoTalkChannelAvailable(path:)`가 정상 동작합니다.
+public final class KakaoPlusManager {
+
+    // MARK: - Property
+
+    /// UMC 동아리 카카오톡 채널 ID (카카오톡 채널 관리자 페이지에서 확인 가능).
+    let channelId = "_MDxhqX"
+
+    private var webChatURL: URL? { URL(string: "https://pf.kakao.com/\(channelId)/chat") }
+
+    // MARK: - Init
+
+    public init() {}
+
+    // MARK: - Function
+
+    /// 카카오톡 채널 문의 채팅을 엽니다.
+    ///
+    /// 카카오톡에 채널 채팅 딥링크가 가능하면 인앱으로 전환하고, 그렇지 않거나 SDK
+    /// 호출이 실패하면 웹 채팅 URL로 폴백합니다. 웹 폴백마저 실패하면 `errorHandler`로
+    /// 실패를 보고합니다(`errorHandler`가 없으면 콘솔 로그만 남깁니다).
+    @MainActor
+    public func openKakaoChannel(errorHandler: ErrorHandler? = nil) {
+        let chatPath = "plusfriend/talk/chat/\(channelId)"
+        guard TalkApi.isKakaoTalkChannelAvailable(path: chatPath) else {
+            openWebChat(errorHandler: errorHandler)
+            return
+        }
+        TalkApi.shared.chatChannel(channelPublicId: channelId) { [weak self] error in
+            guard let self else { return }
+            if let error {
+                print("카카오톡 채널 열기 에러: \(error). 웹으로 폴백합니다.")
+                Task { @MainActor in self.openWebChat(errorHandler: errorHandler) }
+            }
+        }
+    }
+
+    // MARK: - Private Function
+
+    @MainActor
+    private func openWebChat(errorHandler: ErrorHandler?) {
+        guard let url = webChatURL else { reportFailure(errorHandler: errorHandler); return }
+        UIApplication.shared.open(url) { [weak self] success in
+            guard !success else { return }
+            Task { @MainActor in self?.reportFailure(errorHandler: errorHandler) }
+        }
+    }
+
+    @MainActor
+    private func reportFailure(errorHandler: ErrorHandler?) {
+        guard let errorHandler else { print("카카오톡 채널/웹 모두 열기 실패"); return }
+        errorHandler.handle(
+            DomainError.custom(message: "카카오톡 문의 채널을 열 수 없습니다. 잠시 후 다시 시도해주세요."),
+            context: ErrorContext(feature: "KakaoPlusManager", action: "openKakaoChannel")
+        )
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/FailedVerificationUMC.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/FailedVerificationUMC.swift
@@ -1,5 +1,6 @@
 import CoreDesignSystem
 import CoreDI
+import CoreNetwork
 import CoreUIComponents
 import SwiftUI
 import UMCFoundation
@@ -18,6 +19,7 @@ public struct FailedVerificationUMC: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.appFlow) private var appFlow
     @Environment(ErrorHandler.self) private var errorHandler
+    private let kakaoPlusManager = KakaoPlusManager()
 
     // MARK: - Constant
 
@@ -39,10 +41,6 @@ public struct FailedVerificationUMC: View {
         static let submitButtonTitle: String = "전송"
 
         static let homePageURL: String = "https://umc.it.kr"
-        /// UMC 동아리 카카오톡 채널 ID (카카오톡 채널 관리자 페이지에서 확인 가능).
-        static let kakaoChannelWebChatURL: String = "https://pf.kakao.com/_MDxhqX/chat"
-        static let inquiryChannelFailureMessage: String =
-            "카카오톡 문의 채널을 열 수 없습니다. 잠시 후 다시 시도해주세요."
     }
 
     // MARK: - Init
@@ -180,19 +178,10 @@ public struct FailedVerificationUMC: View {
 
     /// 카카오톡 문의 채널을 연다.
     ///
-    /// - Note: 레거시 `KakaoPlusManager`는 `KakaoSDKTalk`에 의존해 카카오톡 설치 시
-    ///   인앱 채팅방으로 바로 전환한다. `CoreFoundation`에 KakaoSDK를 끌어들이지 않기
-    ///   위해 아직 이식하지 않았고, 대신 웹 채팅 URL을 직접 연다.
-    // TODO(#958): KakaoSDKTalk 기반 인앱 채널 연결(KakaoPlusManager) 이식.
+    /// 카카오톡이 설치돼 있고 채널 채팅이 가능하면 인앱으로 전환하고, 그렇지 않거나
+    /// SDK 호출이 실패하면 `KakaoPlusManager`가 내부적으로 웹 채팅 URL로 폴백한다.
     private func openInquiryChannel() {
-        guard let url = URL(string: Constants.kakaoChannelWebChatURL) else {
-            errorHandler.handle(
-                DomainError.custom(message: Constants.inquiryChannelFailureMessage),
-                context: ErrorContext(feature: "Auth", action: "openInquiryChannel")
-            )
-            return
-        }
-        openURL(url)
+        kakaoPlusManager.openKakaoChannel(errorHandler: errorHandler)
     }
 
     private func submitChallengerCode() {

--- a/UMCApp/Project.swift
+++ b/UMCApp/Project.swift
@@ -41,7 +41,9 @@ let project = Project(
                             "CFBundleURLSchemes": ["$(GOOGLE_REVERSED_CLIENT_ID)"],
                         ],
                     ],
-                    "LSApplicationQueriesSchemes": ["kakaokompassauth", "kakaolink", "kakaotalk"],
+                    "LSApplicationQueriesSchemes": [
+                        "kakaokompassauth", "kakaolink", "kakaotalk", "kakaoplus",
+                    ],
                 ]
             ),
             buildableFolders: [

--- a/docs/claude/tuist-file-mapping.md
+++ b/docs/claude/tuist-file-mapping.md
@@ -811,7 +811,7 @@
 | `Manager/Auth/AppleLoginManager.swift` | CoreNetwork (Auth) |
 | `Manager/Auth/GoogleLoginManager.swift` | CoreNetwork (Auth) |
 | `Manager/Auth/KakaoLoginManager.swift` | CoreNetwork (Auth) |
-| `Manager/Auth/KakaoPlusManager.swift` | CoreFoundation (신규 Support 서브폴더) |
+| `Manager/Auth/KakaoPlusManager.swift` | CoreNetwork (Auth) |
 | `Manager/Auth/SocialLoginError.swift` | CoreNetwork (Auth) |
 | `Manager/Location/LocationManager.swift` | 신규 CoreLocation 모듈 |
 | `Manager/User/UserSessionManager.swift` | CoreDomain (또는 App 소유 세션) |


### PR DESCRIPTION
## ✨ PR 유형

Feature — 레거시(AppProduct, v2.2.0 동결)의 `KakaoPlusManager`(KakaoSDKTalk 기반 인앱 카카오 채널 챗)를 UMCApp(Tuist) `CoreNetwork`로 이식. 승인 대기 화면(`FailedVerificationUMC`) 문의하기 버튼을 #945(PR #957)에서 웹 URL로 임시대체했던 것에서 레거시와 동일한 인앱 채널 경험으로 복원합니다.
close #958

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 문의하기 버튼 동작: 카카오톡 설치 시 인앱 채널 채팅방 전환 / 미설치·SDK 실패 시 웹 채팅 URL 폴백 -->
- UI 레이아웃 변경 없음 — 문의하기 버튼의 **동작(action)만** 웹 URL 열기 → 인앱 카카오 채널 열기로 전환
- 카카오톡 미설치·SDK 실패 시 기존 웹 채팅 URL(`https://pf.kakao.com/_MDxhqX/chat`) 폴백은 매니저 내부에 그대로 유지

## 🛠️ 작업내용

- **배치 결정**: `KakaoPlusManager`를 `Core/Network/Sources/Auth/`에 신설 — 형제 소셜 매니저(`KakaoLoginManager`/`AppleLoginManager`/`GoogleLoginManager`)와 동일 위치이며 `CoreNetwork`가 이미 `KakaoSDKAuth/Common/User` external과 `UMCFoundation`(ErrorHandler/DomainError)을 소비 중이라 신규 모듈 의존 엣지가 늘지 않음. 이슈 제약(`CoreFoundation`에 KakaoSDK를 끌어들이지 말 것) 준수
- **`KakaoPlusManager.swift` 신설**: `public final class`, `TalkApi.isKakaoTalkChannelAvailable` → `chatChannel`(인앱) → `UIApplication.open`(웹 폴백) → `ErrorHandler`(최종 실패) 순. 레거시 로직·에러 메시지 1:1 보존, 노출 API만 `public`(절대규칙 #4)
- **`Core/Network/Project.swift`**: `.external(name: "KakaoSDKTalk")` 추가 (kakao-ios-sdk 2.27.0은 `Tuist/Package.swift`에 이미 존재)
- **`FailedVerificationUMC.swift`**: `// TODO(#958)` 제거, `openInquiryChannel()`을 `kakaoPlusManager.openKakaoChannel(errorHandler:)` 위임으로 전환, 매니저 내부로 흡수된 죽은 `Constants`(웹 URL·실패 메시지) 제거. `@Environment(\.openURL)`은 홈 버튼(`openHomePage`)이 계속 사용하므로 유지
- **`Project.swift`**: `LSApplicationQueriesSchemes`에 `kakaoplus` 스킴 추가 — 누락 시 `isKakaoTalkChannelAvailable`이 `canOpenURL` 단계에서 항상 `false`를 반환해 인앱 전환이 무력화(웹 폴백만 동작)되므로 필수. 레거시 Info.plist엔 있었으나 UMCApp 이관 시 누락돼 있던 항목
- **`docs/claude/tuist-file-mapping.md`**: `KakaoPlusManager` 매핑을 잠정 표기 `CoreFoundation(신규 Support 서브폴더)` → `CoreNetwork(Auth)`로 갱신
- **테스트**: 형제 소셜 매니저(정적 SDK 싱글턴 래핑)와 동일 컨벤션에 따라 매니저 단위 테스트는 추가하지 않음. 소비자 View에 검증할 다운스트림 상태가 없음

### 와이어링 방식 결정 근거 (View 직접 보유)

`FailedVerificationUMC`가 `private let kakaoPlusManager = KakaoPlusManager()`로 직접 보유·호출한다. ViewModel 경유/프로토콜+DI 주입 대신 이를 택한 이유:
- 반환값 없는 fire-and-forget 액션으로 다운스트림 상태/분기가 없어(매니저가 실패까지 `ErrorHandler`로 자체 처리) ViewModel이 결과를 받아 상태를 갱신할 지점이 없음
- 레거시 5개 호출부 전부 View-로컬 `let` 프로퍼티 패턴 사용 — 동형 재현
- 같은 파일의 `openHomePage()`(외부 네비게이션 부수효과)도 이미 ViewModel을 거치지 않는 선례

## 📋 추후 진행 상황

- 레거시 나머지 4개 `KakaoPlusManager` 호출부(`LoginView`, 탭 액세서리, MyPage `HelpSection`, `AuthBootstrapView`) 이관 시 `public` 매니저를 즉시 재사용 가능

## 📌 리뷰 포인트

- `UMCApp/Core/Network/Sources/Auth/KakaoPlusManager.swift` — 카카오톡 채널 딥링크 → 웹 → ErrorHandler 폴백 체인, `@MainActor` 경계와 `[weak self]` 클로저(형제 매니저·기존 ViewModel과 동일 패턴), `public` 노출 범위가 최소인지
- `UMCApp/Project.swift` — `LSApplicationQueriesSchemes`에 `kakaoplus` 추가가 기존 스킴(`kakaokompassauth`/`kakaolink`/`kakaotalk`) 보존하며 올바른지
- `UMCApp/Features/Auth/Presentation/Sources/Views/FailedVerificationUMC.swift` — 버튼 배선 전환 후 웹 폴백/실패 안내 동작이 레거시와 동등한지, `openURL` 잔존이 홈 버튼용으로만 남았는지
- `UMCApp/Core/Network/Project.swift` — `KakaoSDKTalk` external 추가

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

---

> ⚠️ **검증 참고**: `make generate` 성공(KakaoSDKTalk external 해석 포함). 모듈 단위 테스트 전부 통과 — CoreNetwork 38/38, AuthPresentation 86/86, AuthDomain 48/48, AuthData 68/68. `CoreNetwork` clean 빌드 시 `KakaoPlusManager` 관련 Swift 6 Sendable 경고/에러 없음. 전체 `UMCApp` 스킴 `make test`는 로컬 환경에 `Secrets.xcconfig`(KAKAO_KEY)가 없어 부팅 크래시로 실행 불가 — 이번 변경과 무관한 선재 환경 문제이므로 실제 키가 구성된 CI/개발 환경에서 재검증 필요.
