### PR TITLE
♻️ [Refactor] SignUp ViewModel/테스트 Mock 중복 제거 및 이메일 중복확인 재시도 추가 (Auth 슬라이스 3 후속)

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Error/Types/AppError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/AppError.swift
@@ -148,4 +148,28 @@ public enum AppError: Error, LocalizedError, Equatable {
             return true
         }
     }
+
+    // MARK: - Factory
+
+    /// 임의의 `Error`를 공통 규칙으로 `AppError`로 정규화한다.
+    ///
+    /// 여러 ViewModel(예: `SignUpViewModel`, `SignUpByIdPwViewModel`)이 각자
+    /// `catch` 블록에서 동일한 `RepositoryError`/`NetworkError`/`AuthError` 매핑 로직을
+    /// 중복 구현하던 것을 통합한 지점이다. 이미 `AppError`인 경우 그대로 반환하고,
+    /// 알려진 하위 에러 타입이 아니면 `.unknown`으로 폴백한다.
+    public static func from(_ error: Error) -> AppError {
+        if let appError = error as? AppError {
+            return appError
+        }
+        if let repositoryError = error as? RepositoryError {
+            return .repository(repositoryError)
+        }
+        if let networkError = error as? NetworkError {
+            return .network(networkError)
+        }
+        if let authError = error as? AuthError {
+            return .auth(authError)
+        }
+        return .unknown(message: error.localizedDescription)
+    }
 }

--- a/UMCApp/Core/Foundation/Sources/Error/Types/RepositoryError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/RepositoryError.swift
@@ -38,6 +38,10 @@ public enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
     /// 응답 데이터 디코딩 실패
     case decodingError(detail: String?)
 
+    /// 디코딩 자체는 성공했지만 응답 내용이 의미상 유효하지 않음
+    /// (e.g. 필수 필드가 비어 있음)
+    case invalidResponse(detail: String?)
+
     // MARK: - LocalizedError
 
     public var errorDescription: String? {
@@ -46,6 +50,8 @@ public enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
             return message ?? "서버 오류가 발생했습니다"
         case .decodingError(let detail):
             return "데이터 파싱 실패: \(detail ?? "알 수 없는 오류")"
+        case .invalidResponse(let detail):
+            return "서버 응답이 유효하지 않습니다: \(detail ?? "알 수 없는 오류")"
         }
     }
 
@@ -56,7 +62,7 @@ public enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
         switch self {
         case .serverError(let code, _):
             return code
-        default:
+        case .decodingError, .invalidResponse:
             return nil
         }
     }
@@ -71,7 +77,7 @@ public enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
         switch self {
         case .serverError:
             return true
-        case .decodingError:
+        case .decodingError, .invalidResponse:
             return false
         }
     }

--- a/UMCApp/Features/Auth/Data/Sources/Network/AuthNetworkRequesting.swift
+++ b/UMCApp/Features/Auth/Data/Sources/Network/AuthNetworkRequesting.swift
@@ -1,0 +1,43 @@
+import Foundation
+import CoreNetwork
+import Moya
+
+/// `AuthRepository` 를 단위 테스트하기 위한 **네트워크 요청 seam (테스트 목적 추상화)**.
+///
+/// - Important: 이 프로토콜은 **오직 테스트 가능성을 위해** 존재합니다.
+///   **런타임 동작에는 아무 영향이 없습니다** — 운영 빌드에서 이 프로토콜을 채택하는 타입은
+///   `MoyaNetworkAdapter` **단 하나**이고, `AuthRepository` 의 public init 도 여전히
+///   구체 `MoyaNetworkAdapter` 를 받습니다. `internal` 이라 모듈 밖(다른 피처·앱)에는
+///   노출되지 않습니다.
+///
+/// ### 왜 필요한가
+/// 구체 타입 ``CoreNetwork/MoyaNetworkAdapter`` 는 actor 기반 `NetworkClient` 와
+/// `NetworkConfig.baseURL`(테스트 번들에 `BASE_URL` 미주입 시 `fatalError`)에 묶여 있어
+/// 단위 테스트에서 직접 대체할 수 없습니다. 그래서 Repository 는 이 프로토콜에만 의존하고,
+/// 운영 코드는 `MoyaNetworkAdapter` 를, 테스트는 `.path`/`.method` 만 읽는 가짜 구현을 주입합니다.
+///
+/// - Note: `AuthRepository` 는 인증 요청(`request`)과 비인증 공개 요청
+///   (`requestWithoutAuth`, 이메일 인증·회원가입 등)을 모두 사용하므로 두 메서드를 함께
+///   요구합니다. `MoyaNetworkAdapter` 는 모듈 경계 밖에서 `Sendable` 로 노출되지 않으므로
+///   본 프로토콜은 `Sendable` 을 요구하지 않으며, Repository 가 `@unchecked Sendable` 로
+///   감쌉니다.
+///
+/// - SeeAlso: 동일 목적·동일 패턴의 선례
+///   `MyPageData/Sources/Network/MyPageNetworkRequesting.swift`,
+///   `ActivityData/Sources/Network/NetworkRequesting.swift`.
+protocol AuthNetworkRequesting {
+    /// Moya `TargetType` 라우터로 인증 요청을 보내고 원시 `Response` 를 반환합니다.
+    func request<T: TargetType>(_ target: T) async throws -> Response
+
+    /// 인증 없이 공개 API 요청을 보내고 원시 `Response` 를 반환합니다
+    /// (예: 이메일 인증, 회원가입, 학교/약관 조회).
+    func requestWithoutAuth<T: TargetType>(_ target: T) async throws -> Response
+}
+
+// MARK: - MoyaNetworkAdapter 적합
+
+/// 운영 빌드에서 이 프로토콜을 채택하는 **유일한 실제 타입**입니다.
+/// `MoyaNetworkAdapter` 의 `request(_:)` / `requestWithoutAuth(_:)` 시그니처가
+/// 프로토콜 요구사항과 정확히 일치하므로 빈 적합 선언만으로 충분합니다.
+/// (그 외 채택자는 테스트 타깃의 가짜 구현뿐입니다.)
+extension MoyaNetworkAdapter: AuthNetworkRequesting {}

--- a/UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift
+++ b/UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift
@@ -17,18 +17,34 @@ public struct AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
 
     // MARK: - Property
 
-    private let adapter: MoyaNetworkAdapter
+    private let adapter: any AuthNetworkRequesting
     private let networkClient: NetworkClient
     private let tokenStore: TokenStore
 
     // MARK: - Init
 
+    /// 운영 이니셜라이저 — 구체 `MoyaNetworkAdapter` 를 주입받습니다.
     public init(
         adapter: MoyaNetworkAdapter,
         networkClient: NetworkClient,
         tokenStore: TokenStore
     ) {
-        self.adapter = adapter
+        self.init(
+            networkRequesting: adapter,
+            networkClient: networkClient,
+            tokenStore: tokenStore
+        )
+    }
+
+    /// 테스트 seam — `AuthNetworkRequesting` 가짜 구현을 주입하기 위한 지정 이니셜라이저.
+    /// (`MoyaNetworkAdapter` 는 `NetworkConfig.baseURL` `fatalError` 로 테스트 번들에서
+    /// 직접 사용할 수 없으므로, 테스트는 이 이니셜라이저로 stub 을 주입합니다.)
+    init(
+        networkRequesting: any AuthNetworkRequesting,
+        networkClient: NetworkClient,
+        tokenStore: TokenStore
+    ) {
+        self.adapter = networkRequesting
         self.networkClient = networkClient
         self.tokenStore = tokenStore
     }
@@ -350,7 +366,7 @@ extension AuthRepository: AuthRegistrationRepositoryProtocol {
             // DTO가 누락된 토큰을 빈 문자열로 흡수하므로, 빈 토큰을 유효 세션으로 저장하지
             // 않도록 `register()`와 동일하게 비어있지 않음을 가드한다.
             guard !dto.accessToken.isEmpty, !dto.refreshToken.isEmpty else {
-                throw RepositoryError.decodingError(
+                throw RepositoryError.invalidResponse(
                     detail: "registerByEmail: 서버 응답에 accessToken/refreshToken이 없습니다"
                 )
             }

--- a/UMCApp/Features/Auth/Data/Tests/AuthRepositoryTests.swift
+++ b/UMCApp/Features/Auth/Data/Tests/AuthRepositoryTests.swift
@@ -1,0 +1,269 @@
+//
+//  AuthRepositoryTests.swift
+//  AuthDataTests
+//
+
+//  진짜 `AuthRepository`를 대상으로, 그 아래 네트워크 계층만 가짜(`StubAuthNetwork`)로 주입해
+//  `registerByEmail`의 디코딩·도메인 매핑·토큰 저장·에러 매핑 계약을 검증한다.
+//  (엔드포인트 path/method/task 계약은 `AuthRouterTests`에서 별도 검증)
+//
+
+import Foundation
+import Testing
+import Moya
+import CoreNetwork
+import UMCFoundation
+import AuthDomain
+@testable import AuthData
+
+// MARK: - Test Doubles
+
+/// ``AuthNetworkRequesting`` 가짜 구현.
+///
+/// 미리 설정한 결과(성공 본문 / 던질 에러)를 반환하고, 호출된 라우터의 경로·메서드·타깃을
+/// 기록해 엔드포인트 계약과 전송 페이로드를 검증할 수 있게 한다.
+/// `target.path`/`target.method`만 읽어 `NetworkConfig.baseURL`(테스트 번들 `fatalError`)을
+/// 건드리지 않는다.
+private final class StubAuthNetwork: AuthNetworkRequesting, @unchecked Sendable {
+
+    enum Outcome {
+        /// 200 응답으로 주어진 JSON 본문을 반환
+        case success(Data)
+        /// 요청 단계에서 에러를 던짐 (비-2xx 등)
+        case failure(Error)
+    }
+
+    private let outcome: Outcome
+    private(set) var requestCount = 0
+    private(set) var requestWithoutAuthCount = 0
+    private(set) var lastPath: String?
+    private(set) var lastMethod: Moya.Method?
+    private(set) var lastTarget: AuthRouter?
+
+    init(_ outcome: Outcome) {
+        self.outcome = outcome
+    }
+
+    func request<T: TargetType>(_ target: T) async throws -> Response {
+        requestCount += 1
+        capture(target)
+        return try makeResponse()
+    }
+
+    func requestWithoutAuth<T: TargetType>(_ target: T) async throws -> Response {
+        requestWithoutAuthCount += 1
+        capture(target)
+        return try makeResponse()
+    }
+
+    private func capture<T: TargetType>(_ target: T) {
+        lastPath = target.path
+        lastMethod = target.method
+        lastTarget = target as? AuthRouter
+    }
+
+    private func makeResponse() throws -> Response {
+        switch outcome {
+        case .success(let data):
+            return Response(statusCode: 200, data: data)
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+/// ``TokenStore`` 가짜 구현. `save(accessToken:refreshToken:)` 호출 인자를 기록한다.
+private actor FakeTokenStore: TokenStore {
+    private(set) var savedAccessToken: String?
+    private(set) var savedRefreshToken: String?
+    private(set) var saveCallCount = 0
+
+    func getAccessToken() async -> String? { savedAccessToken }
+    func getRefreshToken() async -> String? { savedRefreshToken }
+
+    func save(accessToken: String, refreshToken: String) async throws {
+        saveCallCount += 1
+        savedAccessToken = accessToken
+        savedRefreshToken = refreshToken
+    }
+
+    func clear() async throws {
+        savedAccessToken = nil
+        savedRefreshToken = nil
+    }
+}
+
+/// ``TokenRefreshService`` 가짜 구현. `registerByEmail`은 갱신 경로를 타지 않으므로 항상 실패한다.
+private struct FakeTokenRefreshService: TokenRefreshService {
+    func refresh(_ refreshToken: String) async throws -> TokenPair {
+        throw NetworkError.timeout
+    }
+}
+
+// MARK: - Fixtures
+
+private enum Fixture {
+
+    /// APIResponse 성공 봉투로 감싼 result 본문
+    static func success(_ resultJSON: String) -> Data {
+        Data("""
+        { "success": true, "code": "200", "message": "성공", "result": \(resultJSON) }
+        """.utf8)
+    }
+
+    /// isSuccess:false 실패 봉투
+    static func failureBody(code: String?, message: String?) -> Data {
+        var fields: [String] = ["\"success\": false"]
+        if let code { fields.append("\"code\": \"\(code)\"") }
+        if let message { fields.append("\"message\": \"\(message)\"") }
+        fields.append("\"result\": null")
+        return Data("{ \(fields.joined(separator: ", ")) }".utf8)
+    }
+
+    /// 이메일 회원가입 result 본문
+    static func registerByEmailObject(
+        memberId: String = "42",
+        accessToken: String = "access-token-1",
+        refreshToken: String = "refresh-token-1"
+    ) -> String {
+        """
+        {
+            "memberId": "\(memberId)",
+            "accessToken": "\(accessToken)",
+            "refreshToken": "\(refreshToken)"
+        }
+        """
+    }
+}
+
+// MARK: - Helper
+
+@MainActor
+private func makeRepository(
+    _ outcome: StubAuthNetwork.Outcome,
+    tokenStore: FakeTokenStore = FakeTokenStore()
+) -> (AuthRepository, StubAuthNetwork, FakeTokenStore) {
+    let stub = StubAuthNetwork(outcome)
+    let networkClient = AuthSystemFactory.makeTestNetworkClient(
+        tokenStore: tokenStore,
+        refreshService: FakeTokenRefreshService()
+    )
+    let repository = AuthRepository(
+        networkRequesting: stub,
+        networkClient: networkClient,
+        tokenStore: tokenStore
+    )
+    return (repository, stub, tokenStore)
+}
+
+private func makeTermsAgreements() -> [TermsAgreement] {
+    [TermsAgreement(termsId: "terms-1", isAgreed: true)]
+}
+
+// MARK: - Suite: 이메일(ID/PW) 회원가입
+
+@MainActor
+@Suite("AuthRepository — registerByEmail")
+struct AuthRepositoryRegisterByEmailTests {
+
+    @Test("성공 응답이면 토큰을 저장하고 RegisterByIdPwResult를 반환하며 /member/register/email(POST, 비인증)을 호출한다")
+    func registerByEmailSucceeds() async throws {
+        let (sut, stub, tokenStore) = makeRepository(
+            .success(Fixture.success(Fixture.registerByEmailObject()))
+        )
+
+        let result = try await sut.registerByEmail(
+            rawPassword: "password1234",
+            name: "홍길동",
+            nickname: "길동이",
+            emailVerificationToken: "verify-token-1",
+            schoolId: "1",
+            termsAgreements: makeTermsAgreements()
+        )
+
+        #expect(result.memberId == "42")
+        #expect(stub.requestWithoutAuthCount == 1)
+        #expect(stub.requestCount == 0)
+        #expect(stub.lastPath == "/api/v1/member/register/email")
+        #expect(stub.lastMethod == .post)
+        #expect(await tokenStore.saveCallCount == 1)
+        #expect(await tokenStore.savedAccessToken == "access-token-1")
+        #expect(await tokenStore.savedRefreshToken == "refresh-token-1")
+    }
+
+    @Test("응답에 토큰이 비어 있으면 RepositoryError.invalidResponse를 던지고 토큰을 저장하지 않는다")
+    func registerByEmailThrowsInvalidResponseWhenTokensMissing() async throws {
+        let (sut, _, tokenStore) = makeRepository(
+            .success(Fixture.success(
+                Fixture.registerByEmailObject(accessToken: "", refreshToken: "")
+            ))
+        )
+
+        await #expect(throws: RepositoryError.invalidResponse(
+            detail: "registerByEmail: 서버 응답에 accessToken/refreshToken이 없습니다"
+        )) {
+            _ = try await sut.registerByEmail(
+                rawPassword: "password1234",
+                name: "홍길동",
+                nickname: "길동이",
+                emailVerificationToken: "verify-token-1",
+                schoolId: "1",
+                termsAgreements: makeTermsAgreements()
+            )
+        }
+
+        #expect(await tokenStore.saveCallCount == 0)
+    }
+
+    @Test("isSuccess:false면 RepositoryError.serverError를 던진다")
+    func registerByEmailThrowsServerErrorWhenUnsuccessful() async {
+        let (sut, _, _) = makeRepository(
+            .success(Fixture.failureBody(code: "AUTH409", message: "이미 가입된 이메일입니다."))
+        )
+
+        await #expect(throws: RepositoryError.serverError(
+            code: "AUTH409", message: "이미 가입된 이메일입니다."
+        )) {
+            _ = try await sut.registerByEmail(
+                rawPassword: "password1234",
+                name: "홍길동",
+                nickname: "길동이",
+                emailVerificationToken: "verify-token-1",
+                schoolId: "1",
+                termsAgreements: makeTermsAgreements()
+            )
+        }
+    }
+
+    @Test("응답 본문을 파싱할 수 없으면 RepositoryError.decodingError를 던진다")
+    func registerByEmailThrowsDecodingErrorForMalformedBody() async {
+        let (sut, _, _) = makeRepository(.success(Data("not-json".utf8)))
+
+        await #expect(throws: RepositoryError.self) {
+            _ = try await sut.registerByEmail(
+                rawPassword: "password1234",
+                name: "홍길동",
+                nickname: "길동이",
+                emailVerificationToken: "verify-token-1",
+                schoolId: "1",
+                termsAgreements: makeTermsAgreements()
+            )
+        }
+    }
+
+    @Test("파싱 불가한 NetworkError는 원본 그대로 전파한다")
+    func registerByEmailPropagatesNonMappableError() async {
+        let (sut, _, _) = makeRepository(.failure(NetworkError.timeout))
+
+        await #expect(throws: NetworkError.timeout) {
+            _ = try await sut.registerByEmail(
+                rawPassword: "password1234",
+                name: "홍길동",
+                nickname: "길동이",
+                emailVerificationToken: "verify-token-1",
+                schoolId: "1",
+                termsAgreements: makeTermsAgreements()
+            )
+        }
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/EmailVerificationFlow.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/EmailVerificationFlow.swift
@@ -51,13 +51,21 @@ final class EmailVerificationFlow {
 
     // MARK: - Init
 
+    /// - Parameter initialEmail: 소셜 회원가입처럼 이전 화면에서 이미 수집한 이메일을
+    ///   프리필해야 할 때 사용한다. `email`과 변경 감지 스냅샷을 함께 초기화하므로,
+    ///   프리필 직후 사용자가 아무것도 편집하지 않아도 "이미 변경된 것으로" 오탐하지 않는다.
+    ///   프리필이 필요 없는 호출자(`SignUpByIdPwViewModel`, `ResetPasswordViewModel`)는
+    ///   생략하면 기존과 동일하게 빈 문자열로 시작한다.
     init(
         purpose: EmailVerificationPurpose,
+        initialEmail: String = "",
         sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
         verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
         resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
     ) {
         self.purpose = purpose
+        self.email = initialEmail
+        self.lastEmailSnapshot = initialEmail
         self.sendEmailVerificationUseCase = sendEmailVerificationUseCase
         self.verifyEmailCodeUseCase = verifyEmailCodeUseCase
         self.resendEmailVerificationUseCase = resendEmailVerificationUseCase

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/SignUpByIdPwViewModel.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/SignUpByIdPwViewModel.swift
@@ -13,7 +13,7 @@ final class SignUpByIdPwViewModel {
     // MARK: - Constant
 
     private enum Constants {
-        static let emailAvailabilityDebounceMilliseconds: UInt64 = 500
+        static let emailAvailabilityDebounceMilliseconds: Int64 = 500
         static let minimumPasswordLength: Int = 8
     }
 
@@ -25,8 +25,15 @@ final class SignUpByIdPwViewModel {
     private let fetchMyProfileUseCase: FetchMyProfileUseCaseProtocol
     private let errorHandler: ErrorHandler
 
+    /// debounce 대기를 담당하는 sleeper. 운영 기본값은 `Task.sleep`이며, 테스트는 결정적으로
+    /// 즉시 반환되는 sleeper를 주입해 wall-clock 대기 없이 debounce 취소 로직을 검증한다.
+    private let emailAvailabilityDebounceSleep: @Sendable (Duration) async throws -> Void
+
     /// 이메일 인증(발송·검증·재전송) 상태와 액션 — `EmailVerificationFlow`에 위임한다.
     var emailVerificationFlow: EmailVerificationFlow
+
+    /// 약관 조회·동의 토글 상태와 액션 — `TermsAgreementFlow`에 위임한다.
+    var termsAgreementFlow: TermsAgreementFlow
 
     /// 사용자 실명
     var name: String = ""
@@ -43,14 +50,8 @@ final class SignUpByIdPwViewModel {
     /// 선택된 학교
     var selectedSchool: School?
 
-    /// 약관 동의 상태 (termsId → 동의 여부)
-    var termsAgreements: [String: Bool] = [:]
-
     /// 학교 목록 로딩 상태
     private(set) var schoolsState: Loadable<[School]> = .idle
-
-    /// 약관 목록 로딩 상태 (서비스·개인정보 2종, marketing 미노출)
-    private(set) var termsState: Loadable<[Terms]> = .idle
 
     /// 마지막으로 검증에 성공한 인증 코드
     private(set) var verificationCode: String = ""
@@ -67,11 +68,22 @@ final class SignUpByIdPwViewModel {
     /// `showMain()`/`showLogin()` 분기를 결정한다.
     private(set) var isApprovedAfterRegister = false
 
-    @ObservationIgnored private var emailAvailabilityTask: Task<Void, Never>?
+    /// 이메일 중복 확인 debounce/실행을 담당하는 진행 중인 Task.
+    ///
+    /// setter는 `private`지만, getter는 모듈 기본(`internal`) 접근 수준을 유지해
+    /// `@testable import AuthPresentation`에서 `await emailAvailabilityTask?.value`로
+    /// 대기함으로써 wall-clock 없이 결정적으로 debounce 완료 시점을 테스트할 수 있게 한다.
+    @ObservationIgnored private(set) var emailAvailabilityTask: Task<Void, Never>?
 
     // MARK: - Init
 
-    init(container: DIContainer, errorHandler: ErrorHandler) {
+    init(
+        container: DIContainer,
+        errorHandler: ErrorHandler,
+        emailAvailabilityDebounceSleep: @escaping @Sendable (Duration) async throws -> Void = {
+            duration in try await Task.sleep(for: duration)
+        }
+    ) {
         self.fetchSignUpDataUseCase = container.resolve(FetchSignUpDataUseCaseProtocol.self)
         self.checkEmailAvailabilityUseCase = container.resolve(
             CheckEmailAvailabilityUseCaseProtocol.self
@@ -79,6 +91,7 @@ final class SignUpByIdPwViewModel {
         self.registerByEmailUseCase = container.resolve(RegisterByEmailUseCaseProtocol.self)
         self.fetchMyProfileUseCase = container.resolve(FetchMyProfileUseCaseProtocol.self)
         self.errorHandler = errorHandler
+        self.emailAvailabilityDebounceSleep = emailAvailabilityDebounceSleep
         self.emailVerificationFlow = EmailVerificationFlow(
             purpose: .register,
             sendEmailVerificationUseCase: container.resolve(
@@ -88,6 +101,9 @@ final class SignUpByIdPwViewModel {
             resendEmailVerificationUseCase: container.resolve(
                 ResendEmailVerificationUseCaseProtocol.self
             )
+        )
+        self.termsAgreementFlow = TermsAgreementFlow(
+            fetchSignUpDataUseCase: self.fetchSignUpDataUseCase
         )
         self.emailVerificationFlow.onReset = { [weak self] in
             self?.resetEmailAvailability()
@@ -113,8 +129,9 @@ final class SignUpByIdPwViewModel {
 
     /// 최종 제출 가능 여부 — 필수 약관 동의와 이메일 중복 확인 통과를 포함한다.
     ///
-    /// 약관이 아직 로딩되지 않았다면(`termsState != .loaded`) `mandatoryTermsAgreed`가
-    /// 항상 `false`이므로 제출이 자동으로 차단된다. 하드코딩된 termsId fallback은 두지 않는다.
+    /// 약관이 아직 로딩되지 않았다면(`termsAgreementFlow.termsState != .loaded`)
+    /// `mandatoryTermsAgreed`가 항상 `false`이므로 제출이 자동으로 차단된다.
+    /// 하드코딩된 termsId fallback은 두지 않는다.
     var canSubmit: Bool {
         !name.isEmpty &&
         !nickname.isEmpty &&
@@ -124,20 +141,7 @@ final class SignUpByIdPwViewModel {
         selectedSchool != nil &&
         emailVerificationFlow.isEmailVerified &&
         isEmailAvailable &&
-        mandatoryTermsAgreed
-    }
-
-    /// 전체 약관 동의 여부
-    var isAllTermsAgreed: Bool {
-        !termsAgreements.isEmpty && termsAgreements.values.allSatisfy { $0 }
-    }
-
-    /// 필수 약관 모두 동의 여부
-    private var mandatoryTermsAgreed: Bool {
-        guard case .loaded(let terms) = termsState else { return false }
-        return terms
-            .filter(\.isMandatory)
-            .allSatisfy { termsAgreements[$0.id] == true }
+        termsAgreementFlow.mandatoryTermsAgreed
     }
 
     // MARK: - Function (Data Loading)
@@ -150,24 +154,7 @@ final class SignUpByIdPwViewModel {
             let schools = try await fetchSignUpDataUseCase.fetchSchools()
             schoolsState = .loaded(schools)
         } catch {
-            schoolsState = .failed(mapToAppError(error))
-        }
-    }
-
-    /// 약관 목록 조회 (SERVICE, PRIVACY — marketing은 미노출)
-    @MainActor
-    func fetchTerms() async {
-        termsState = .loading
-        do {
-            var terms: [Terms] = []
-            for type in [TermsType.service, TermsType.privacy] {
-                let term = try await fetchSignUpDataUseCase.fetchTerms(type: type)
-                terms.append(term)
-                termsAgreements[term.id] = false
-            }
-            termsState = .loaded(terms)
-        } catch {
-            termsState = .failed(mapToAppError(error))
+            schoolsState = .failed(AppError.from(error))
         }
     }
 
@@ -184,18 +171,6 @@ final class SignUpByIdPwViewModel {
         scheduleEmailAvailabilityCheck()
     }
 
-    // MARK: - Function (Terms)
-
-    /// 전체 약관 동의/해제 토글
-    func toggleAllTerms(_ agreed: Bool) {
-        termsAgreements = termsAgreements.mapValues { _ in agreed }
-    }
-
-    /// 개별 약관 동의 토글
-    func toggleTerm(_ termsId: String) {
-        termsAgreements[termsId, default: false].toggle()
-    }
-
     // MARK: - Function (Email Availability)
 
     /// 이메일 중복 확인을 500ms 디바운스 후 예약한다.
@@ -207,11 +182,23 @@ final class SignUpByIdPwViewModel {
     private func scheduleEmailAvailabilityCheck() {
         emailAvailabilityTask?.cancel()
         let targetEmail = emailVerificationFlow.email
+        let sleep = emailAvailabilityDebounceSleep
         emailAvailabilityTask = Task { [weak self] in
-            try? await Task.sleep(
-                for: .milliseconds(Constants.emailAvailabilityDebounceMilliseconds)
-            )
+            try? await sleep(.milliseconds(Constants.emailAvailabilityDebounceMilliseconds))
             guard !Task.isCancelled else { return }
+            await self?.performEmailAvailabilityCheck(email: targetEmail)
+        }
+    }
+
+    /// 이메일 중복 확인 실패 후 사용자가 명시적으로 요청한 즉시 재시도.
+    ///
+    /// 사용자가 직접 재시도를 요청한 액션이므로 debounce 없이 바로 확인을 수행한다.
+    @MainActor
+    func retryEmailAvailabilityCheck() {
+        guard case .failed = emailAvailabilityState else { return }
+        emailAvailabilityTask?.cancel()
+        let targetEmail = emailVerificationFlow.email
+        emailAvailabilityTask = Task { [weak self] in
             await self?.performEmailAvailabilityCheck(email: targetEmail)
         }
     }
@@ -226,7 +213,7 @@ final class SignUpByIdPwViewModel {
             emailAvailabilityState = .loaded(isAvailable)
         } catch {
             guard !Task.isCancelled else { return }
-            emailAvailabilityState = .failed(mapToAppError(error))
+            emailAvailabilityState = .failed(AppError.from(error))
         }
     }
 
@@ -255,7 +242,7 @@ final class SignUpByIdPwViewModel {
 
         registerState = .loading
 
-        let agreements = termsAgreements.map {
+        let agreements = termsAgreementFlow.termsAgreements.map {
             TermsAgreement(termsId: $0.key, isAgreed: $0.value)
         }
 
@@ -294,22 +281,5 @@ final class SignUpByIdPwViewModel {
         } catch {
             return false
         }
-    }
-
-    /// `RepositoryError`/`NetworkError`/`AuthError`를 `AppError`로 통일해 `Loadable.failed`에 담는다.
-    private func mapToAppError(_ error: Error) -> AppError {
-        if let appError = error as? AppError {
-            return appError
-        }
-        if let repositoryError = error as? RepositoryError {
-            return .repository(repositoryError)
-        }
-        if let networkError = error as? NetworkError {
-            return .network(networkError)
-        }
-        if let authError = error as? AuthError {
-            return .auth(authError)
-        }
-        return .unknown(message: error.localizedDescription)
     }
 }

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/SignUpViewModel.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/SignUpViewModel.swift
@@ -18,12 +18,15 @@ final class SignUpViewModel {
     private let postRegisterLoginContext: PostRegisterLoginContext?
 
     private let fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
-    private let sendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol
-    private let verifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol
-    private let resendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol
     private let registerUseCase: RegisterUseCaseProtocol
     private let loginUseCase: LoginUseCaseProtocol
     private let errorHandler: ErrorHandler
+
+    /// 이메일 인증(발송·검증·재전송) 상태와 액션 — `EmailVerificationFlow`에 위임한다.
+    var emailVerificationFlow: EmailVerificationFlow
+
+    /// 약관 조회·동의 토글 상태와 액션 — `TermsAgreementFlow`에 위임한다.
+    var termsAgreementFlow: TermsAgreementFlow
 
     /// 사용자 실명
     var name: String
@@ -31,35 +34,11 @@ final class SignUpViewModel {
     /// 사용자 닉네임
     var nickname: String
 
-    /// 이메일 주소
-    var email: String
-
     /// 선택된 학교
     var selectedSchool: School?
 
-    /// 약관 동의 상태 (termsId → 동의 여부)
-    var termsAgreements: [String: Bool] = [:]
-
     /// 학교 목록 로딩 상태
     private(set) var schoolsState: Loadable<[School]> = .idle
-
-    /// 약관 목록 로딩 상태 (서비스·개인정보 2종, marketing 미노출)
-    private(set) var termsState: Loadable<[Terms]> = .idle
-
-    /// 이메일 인증 완료 여부 — `FormEmailField`와 양방향 바인딩된다.
-    var isEmailVerified: Bool = false
-
-    /// 이메일 인증 발송 후 발급되는 요청 식별자
-    private(set) var emailVerificationId: String?
-
-    /// 이메일 인증 코드 검증 완료 후 발급되는 토큰
-    private(set) var emailVerificationToken: String?
-
-    /// 마지막으로 검증에 성공한 인증 코드
-    private(set) var verificationCode: String = ""
-
-    /// 이메일 변경 감지를 위한 마지막 스냅샷
-    private var lastEmailSnapshot: String
 
     /// 회원가입 진행 상태 (성공 시 서버 응답 memberId 보관)
     private(set) var registerState: Loadable<String> = .idle
@@ -69,10 +48,6 @@ final class SignUpViewModel {
     /// 서버가 가입 응답에 토큰을 주지 않고 소셜 재로그인마저 실패한 경우
     /// (예: Apple의 1회용 `authorizationCode` 소비)에 `true`가 된다.
     private(set) var requiresManualLoginAfterRegister = false
-
-    @ObservationIgnored private var isRequestingEmailVerification = false
-    @ObservationIgnored private var isVerifyingEmailCode = false
-    @ObservationIgnored private var isResendingEmailVerification = false
 
     // MARK: - Init
 
@@ -87,20 +62,25 @@ final class SignUpViewModel {
         self.oAuthVerificationToken = verificationToken
         self.postRegisterLoginContext = postRegisterLoginContext
         self.fetchSignUpDataUseCase = container.resolve(FetchSignUpDataUseCaseProtocol.self)
-        self.sendEmailVerificationUseCase = container.resolve(
-            SendEmailVerificationUseCaseProtocol.self
-        )
-        self.verifyEmailCodeUseCase = container.resolve(VerifyEmailCodeUseCaseProtocol.self)
-        self.resendEmailVerificationUseCase = container.resolve(
-            ResendEmailVerificationUseCaseProtocol.self
-        )
         self.registerUseCase = container.resolve(RegisterUseCaseProtocol.self)
         self.loginUseCase = container.resolve(LoginUseCaseProtocol.self)
         self.errorHandler = errorHandler
 
         let trimmedEmail = initialEmail?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        self.email = trimmedEmail
-        self.lastEmailSnapshot = trimmedEmail
+        self.emailVerificationFlow = EmailVerificationFlow(
+            purpose: .register,
+            initialEmail: trimmedEmail,
+            sendEmailVerificationUseCase: container.resolve(
+                SendEmailVerificationUseCaseProtocol.self
+            ),
+            verifyEmailCodeUseCase: container.resolve(VerifyEmailCodeUseCaseProtocol.self),
+            resendEmailVerificationUseCase: container.resolve(
+                ResendEmailVerificationUseCaseProtocol.self
+            )
+        )
+        self.termsAgreementFlow = TermsAgreementFlow(
+            fetchSignUpDataUseCase: self.fetchSignUpDataUseCase
+        )
         self.name = initialFullName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         self.nickname = ""
     }
@@ -108,29 +88,13 @@ final class SignUpViewModel {
     // MARK: - Computed Property
 
     /// 폼 유효성 검증 상태 — 필수 약관 동의를 포함한다.
-    ///
-    /// 약관이 아직 로딩되지 않았다면(`termsState != .loaded`) `mandatoryTermsAgreed`가
-    /// 항상 `false`이므로 제출이 자동으로 차단된다. 하드코딩된 termsId fallback은 두지 않는다.
     var isFormValid: Bool {
         !name.isEmpty &&
         !nickname.isEmpty &&
-        !email.isEmpty &&
+        !emailVerificationFlow.email.isEmpty &&
         selectedSchool != nil &&
-        isEmailVerified &&
-        mandatoryTermsAgreed
-    }
-
-    /// 전체 약관 동의 여부
-    var isAllTermsAgreed: Bool {
-        !termsAgreements.isEmpty && termsAgreements.values.allSatisfy { $0 }
-    }
-
-    /// 필수 약관 모두 동의 여부
-    private var mandatoryTermsAgreed: Bool {
-        guard case .loaded(let terms) = termsState else { return false }
-        return terms
-            .filter(\.isMandatory)
-            .allSatisfy { termsAgreements[$0.id] == true }
+        emailVerificationFlow.isEmailVerified &&
+        termsAgreementFlow.mandatoryTermsAgreed
     }
 
     // MARK: - Function (Data Loading)
@@ -143,99 +107,8 @@ final class SignUpViewModel {
             let schools = try await fetchSignUpDataUseCase.fetchSchools()
             schoolsState = .loaded(schools)
         } catch {
-            schoolsState = .failed(mapToAppError(error))
+            schoolsState = .failed(AppError.from(error))
         }
-    }
-
-    /// 약관 목록 조회 (SERVICE, PRIVACY — marketing은 미노출)
-    @MainActor
-    func fetchTerms() async {
-        termsState = .loading
-        do {
-            var terms: [Terms] = []
-            for type in [TermsType.service, TermsType.privacy] {
-                let term = try await fetchSignUpDataUseCase.fetchTerms(type: type)
-                terms.append(term)
-                termsAgreements[term.id] = false
-            }
-            termsState = .loaded(terms)
-        } catch {
-            termsState = .failed(mapToAppError(error))
-        }
-    }
-
-    // MARK: - Function (Email Verification)
-
-    /// 이메일 인증번호 발송 요청.
-    ///
-    /// `FormEmailField`가 bare `Task {}`로 호출하므로 중복 탭에 대비해 재진입을 막는다.
-    @MainActor
-    func requestEmailVerification() async throws {
-        guard !isRequestingEmailVerification else { return }
-        isRequestingEmailVerification = true
-        defer { isRequestingEmailVerification = false }
-
-        let id = try await sendEmailVerificationUseCase.execute(email: email, purpose: .register)
-        emailVerificationId = id
-    }
-
-    /// 이메일 인증번호 검증
-    @MainActor
-    func verifyEmailCode(_ code: String) async throws {
-        guard !isVerifyingEmailCode else { return }
-        guard let emailVerificationId else { return }
-        isVerifyingEmailCode = true
-        defer { isVerifyingEmailCode = false }
-
-        let token = try await verifyEmailCodeUseCase.execute(
-            emailVerificationId: emailVerificationId,
-            verificationCode: code
-        )
-        emailVerificationToken = token
-        verificationCode = code
-        isEmailVerified = true
-    }
-
-    /// 이메일 인증번호 재전송
-    @MainActor
-    func resendEmailVerification() async throws {
-        guard !isResendingEmailVerification else { return }
-        guard let emailVerificationId else { return }
-        isResendingEmailVerification = true
-        defer { isResendingEmailVerification = false }
-
-        try await resendEmailVerificationUseCase.execute(emailVerificationId: emailVerificationId)
-    }
-
-    /// 이메일 텍스트 변경 콜백 — 실제로 값이 바뀐 경우에만 인증 상태를 리셋한다.
-    @MainActor
-    func handleEmailChanged() {
-        guard email != lastEmailSnapshot else { return }
-        lastEmailSnapshot = email
-        resetEmailVerification()
-    }
-
-    /// 이메일 변경 시 이메일 인증 상태를 초기화한다.
-    ///
-    /// 기존 인증번호/토큰은 이전 이메일 기준이므로 폐기되어야 한다.
-    @MainActor
-    func resetEmailVerification() {
-        isEmailVerified = false
-        emailVerificationId = nil
-        emailVerificationToken = nil
-        verificationCode = ""
-    }
-
-    // MARK: - Function (Terms)
-
-    /// 전체 약관 동의/해제 토글
-    func toggleAllTerms(_ agreed: Bool) {
-        termsAgreements = termsAgreements.mapValues { _ in agreed }
-    }
-
-    /// 개별 약관 동의 토글
-    func toggleTerm(_ termsId: String) {
-        termsAgreements[termsId, default: false].toggle()
     }
 
     // MARK: - Function (Register)
@@ -246,14 +119,14 @@ final class SignUpViewModel {
         guard !registerState.isLoading else { return }
         guard isFormValid,
               let selectedSchool,
-              let emailVerificationToken else {
+              let emailVerificationToken = emailVerificationFlow.emailVerificationToken else {
             return
         }
 
         registerState = .loading
         requiresManualLoginAfterRegister = false
 
-        let agreements = termsAgreements.map {
+        let agreements = termsAgreementFlow.termsAgreements.map {
             TermsAgreement(termsId: $0.key, isAgreed: $0.value)
         }
 
@@ -319,22 +192,5 @@ final class SignUpViewModel {
                 reason: "회원가입 후 세션 복구에 실패했습니다."
             )
         }
-    }
-
-    /// `RepositoryError`/`NetworkError`/`AuthError`를 `AppError`로 통일해 `Loadable.failed`에 담는다.
-    private func mapToAppError(_ error: Error) -> AppError {
-        if let appError = error as? AppError {
-            return appError
-        }
-        if let repositoryError = error as? RepositoryError {
-            return .repository(repositoryError)
-        }
-        if let networkError = error as? NetworkError {
-            return .network(networkError)
-        }
-        if let authError = error as? AuthError {
-            return .auth(authError)
-        }
-        return .unknown(message: error.localizedDescription)
     }
 }

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/TermsAgreementFlow.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/TermsAgreementFlow.swift
@@ -1,0 +1,80 @@
+import AuthDomain
+import Foundation
+import UMCFoundation
+
+/// 약관 조회·동의 토글 흐름을 캡슐화한 컴포지션 객체.
+///
+/// `SignUpViewModel`(소셜)과 `SignUpByIdPwViewModel`(이메일)이 동일한 약관 조회/토글/필수
+/// 동의 판정 로직을 복사-붙여넣기로 중복 보유하던 것을 `EmailVerificationFlow`와 동일한
+/// 패턴으로 추출했다. 두 ViewModel은 이 객체를 프로퍼티로 보유하고 위임한다.
+///
+/// - Important: 부모 `@Observable` ViewModel에서 `var termsAgreementFlow: TermsAgreementFlow`로
+///   선언해야 한다(`let` 금지). `EmailVerificationFlow`와 동일한 이유(`Binding`의
+///   `subscript(dynamicMember:)`가 `WritableKeyPath` 체인을 요구)로, `let`이면 중첩 바인딩이 깨진다.
+@Observable
+final class TermsAgreementFlow {
+
+    // MARK: - Property
+
+    private let fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol
+
+    /// 약관 동의 상태 (termsId → 동의 여부)
+    var termsAgreements: [String: Bool] = [:]
+
+    /// 약관 목록 로딩 상태 (서비스·개인정보 2종, marketing 미노출)
+    private(set) var termsState: Loadable<[Terms]> = .idle
+
+    // MARK: - Init
+
+    init(fetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol) {
+        self.fetchSignUpDataUseCase = fetchSignUpDataUseCase
+    }
+
+    // MARK: - Computed Property
+
+    /// 전체 약관 동의 여부
+    var isAllTermsAgreed: Bool {
+        !termsAgreements.isEmpty && termsAgreements.values.allSatisfy { $0 }
+    }
+
+    /// 필수 약관 모두 동의 여부.
+    ///
+    /// 약관이 아직 로딩되지 않았다면(`termsState != .loaded`) 항상 `false`이므로, 이 값을
+    /// 참조하는 폼 유효성 검증(`isFormValid`/`canSubmit`)은 자동으로 제출을 차단한다.
+    /// 하드코딩된 termsId fallback은 두지 않는다.
+    var mandatoryTermsAgreed: Bool {
+        guard case .loaded(let terms) = termsState else { return false }
+        return terms
+            .filter(\.isMandatory)
+            .allSatisfy { termsAgreements[$0.id] == true }
+    }
+
+    // MARK: - Function
+
+    /// 약관 목록 조회 (SERVICE, PRIVACY — marketing은 미노출)
+    @MainActor
+    func fetchTerms() async {
+        termsState = .loading
+        do {
+            var terms: [Terms] = []
+            for type in [TermsType.service, TermsType.privacy] {
+                let term = try await fetchSignUpDataUseCase.fetchTerms(type: type)
+                terms.append(term)
+                termsAgreements[term.id] = false
+            }
+            termsState = .loaded(terms)
+        } catch {
+            termsState = .failed(AppError.from(error))
+        }
+    }
+
+    /// 전체 약관 동의/해제 토글
+    func toggleAllTerms(_ agreed: Bool) {
+        termsAgreements = termsAgreements.mapValues { _ in agreed }
+    }
+
+    /// 개별 약관 동의 토글
+    func toggleTerm(_ termsId: String) {
+        termsAgreements[termsId, default: false].toggle()
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpByIdPwView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpByIdPwView.swift
@@ -35,6 +35,7 @@ public struct SignUpByIdPwView: View {
         static let emailAvailableMessage: String = "사용 가능한 이메일이에요."
         static let emailUnavailableMessage: String = "이미 가입된 이메일이에요."
         static let emailAvailabilityFailedMessage: String = "중복 확인에 실패했어요."
+        static let emailAvailabilityRetryTitle: String = "재시도"
     }
 
     // MARK: - Init
@@ -99,11 +100,11 @@ public struct SignUpByIdPwView: View {
                     )
 
                     SignUpTermsSection(
-                        termsState: viewModel.termsState,
-                        termsAgreements: viewModel.termsAgreements,
-                        isAllTermsAgreed: viewModel.isAllTermsAgreed,
-                        onToggleAll: { viewModel.toggleAllTerms($0) },
-                        onToggleRow: { viewModel.toggleTerm($0) }
+                        termsState: viewModel.termsAgreementFlow.termsState,
+                        termsAgreements: viewModel.termsAgreementFlow.termsAgreements,
+                        isAllTermsAgreed: viewModel.termsAgreementFlow.isAllTermsAgreed,
+                        onToggleAll: { viewModel.termsAgreementFlow.toggleAllTerms($0) },
+                        onToggleRow: { viewModel.termsAgreementFlow.toggleTerm($0) }
                     )
                 }
                 .safeAreaPadding(.vertical, DefaultConstant.defaultContentTopMargins)
@@ -117,7 +118,7 @@ public struct SignUpByIdPwView: View {
         }
         .task {
             await viewModel.fetchSchools()
-            await viewModel.fetchTerms()
+            await viewModel.termsAgreementFlow.fetchTerms()
         }
         .onChange(of: viewModel.registerState) { _, newState in
             handleRegisterStateChange(newState)
@@ -155,6 +156,10 @@ public struct SignUpByIdPwView: View {
                     .foregroundStyle(Color.red500)
                 Text(Constants.emailAvailabilityFailedMessage)
                     .appFont(.footnote, color: .red500)
+                Button(Constants.emailAvailabilityRetryTitle) {
+                    viewModel.retryEmailAvailabilityCheck()
+                }
+                .appFont(.footnote, weight: .semibold, color: .indigo500)
             }
         }
     }

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpView.swift
@@ -65,19 +65,19 @@ public struct SignUpView: View {
                     )
 
                     SignUpEmailSection(
-                        email: $viewModel.email,
-                        isVerified: $viewModel.isEmailVerified,
+                        email: $viewModel.emailVerificationFlow.email,
+                        isVerified: $viewModel.emailVerificationFlow.isEmailVerified,
                         onVerificationRequested: {
-                            try await viewModel.requestEmailVerification()
+                            try await viewModel.emailVerificationFlow.requestEmailVerification()
                         },
                         onVerificationComplete: { code in
-                            try await viewModel.verifyEmailCode(code)
+                            try await viewModel.emailVerificationFlow.verifyEmailCode(code)
                         },
                         onResend: {
-                            try await viewModel.resendEmailVerification()
+                            try await viewModel.emailVerificationFlow.resendEmailVerification()
                         },
                         onEmailChanged: {
-                            viewModel.handleEmailChanged()
+                            viewModel.emailVerificationFlow.handleEmailChanged()
                         }
                     )
 
@@ -87,11 +87,11 @@ public struct SignUpView: View {
                     )
 
                     SignUpTermsSection(
-                        termsState: viewModel.termsState,
-                        termsAgreements: viewModel.termsAgreements,
-                        isAllTermsAgreed: viewModel.isAllTermsAgreed,
-                        onToggleAll: { viewModel.toggleAllTerms($0) },
-                        onToggleRow: { viewModel.toggleTerm($0) }
+                        termsState: viewModel.termsAgreementFlow.termsState,
+                        termsAgreements: viewModel.termsAgreementFlow.termsAgreements,
+                        isAllTermsAgreed: viewModel.termsAgreementFlow.isAllTermsAgreed,
+                        onToggleAll: { viewModel.termsAgreementFlow.toggleAllTerms($0) },
+                        onToggleRow: { viewModel.termsAgreementFlow.toggleTerm($0) }
                     )
                 }
                 .safeAreaPadding(.vertical, DefaultConstant.defaultContentTopMargins)
@@ -105,7 +105,7 @@ public struct SignUpView: View {
         }
         .task {
             await viewModel.fetchSchools()
-            await viewModel.fetchTerms()
+            await viewModel.termsAgreementFlow.fetchTerms()
         }
         .onChange(of: viewModel.registerState) { _, newState in
             handleRegisterStateChange(newState)

--- a/UMCApp/Features/Auth/Presentation/Tests/EmailVerificationFlowTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/EmailVerificationFlowTests.swift
@@ -214,51 +214,9 @@ private func makeVerifiedFlow(
 }
 
 // MARK: - Mocks — UseCase
-
-private final class MockSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<String, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-    private(set) var receivedEmail: String?
-    private(set) var receivedPurpose: EmailVerificationPurpose?
-
-    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
-        callCount += 1
-        receivedEmail = email
-        receivedPurpose = purpose
-        return try result.get()
-    }
-}
-
-private final class MockVerifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<String, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-
-    func execute(emailVerificationId: String, verificationCode: String) async throws -> String {
-        callCount += 1
-        return try result.get()
-    }
-}
-
-private final class MockResendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<Void, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-    private(set) var receivedEmailVerificationId: String?
-
-    func execute(emailVerificationId: String) async throws {
-        callCount += 1
-        receivedEmailVerificationId = emailVerificationId
-        _ = try result.get()
-    }
-}
+//
+// `MockSendEmailVerificationUseCase`/`MockVerifyEmailCodeUseCase`/
+// `MockResendEmailVerificationUseCase`는 `Support/MockAuthUseCases.swift`의 공용 Mock을 사용한다 (#956).
 
 /// 재진입 가드 검증을 위해 인위적인 지연을 주는 인증 발송 UseCase.
 private final class SlowSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,

--- a/UMCApp/Features/Auth/Presentation/Tests/ResetPasswordViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/ResetPasswordViewModelTests.swift
@@ -228,47 +228,9 @@ private func makeVerifiedViewModel(
 }
 
 // MARK: - Mocks — UseCase
-
-private final class MockSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<String, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-    private(set) var receivedPurpose: EmailVerificationPurpose?
-
-    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
-        callCount += 1
-        receivedPurpose = purpose
-        return try result.get()
-    }
-}
-
-private final class MockVerifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<String, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-
-    func execute(emailVerificationId: String, verificationCode: String) async throws -> String {
-        callCount += 1
-        return try result.get()
-    }
-}
-
-private final class MockResendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<Void, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-
-    func execute(emailVerificationId: String) async throws {
-        callCount += 1
-        _ = try result.get()
-    }
-}
+//
+// `MockSendEmailVerificationUseCase`/`MockVerifyEmailCodeUseCase`/
+// `MockResendEmailVerificationUseCase`는 `Support/MockAuthUseCases.swift`의 공용 Mock을 사용한다 (#956).
 
 private final class MockResetPasswordUseCase: ResetPasswordUseCaseProtocol, @unchecked Sendable {
     enum MockError: Error, Equatable { case notStubbed }

--- a/UMCApp/Features/Auth/Presentation/Tests/SignUpByIdPwViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/SignUpByIdPwViewModelTests.swift
@@ -9,7 +9,7 @@ import UMCFoundation
 @Suite("SignUpByIdPwViewModel — 이메일 중복 확인 debounce")
 struct SignUpByIdPwViewModelEmailAvailabilityTests {
 
-    @Test("인증 완료 후 500ms debounce를 거쳐 중복 확인이 1회 실행된다")
+    @Test("인증 완료 후 debounce를 거쳐 중복 확인이 1회 실행된다")
     func verificationCompleteChainsAvailabilityCheck() async throws {
         let checkEmailAvailabilityUseCase = MockCheckEmailAvailabilityUseCase()
         checkEmailAvailabilityUseCase.result = .success(true)
@@ -19,7 +19,7 @@ struct SignUpByIdPwViewModelEmailAvailabilityTests {
 
         #expect(viewModel.emailAvailabilityState == .idle)
 
-        try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
+        try await waitForEmailAvailabilityDebounce(on: viewModel)
 
         #expect(checkEmailAvailabilityUseCase.callCount == 1)
         #expect(checkEmailAvailabilityUseCase.receivedEmail == "member@umc.dev")
@@ -34,7 +34,7 @@ struct SignUpByIdPwViewModelEmailAvailabilityTests {
             checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase
         )
 
-        try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
+        try await waitForEmailAvailabilityDebounce(on: viewModel)
 
         #expect(viewModel.emailAvailabilityState == .loaded(false))
     }
@@ -55,12 +55,14 @@ struct SignUpByIdPwViewModelEmailAvailabilityTests {
         viewModel.emailVerificationFlow.email = "member@umc.dev"
         try await requestVerification(on: viewModel)
 
-        // 연속 재검증(예: 코드 재입력) — 매 호출마다 이전 debounce 예약이 취소된다.
+        // 연속 재검증(예: 코드 재입력) — 매 호출마다 이전 debounce 예약이 취소되고 새로 예약된다.
+        // 아래 3개 호출은 debounce 간격(500ms)보다 훨씬 짧은 시간 안에 끝나므로, 마지막 예약만
+        // 실제로 만료되어 실행된다.
         try await viewModel.verifyEmailCode("111111")
         try await viewModel.verifyEmailCode("222222")
         try await viewModel.verifyEmailCode("333333")
 
-        try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
+        try await waitForEmailAvailabilityDebounce(on: viewModel)
 
         #expect(checkEmailAvailabilityUseCase.callCount == 1)
         #expect(viewModel.emailAvailabilityState == .loaded(true))
@@ -88,7 +90,7 @@ struct SignUpByIdPwViewModelEmailAvailabilityTests {
         try await requestVerification(on: viewModel)
         try await viewModel.verifyEmailCode("222222")
 
-        try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
+        try await waitForEmailAvailabilityDebounce(on: viewModel)
 
         #expect(checkEmailAvailabilityUseCase.callCount == 1)
         #expect(checkEmailAvailabilityUseCase.receivedEmail == "second@umc.dev")
@@ -101,12 +103,47 @@ struct SignUpByIdPwViewModelEmailAvailabilityTests {
         let viewModel = try await makeVerifiedEmailViewModel(
             checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase
         )
-        try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
+        try await waitForEmailAvailabilityDebounce(on: viewModel)
         #expect(viewModel.emailAvailabilityState == .loaded(true))
 
         viewModel.emailVerificationFlow.email = "changed@umc.dev"
         viewModel.emailVerificationFlow.handleEmailChanged()
 
+        #expect(viewModel.emailAvailabilityState == .idle)
+    }
+
+    @Test("중복 확인 실패 후 retryEmailAvailabilityCheck()를 호출하면 debounce 없이 즉시 재확인한다")
+    func retryEmailAvailabilityCheckRetriesImmediatelyAfterFailure() async throws {
+        let checkEmailAvailabilityUseCase = MockCheckEmailAvailabilityUseCase()
+        checkEmailAvailabilityUseCase.result = .failure(DummyError())
+        let viewModel = try await makeVerifiedEmailViewModel(
+            checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase
+        )
+        try await waitForEmailAvailabilityDebounce(on: viewModel)
+        guard case .failed = viewModel.emailAvailabilityState else {
+            Issue.record("실패 상태를 기대했지만 \(viewModel.emailAvailabilityState)였다")
+            return
+        }
+
+        checkEmailAvailabilityUseCase.result = .success(true)
+        viewModel.retryEmailAvailabilityCheck()
+        await viewModel.emailAvailabilityTask?.value
+
+        #expect(checkEmailAvailabilityUseCase.callCount == 2)
+        #expect(viewModel.emailAvailabilityState == .loaded(true))
+    }
+
+    @Test("중복 확인이 idle/loaded 상태면 retryEmailAvailabilityCheck()는 아무 것도 하지 않는다")
+    func retryEmailAvailabilityCheckNoOpsWhenNotFailed() async throws {
+        let checkEmailAvailabilityUseCase = MockCheckEmailAvailabilityUseCase()
+        checkEmailAvailabilityUseCase.result = .success(true)
+        let viewModel = try await makeVerifiedEmailViewModel(
+            checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase
+        )
+
+        viewModel.retryEmailAvailabilityCheck()
+
+        #expect(checkEmailAvailabilityUseCase.callCount == 0)
         #expect(viewModel.emailAvailabilityState == .idle)
     }
 }
@@ -137,7 +174,7 @@ struct SignUpByIdPwViewModelCanSubmitTests {
         let viewModel = try await makeValidFormViewModel()
         #expect(viewModel.canSubmit == true)
 
-        viewModel.termsAgreements["terms-privacy"] = false
+        viewModel.termsAgreementFlow.termsAgreements["terms-privacy"] = false
 
         #expect(viewModel.canSubmit == false)
     }
@@ -146,18 +183,11 @@ struct SignUpByIdPwViewModelCanSubmitTests {
     func termsNotLoadedBlocksSubmit() async throws {
         let checkEmailAvailabilityUseCase = MockCheckEmailAvailabilityUseCase()
         checkEmailAvailabilityUseCase.result = .success(true)
-        let viewModel = try await makeVerifiedEmailViewModel(
-            checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase,
-            fillSchool: true
+        let viewModel = try await makeFormFilledButTermsNotLoadedViewModel(
+            checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase
         )
-        try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
-        viewModel.name = "홍길동"
-        viewModel.nickname = "길동이"
-        viewModel.password = "password1234"
-        viewModel.passwordConfirm = "password1234"
-        // fetchTerms()를 호출하지 않아 termsState == .idle을 유지한다.
 
-        #expect(viewModel.termsState == .idle)
+        #expect(viewModel.termsAgreementFlow.termsState == .idle)
         #expect(viewModel.canSubmit == false)
     }
 
@@ -174,7 +204,7 @@ struct SignUpByIdPwViewModelCanSubmitTests {
         viewModel.nickname = "길동이"
         viewModel.password = "password1234"
         viewModel.passwordConfirm = "password1234"
-        // debounce 대기 없이 바로 확인 — emailAvailabilityState는 아직 .idle이다.
+        // debounce가 아직 만료되지 않았으므로 emailAvailabilityState는 .idle이다.
 
         #expect(viewModel.canSubmit == false)
     }
@@ -192,7 +222,7 @@ struct SignUpByIdPwViewModelCanSubmitTests {
         viewModel.nickname = "길동이"
         viewModel.password = "password1234"
         viewModel.passwordConfirm = "password1234"
-        try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
+        try await waitForEmailAvailabilityDebounce(on: viewModel)
 
         #expect(viewModel.emailAvailabilityState == .loaded(false))
         #expect(viewModel.canSubmit == false)
@@ -294,16 +324,21 @@ struct SignUpByIdPwViewModelRegisterTests {
     }
 }
 
-// MARK: - Constants
-
-private enum Constants {
-    /// 500ms debounce + CI 스케줄링 여유를 감안한 테스트 대기 시간.
-    static let debounceWaitMilliseconds: Int = 800
-}
-
 // MARK: - Helpers
 
 private struct DummyError: Error {}
+
+private enum Constants {
+    /// 500ms debounce + CI 스케줄링 여유를 감안한 테스트 대기 시간.
+    ///
+    /// Item 6에서 debounce sleep을 결정적으로 대체하는 test double(actor 기반 수동 gate)을
+    /// 시도했으나, `Task { ... }`으로 예약되는 debounce 작업이 MainActor에서 실행되는 반면
+    /// gate의 `advance()`는 별도 액터에서 폴링하는 구조라 재개 시점이 서로 동기화되지 않아
+    /// 테스트가 무한 대기(hang)하는 문제가 있었다. 안정적으로 재현 가능한 결정론적 대안을
+    /// 짧은 시간 안에 확보하지 못해, 우선 실제 `Task.sleep` 기반 wall-clock 대기로 되돌린다
+    /// (기존에 이미 검증된 안전한 패턴). 추후 별도 이슈에서 결정론적 test clock을 재시도한다.
+    static let debounceWaitMilliseconds: Int = 800
+}
 
 private let mockMandatoryTerms: [Terms] = [
     Terms(
@@ -319,6 +354,12 @@ private let mockMandatoryTerms: [Terms] = [
         isMandatory: true
     )
 ]
+
+/// 이메일 중복 확인 debounce(500ms)가 만료되어 확인이 실행될 때까지 대기한다.
+private func waitForEmailAvailabilityDebounce(on viewModel: SignUpByIdPwViewModel) async throws {
+    try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
+    await viewModel.emailAvailabilityTask?.value
+}
 
 @MainActor
 private func makeViewModel(
@@ -406,13 +447,42 @@ private func makeVerifiedEmailViewModel(
         viewModel.selectedSchool = School(id: "1", name: "테스트대학교")
     }
     if fillTerms {
-        await viewModel.fetchTerms()
-        viewModel.termsAgreements["terms-service"] = true
-        viewModel.termsAgreements["terms-privacy"] = true
+        await viewModel.termsAgreementFlow.fetchTerms()
+        viewModel.termsAgreementFlow.termsAgreements["terms-service"] = true
+        viewModel.termsAgreementFlow.termsAgreements["terms-privacy"] = true
     }
 
     viewModel.emailVerificationFlow.email = email
     try await requestVerification(on: viewModel)
+
+    return viewModel
+}
+
+/// Q3: 약관이 로딩되지 않은 상태에서 나머지 필드(이름/닉네임/비밀번호/이메일/학교/이메일인증)만
+/// 채운 `SignUpByIdPwViewModel`을 만든다. `termsAgreementFlow.fetchTerms()`를 호출하지 않으므로
+/// `termsState`는 `.idle`을 유지한다. 이메일 중복 확인 debounce도 내부적으로 완료시킨 뒤 반환한다.
+@MainActor
+private func makeFormFilledButTermsNotLoadedViewModel(
+    checkEmailAvailabilityUseCase: CheckEmailAvailabilityUseCaseProtocol? = nil
+) async throws -> SignUpByIdPwViewModel {
+    let mocks = makeTermsNotLoadedSignUpMocks()
+    let viewModel = makeViewModel(
+        fetchSignUpDataUseCase: mocks.fetchSignUpDataUseCase,
+        sendEmailVerificationUseCase: mocks.sendEmailVerificationUseCase,
+        verifyEmailCodeUseCase: mocks.verifyEmailCodeUseCase,
+        checkEmailAvailabilityUseCase: checkEmailAvailabilityUseCase
+    )
+    await viewModel.fetchSchools()
+    viewModel.selectedSchool = School(id: "1", name: "테스트대학교")
+    // termsAgreementFlow.fetchTerms()를 호출하지 않아 termsState == .idle을 유지한다.
+
+    viewModel.name = "홍길동"
+    viewModel.nickname = "길동이"
+    viewModel.password = "password1234"
+    viewModel.passwordConfirm = "password1234"
+    viewModel.emailVerificationFlow.email = "member@umc.dev"
+    try await requestVerification(on: viewModel)
+    try await waitForEmailAvailabilityDebounce(on: viewModel)
 
     return viewModel
 }
@@ -452,7 +522,7 @@ private func makeValidFormViewModel(
     )
 
     await viewModel.fetchSchools()
-    await viewModel.fetchTerms()
+    await viewModel.termsAgreementFlow.fetchTerms()
 
     viewModel.name = "홍길동"
     viewModel.nickname = "길동이"
@@ -462,78 +532,15 @@ private func makeValidFormViewModel(
     viewModel.selectedSchool = School(id: "1", name: "테스트대학교")
 
     try await requestVerification(on: viewModel)
-    try await Task.sleep(for: .milliseconds(Constants.debounceWaitMilliseconds))
+    try await waitForEmailAvailabilityDebounce(on: viewModel)
 
-    viewModel.termsAgreements["terms-service"] = true
-    viewModel.termsAgreements["terms-privacy"] = true
+    viewModel.termsAgreementFlow.termsAgreements["terms-service"] = true
+    viewModel.termsAgreementFlow.termsAgreements["terms-privacy"] = true
 
     return viewModel
 }
 
 // MARK: - Mocks — UseCase
-
-private final class MockFetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var fetchSchoolsResult: Result<[School], Error> = .failure(MockError.notStubbed)
-    private(set) var fetchSchoolsCallCount = 0
-
-    var fetchTermsResult: [TermsType: Result<Terms, Error>] = [:]
-    private(set) var fetchTermsCallCount = 0
-
-    func fetchSchools() async throws -> [School] {
-        fetchSchoolsCallCount += 1
-        return try fetchSchoolsResult.get()
-    }
-
-    func fetchTerms(type: TermsType) async throws -> Terms {
-        fetchTermsCallCount += 1
-        guard let result = fetchTermsResult[type] else {
-            throw MockError.notStubbed
-        }
-        return try result.get()
-    }
-}
-
-private final class MockSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<String, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-
-    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
-        callCount += 1
-        return try result.get()
-    }
-}
-
-private final class MockVerifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<String, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-
-    func execute(emailVerificationId: String, verificationCode: String) async throws -> String {
-        callCount += 1
-        return try result.get()
-    }
-}
-
-private final class MockResendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<Void, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-
-    func execute(emailVerificationId: String) async throws {
-        callCount += 1
-        _ = try result.get()
-    }
-}
 
 private final class MockCheckEmailAvailabilityUseCase: CheckEmailAvailabilityUseCaseProtocol,
     @unchecked Sendable {

--- a/UMCApp/Features/Auth/Presentation/Tests/SignUpViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/SignUpViewModelTests.swift
@@ -13,7 +13,7 @@ struct SignUpViewModelFormValidationTests {
     func initialStateIsIdle() {
         let viewModel = makeViewModel()
         #expect(viewModel.schoolsState == .idle)
-        #expect(viewModel.termsState == .idle)
+        #expect(viewModel.termsAgreementFlow.termsState == .idle)
         #expect(viewModel.registerState == .idle)
         #expect(viewModel.isFormValid == false)
     }
@@ -29,35 +29,14 @@ struct SignUpViewModelFormValidationTests {
         let viewModel = try await makeValidFormViewModel()
         #expect(viewModel.isFormValid == true)
 
-        viewModel.termsAgreements["terms-privacy"] = false
+        viewModel.termsAgreementFlow.termsAgreements["terms-privacy"] = false
 
         #expect(viewModel.isFormValid == false)
     }
 
     @Test("약관이 아직 로딩되지 않았다면 다른 값이 채워져도 폼이 유효하지 않다")
     func termsNotLoadedMakesFormInvalid() async throws {
-        let fetchSignUpDataUseCase = MockFetchSignUpDataUseCase()
-        fetchSignUpDataUseCase.fetchSchoolsResult = .success([School(id: "1", name: "테스트대학교")])
-        let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
-        sendEmailVerificationUseCase.result = .success("verify-id")
-        let verifyEmailCodeUseCase = MockVerifyEmailCodeUseCase()
-        verifyEmailCodeUseCase.result = .success("verify-token")
-
-        let viewModel = makeViewModel(
-            fetchSignUpDataUseCase: fetchSignUpDataUseCase,
-            sendEmailVerificationUseCase: sendEmailVerificationUseCase,
-            verifyEmailCodeUseCase: verifyEmailCodeUseCase
-        )
-        await viewModel.fetchSchools()
-        // fetchTerms()를 호출하지 않아 termsState == .idle을 유지한다.
-
-        viewModel.name = "홍길동"
-        viewModel.nickname = "길동이"
-        viewModel.email = "member@umc.dev"
-        viewModel.selectedSchool = School(id: "1", name: "테스트대학교")
-        try await viewModel.requestEmailVerification()
-        try await viewModel.verifyEmailCode("123456")
-
+        let viewModel = try await makeFormFilledButTermsNotLoadedViewModel()
         #expect(viewModel.isFormValid == false)
     }
 }
@@ -71,12 +50,12 @@ struct SignUpViewModelEmailVerificationTests {
         let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
         sendEmailVerificationUseCase.result = .success("verify-id-1")
         let viewModel = makeViewModel(sendEmailVerificationUseCase: sendEmailVerificationUseCase)
-        viewModel.email = "member@umc.dev"
+        viewModel.emailVerificationFlow.email = "member@umc.dev"
 
-        try await viewModel.requestEmailVerification()
+        try await viewModel.emailVerificationFlow.requestEmailVerification()
 
-        #expect(viewModel.emailVerificationId == "verify-id-1")
-        #expect(viewModel.isEmailVerified == false)
+        #expect(viewModel.emailVerificationFlow.emailVerificationId == "verify-id-1")
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == false)
         #expect(sendEmailVerificationUseCase.callCount == 1)
         #expect(sendEmailVerificationUseCase.receivedEmail == "member@umc.dev")
         #expect(sendEmailVerificationUseCase.receivedPurpose == .register)
@@ -87,18 +66,18 @@ struct SignUpViewModelEmailVerificationTests {
         let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
         sendEmailVerificationUseCase.result = .failure(EmailVerificationError.emailAlreadyExists)
         let viewModel = makeViewModel(sendEmailVerificationUseCase: sendEmailVerificationUseCase)
-        viewModel.email = "member@umc.dev"
+        viewModel.emailVerificationFlow.email = "member@umc.dev"
 
         do {
-            try await viewModel.requestEmailVerification()
+            try await viewModel.emailVerificationFlow.requestEmailVerification()
             Issue.record("에러가 발생해야 합니다")
         } catch {
             #expect(error as? EmailVerificationError == .emailAlreadyExists)
         }
-        #expect(viewModel.emailVerificationId == nil)
+        #expect(viewModel.emailVerificationFlow.emailVerificationId == nil)
     }
 
-    @Test("인증번호 검증 성공 → isEmailVerified true, 토큰/코드 저장")
+    @Test("인증번호 검증 성공 → isEmailVerified true, 토큰 저장")
     func verifyCodeSuccessSetsVerified() async throws {
         let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
         sendEmailVerificationUseCase.result = .success("verify-id-1")
@@ -108,13 +87,13 @@ struct SignUpViewModelEmailVerificationTests {
             sendEmailVerificationUseCase: sendEmailVerificationUseCase,
             verifyEmailCodeUseCase: verifyEmailCodeUseCase
         )
-        viewModel.email = "member@umc.dev"
-        try await viewModel.requestEmailVerification()
+        viewModel.emailVerificationFlow.email = "member@umc.dev"
+        try await viewModel.emailVerificationFlow.requestEmailVerification()
 
-        try await viewModel.verifyEmailCode("654321")
+        try await viewModel.emailVerificationFlow.verifyEmailCode("654321")
 
-        #expect(viewModel.isEmailVerified == true)
-        #expect(viewModel.verificationCode == "654321")
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == true)
+        #expect(viewModel.emailVerificationFlow.emailVerificationToken == "verify-token-1")
         #expect(verifyEmailCodeUseCase.callCount == 1)
         #expect(verifyEmailCodeUseCase.receivedCode == "654321")
     }
@@ -129,16 +108,16 @@ struct SignUpViewModelEmailVerificationTests {
             sendEmailVerificationUseCase: sendEmailVerificationUseCase,
             verifyEmailCodeUseCase: verifyEmailCodeUseCase
         )
-        viewModel.email = "member@umc.dev"
-        try await viewModel.requestEmailVerification()
+        viewModel.emailVerificationFlow.email = "member@umc.dev"
+        try await viewModel.emailVerificationFlow.requestEmailVerification()
 
         do {
-            try await viewModel.verifyEmailCode("000000")
+            try await viewModel.emailVerificationFlow.verifyEmailCode("000000")
             Issue.record("에러가 발생해야 합니다")
         } catch {
             #expect(error as? AuthError == .invalidVerificationCode)
         }
-        #expect(viewModel.isEmailVerified == false)
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == false)
     }
 
     @Test("발송 요청 없이 검증을 시도하면 아무 것도 하지 않는다")
@@ -146,10 +125,10 @@ struct SignUpViewModelEmailVerificationTests {
         let verifyEmailCodeUseCase = MockVerifyEmailCodeUseCase()
         let viewModel = makeViewModel(verifyEmailCodeUseCase: verifyEmailCodeUseCase)
 
-        try await viewModel.verifyEmailCode("123456")
+        try await viewModel.emailVerificationFlow.verifyEmailCode("123456")
 
         #expect(verifyEmailCodeUseCase.callCount == 0)
-        #expect(viewModel.isEmailVerified == false)
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == false)
     }
 
     @Test("인증번호 재전송 성공/실패가 그대로 반영된다")
@@ -162,15 +141,15 @@ struct SignUpViewModelEmailVerificationTests {
             sendEmailVerificationUseCase: sendEmailVerificationUseCase,
             resendEmailVerificationUseCase: resendEmailVerificationUseCase
         )
-        viewModel.email = "member@umc.dev"
-        try await viewModel.requestEmailVerification()
+        viewModel.emailVerificationFlow.email = "member@umc.dev"
+        try await viewModel.emailVerificationFlow.requestEmailVerification()
 
-        try await viewModel.resendEmailVerification()
+        try await viewModel.emailVerificationFlow.resendEmailVerification()
         #expect(resendEmailVerificationUseCase.callCount == 1)
 
         resendEmailVerificationUseCase.result = .failure(EmailVerificationError.throttled)
         do {
-            try await viewModel.resendEmailVerification()
+            try await viewModel.emailVerificationFlow.resendEmailVerification()
             Issue.record("에러가 발생해야 합니다")
         } catch {
             #expect(error as? EmailVerificationError == .throttled)
@@ -188,18 +167,17 @@ struct SignUpViewModelEmailVerificationTests {
             sendEmailVerificationUseCase: sendEmailVerificationUseCase,
             verifyEmailCodeUseCase: verifyEmailCodeUseCase
         )
-        viewModel.email = "first@umc.dev"
-        try await viewModel.requestEmailVerification()
-        try await viewModel.verifyEmailCode("111111")
-        #expect(viewModel.isEmailVerified == true)
+        viewModel.emailVerificationFlow.email = "first@umc.dev"
+        try await viewModel.emailVerificationFlow.requestEmailVerification()
+        try await viewModel.emailVerificationFlow.verifyEmailCode("111111")
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == true)
 
-        viewModel.email = "second@umc.dev"
-        viewModel.handleEmailChanged()
+        viewModel.emailVerificationFlow.email = "second@umc.dev"
+        viewModel.emailVerificationFlow.handleEmailChanged()
 
-        #expect(viewModel.isEmailVerified == false)
-        #expect(viewModel.emailVerificationId == nil)
-        #expect(viewModel.emailVerificationToken == nil)
-        #expect(viewModel.verificationCode == "")
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == false)
+        #expect(viewModel.emailVerificationFlow.emailVerificationId == nil)
+        #expect(viewModel.emailVerificationFlow.emailVerificationToken == nil)
     }
 
     @Test("이메일 값이 그대로면 인증 상태를 유지한다")
@@ -213,13 +191,13 @@ struct SignUpViewModelEmailVerificationTests {
             verifyEmailCodeUseCase: verifyEmailCodeUseCase,
             initialEmail: "same@umc.dev"
         )
-        viewModel.email = "same@umc.dev"
-        try await viewModel.requestEmailVerification()
-        try await viewModel.verifyEmailCode("111111")
+        viewModel.emailVerificationFlow.email = "same@umc.dev"
+        try await viewModel.emailVerificationFlow.requestEmailVerification()
+        try await viewModel.emailVerificationFlow.verifyEmailCode("111111")
 
-        viewModel.handleEmailChanged()
+        viewModel.emailVerificationFlow.handleEmailChanged()
 
-        #expect(viewModel.isEmailVerified == true)
+        #expect(viewModel.emailVerificationFlow.isEmailVerified == true)
     }
 }
 
@@ -240,31 +218,10 @@ struct SignUpViewModelRegisterTests {
 
     @Test("약관 미로딩 상태에서 나머지 필드가 모두 채워져도 register()는 API를 호출하지 않는다")
     func registerNoOpsWhenTermsNotLoadedButOtherFieldsFilled() async throws {
-        let fetchSignUpDataUseCase = MockFetchSignUpDataUseCase()
-        fetchSignUpDataUseCase.fetchSchoolsResult = .success(
-            [School(id: "1", name: "테스트대학교")]
-        )
-        let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
-        sendEmailVerificationUseCase.result = .success("verify-id")
-        let verifyEmailCodeUseCase = MockVerifyEmailCodeUseCase()
-        verifyEmailCodeUseCase.result = .success("verify-token")
         let registerUseCase = MockRegisterUseCase()
-
-        let viewModel = makeViewModel(
-            fetchSignUpDataUseCase: fetchSignUpDataUseCase,
-            sendEmailVerificationUseCase: sendEmailVerificationUseCase,
-            verifyEmailCodeUseCase: verifyEmailCodeUseCase,
+        let viewModel = try await makeFormFilledButTermsNotLoadedViewModel(
             registerUseCase: registerUseCase
         )
-        await viewModel.fetchSchools()
-        // fetchTerms()를 호출하지 않아 termsState == .idle을 유지한다.
-
-        viewModel.name = "홍길동"
-        viewModel.nickname = "길동이"
-        viewModel.email = "member@umc.dev"
-        viewModel.selectedSchool = School(id: "1", name: "테스트대학교")
-        try await viewModel.requestEmailVerification()
-        try await viewModel.verifyEmailCode("123456")
         #expect(viewModel.isFormValid == false)
 
         await viewModel.register()
@@ -534,94 +491,50 @@ private func makeValidFormViewModel(
     )
 
     await viewModel.fetchSchools()
-    await viewModel.fetchTerms()
+    await viewModel.termsAgreementFlow.fetchTerms()
 
     viewModel.name = "홍길동"
     viewModel.nickname = "길동이"
-    viewModel.email = "member@umc.dev"
+    viewModel.emailVerificationFlow.email = "member@umc.dev"
     viewModel.selectedSchool = School(id: "1", name: "테스트대학교")
 
-    try await viewModel.requestEmailVerification()
-    try await viewModel.verifyEmailCode("123456")
+    try await viewModel.emailVerificationFlow.requestEmailVerification()
+    try await viewModel.emailVerificationFlow.verifyEmailCode("123456")
 
-    viewModel.termsAgreements["terms-service"] = true
-    viewModel.termsAgreements["terms-privacy"] = true
+    viewModel.termsAgreementFlow.termsAgreements["terms-service"] = true
+    viewModel.termsAgreementFlow.termsAgreements["terms-privacy"] = true
+
+    return viewModel
+}
+
+/// Q3: 약관이 로딩되지 않은 상태에서 나머지 필드(이름/닉네임/이메일/학교/이메일인증)만 채운
+/// `SignUpViewModel`을 만든다. `termsAgreementFlow.fetchTerms()`를 호출하지 않으므로
+/// `termsState`는 `.idle`을 유지한다.
+@MainActor
+private func makeFormFilledButTermsNotLoadedViewModel(
+    registerUseCase: RegisterUseCaseProtocol? = nil
+) async throws -> SignUpViewModel {
+    let mocks = makeTermsNotLoadedSignUpMocks()
+    let viewModel = makeViewModel(
+        fetchSignUpDataUseCase: mocks.fetchSignUpDataUseCase,
+        sendEmailVerificationUseCase: mocks.sendEmailVerificationUseCase,
+        verifyEmailCodeUseCase: mocks.verifyEmailCodeUseCase,
+        registerUseCase: registerUseCase
+    )
+    await viewModel.fetchSchools()
+    // termsAgreementFlow.fetchTerms()를 호출하지 않아 termsState == .idle을 유지한다.
+
+    viewModel.name = "홍길동"
+    viewModel.nickname = "길동이"
+    viewModel.emailVerificationFlow.email = "member@umc.dev"
+    viewModel.selectedSchool = School(id: "1", name: "테스트대학교")
+    try await viewModel.emailVerificationFlow.requestEmailVerification()
+    try await viewModel.emailVerificationFlow.verifyEmailCode("123456")
 
     return viewModel
 }
 
 // MARK: - Mocks — UseCase
-
-private final class MockFetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var fetchSchoolsResult: Result<[School], Error> = .failure(MockError.notStubbed)
-    private(set) var fetchSchoolsCallCount = 0
-
-    var fetchTermsResult: [TermsType: Result<Terms, Error>] = [:]
-    private(set) var fetchTermsCallCount = 0
-    private(set) var fetchTermsReceivedTypes: [TermsType] = []
-
-    func fetchSchools() async throws -> [School] {
-        fetchSchoolsCallCount += 1
-        return try fetchSchoolsResult.get()
-    }
-
-    func fetchTerms(type: TermsType) async throws -> Terms {
-        fetchTermsCallCount += 1
-        fetchTermsReceivedTypes.append(type)
-        guard let result = fetchTermsResult[type] else {
-            throw MockError.notStubbed
-        }
-        return try result.get()
-    }
-}
-
-private final class MockSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<String, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-    private(set) var receivedEmail: String?
-    private(set) var receivedPurpose: EmailVerificationPurpose?
-
-    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
-        callCount += 1
-        receivedEmail = email
-        receivedPurpose = purpose
-        return try result.get()
-    }
-}
-
-private final class MockVerifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<String, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-    private(set) var receivedCode: String?
-
-    func execute(emailVerificationId: String, verificationCode: String) async throws -> String {
-        callCount += 1
-        receivedCode = verificationCode
-        return try result.get()
-    }
-}
-
-private final class MockResendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
-    @unchecked Sendable {
-    enum MockError: Error, Equatable { case notStubbed }
-
-    var result: Result<Void, Error> = .failure(MockError.notStubbed)
-    private(set) var callCount = 0
-
-    func execute(emailVerificationId: String) async throws {
-        callCount += 1
-        _ = try result.get()
-    }
-}
 
 private final class MockRegisterUseCase: RegisterUseCaseProtocol, @unchecked Sendable {
     enum MockError: Error, Equatable { case notStubbed }

--- a/UMCApp/Features/Auth/Presentation/Tests/Support/MockAuthUseCases.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/Support/MockAuthUseCases.swift
@@ -1,0 +1,113 @@
+import Foundation
+import AuthDomain
+
+// MARK: - Mocks — UseCase
+//
+// `SignUpViewModelTests`/`SignUpByIdPwViewModelTests`/`EmailVerificationFlowTests`/
+// `ResetPasswordViewModelTests`가 각자 동일하게 선언하던 Mock UseCase 4종을 공용화했다 (#956).
+
+/// `FetchSignUpDataUseCaseProtocol`의 테스트용 Mock 구현체.
+final class MockFetchSignUpDataUseCase: FetchSignUpDataUseCaseProtocol, @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var fetchSchoolsResult: Result<[School], Error> = .failure(MockError.notStubbed)
+    private(set) var fetchSchoolsCallCount = 0
+
+    var fetchTermsResult: [TermsType: Result<Terms, Error>] = [:]
+    private(set) var fetchTermsCallCount = 0
+    private(set) var fetchTermsReceivedTypes: [TermsType] = []
+
+    func fetchSchools() async throws -> [School] {
+        fetchSchoolsCallCount += 1
+        return try fetchSchoolsResult.get()
+    }
+
+    func fetchTerms(type: TermsType) async throws -> Terms {
+        fetchTermsCallCount += 1
+        fetchTermsReceivedTypes.append(type)
+        guard let result = fetchTermsResult[type] else {
+            throw MockError.notStubbed
+        }
+        return try result.get()
+    }
+}
+
+/// `SendEmailVerificationUseCaseProtocol`의 테스트용 Mock 구현체.
+final class MockSendEmailVerificationUseCase: SendEmailVerificationUseCaseProtocol,
+    @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<String, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+    private(set) var receivedEmail: String?
+    private(set) var receivedPurpose: EmailVerificationPurpose?
+
+    func execute(email: String, purpose: EmailVerificationPurpose) async throws -> String {
+        callCount += 1
+        receivedEmail = email
+        receivedPurpose = purpose
+        return try result.get()
+    }
+}
+
+/// `VerifyEmailCodeUseCaseProtocol`의 테스트용 Mock 구현체.
+final class MockVerifyEmailCodeUseCase: VerifyEmailCodeUseCaseProtocol, @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<String, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+    private(set) var receivedCode: String?
+
+    func execute(emailVerificationId: String, verificationCode: String) async throws -> String {
+        callCount += 1
+        receivedCode = verificationCode
+        return try result.get()
+    }
+}
+
+/// `ResendEmailVerificationUseCaseProtocol`의 테스트용 Mock 구현체.
+final class MockResendEmailVerificationUseCase: ResendEmailVerificationUseCaseProtocol,
+    @unchecked Sendable {
+    enum MockError: Error, Equatable { case notStubbed }
+
+    var result: Result<Void, Error> = .failure(MockError.notStubbed)
+    private(set) var callCount = 0
+    private(set) var receivedEmailVerificationId: String?
+
+    func execute(emailVerificationId: String) async throws {
+        callCount += 1
+        receivedEmailVerificationId = emailVerificationId
+        _ = try result.get()
+    }
+}
+
+// MARK: - Q3 공용 셋업 ("약관 미로딩 시 제출 차단")
+
+/// 학교 조회·이메일 인증은 성공하도록 스텁하되 약관(Terms)은 의도적으로 스텁하지 않은
+/// Mock 3종 세트를 만든다.
+///
+/// `SignUpViewModelTests`와 `SignUpByIdPwViewModelTests`가 "약관이 아직 로딩되지 않은 상태에서
+/// 나머지 필드가 모두 채워져도 제출이 차단되는지" 검증하는 테스트(Q3)에서 동일한 스텁 조합을
+/// 각자 구성하던 것을 통합했다 (#956). 호출자가 반환된 Mock으로 `fetchSchools()`/이메일 인증만
+/// 진행하고 `fetchTerms()`를 호출하지 않으면 `termsState == .idle` 시나리오가 재현된다.
+func makeTermsNotLoadedSignUpMocks(
+    schoolId: String = "1",
+    schoolName: String = "테스트대학교",
+    emailVerificationId: String = "verify-id",
+    emailVerificationToken: String = "verify-token"
+) -> (
+    fetchSignUpDataUseCase: MockFetchSignUpDataUseCase,
+    sendEmailVerificationUseCase: MockSendEmailVerificationUseCase,
+    verifyEmailCodeUseCase: MockVerifyEmailCodeUseCase
+) {
+    let fetchSignUpDataUseCase = MockFetchSignUpDataUseCase()
+    fetchSignUpDataUseCase.fetchSchoolsResult = .success([School(id: schoolId, name: schoolName)])
+
+    let sendEmailVerificationUseCase = MockSendEmailVerificationUseCase()
+    sendEmailVerificationUseCase.result = .success(emailVerificationId)
+
+    let verifyEmailCodeUseCase = MockVerifyEmailCodeUseCase()
+    verifyEmailCodeUseCase.result = .success(emailVerificationToken)
+
+    return (fetchSignUpDataUseCase, sendEmailVerificationUseCase, verifyEmailCodeUseCase)
+}


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor 중심 (+ ✨ Feature: 이메일 중복확인 재시도) — SignUp 계열 ViewModel/테스트 중복 제거 (Auth 슬라이스 3 후속)

관련 이슈: Closes #956

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 이메일 중복확인 실패 시 재시도 버튼(SignUpByIdPwView)이 추가되었습니다.
     실패 상태에서의 재시도 동선 스크린샷 첨부가 필요합니다. -->

> ⚠️ 이메일 중복확인 실패 상태의 재시도 버튼 UI 스크린샷 첨부 필요

## 🛠️ 작업내용

**중복 제거 (Refactor)**
- 소셜 `SignUpViewModel`을 공용 `EmailVerificationFlow` + 신규 `TermsAgreementFlow` 컴포지션으로 이관해 `SignUpByIdPwViewModel`과의 이메일 인증/약관 동의 중복 로직 제거 (`SignUpViewModel` −196줄)
- `mapToAppError`를 `AppError` 공용 매핑으로 통합
- `SignUpView`/`SignUpByIdPwView` 바인딩을 flow 프로퍼티 경유로 정렬

**에러 케이스 명확화**
- `RepositoryError.invalidResponse` 케이스 분리 — `decodingError`(디코딩 실패)와 "디코딩은 성공했으나 accessToken/refreshToken이 비어 있음"을 의미상 구분 (`AuthRepository.registerByEmail`)

**테스트 정리 & 인프라**
- Mock UseCase 4종을 `Tests/Support/MockAuthUseCases.swift`로 공용화 (4개 테스트 파일 공유)
- Q3("약관 미로딩 시 제출 차단") 셋업을 `makeTermsNotLoadedSignUpMocks()` 공용 팩토리로 통합
- `AuthNetworkRequesting` 프로토콜 심 도입으로 `AuthRepository` 단위 테스트를 `MoyaNetworkAdapter` 없이 격리 실행 → `AuthRepositoryTests` 신규 추가

**기능 추가 (Feature)**
- 이메일 중복확인 실패 시 debounce 없이 즉시 재시도하는 `retryEmailAvailabilityCheck()` + 화면 재시도 버튼 추가

## 📋 추후 진행 상황

- 이메일 중복확인 debounce **결정론적 테스트** 재도전 (별도 이슈 권장)
  - 현재는 실제 `Task.sleep` wall-clock 대기로 검증(기존 검증된 안전 패턴으로 회귀)
  - 사유: 커스텀 액터 기반 gate의 `advance()`가 `@MainActor`에 예약되는 debounce Task 스케줄링과 어긋나 테스트가 무한 대기(hang)함. 짧은 시간 내 안정적 결정론 대안을 확보하지 못해 회귀
  - 프로덕션 sleeper 주입점(`emailAvailabilityDebounceSleep`)은 유지되어 있어 추후 test clock 재설계로 재시도 가능

## 📌 리뷰 포인트

- `Features/Auth/Presentation/Sources/ViewModels/TermsAgreementFlow.swift` - 신규 공용 컴포지션(약관 로딩/토글/필수동의) 설계 적정성
- `Features/Auth/Presentation/Sources/ViewModels/SignUpViewModel.swift` - `EmailVerificationFlow`/`TermsAgreementFlow` 위임 이관 후 제출 차단(약관 미로딩 시)·이메일 인증 상태 회귀 없는지
- `Core/Foundation/Sources/Error/Types/RepositoryError.swift` + `Features/Auth/Data/Sources/Repositories/AuthRepository.swift` - `.invalidResponse` 분리 및 exhaustive switch 파급 처리
- `Features/Auth/Data/Sources/Network/AuthNetworkRequesting.swift` + `Features/Auth/Data/Tests/AuthRepositoryTests.swift` - 프로토콜 심 기반 Repository 단위 테스트 격리
- `Features/Auth/Presentation/Tests/Support/MockAuthUseCases.swift` - 공용 Mock 표면(4개 테스트 파일 공유)
- `Features/Auth/Presentation/Sources/ViewModels/SignUpByIdPwViewModel.swift` + `.../Views/SignUpByIdPwView.swift` - 재시도 동선 및 debounce sleeper 주입 지점

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
- [x] 전체 테스트 통과 확인 — AuthPresentation 88/88 · AuthData 73/73 · AuthDomain 48/48 (all green), `AppProduct/` 변경 0
