### PR TITLE
♻️ [Refactor] StudyScheduleRegistration ViewModel 이식 (일정 등록 플로우)

### DIFF
--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendancePolicyError.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/AttendancePolicyError.swift
@@ -1,0 +1,45 @@
+//
+//  AttendancePolicyError.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 6/27/26.
+//
+
+import Foundation
+
+/// 출석 정책 입력 폼의 인라인 검증 에러
+///
+/// 스터디 일정 등록 화면의 출석 정책 섹션에서 사용자 입력을 검증할 때 사용합니다.
+/// 단조 증가(checkInStartAt < onTimeEndAt < lateEndAt)와 일정 시작 범위
+/// (checkInStartAt < startsAt) 위반 케이스를 표현합니다.
+public enum AttendancePolicyError: Equatable, Sendable {
+
+    /// 시각 순서가 단조 증가가 아님
+    case invalidOrder(OrderField)
+
+    /// 출석 시작 시각이 일정 시작 시각보다 늦거나 같음
+    ///
+    /// 서버(`POST /api/v2/schedules`)가 거부하는 조건이지만 범용 메시지만 내려주므로
+    /// 클라이언트에서 선검증합니다.
+    case checkInAfterScheduleStart
+
+    /// 단조 증가 위반 위치
+    public enum OrderField: Equatable, Sendable {
+        /// 출석 시작 ≥ 출석 인정 마감
+        case checkInVsOnTime
+        /// 출석 인정 마감 ≥ 지각 인정 마감
+        case onTimeVsLate
+    }
+
+    /// 화면에 노출할 한국어 메시지
+    public var message: String {
+        switch self {
+        case .invalidOrder(.checkInVsOnTime):
+            return "출석 시작은 출석 인정 마감보다 빨라야 합니다."
+        case .invalidOrder(.onTimeVsLate):
+            return "출석 인정 마감은 지각 인정 마감보다 빨라야 합니다."
+        case .checkInAfterScheduleStart:
+            return "출석 시작은 일정 시작보다 빨라야 합니다."
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/StudyScheduleRegistrationViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/StudyScheduleRegistrationViewModel.swift
@@ -1,0 +1,252 @@
+//
+//  StudyScheduleRegistrationViewModel.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 6/27/26.
+//
+
+import ActivityDomain
+import Foundation
+import UMCFoundation
+
+/// 스터디 일정 등록 화면의 상태를 관리하는 뷰 모델
+///
+/// 스터디명·주차 커리큘럼·일시·장소·출석 정책을 입력받아 일정을 등록합니다.
+/// 주차 커리큘럼 옵션과 참여자(멘토 + 스터디원) 목록을 서버에서 조회하고,
+/// 출석 정책 시각의 단조 증가/일정 범위를 인라인 검증합니다.
+///
+/// - Note: 실제 일정 등록은 Schedule 모듈 이식 후 결선됩니다. 1단계 일정 생성
+///   (`POST /api/v2/schedules`)과 실패 롤백(일정 삭제)이 미이식 Schedule 도메인
+///   소관이라 ``submitSchedule()`` 는 현재 스텁입니다 (`ChallengerAttendanceViewModel`
+///   의 세션 로딩 스텁과 동일 패턴). 결선 시 본인 제외 참여자/출석 정책으로 일정을
+///   생성해 `scheduleId` 를 얻고, 이미 이식된 그룹-일정 연결
+///   (`linkStudyGroupSchedule`, step-2)로 연결합니다.
+@MainActor
+@Observable
+final class StudyScheduleRegistrationViewModel {
+
+    // MARK: - Dependency
+
+    private let studyMembersUseCase: FetchStudyMembersUseCaseProtocol
+    private let studyRepository: StudyRepositoryProtocol
+    private let studyGroupId: String
+    private let currentMemberId: String?
+
+    // MARK: - Property
+
+    /// 스터디명 (초기값은 스터디 그룹 이름)
+    var studyName: String
+
+    /// 선택된 장소 이름
+    ///
+    /// 장소 선택 UI(`PlaceSelectView`)와 좌표 모델은 위치 검색 서브시스템과 함께
+    /// View 이식 시점에 결선됩니다. 현재 단계에서는 입력 이름만 보관합니다.
+    var placeName: String = ""
+
+    /// 비대면 일정 여부
+    ///
+    /// `true` 이면 장소 입력을 비우고, 등록 시 장소 없이 전송할 예정입니다.
+    var isOnline: Bool = false
+
+    /// 시작 일시
+    var startDate: Date = .now.addingTimeInterval(3600)
+
+    /// 종료 일시
+    var endDate: Date = .now.addingTimeInterval(7200)
+
+    /// 주차 커리큘럼 옵션 목록 (서버 조회 결과)
+    private(set) var weeklyOptions: [WeeklyCurriculumOption] = []
+
+    /// 선택된 주차 커리큘럼
+    var selectedWeeklyOption: WeeklyCurriculumOption?
+
+    /// 주차 옵션 로딩 상태
+    private(set) var weeklyOptionsState: Loadable<[WeeklyCurriculumOption]> = .idle
+
+    /// 참여자 목록 (본인 제외 멘토 + 스터디원)
+    private(set) var participantMembers: [StudyGroupMember] = []
+
+    /// 참여자 로딩 상태
+    private(set) var participantsState: Loadable<[StudyGroupMember]> = .idle
+
+    // MARK: - DatePicker Toggle State
+
+    /// 시작 날짜 DatePicker 표시 여부
+    var showStartDatePicker = false
+    /// 시작 시간 DatePicker 표시 여부
+    var showStartTimePicker = false
+    /// 종료 날짜 DatePicker 표시 여부
+    var showEndDatePicker = false
+    /// 종료 시간 DatePicker 표시 여부
+    var showEndTimePicker = false
+
+    // MARK: - Attendance Policy
+
+    /// 체크인 시작 시각
+    var attendanceCheckInStartAt: Date = .now
+    /// 정시 출석 종료 시각
+    var attendanceOnTimeEndAt: Date = .now
+    /// 지각 종료 시각
+    var attendanceLateEndAt: Date = .now
+
+    /// 출석 정책 인라인 검증 에러
+    private(set) var attendancePolicyError: AttendancePolicyError?
+
+    /// 사용자가 출석 정책 시각을 직접 수정한 적이 있는지 여부 (자동 prefill 차단용)
+    private var isAttendancePolicyDirty: Bool = false
+
+    /// 체크인 시작 날짜 DatePicker 표시 여부
+    var showCheckInStartDatePicker: Bool = false
+    /// 체크인 시작 시간 DatePicker 표시 여부
+    var showCheckInStartTimePicker: Bool = false
+    /// 정시 종료 날짜 DatePicker 표시 여부
+    var showOnTimeEndDatePicker: Bool = false
+    /// 정시 종료 시간 DatePicker 표시 여부
+    var showOnTimeEndTimePicker: Bool = false
+    /// 지각 종료 날짜 DatePicker 표시 여부
+    var showLateEndDatePicker: Bool = false
+    /// 지각 종료 시간 DatePicker 표시 여부
+    var showLateEndTimePicker: Bool = false
+
+    // MARK: - Computed Property
+
+    /// 등록 버튼 활성화 여부
+    var canSubmit: Bool {
+        !studyName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (isOnline || !placeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            && !studyGroupId.isEmpty
+            && endDate >= startDate
+            && selectedWeeklyOption != nil
+            && attendancePolicyError == nil
+    }
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - studyName: 스터디 그룹 이름 (초기값)
+    ///   - studyGroupId: 스터디 그룹 식별자 (서버 응답 String ID)
+    ///   - studyMembersUseCase: 스터디 그룹 멤버 조회 UseCase
+    ///   - studyRepository: 주차 커리큘럼 옵션 조회 및 그룹-일정 연결 Repository
+    ///   - currentMemberId: 본인 멤버 ID — 참여자 목록에서 제외 (기본값은 저장된 값)
+    init(
+        studyName: String,
+        studyGroupId: String,
+        studyMembersUseCase: FetchStudyMembersUseCaseProtocol,
+        studyRepository: StudyRepositoryProtocol,
+        currentMemberId: String? = AppStorageKey.memberIdString()
+    ) {
+        self.studyName = studyName
+        self.studyGroupId = studyGroupId
+        self.studyMembersUseCase = studyMembersUseCase
+        self.studyRepository = studyRepository
+        self.currentMemberId = currentMemberId
+        prefillAttendancePolicyIfNeeded()
+    }
+
+    // MARK: - Loading
+
+    /// 스터디 그룹 멤버(멘토 + 스터디원)를 조회해 본인을 제외하고 보관합니다.
+    func loadParticipantMembers() async {
+        if case .loading = participantsState { return }
+        participantsState = .loading
+        do {
+            let allMembers = try await studyMembersUseCase
+                .fetchStudyGroupMembers(groupId: studyGroupId)
+            let filtered = currentMemberId.map { selfId in
+                allMembers.filter { $0.memberID != selfId }
+            } ?? allMembers
+            participantMembers = filtered
+            participantsState = .loaded(filtered)
+        } catch let error as DomainError {
+            participantsState = .failed(.domain(error))
+        } catch let error as AppError {
+            participantsState = .failed(error)
+        } catch {
+            participantsState = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    /// 주차 커리큘럼 옵션 목록을 서버에서 불러옵니다.
+    ///
+    /// 선택값이 아직 없으면 첫 옵션을 자동 선택합니다.
+    func loadWeeklyOptions() async {
+        if case .loading = weeklyOptionsState { return }
+        weeklyOptionsState = .loading
+        do {
+            let options = try await studyRepository.fetchWeeklyCurriculumOptions()
+            weeklyOptions = options
+            weeklyOptionsState = .loaded(options)
+            if selectedWeeklyOption == nil {
+                selectedWeeklyOption = options.first
+            }
+        } catch let error as DomainError {
+            weeklyOptionsState = .failed(.domain(error))
+        } catch let error as AppError {
+            weeklyOptionsState = .failed(error)
+        } catch {
+            weeklyOptionsState = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    // MARK: - Attendance Policy Function
+
+    /// 일정 시작 시각을 기준으로 출석 정책 기본값을 자동으로 채웁니다.
+    ///
+    /// 사용자가 한 번이라도 직접 시각을 수정한 경우에는 덮어쓰지 않습니다.
+    /// 단, 일정 시작 시각에 의존하는 검증은 prefill 을 건너뛰는 경우에도 항상 갱신합니다.
+    func prefillAttendancePolicyIfNeeded() {
+        defer { validateAttendancePolicy() }
+        guard !isAttendancePolicyDirty else { return }
+        let onTimeThreshold = TimeInterval(AttendancePolicy.onTimeThresholdMinutes * 60)
+        let lateThreshold = TimeInterval(AttendancePolicy.lateThresholdMinutes * 60)
+        attendanceCheckInStartAt = startDate.addingTimeInterval(-onTimeThreshold)
+        attendanceOnTimeEndAt = startDate.addingTimeInterval(onTimeThreshold)
+        attendanceLateEndAt = startDate.addingTimeInterval(lateThreshold)
+    }
+
+    /// 출석 정책 시각 변경 시 dirty 표시 + 검증을 갱신합니다.
+    func attendanceTimesChanged() {
+        isAttendancePolicyDirty = true
+        validateAttendancePolicy()
+    }
+
+    private func validateAttendancePolicy() {
+        guard attendanceCheckInStartAt < attendanceOnTimeEndAt else {
+            attendancePolicyError = .invalidOrder(.checkInVsOnTime)
+            return
+        }
+        guard attendanceOnTimeEndAt < attendanceLateEndAt else {
+            attendancePolicyError = .invalidOrder(.onTimeVsLate)
+            return
+        }
+        guard attendanceCheckInStartAt < startDate else {
+            attendancePolicyError = .checkInAfterScheduleStart
+            return
+        }
+        attendancePolicyError = nil
+    }
+
+    // MARK: - Function
+
+    /// 대면/비대면 전환 토글 변경을 처리합니다.
+    ///
+    /// 비대면으로 전환 시 장소 입력을 초기화합니다.
+    func inPersonModeToggleChanged(to isInPerson: Bool) {
+        isOnline = !isInPerson
+        if isOnline {
+            placeName = ""
+        }
+    }
+
+    /// 스케줄 등록 실행
+    /// - Returns: 등록 성공 여부
+    func submitSchedule() async -> Bool {
+        guard canSubmit else { return false }
+        // TODO: Schedule 모듈 이식 후 일정 등록 2단계 결선 - [26.06.27] 이재원
+        // — 1단계 일정 생성(POST /api/v2/schedules)과 실패 롤백(일정 삭제)이 미이식
+        //   Schedule 도메인 소관. 결선 시: 본인 제외 참여자 + 출석 정책으로 일정 생성 →
+        //   scheduleId 획득 → studyRepository.linkStudyGroupSchedule(step-2, 이식 완료)
+        //   연결 → 실패 시 AlertPrompt 재시도/취소 + 롤백 + ErrorHandler 결선.
+        return false
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Tests/StudyScheduleRegistrationViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/StudyScheduleRegistrationViewModelTests.swift
@@ -1,0 +1,495 @@
+//
+//  StudyScheduleRegistrationViewModelTests.swift
+//  ActivityPresentationTests
+//
+//  Created by jaewon Lee on 6/27/26.
+//
+
+import Foundation
+import Testing
+import ActivityDomain
+import UMCFoundation
+@testable import ActivityPresentation
+
+// 이 테스트 파일은 전부 #if DEBUG 전용 Mock 에 의존하므로 본문 전체를 가드한다.
+#if DEBUG
+
+// MARK: - Helpers
+
+/// 결정론적 기준 시각 — wall-clock 비의존
+private let fixedNow = Date(timeIntervalSince1970: 1_000_000)
+
+private func makeOption(
+    id: String = "W-1",
+    weekNo: String = "1",
+    title: String = "OT"
+) -> WeeklyCurriculumOption {
+    WeeklyCurriculumOption(weeklyCurriculumId: id, weekNo: weekNo, title: title)
+}
+
+private func makeMember(
+    memberID: String?,
+    name: String = "멤버"
+) -> StudyGroupMember {
+    StudyGroupMember(
+        serverID: memberID ?? "S-0",
+        memberID: memberID,
+        name: name,
+        university: "한성대학교"
+    )
+}
+
+@MainActor
+private func makeViewModel(
+    studyName: String = "iOS 스터디",
+    studyGroupId: String = "1",
+    membersUseCase: MockFetchStudyMembersUseCase = MockFetchStudyMembersUseCase(),
+    repository: MockStudyScheduleRepository = MockStudyScheduleRepository(),
+    currentMemberId: String? = nil
+) -> StudyScheduleRegistrationViewModel {
+    StudyScheduleRegistrationViewModel(
+        studyName: studyName,
+        studyGroupId: studyGroupId,
+        studyMembersUseCase: membersUseCase,
+        studyRepository: repository,
+        currentMemberId: currentMemberId
+    )
+}
+
+/// `canSubmit == true` 를 만족하는 기본 뷰 모델 (비대면 + 주차 선택 완료)
+@MainActor
+private func makeReadyViewModel() -> StudyScheduleRegistrationViewModel {
+    let viewModel = makeViewModel()
+    viewModel.isOnline = true
+    viewModel.selectedWeeklyOption = makeOption()
+    return viewModel
+}
+
+private struct DummyError: Error {}
+
+// MARK: - Mocks
+
+private final class MockFetchStudyMembersUseCase: @unchecked Sendable,
+    FetchStudyMembersUseCaseProtocol {
+
+    var result: Result<[StudyGroupMember], Error> = .success([])
+    private(set) var callCount = 0
+    private(set) var lastGroupId: String?
+
+    func fetchStudyGroupMembers(groupId: String) async throws -> [StudyGroupMember] {
+        callCount += 1
+        lastGroupId = groupId
+        return try result.get()
+    }
+}
+
+/// `StudyRepositoryProtocol` 의 테스트 전용 Mock.
+///
+/// 본 뷰 모델이 사용하는 `fetchWeeklyCurriculumOptions()` 만 제어 가능한 stub 으로 노출하고,
+/// 나머지 메서드는 계약 밖이므로 호출 시 `fatalError` 로 즉시 실패합니다.
+private final class MockStudyScheduleRepository: @unchecked Sendable,
+    StudyRepositoryProtocol {
+
+    var weeklyOptionsResult: Result<[WeeklyCurriculumOption], Error> = .success([])
+    private(set) var fetchWeeklyCurriculumOptionsCallCount = 0
+
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption] {
+        fetchWeeklyCurriculumOptionsCallCount += 1
+        return try weeklyOptionsResult.get()
+    }
+
+    // MARK: 계약 밖 메서드 (호출 시 실패 — 본 뷰 모델은 사용하지 않음)
+
+    func fetchCurriculumProgress() async throws -> CurriculumProgressModel {
+        fatalError("fetchCurriculumProgress 는 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func fetchMissions() async throws -> [MissionCardModel] {
+        fatalError("fetchMissions 는 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func fetchStudyGroupDetails() async throws -> [StudyGroupInfo] {
+        fatalError("fetchStudyGroupDetails 는 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func fetchStudyGroupDetailsPage(
+        cursor: String?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage {
+        fatalError("fetchStudyGroupDetailsPage 는 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func fetchStudyGroupDetail(groupId: String) async throws -> StudyGroupInfo {
+        fatalError("fetchStudyGroupDetail 은 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: String?
+    ) async throws -> String? {
+        fatalError("resolveChallengerId 는 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws {
+        fatalError("createStudyGroup 은 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func updateStudyGroup(groupId: String, name: String) async throws {
+        fatalError("updateStudyGroup 은 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func deleteStudyGroup(groupId: String) async throws {
+        fatalError("deleteStudyGroup 은 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func addStudyGroupMember(groupId: String, memberId: String) async throws {
+        fatalError("addStudyGroupMember 는 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func removeStudyGroupMember(groupId: String, memberId: String) async throws {
+        fatalError("removeStudyGroupMember 는 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func addStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        fatalError("addStudyGroupMentor 는 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {
+        fatalError("removeStudyGroupMentor 는 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+
+    func linkStudyGroupSchedule(
+        scheduleId: String,
+        studyGroupId: String,
+        weeklyCurriculumId: String
+    ) async throws {
+        fatalError("linkStudyGroupSchedule 은 StudyScheduleRegistrationViewModel 계약 밖입니다.")
+    }
+}
+
+// MARK: - 등록 가능 여부 (canSubmit)
+
+@MainActor
+@Suite("StudyScheduleRegistrationViewModel — 등록 가능 여부 (도메인 규칙)")
+struct StudyScheduleRegistrationViewModelCanSubmitTests {
+
+    @Test("필수 입력 충족 → 등록 가능")
+    func readyViewModelIsSubmittable() {
+        #expect(makeReadyViewModel().canSubmit == true)
+    }
+
+    @Test("스터디명이 공백/개행뿐 → 불가", arguments: ["", "   ", "\n", " \n "])
+    func blankStudyNameBlocksSubmit(name: String) {
+        let viewModel = makeReadyViewModel()
+        viewModel.studyName = name
+        #expect(viewModel.canSubmit == false)
+    }
+
+    @Test("대면인데 장소가 공백/개행뿐 → 불가", arguments: ["", "   ", "\n", " \n "])
+    func inPersonWithBlankPlaceBlocksSubmit(place: String) {
+        let viewModel = makeReadyViewModel()
+        viewModel.isOnline = false
+        viewModel.placeName = place
+        #expect(viewModel.canSubmit == false)
+    }
+
+    @Test("대면 + 장소 입력 → 가능")
+    func inPersonWithPlaceAllowsSubmit() {
+        let viewModel = makeReadyViewModel()
+        viewModel.isOnline = false
+        viewModel.placeName = "한성대 상상관"
+        #expect(viewModel.canSubmit == true)
+    }
+
+    @Test("스터디 그룹 ID 가 비어 있음 → 불가")
+    func emptyStudyGroupIdBlocksSubmit() {
+        let viewModel = makeViewModel(studyGroupId: "")
+        viewModel.isOnline = true
+        viewModel.selectedWeeklyOption = makeOption()
+        #expect(viewModel.canSubmit == false)
+    }
+
+    @Test("종료가 시작보다 빠름 → 불가")
+    func endBeforeStartBlocksSubmit() {
+        let viewModel = makeReadyViewModel()
+        viewModel.endDate = viewModel.startDate.addingTimeInterval(-1)
+        #expect(viewModel.canSubmit == false)
+    }
+
+    @Test("주차 커리큘럼 미선택 → 불가")
+    func missingWeeklyOptionBlocksSubmit() {
+        let viewModel = makeReadyViewModel()
+        viewModel.selectedWeeklyOption = nil
+        #expect(viewModel.canSubmit == false)
+    }
+
+    @Test("출석 정책 검증 에러 존재 → 불가")
+    func attendancePolicyErrorBlocksSubmit() {
+        let viewModel = makeReadyViewModel()
+        // 출석 시작 ≥ 출석 인정 마감 → 단조 증가 위반
+        viewModel.attendanceOnTimeEndAt = viewModel.attendanceCheckInStartAt
+        viewModel.attendanceTimesChanged()
+        #expect(viewModel.attendancePolicyError != nil)
+        #expect(viewModel.canSubmit == false)
+    }
+}
+
+// MARK: - 출석 정책 검증
+
+@MainActor
+@Suite("StudyScheduleRegistrationViewModel — 출석 정책 검증 (도메인 규칙)")
+struct StudyScheduleRegistrationViewModelPolicyValidationTests {
+
+    @Test("출석 시작 ≥ 출석 인정 마감 → checkInVsOnTime 에러")
+    func checkInNotBeforeOnTimeFails() {
+        let viewModel = makeViewModel()
+        viewModel.startDate = fixedNow
+        viewModel.attendanceCheckInStartAt = fixedNow.addingTimeInterval(600)
+        viewModel.attendanceOnTimeEndAt = fixedNow.addingTimeInterval(600)
+        viewModel.attendanceLateEndAt = fixedNow.addingTimeInterval(1_200)
+        viewModel.attendanceTimesChanged()
+        #expect(viewModel.attendancePolicyError == .invalidOrder(.checkInVsOnTime))
+    }
+
+    @Test("출석 인정 마감 ≥ 지각 인정 마감 → onTimeVsLate 에러")
+    func onTimeNotBeforeLateFails() {
+        let viewModel = makeViewModel()
+        viewModel.startDate = fixedNow
+        viewModel.attendanceCheckInStartAt = fixedNow.addingTimeInterval(-600)
+        viewModel.attendanceOnTimeEndAt = fixedNow.addingTimeInterval(600)
+        viewModel.attendanceLateEndAt = fixedNow.addingTimeInterval(600)
+        viewModel.attendanceTimesChanged()
+        #expect(viewModel.attendancePolicyError == .invalidOrder(.onTimeVsLate))
+    }
+
+    @Test("출석 시작 ≥ 일정 시작 → checkInAfterScheduleStart 에러")
+    func checkInNotBeforeScheduleStartFails() {
+        let viewModel = makeViewModel()
+        viewModel.startDate = fixedNow
+        // 단조 증가는 충족하되 출석 시작이 일정 시작보다 빠르지 않은 경우
+        viewModel.attendanceCheckInStartAt = fixedNow
+        viewModel.attendanceOnTimeEndAt = fixedNow.addingTimeInterval(600)
+        viewModel.attendanceLateEndAt = fixedNow.addingTimeInterval(1_200)
+        viewModel.attendanceTimesChanged()
+        #expect(viewModel.attendancePolicyError == .checkInAfterScheduleStart)
+    }
+
+    @Test("단조 증가 + 일정 시작 이전 → 에러 없음")
+    func validPolicyHasNoError() {
+        let viewModel = makeViewModel()
+        viewModel.startDate = fixedNow
+        viewModel.attendanceCheckInStartAt = fixedNow.addingTimeInterval(-600)
+        viewModel.attendanceOnTimeEndAt = fixedNow.addingTimeInterval(600)
+        viewModel.attendanceLateEndAt = fixedNow.addingTimeInterval(1_200)
+        viewModel.attendanceTimesChanged()
+        #expect(viewModel.attendancePolicyError == nil)
+    }
+}
+
+// MARK: - 출석 정책 prefill
+
+@MainActor
+@Suite("StudyScheduleRegistrationViewModel — 출석 정책 prefill (도메인 규칙)")
+struct StudyScheduleRegistrationViewModelPrefillTests {
+
+    @Test("미수정 상태 → 일정 시작 기준 임계값으로 자동 채움")
+    func prefillsRelativeToStartDate() {
+        let viewModel = makeViewModel()
+        viewModel.startDate = fixedNow
+        viewModel.prefillAttendancePolicyIfNeeded()
+
+        let onTime = TimeInterval(AttendancePolicy.onTimeThresholdMinutes * 60)
+        let late = TimeInterval(AttendancePolicy.lateThresholdMinutes * 60)
+        #expect(viewModel.attendanceCheckInStartAt == fixedNow.addingTimeInterval(-onTime))
+        #expect(viewModel.attendanceOnTimeEndAt == fixedNow.addingTimeInterval(onTime))
+        #expect(viewModel.attendanceLateEndAt == fixedNow.addingTimeInterval(late))
+    }
+
+    @Test("사용자가 시각을 직접 수정한 뒤 → prefill 이 덮어쓰지 않음")
+    func prefillSkipsAfterUserEdit() {
+        let viewModel = makeViewModel()
+        let manualCheckIn = fixedNow.addingTimeInterval(-30)
+        viewModel.attendanceCheckInStartAt = manualCheckIn
+        viewModel.attendanceOnTimeEndAt = fixedNow.addingTimeInterval(60)
+        viewModel.attendanceLateEndAt = fixedNow.addingTimeInterval(120)
+        viewModel.attendanceTimesChanged()  // dirty 표시
+
+        viewModel.startDate = fixedNow.addingTimeInterval(10_000)
+        viewModel.prefillAttendancePolicyIfNeeded()
+
+        #expect(viewModel.attendanceCheckInStartAt == manualCheckIn)
+    }
+}
+
+// MARK: - 대면/비대면 토글
+
+@MainActor
+@Suite("StudyScheduleRegistrationViewModel — 대면/비대면 토글 (도메인 규칙)")
+struct StudyScheduleRegistrationViewModelToggleTests {
+
+    @Test("비대면 전환 → isOnline true + 장소 초기화")
+    func switchingToOnlineClearsPlace() {
+        let viewModel = makeViewModel()
+        viewModel.placeName = "한성대 상상관"
+        viewModel.inPersonModeToggleChanged(to: false)
+        #expect(viewModel.isOnline == true)
+        #expect(viewModel.placeName.isEmpty)
+    }
+
+    @Test("대면 전환 → isOnline false + 장소 보존")
+    func switchingToInPersonKeepsPlace() {
+        let viewModel = makeViewModel()
+        viewModel.placeName = "한성대 상상관"
+        viewModel.inPersonModeToggleChanged(to: true)
+        #expect(viewModel.isOnline == false)
+        #expect(viewModel.placeName == "한성대 상상관")
+    }
+}
+
+// MARK: - 참여자 로딩
+
+@MainActor
+@Suite("StudyScheduleRegistrationViewModel — 참여자 로딩 (도메인 규칙)")
+struct StudyScheduleRegistrationViewModelParticipantsTests {
+
+    @Test("성공 + 본인 ID 일치 → 본인 제외하고 loaded")
+    func loadsParticipantsExcludingSelf() async {
+        let useCase = MockFetchStudyMembersUseCase()
+        useCase.result = .success([
+            makeMember(memberID: "M-1"),
+            makeMember(memberID: "M-2"),
+            makeMember(memberID: "M-self"),
+        ])
+        let viewModel = makeViewModel(membersUseCase: useCase, currentMemberId: "M-self")
+
+        await viewModel.loadParticipantMembers()
+
+        #expect(viewModel.participantMembers.map(\.memberID) == ["M-1", "M-2"])
+        #expect(viewModel.participantsState.value?.map(\.memberID) == ["M-1", "M-2"])
+        #expect(useCase.lastGroupId == "1")
+    }
+
+    @Test("본인 ID 없음 → 전체 멤버 유지")
+    func loadsAllParticipantsWithoutSelfId() async {
+        let useCase = MockFetchStudyMembersUseCase()
+        useCase.result = .success([
+            makeMember(memberID: "M-1"),
+            makeMember(memberID: "M-2"),
+        ])
+        let viewModel = makeViewModel(membersUseCase: useCase, currentMemberId: nil)
+
+        await viewModel.loadParticipantMembers()
+
+        #expect(viewModel.participantMembers.map(\.memberID) == ["M-1", "M-2"])
+    }
+
+    @Test("DomainError → failed(.domain) 인라인 상태")
+    func participantsDomainErrorMapsToFailed() async {
+        let useCase = MockFetchStudyMembersUseCase()
+        useCase.result = .failure(DomainError.custom(message: "참여자 조회 실패"))
+        let viewModel = makeViewModel(membersUseCase: useCase)
+
+        await viewModel.loadParticipantMembers()
+
+        #expect(viewModel.participantsState == .failed(.domain(.custom(message: "참여자 조회 실패"))))
+    }
+
+    @Test("기타 에러 → failed 상태 (크래시 없이 인라인 처리)")
+    func participantsUnknownErrorMapsToFailed() async {
+        let useCase = MockFetchStudyMembersUseCase()
+        useCase.result = .failure(DummyError())
+        let viewModel = makeViewModel(membersUseCase: useCase)
+
+        await viewModel.loadParticipantMembers()
+
+        #expect(viewModel.participantsState.error != nil)
+        #expect(viewModel.participantMembers.isEmpty)
+    }
+}
+
+// MARK: - 주차 옵션 로딩
+
+@MainActor
+@Suite("StudyScheduleRegistrationViewModel — 주차 옵션 로딩 (도메인 규칙)")
+struct StudyScheduleRegistrationViewModelWeeklyOptionsTests {
+
+    @Test("성공 + 미선택 → loaded + 첫 옵션 자동 선택")
+    func loadsAndAutoSelectsFirst() async {
+        let repository = MockStudyScheduleRepository()
+        let first = makeOption(id: "W-1", weekNo: "1", title: "OT")
+        repository.weeklyOptionsResult = .success([
+            first,
+            makeOption(id: "W-2", weekNo: "2", title: "Git"),
+        ])
+        let viewModel = makeViewModel(repository: repository)
+
+        await viewModel.loadWeeklyOptions()
+
+        #expect(viewModel.weeklyOptionsState.value?.count == 2)
+        #expect(viewModel.selectedWeeklyOption == first)
+    }
+
+    @Test("성공 + 이미 선택됨 → 자동 선택이 덮어쓰지 않음")
+    func keepsExistingSelection() async {
+        let repository = MockStudyScheduleRepository()
+        repository.weeklyOptionsResult = .success([
+            makeOption(id: "W-1", weekNo: "1", title: "OT"),
+            makeOption(id: "W-2", weekNo: "2", title: "Git"),
+        ])
+        let viewModel = makeViewModel(repository: repository)
+        let preset = makeOption(id: "W-2", weekNo: "2", title: "Git")
+        viewModel.selectedWeeklyOption = preset
+
+        await viewModel.loadWeeklyOptions()
+
+        #expect(viewModel.selectedWeeklyOption == preset)
+    }
+
+    @Test("빈 목록 → loaded([]) + 선택 없음")
+    func emptyOptionsLeaveSelectionNil() async {
+        let repository = MockStudyScheduleRepository()
+        repository.weeklyOptionsResult = .success([])
+        let viewModel = makeViewModel(repository: repository)
+
+        await viewModel.loadWeeklyOptions()
+
+        #expect(viewModel.weeklyOptionsState.value?.isEmpty == true)
+        #expect(viewModel.selectedWeeklyOption == nil)
+    }
+
+    @Test("DomainError → failed(.domain) 인라인 상태")
+    func weeklyOptionsDomainErrorMapsToFailed() async {
+        let repository = MockStudyScheduleRepository()
+        repository.weeklyOptionsResult = .failure(DomainError.custom(message: "주차 조회 실패"))
+        let viewModel = makeViewModel(repository: repository)
+
+        await viewModel.loadWeeklyOptions()
+
+        #expect(viewModel.weeklyOptionsState == .failed(.domain(.custom(message: "주차 조회 실패"))))
+    }
+}
+
+// MARK: - 일정 등록 스텁
+
+@MainActor
+@Suite("StudyScheduleRegistrationViewModel — 일정 등록 스텁 (도메인 규칙)")
+struct StudyScheduleRegistrationViewModelSubmitStubTests {
+
+    @Test("필수 입력 충족이어도 false — Schedule 모듈 이식 전 스텁 계약")
+    func submitReturnsFalseWhileStubbed() async {
+        let viewModel = makeReadyViewModel()
+        #expect(viewModel.canSubmit == true)
+
+        let result = await viewModel.submitSchedule()
+
+        #expect(result == false)
+    }
+}
+
+#endif


### PR DESCRIPTION
> 관련 이슈: #890 — 본 PR은 **ViewModel 슬라이스** (View 미포함이라 auto-close 하지 않고 #890 유지)

## ✨ PR 유형

<img width="1512" height="1012" alt="image" src="https://github.com/user-attachments/assets/0d4ecdc8-51f9-4945-93c5-e491058bb758" />
<img width="1512" height="1012" alt="스크린샷 2026-07-11 오후 9 56 07" src="https://github.com/user-attachments/assets/00c8fca4-e767-4caa-b5ff-0d79234c40a0" />


## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (ViewModel + Domain + Tests). 단, 테스트 코드(`*Tests.swift`)가 포함되어 CI 미적용 기간 한시 정책에 따라 **테스트 성공 + 커버리지 캡쳐**를 첨부합니다.

<!-- ⬇️ 여기에 Xcode 테스트 네비게이터(모든 케이스 ✅) 스크린샷 + Report Navigator Coverage 탭 캡쳐를 업로드하세요 -->

**테스트 결과**: `ActivityPresentation` — 55 tests / 13 suites ✅ (신규 `StudyScheduleRegistrationViewModel` 7 suites 포함)

## 🛠️ 작업내용

레거시 `StudyScheduleRegistrationViewModel` 을 `ActivityPresentation` 모듈로 이식했습니다. View 는 미이식 Schedule 도메인(1단계 일정 생성 `POST /api/v2/schedules` + 위치 검색 서브시스템)에 의존하므로 이번 슬라이스에서 제외하고, ViewModel 의 폼/검증/조회 로직을 완결했습니다.

| 커밋 | 레이어 | 내용 |
|------|--------|------|
| `refactor: 출석 정책 검증 에러 도메인 모델 이식` | ActivityDomain | `AttendancePolicyError` (검증 실패 케이스만 — dead case 배제) |
| `refactor: StudyScheduleRegistrationViewModel 이식` | ActivityPresentation | `@Observable` VM — 스터디명/장소/일시/주차/출석정책 폼 + 인라인 검증 + 참여자·주차옵션 로딩 |
| `test: StudyScheduleRegistrationViewModel 단위 테스트 추가` | Tests | Swift Testing 7 suites (검증 규칙·prefill·경계값·로딩·스텁 계약) |

- 서버 응답 식별자는 전 레이어 `String` 통일 (`studyGroupId`/`memberId`/`weeklyCurriculumId`)
- 참여자 조회는 `FetchStudyMembersUseCaseProtocol`, 주차 옵션·그룹-일정 연결은 `StudyRepositoryProtocol` 경유 (facade 비대화 방지 설계 준수)
- 장소는 위치 검색 서브시스템 미이식이라 `placeName: String` 으로만 보관 (좌표 모델은 View 이식 시 결선)

## 📋 추후 진행 상황

- **`StudyScheduleRegistrationView` 이식** + `submitSchedule()` 결선 — #890 의 잔여 범위. Schedule 생성 파이프라인(1단계 일정 생성 + 실패 롤백) + 위치 검색 서브시스템(`PlaceSelectView`) + 일정 UI 컴포넌트 이식 후 후속 PR 에서 진행
- `submitSchedule()` 스텁의 TODO 주석에 결선 경로를 명시해 두었습니다.

## 📌 리뷰 포인트

- **`StudyScheduleRegistrationViewModel.swift`** — `@Observable` 상태 관리 · `canSubmit` 검증식(공백/개행 트림 포함) · `validateAttendancePolicy` 3단 단조 증가 검증
- **`AttendancePolicyError.swift`** — 도메인 검증 에러 (발생 케이스만 정의)
- **`submitSchedule()` 스텁 계약**: `canSubmit == true` 여도 현재 `false` 반환은 의도된 스텁입니다 (Schedule 모듈 미이식). 프로덕션 UI 결선은 View 이식 시점까지 미노출.
- 베이스 브랜치가 `refactor/886`(연속 브랜치 파생)인 점 — `linkStudyGroupSchedule`(선행 #886) 위에 쌓입니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
