### PR TITLE
♻️ [Refactor] 프로필 조회(/member/me) 세션 단위 캐싱 통합 — 화면 3중 독립 호출 단일 캐시화

### DIFF
--- a/UMCApp/Core/Domain/Sources/Member/MemberProfileRepositoryProtocol.swift
+++ b/UMCApp/Core/Domain/Sources/Member/MemberProfileRepositoryProtocol.swift
@@ -1,6 +1,37 @@
 /// 정본 프로필 조회 데이터 접근 계층 인터페이스.
+///
+/// 구현체는 세션 단위 캐싱 여부를 자유롭게 선택할 수 있다. `fetchMyProfile()`은 기존 소비부
+/// (Auth/Home/MyPage)의 계약을 그대로 유지하고, 캐싱을 지원하는 구현체(`CachedMemberProfileRepository`)만
+/// `forceRefresh`/`primeCache`/`invalidateCache`를 의미 있게 구현한다. 캐싱을 지원하지 않는 구현체는
+/// 기본 구현(그대로 위임하거나 no-op)을 그대로 사용하면 된다.
 public protocol MemberProfileRepositoryProtocol: Sendable {
 
     /// 내 프로필을 조회한다.
+    /// - Note: 캐싱 구현체 기준으로는 `fetchMyProfile(forceRefresh: false)`와 동일하다.
     func fetchMyProfile() async throws -> Profile
+
+    /// 내 프로필을 조회한다.
+    /// - Parameter forceRefresh: `true`이면 캐시를 무시하고 서버에서 새로 조회한다.
+    func fetchMyProfile(forceRefresh: Bool) async throws -> Profile
+
+    /// 서버가 반환한 최신 프로필 스냅샷으로 캐시를 갱신한다.
+    ///
+    /// 프로필 수정 API(링크 수정, 이미지 변경 등)는 응답으로 최신 스냅샷을 함께 반환하므로,
+    /// 별도 재조회 없이 이 스냅샷으로 캐시를 최신화할 때 사용한다. 캐싱을 지원하지 않는
+    /// 구현체는 no-op이다.
+    func primeCache(with profile: Profile) async
+
+    /// 캐시를 무효화한다 (로그아웃/세션 만료 등). 캐싱을 지원하지 않는 구현체는 no-op이다.
+    func invalidateCache() async
+}
+
+extension MemberProfileRepositoryProtocol {
+
+    public func fetchMyProfile(forceRefresh: Bool) async throws -> Profile {
+        try await fetchMyProfile()
+    }
+
+    public func primeCache(with profile: Profile) async {}
+
+    public func invalidateCache() async {}
 }

--- a/UMCApp/Core/Network/Sources/Member/CachedMemberProfileRepository.swift
+++ b/UMCApp/Core/Network/Sources/Member/CachedMemberProfileRepository.swift
@@ -1,0 +1,88 @@
+//
+//  CachedMemberProfileRepository.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 7/11/26.
+//
+
+import CoreDomain
+import Foundation
+
+/// 정본 프로필 조회 파이프라인(``MemberProfileRepository``)에 세션 단위 캐싱을 적용하는 데코레이터.
+///
+/// `MemberProfileRepositoryProtocol` 소비부(Auth/Home/MyPage)의 공개 계약은 그대로 두고, 동일 세션
+/// 내 반복되는 `GET /api/v1/member/me` 왕복을 캐시 히트로 흡수한다. 캐시 수명은 이 인스턴스의
+/// 수명과 같다 — `DIContainer`가 싱글턴으로 캐싱하므로 로그아웃/세션 만료 시 `DIContainer.resetCache()`가
+/// 인스턴스 자체를 폐기하면 자연히 초기화된다. 그와 별개로 ``invalidateCache()``를 명시적으로 호출하는
+/// 경로(로그아웃·세션 만료 흐름)도 함께 두어, 인스턴스가 아직 살아있는 동안의 진행 중인 요청까지
+/// 방어적으로 정리한다.
+///
+/// `actor`로 격리해 캐시 상태(`cachedProfile`/`inFlightTask`)에 대한 동시 접근을 직렬화하고,
+/// 동시에 들어오는 여러 `fetchMyProfile()` 호출은 진행 중인 네트워크 요청 하나로 병합한다
+/// (in-flight coalescing).
+public actor CachedMemberProfileRepository: MemberProfileRepositoryProtocol {
+
+    // MARK: - Property
+
+    private let remote: MemberProfileRepositoryProtocol
+    private var cachedProfile: Profile?
+    private var inFlightTask: Task<Profile, Error>?
+
+    /// 캐시가 마지막으로 리셋(무효화/강제 프라임)된 시점을 나타내는 세대 번호.
+    ///
+    /// 진행 중인 네트워크 요청이 완료됐을 때, 그 사이 캐시가 무효화/갱신됐다면(세대가 바뀌었다면)
+    /// 뒤늦게 도착한 결과로 캐시를 덮어쓰지 않기 위한 가드다.
+    private var generation = 0
+
+    // MARK: - Init
+
+    public init(remote: MemberProfileRepositoryProtocol) {
+        self.remote = remote
+    }
+
+    // MARK: - Function
+
+    public func fetchMyProfile() async throws -> Profile {
+        try await fetchMyProfile(forceRefresh: false)
+    }
+
+    public func fetchMyProfile(forceRefresh: Bool) async throws -> Profile {
+        if !forceRefresh, let cachedProfile {
+            return cachedProfile
+        }
+
+        if let inFlightTask {
+            return try await inFlightTask.value
+        }
+
+        let requestGeneration = generation
+        let task = Task { try await self.remote.fetchMyProfile() }
+        inFlightTask = task
+
+        do {
+            let profile = try await task.value
+            if generation == requestGeneration {
+                cachedProfile = profile
+                inFlightTask = nil
+            }
+            return profile
+        } catch {
+            if generation == requestGeneration {
+                inFlightTask = nil
+            }
+            throw error
+        }
+    }
+
+    public func primeCache(with profile: Profile) async {
+        generation += 1
+        cachedProfile = profile
+        inFlightTask = nil
+    }
+
+    public func invalidateCache() async {
+        generation += 1
+        cachedProfile = nil
+        inFlightTask = nil
+    }
+}

--- a/UMCApp/Core/Network/Tests/Member/CachedMemberProfileRepositoryTests.swift
+++ b/UMCApp/Core/Network/Tests/Member/CachedMemberProfileRepositoryTests.swift
@@ -1,0 +1,192 @@
+//
+//  CachedMemberProfileRepositoryTests.swift
+//  CoreNetworkTests
+//
+//  캐시 히트/미스, `primeCache`/`invalidateCache` 무효화 트리거, 동시 호출 병합
+//  (in-flight coalescing)을 검증한다.
+//
+
+import CoreDomain
+import Foundation
+import Testing
+@testable import CoreNetwork
+
+@Suite("CachedMemberProfileRepository — 세션 단위 캐싱")
+struct CachedMemberProfileRepositoryTests {
+
+    // MARK: - 캐시 히트/미스
+
+    @Test("최초 호출은 원격에서 조회하고, 이후 호출은 캐시를 반환해 원격 호출이 1회로 유지된다")
+    func secondCallHitsCache() async throws {
+        let profile = Fixture.profile(memberId: "1")
+        let remote = FakeRemoteMemberProfileRepository(result: .success(profile))
+        let sut = CachedMemberProfileRepository(remote: remote)
+
+        let first = try await sut.fetchMyProfile()
+        let second = try await sut.fetchMyProfile()
+
+        #expect(first == profile)
+        #expect(second == profile)
+        #expect(await remote.callCount == 1)
+    }
+
+    @Test("forceRefresh: true는 캐시가 있어도 원격을 다시 호출하고 캐시를 최신 값으로 교체한다")
+    func forceRefreshBypassesCache() async throws {
+        let remote = FakeRemoteMemberProfileRepository(result: .success(Fixture.profile(memberId: "1")))
+        let sut = CachedMemberProfileRepository(remote: remote)
+        _ = try await sut.fetchMyProfile()
+
+        await remote.setResult(.success(Fixture.profile(memberId: "2")))
+        let refreshed = try await sut.fetchMyProfile(forceRefresh: true)
+        let cachedAfterRefresh = try await sut.fetchMyProfile()
+
+        #expect(refreshed.memberId == "2")
+        #expect(cachedAfterRefresh.memberId == "2")
+        #expect(await remote.callCount == 2)
+    }
+
+    @Test("원격 조회가 실패하면 캐시에 남기지 않고, 다음 호출은 다시 원격을 조회한다")
+    func failureIsNotCached() async throws {
+        let remote = FakeRemoteMemberProfileRepository(result: .failure(FakeRemoteMemberProfileRepository.FakeError.boom))
+        let sut = CachedMemberProfileRepository(remote: remote)
+
+        await #expect(throws: FakeRemoteMemberProfileRepository.FakeError.boom) {
+            _ = try await sut.fetchMyProfile()
+        }
+
+        await remote.setResult(.success(Fixture.profile(memberId: "1")))
+        let recovered = try await sut.fetchMyProfile()
+
+        #expect(recovered.memberId == "1")
+        #expect(await remote.callCount == 2)
+    }
+
+    // MARK: - 무효화 트리거
+
+    @Test("primeCache — 원격 호출 없이 캐시를 채우고, 이후 fetchMyProfile()은 원격을 호출하지 않는다")
+    func primeCacheWarmsCacheWithoutNetworkCall() async throws {
+        let remote = FakeRemoteMemberProfileRepository(
+            result: .failure(FakeRemoteMemberProfileRepository.FakeError.boom)
+        )
+        let sut = CachedMemberProfileRepository(remote: remote)
+        let profile = Fixture.profile(memberId: "primed")
+
+        await sut.primeCache(with: profile)
+        let result = try await sut.fetchMyProfile()
+
+        #expect(result == profile)
+        #expect(await remote.callCount == 0)
+    }
+
+    @Test("invalidateCache — 캐시를 비워 다음 fetchMyProfile() 호출이 원격을 다시 조회한다")
+    func invalidateCacheClearsCachedProfile() async throws {
+        let remote = FakeRemoteMemberProfileRepository(result: .success(Fixture.profile(memberId: "1")))
+        let sut = CachedMemberProfileRepository(remote: remote)
+        _ = try await sut.fetchMyProfile()
+
+        await sut.invalidateCache()
+        await remote.setResult(.success(Fixture.profile(memberId: "2")))
+        let afterInvalidate = try await sut.fetchMyProfile()
+
+        #expect(afterInvalidate.memberId == "2")
+        #expect(await remote.callCount == 2)
+    }
+
+    // MARK: - 동시 호출 병합 (in-flight coalescing)
+
+    @Test("겹치는 동시 호출은 진행 중인 요청 하나로 병합되어 원격 호출이 1회만 발생한다")
+    func concurrentCallsCoalesceIntoSingleNetworkRequest() async throws {
+        let gate = Gate()
+        let profile = Fixture.profile(memberId: "1")
+        let remote = FakeRemoteMemberProfileRepository(result: .success(profile))
+        await remote.setGate(gate)
+        let sut = CachedMemberProfileRepository(remote: remote)
+
+        async let first = sut.fetchMyProfile()
+        async let second = sut.fetchMyProfile()
+
+        try await waitUntil { await remote.callCount == 1 }
+        await gate.release()
+
+        let (firstResult, secondResult) = try await (first, second)
+
+        #expect(firstResult == profile)
+        #expect(secondResult == profile)
+        #expect(await remote.callCount == 1)
+    }
+}
+
+// MARK: - Fixture
+
+private enum Fixture {
+    static func profile(memberId: String) -> Profile {
+        Profile(memberId: memberId, name: "홍길동", nickname: "길동이", generations: ["11"])
+    }
+}
+
+// MARK: - Test Doubles
+
+private actor FakeRemoteMemberProfileRepository: MemberProfileRepositoryProtocol {
+    enum FakeError: Error, Equatable {
+        case boom
+    }
+
+    private(set) var callCount = 0
+    private var result: Result<Profile, Error>
+    private var gate: Gate?
+
+    init(result: Result<Profile, Error>) {
+        self.result = result
+    }
+
+    func setResult(_ result: Result<Profile, Error>) {
+        self.result = result
+    }
+
+    /// 특정 시점까지 반환을 붙잡아두는 게이트를 설정한다 (동시 호출 병합 검증용).
+    func setGate(_ gate: Gate) {
+        self.gate = gate
+    }
+
+    func fetchMyProfile() async throws -> Profile {
+        callCount += 1
+        if let gate {
+            await gate.waitUntilReleased()
+        }
+        return try result.get()
+    }
+}
+
+/// 두 개 이상의 동시 호출이 실제로 겹친 상태에서 결과를 함께 흘려보내기 위한 신호 게이트.
+private actor Gate {
+    private var isReleased = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func release() {
+        isReleased = true
+        continuations.forEach { $0.resume() }
+        continuations.removeAll()
+    }
+
+    func waitUntilReleased() async {
+        if isReleased { return }
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+}
+
+/// 폴링 기반 조건 대기 (다른 테스트 파일들과 동일한 패턴).
+private func waitUntil(
+    timeout: Duration = .seconds(2),
+    _ condition: () async -> Bool
+) async throws {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while await !condition() {
+        if ContinuousClock.now >= deadline {
+            Issue.record("waitUntil 타임아웃")
+            return
+        }
+        await Task.yield()
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/FailedVerificationUMCViewModel.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/FailedVerificationUMCViewModel.swift
@@ -225,6 +225,8 @@ final class FailedVerificationUMCViewModel {
         do {
             try await networkClient.logout()
             userSessionManager.reset()
+            await container.resolveIfRegistered(MemberProfileRepositoryProtocol.self)?
+                .invalidateCache()
             container.resetCache()
             destination = .login
         } catch {
@@ -247,6 +249,8 @@ final class FailedVerificationUMCViewModel {
             UserDefaults.standard.set(false, forKey: AppStorageKey.canAutoLogin)
             try await networkClient.logout()
             userSessionManager.reset()
+            await container.resolveIfRegistered(MemberProfileRepositoryProtocol.self)?
+                .invalidateCache()
             container.resetCache()
             destination = .login
         } catch {

--- a/UMCApp/Features/Auth/Presentation/Tests/FailedVerificationUMCViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/FailedVerificationUMCViewModelTests.swift
@@ -182,6 +182,23 @@ struct FailedVerificationUMCViewModelTests {
         #expect(sessionManager.isAdminModeEnabled == false)
     }
 
+    @Test("로그아웃 성공 시 정본 프로필 캐시를 무효화한다")
+    func logoutConfirmInvalidatesMemberProfileCache() async throws {
+        let tokenStore = FakeTokenStore()
+        let memberProfileRepository = MockMemberProfileRepository()
+        let viewModel = makeViewModel(
+            tokenStore: tokenStore,
+            memberProfileRepository: memberProfileRepository
+        )
+
+        viewModel.presentLogoutPrompt()
+        viewModel.alertPrompt?.positiveBtnAction?()
+
+        try await waitUntil { viewModel.destination == .login }
+
+        #expect(memberProfileRepository.invalidateCacheCallCount == 1)
+    }
+
     @Test("로그아웃 실패 시 ErrorHandler에 에러를 전달하고 화면 전환과 세션 초기화를 하지 않는다")
     func logoutFailureReportsErrorWithoutNavigating() async throws {
         let tokenStore = FakeTokenStore()
@@ -238,6 +255,25 @@ struct FailedVerificationUMCViewModelTests {
         #expect(sessionManager.currentRole == .challenger)
         #expect(sessionManager.allRoles.isEmpty)
         #expect(sessionManager.isAdminModeEnabled == false)
+    }
+
+    @Test("회원 탈퇴 성공 시 정본 프로필 캐시를 무효화한다")
+    func deleteAccountSuccessInvalidatesMemberProfileCache() async throws {
+        let deleteMemberUseCase = MockDeleteMemberUseCase()
+        let tokenStore = FakeTokenStore()
+        let memberProfileRepository = MockMemberProfileRepository()
+        let viewModel = makeViewModel(
+            deleteMemberUseCase: deleteMemberUseCase,
+            tokenStore: tokenStore,
+            memberProfileRepository: memberProfileRepository
+        )
+
+        viewModel.presentDeleteAccountPrompt()
+        viewModel.alertPrompt?.positiveBtnAction?()
+
+        try await waitUntil { viewModel.destination == .login }
+
+        #expect(memberProfileRepository.invalidateCacheCallCount == 1)
     }
 
     @Test("회원 탈퇴는 성공했지만 로그아웃(토큰 정리)이 실패하면 화면 전환과 세션 초기화를 하지 않는다")
@@ -315,7 +351,8 @@ private func makeViewModel(
     deleteMemberUseCase: DeleteMemberUseCaseProtocol? = nil,
     tokenStore: FakeTokenStore? = nil,
     syncProfileStorageUseCase: SyncProfileStorageUseCaseProtocol? = nil,
-    userSessionManager: UserSessionManager? = nil
+    userSessionManager: UserSessionManager? = nil,
+    memberProfileRepository: MemberProfileRepositoryProtocol? = nil
 ) -> FailedVerificationUMCViewModel {
     let registerUseCase = registerExistingChallengerUseCase
         ?? MockRegisterExistingChallengerUseCase()
@@ -333,6 +370,9 @@ private func makeViewModel(
     container.register(UserSessionManager.self) { sessionManager }
     container.register(NetworkClient.self) {
         NetworkClient(tokenStore: store, refreshService: FakeTokenRefreshService())
+    }
+    if let memberProfileRepository {
+        container.register(MemberProfileRepositoryProtocol.self) { memberProfileRepository }
     }
 
     return FailedVerificationUMCViewModel(
@@ -404,6 +444,23 @@ private final class MockFetchMemberProfileUseCase: FetchMemberProfileUseCaseProt
     func execute() async throws -> Profile {
         callCount += 1
         return try result.get()
+    }
+}
+
+/// 로그아웃/탈퇴 시 정본 프로필 캐시 무효화 호출 여부를 추적하는 Mock.
+private final class MockMemberProfileRepository:
+    MemberProfileRepositoryProtocol, @unchecked Sendable {
+    enum MockError: Error { case notStubbed }
+
+    var result: Result<Profile, Error> = .failure(MockError.notStubbed)
+    private(set) var invalidateCacheCallCount = 0
+
+    func fetchMyProfile() async throws -> Profile {
+        try result.get()
+    }
+
+    func invalidateCache() async {
+        invalidateCacheCallCount += 1
     }
 }
 

--- a/UMCApp/Features/MyPage/Data/Sources/Repository/MyPageRepository.swift
+++ b/UMCApp/Features/MyPage/Data/Sources/Repository/MyPageRepository.swift
@@ -167,7 +167,9 @@ public final class MyPageRepository: MyPageRepositoryProtocol, @unchecked Sendab
                 from: response.data
             )
 
-            return try apiResponse.unwrap().toDomain().toProfileData()
+            let profile = try apiResponse.unwrap().toDomain()
+            await memberProfileRepository.primeCache(with: profile)
+            return profile.toProfileData()
         } catch let error as NetworkError {
             throw Self.parseServerError(from: error) ?? error
         }
@@ -270,13 +272,15 @@ private extension MyPageRepository {
                 )
             )
         )
-        
+
         let apiResponse = try decoder.decode(
             APIResponse<MemberProfileResponseDTO>.self,
             from: response.data
         )
 
-        return try apiResponse.unwrap().toDomain().toProfileData()
+        let profile = try apiResponse.unwrap().toDomain()
+        await memberProfileRepository.primeCache(with: profile)
+        return profile.toProfileData()
     }
     
     /// 프로필 링크 배열을 정규화합니다.

--- a/UMCApp/Features/MyPage/Data/Tests/MyPageRepositoryTests.swift
+++ b/UMCApp/Features/MyPage/Data/Tests/MyPageRepositoryTests.swift
@@ -87,10 +87,17 @@ private final class MockMemberProfileRepository:
 
     var result: Result<Profile, Error> = .failure(MockError.notStubbed)
     private(set) var fetchMyProfileCallCount = 0
+    private(set) var primeCacheCallCount = 0
+    private(set) var primedProfiles: [Profile] = []
 
     func fetchMyProfile() async throws -> Profile {
         fetchMyProfileCallCount += 1
         return try result.get()
+    }
+
+    func primeCache(with profile: Profile) async {
+        primeCacheCallCount += 1
+        primedProfiles.append(profile)
     }
 }
 
@@ -573,6 +580,37 @@ struct MyPageRepositoryUpdateLinksTests {
         #expect(byType["BLOG"] == "")
     }
 
+    @Test("updateProfileLinks — 성공 시 정본 프로필 캐시를 응답 스냅샷으로 갱신한다")
+    func updateLinksPrimesMemberProfileCache() async throws {
+        let memberProfileRepository = MockMemberProfileRepository()
+        let (sut, _) = makeRepository(
+            .success(Fixture.success(Fixture.profileObject)),
+            memberProfileRepository: memberProfileRepository
+        )
+
+        _ = try await sut.updateProfileLinks([ProfileLink(type: .github, url: "x")])
+
+        #expect(memberProfileRepository.primeCacheCallCount == 1)
+        #expect(memberProfileRepository.primedProfiles.first?.memberId == "42")
+    }
+
+    @Test("updateProfileLinks — 실패하면 정본 프로필 캐시를 갱신하지 않는다")
+    func updateLinksFailureDoesNotPrimeCache() async {
+        let memberProfileRepository = MockMemberProfileRepository()
+        let body = Fixture.failureBody(code: "M400", message: "잘못된 링크 형식입니다.")
+        let (sut, _) = makeRepository(
+            .failure(NetworkError.requestFailed(statusCode: 400, data: body)),
+            memberProfileRepository: memberProfileRepository
+        )
+
+        await #expect(throws: RepositoryError.serverError(
+            code: "M400", message: "잘못된 링크 형식입니다."
+        )) {
+            _ = try await sut.updateProfileLinks([ProfileLink(type: .github, url: "x")])
+        }
+        #expect(memberProfileRepository.primeCacheCallCount == 0)
+    }
+
     @Test("updateProfileLinks — 서버 에러 본문(requestFailed)을 RepositoryError.serverError로 승격한다")
     func updateLinksMapsServerError() async {
         let body = Fixture.failureBody(code: "M400", message: "잘못된 링크 형식입니다.")
@@ -631,5 +669,26 @@ struct MyPageRepositoryUpdateImageTests {
         #expect(stub.lastPath == "/api/v1/member")
         #expect(stub.lastMethod == .patch)
         #expect(result.challengeId == 777)
+    }
+
+    @Test("updateProfileImage — 성공 시 정본 프로필 캐시를 PATCH 응답 스냅샷으로 갱신한다")
+    func updateImagePrimesMemberProfileCache() async throws {
+        let storage = FakeStorageRepository()
+        let stub = StubMyPageNetwork(.success(Fixture.success(Fixture.profileObject)))
+        let memberProfileRepository = MockMemberProfileRepository()
+        let sut = MyPageRepository(
+            networkRequesting: stub,
+            memberProfileRepository: memberProfileRepository,
+            storageRepository: storage
+        )
+
+        _ = try await sut.updateProfileImage(
+            imageData: Data([0x01, 0x02, 0x03]),
+            fileName: "profile.jpg",
+            contentType: "image/jpeg"
+        )
+
+        #expect(memberProfileRepository.primeCacheCallCount == 1)
+        #expect(memberProfileRepository.primedProfiles.first?.memberId == "42")
     }
 }

--- a/UMCApp/UMCApp/Sources/AppRootView.swift
+++ b/UMCApp/UMCApp/Sources/AppRootView.swift
@@ -84,19 +84,25 @@ struct AppRootView: View {
     /// 세션 만료 시 세션 역할 상태 초기화 → DI 캐시 초기화 → 로그인 화면 전환 →
     /// (비동기) 토큰 삭제를 수행한다.
     ///
-    /// - Note: `resetCache()`보다 먼저 `NetworkClient` 참조를 동기적으로 확보한다.
-    ///   순서를 바꾸면 `Task` 내부의 `resolve`가 캐시 미스로 새 인스턴스를 생성해
+    /// - Note: `resetCache()`보다 먼저 `NetworkClient`/정본 프로필 캐시 참조를 동기적으로
+    ///   확보한다. 순서를 바꾸면 `Task` 내부의 `resolve`가 캐시 미스로 새 인스턴스를 생성해
     ///   기존 인스턴스의 `refreshTask`가 취소되지 않고, `DIContainer`는 락이 없는
-    ///   `final class`라 캐시 딕셔너리에 대한 동시 접근 크래시 위험도 있다. 토큰 삭제
-    ///   자체는 `NetworkClient`가 `actor`라 비동기이므로 `Task`로 발행하고 완료를
-    ///   기다리지 않는다.
+    ///   `final class`라 캐시 딕셔너리에 대한 동시 접근 크래시 위험도 있다. 토큰 삭제와
+    ///   프로필 캐시 무효화 자체는 각각 `actor`라 비동기이므로 `Task`로 발행하고 완료를
+    ///   기다리지 않는다. `resetCache()`가 인스턴스 자체를 폐기해도, 세션 만료 시점에
+    ///   진행 중이던 프로필 조회가 있었다면 그 결과가 뒤늦게 캐시를 채우지 않도록
+    ///   명시적으로 `invalidateCache()`를 함께 호출한다.
     private func handleAuthSessionExpired() {
         let networkClient = di.resolve(NetworkClient.self)
+        let memberProfileRepository = di.resolveIfRegistered(MemberProfileRepositoryProtocol.self)
         di.resolve(UserSessionManager.self).reset()
         di.resetCache()
         viewModel.logout()
         Task {
             try? await networkClient.logout()
+        }
+        Task {
+            await memberProfileRepository?.invalidateCache()
         }
     }
 

--- a/UMCApp/UMCApp/Sources/DIContainer+MemberProfile.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+MemberProfile.swift
@@ -10,9 +10,16 @@ import CoreDomain
 import CoreNetwork
 
 extension DIContainer {
+    /// 정본 프로필 조회 파이프라인을 등록한다.
+    ///
+    /// `MemberProfileRepositoryProtocol`은 세션 단위 캐싱 데코레이터(``CachedMemberProfileRepository``)로
+    /// 등록된다 — `resolve()`가 인스턴스를 캐싱하므로(싱글턴 동작), 캐시 수명도 자연히 세션(로그인~로그아웃)
+    /// 단위가 된다. 소비부(Auth/Home/MyPage)는 프로토콜만 바라보므로 캐싱 도입이 계약에 영향을 주지 않는다.
     func registerMemberProfileDependencies() {
         register(MemberProfileRepositoryProtocol.self) {
-            MemberProfileRepository(adapter: self.resolve(MoyaNetworkAdapter.self))
+            CachedMemberProfileRepository(
+                remote: MemberProfileRepository(adapter: self.resolve(MoyaNetworkAdapter.self))
+            )
         }
         register(FetchMemberProfileUseCaseProtocol.self) {
             FetchMemberProfileUseCase(


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor — 프로필 조회(`GET /api/v1/member/me`)를 **세션 단위 단일 캐시**로 통합. #961(PR #971)에서 정본 1벌로 합류한 파이프라인에 캐싱 정책을 한 곳에서 도입해, Auth/Home/MyPage 3곳이 화면 진입마다 독립적으로 왕복하던 패턴을 단일 캐시 소스로 정리했습니다. 소비부 공개 계약은 무변경(캐시는 내부 구현 디테일). resolves #972

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 — 네트워크/데이터 레이어 리팩토링입니다.

## 🛠️ 작업내용

**캐싱 데코레이터 신설**
- `CachedMemberProfileRepository`(신규 `actor`, CoreNetwork) — 정본 stateless `MemberProfileRepository`를 래핑, 동일 `MemberProfileRepositoryProtocol` 준수로 소비부에 완전히 투명
- **세션 단위 캐싱** — TTL 대신 인스턴스 수명에 연동. 로그아웃/세션 만료 시 `DIContainer.resetCache()`가 데코레이터를 폐기 → 다음 resolve에서 빈 캐시로 재생성
- **in-flight coalescing** — 동시 호출 시 하나의 `Task`를 공유해 네트워크 1회 (기존 토큰 갱신 패턴 차용)
- **generation 카운터** — stale in-flight 완료가 무효화 이후 캐시를 덮어쓰는 경합 방지
- 실패 응답은 캐시하지 않음

**프로토콜 additive 확장(계약 무변경)**
- `MemberProfileRepositoryProtocol`에 `fetchMyProfile(forceRefresh:)` / `primeCache(with:)` / `invalidateCache()`를 default 구현과 함께 추가 → 기존 conformer·Mock 무변경 컴파일

**DI 등록**
- `DIContainer+MemberProfile` 등록 지점 1곳에서 정본을 `CachedMemberProfileRepository`로 래핑

**무효화 트리거 배선**
- MyPage `updateProfileLinks()` / `patchMemberProfileImage()` 성공 시 PATCH 응답 `Profile`로 `primeCache(with:)` (서버 확정 스냅샷으로 캐시 갱신)
- 로그아웃·회원 탈퇴(`FailedVerificationUMCViewModel`) 및 세션 만료(`AppRootView.handleAuthSessionExpired`) 시 `invalidateCache()`

**테스트**
- 신규 `CachedMemberProfileRepositoryTests` 6종(히트/미스·forceRefresh 우회·실패 미캐시·primeCache·invalidate·coalescing)
- `MyPageRepositoryTests` +3(링크/이미지 수정 성공 시 priming, 실패 시 미priming)
- `FailedVerificationUMCViewModelTests` +2(로그아웃/탈퇴 성공 시 invalidate 1회)

## 📋 추후 진행 상황

- `fetchMyProfile(forceRefresh:)` 경로를 pull-to-refresh 등 실제 강제 갱신 UI에 연결
- 전체 워크스페이스 `make test` 스윕으로 CI 패리티 최종 확인(본 PR은 영향 6개 스킴 + 앱 빌드로 검증)

## 📌 리뷰 포인트

- `UMCApp/Core/Network/Sources/Member/CachedMemberProfileRepository.swift` — actor 격리, in-flight coalescing, generation 경합 가드 로직
- `UMCApp/Core/Domain/Sources/Member/MemberProfileRepositoryProtocol.swift` — additive 메서드가 기존 계약을 깨지 않는지(default 구현)
- `UMCApp/UMCApp/Sources/DIContainer+MemberProfile.swift` — 캐시 수명과 싱글턴 resolve 관계
- `UMCApp/Features/MyPage/Data/Sources/Repository/MyPageRepository.swift` — 프로필 수정 성공 시 primeCache 호출 위치(응답 디코딩 직후)
- `UMCApp/UMCApp/Sources/AppRootView.swift` / `.../FailedVerificationUMCViewModel.swift` — 무효화와 `resetCache()` 순서 불변식

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
