### PR TITLE
♻️ [Refactor] MemberRepository 구현체 이식 + Router 챌린저 검색·포인트 case 확장

### DIFF
--- a/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerPointCreateRequestDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerPointCreateRequestDTO.swift
@@ -1,0 +1,38 @@
+//
+//  ChallengerPointCreateRequestDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Foundation
+import UMCFoundation
+
+/// 챌린저 포인트 부여 요청 DTO
+///
+/// `POST /api/v1/challenger/{challengerId}/points`
+///
+/// - Note: Request(Encodable) DTO 이므로 배점(`pointValue`)은 정수 그대로 직렬화합니다.
+///   절대 규칙 #2(서버 응답 정수 String 통일)는 식별자에 적용되며, 배점은 식별자가 아닙니다.
+///   `pointType` 은 서버 문자열 rawValue 로 직렬화됩니다(``UMCFoundation/ChallengerPointType``).
+struct ChallengerPointCreateRequestDTO: Encodable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    /// 포인트 유형
+    let pointType: ChallengerPointType
+
+    /// 배점 (`ChallengerPointType/isCustom` 이면 호출자가 직접 입력)
+    let pointValue: Int
+
+    /// 부여 사유
+    let description: String
+
+    // MARK: - Init
+
+    init(pointType: ChallengerPointType, pointValue: Int, description: String) {
+        self.pointType = pointType
+        self.pointValue = pointValue
+        self.description = description
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerProfileDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerProfileDTO.swift
@@ -13,8 +13,8 @@ import Foundation
 ///
 /// - Note: 레거시는 멤버 관리 포인트 히스토리를 MyPage `ChallengerMemberDTO` 전체로
 ///   디코딩했습니다. 본 모듈의 ``MemberRepository/fetchPointHistory(challengerId:)`` 는
-///   `challengerPoints` 만 사용하므로 해당 필드만 디코딩하여 MyPage 모듈 의존 없이
-///   자기완결적으로 챌린저 엔드포인트를 이식합니다(나머지 응답 필드는 무시).
+///   `challengerPoints` 만 쓰므로 그 필드만 디코딩합니다. MyPage 모듈에 기대지 않고
+///   챌린저 엔드포인트를 이식하려는 것입니다(나머지 응답 필드는 무시).
 /// - Note: 레거시 `ChallengerMemberDTO` 와 동일하게, `challengerPoints` 가 비어 있으면 루트
 ///   `points` 키를 폴백으로 사용합니다(서버가 두 키 형식을 혼용하므로 히스토리 누락 방지).
 struct ChallengerProfileDTO: Codable, Sendable, Equatable {

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerProfileDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerProfileDTO.swift
@@ -1,0 +1,60 @@
+//
+//  ChallengerProfileDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Foundation
+
+/// 챌린저 프로필 응답 DTO (포인트 히스토리 전용 부분 디코딩)
+///
+/// `GET /api/v1/challenger/{challengerId}`
+///
+/// - Note: 레거시는 멤버 관리 포인트 히스토리를 MyPage `ChallengerMemberDTO` 전체로
+///   디코딩했습니다. 본 모듈의 ``MemberRepository/fetchPointHistory(challengerId:)`` 는
+///   `challengerPoints` 만 사용하므로 해당 필드만 디코딩하여 MyPage 모듈 의존 없이
+///   자기완결적으로 챌린저 엔드포인트를 이식합니다(나머지 응답 필드는 무시).
+/// - Note: 레거시 `ChallengerMemberDTO` 와 동일하게, `challengerPoints` 가 비어 있으면 루트
+///   `points` 키를 폴백으로 사용합니다(서버가 두 키 형식을 혼용하므로 히스토리 누락 방지).
+struct ChallengerProfileDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let challengerPoints: [MemberManagementPointDTO]
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerPoints
+        case fallbackPoints = "points"
+    }
+
+    // MARK: - Init
+
+    init(challengerPoints: [MemberManagementPointDTO]) {
+        self.challengerPoints = challengerPoints
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let primary = try container.decodeIfPresent(
+            [MemberManagementPointDTO].self,
+            forKey: .challengerPoints
+        ) ?? []
+        let fallback = try container.decodeIfPresent(
+            [MemberManagementPointDTO].self,
+            forKey: .fallbackPoints
+        ) ?? []
+        challengerPoints = primary.isEmpty ? fallback : primary
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(challengerPoints, forKey: .challengerPoints)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerSearchOffsetDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerSearchOffsetDTO.swift
@@ -1,0 +1,246 @@
+//
+//  ChallengerSearchOffsetDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - ChallengerSearchOffsetResultDTO
+
+/// 챌린저 오프셋 검색 결과 DTO
+///
+/// `GET /api/v1/challenger/search/offset`
+struct ChallengerSearchOffsetResultDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let page: ChallengerSearchOffsetPageDTO
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case page
+    }
+
+    // MARK: - Init
+
+    init(page: ChallengerSearchOffsetPageDTO) {
+        self.page = page
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        page = try container.decodeIfPresent(
+            ChallengerSearchOffsetPageDTO.self,
+            forKey: .page
+        ) ?? .empty
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(page, forKey: .page)
+    }
+}
+
+// MARK: - ChallengerSearchOffsetPageDTO
+
+/// 오프셋 페이지 메타 + 항목 목록
+struct ChallengerSearchOffsetPageDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let content: [ChallengerSearchOffsetItemDTO]
+    let page: Int
+    let size: Int
+    let totalElements: Int
+    let totalPages: Int
+    let hasNext: Bool
+    let hasPrevious: Bool
+
+    // MARK: - Empty
+
+    /// `page` 필드 부재 시 사용할 빈 페이지.
+    static let empty = ChallengerSearchOffsetPageDTO(
+        content: [],
+        page: 0,
+        size: 0,
+        totalElements: 0,
+        totalPages: 0,
+        hasNext: false,
+        hasPrevious: false
+    )
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case content
+        case page
+        case size
+        case totalElements
+        case totalPages
+        case hasNext
+        case hasPrevious
+    }
+
+    // MARK: - Init
+
+    init(
+        content: [ChallengerSearchOffsetItemDTO],
+        page: Int,
+        size: Int,
+        totalElements: Int,
+        totalPages: Int,
+        hasNext: Bool,
+        hasPrevious: Bool
+    ) {
+        self.content = content
+        self.page = page
+        self.size = size
+        self.totalElements = totalElements
+        self.totalPages = totalPages
+        self.hasNext = hasNext
+        self.hasPrevious = hasPrevious
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        content = try container.decodeIfPresent(
+            [ChallengerSearchOffsetItemDTO].self,
+            forKey: .content
+        ) ?? []
+        page = try container.decodeIntFlexibleIfPresent(forKey: .page) ?? 0
+        size = try container.decodeIntFlexibleIfPresent(forKey: .size) ?? 0
+        totalElements = try container.decodeIntFlexibleIfPresent(forKey: .totalElements) ?? 0
+        totalPages = try container.decodeIntFlexibleIfPresent(forKey: .totalPages) ?? 0
+        hasNext = try container.decodeBoolFlexibleIfPresent(forKey: .hasNext) ?? false
+        hasPrevious = try container.decodeBoolFlexibleIfPresent(forKey: .hasPrevious) ?? false
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(content, forKey: .content)
+        try container.encode(page, forKey: .page)
+        try container.encode(size, forKey: .size)
+        try container.encode(totalElements, forKey: .totalElements)
+        try container.encode(totalPages, forKey: .totalPages)
+        try container.encode(hasNext, forKey: .hasNext)
+        try container.encode(hasPrevious, forKey: .hasPrevious)
+    }
+}
+
+// MARK: - ChallengerSearchOffsetItemDTO
+
+/// 검색 결과 단일 챌린저 항목
+struct ChallengerSearchOffsetItemDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let challengerId: String
+    let memberId: String
+    let gisuId: String
+    /// 기수 표시 번호(예: 9). 식별자가 아닌 표시·정렬용 수치라 `Int`.
+    let generation: Int?
+    let gisu: Int?
+    let part: String
+    let name: String
+    let nickname: String
+    let schoolName: String
+    let pointSum: Double
+    let profileImageURL: String?
+    let roleTypes: [ManagementTeam]
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerId
+        case memberId
+        case gisuId
+        case generation
+        case gisu
+        case part
+        case name
+        case nickname
+        case schoolName
+        case pointSum
+        case profileImageURL = "profileImageLink"
+        case roleTypes
+    }
+
+    // MARK: - Init
+
+    init(
+        challengerId: String,
+        memberId: String,
+        gisuId: String,
+        generation: Int?,
+        gisu: Int?,
+        part: String,
+        name: String,
+        nickname: String,
+        schoolName: String,
+        pointSum: Double,
+        profileImageURL: String?,
+        roleTypes: [ManagementTeam]
+    ) {
+        self.challengerId = challengerId
+        self.memberId = memberId
+        self.gisuId = gisuId
+        self.generation = generation
+        self.gisu = gisu
+        self.part = part
+        self.name = name
+        self.nickname = nickname
+        self.schoolName = schoolName
+        self.pointSum = pointSum
+        self.profileImageURL = profileImageURL
+        self.roleTypes = roleTypes
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        challengerId = try container.decodeFlexibleStringIfPresent(forKey: .challengerId) ?? ""
+        memberId = try container.decodeFlexibleStringIfPresent(forKey: .memberId) ?? ""
+        gisuId = try container.decodeFlexibleStringIfPresent(forKey: .gisuId) ?? ""
+        generation = try container.decodeIntFlexibleIfPresent(forKey: .generation)
+        gisu = try container.decodeIntFlexibleIfPresent(forKey: .gisu)
+        part = try container.decodeIfPresent(String.self, forKey: .part) ?? ""
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
+        schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
+        pointSum = try container.decodeDoubleFlexibleIfPresent(forKey: .pointSum) ?? 0
+        profileImageURL = try container.decodeIfPresent(String.self, forKey: .profileImageURL)
+        let rawRoleTypes = try container.decodeIfPresent([String].self, forKey: .roleTypes) ?? []
+        roleTypes = rawRoleTypes.compactMap(ManagementTeam.init(rawValue:))
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(challengerId, forKey: .challengerId)
+        try container.encode(memberId, forKey: .memberId)
+        try container.encode(gisuId, forKey: .gisuId)
+        try container.encodeIfPresent(generation, forKey: .generation)
+        try container.encodeIfPresent(gisu, forKey: .gisu)
+        try container.encode(part, forKey: .part)
+        try container.encode(name, forKey: .name)
+        try container.encode(nickname, forKey: .nickname)
+        try container.encode(schoolName, forKey: .schoolName)
+        try container.encode(pointSum, forKey: .pointSum)
+        try container.encodeIfPresent(profileImageURL, forKey: .profileImageURL)
+        try container.encode(roleTypes.map(\.rawValue), forKey: .roleTypes)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerSearchQuery.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerSearchQuery.swift
@@ -1,0 +1,44 @@
+//
+//  ChallengerSearchQuery.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Foundation
+
+/// 챌린저 오프셋 검색 Query DTO
+///
+/// `GET /api/v1/challenger/search/offset`
+///
+/// 라우터 `task` 에 인라인 딕셔너리를 두지 않도록 쿼리 파라미터를 캡슐화합니다(절대 규칙 #6).
+///
+/// - Note: `page`/`size` 는 클라이언트 페이지네이션 수치라 `Int`, `schoolId` 는 서버 식별자라
+///   `String` 입니다(절대 규칙 #2).
+struct ChallengerSearchQuery: Sendable, Equatable {
+
+    // MARK: - Property
+
+    let page: Int
+    let size: Int
+    let schoolId: String
+
+    // MARK: - Init
+
+    init(page: Int, size: Int, schoolId: String) {
+        self.page = page
+        self.size = size
+        self.schoolId = schoolId
+    }
+
+    // MARK: - Parameters
+
+    /// Query Parameter Dictionary 변환.
+    var toParameters: [String: Any] {
+        [
+            "page": page,
+            "size": size,
+            "schoolId": schoolId
+        ]
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/MemberManagementProfileDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/MemberManagementProfileDTO.swift
@@ -15,7 +15,7 @@ import UMCFoundation
 /// `GET /api/v1/member/profile/{memberId}`
 ///
 /// 같은 엔드포인트를 ``MemberProfileDTO``(챌린저 ID 해석 전용, `challengerRecords` 만)도
-/// 디코딩하지만, 멤버 관리에는 이름·역할·기수별 포인트가 필요하므로 별도 리치 DTO 로 분리합니다.
+/// 디코딩하지만, 멤버 관리에는 이름·역할·기수별 포인트가 필요해 필드가 더 많은 별도 DTO 로 나눴습니다.
 /// 서버 식별자는 전 레이어 `String` 통일 규칙에 따라 `String` 으로 디코딩합니다(절대 규칙 #2).
 struct MemberManagementProfileDTO: Codable, Sendable, Equatable {
 

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/MemberManagementProfileDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/MemberManagementProfileDTO.swift
@@ -1,0 +1,289 @@
+//
+//  MemberManagementProfileDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - MemberManagementProfileDTO
+
+/// 멤버 프로필 응답 DTO (멤버 관리 화면용 · 리치 필드)
+///
+/// `GET /api/v1/member/profile/{memberId}`
+///
+/// 같은 엔드포인트를 ``MemberProfileDTO``(챌린저 ID 해석 전용, `challengerRecords` 만)도
+/// 디코딩하지만, 멤버 관리에는 이름·역할·기수별 포인트가 필요하므로 별도 리치 DTO 로 분리합니다.
+/// 서버 식별자는 전 레이어 `String` 통일 규칙에 따라 `String` 으로 디코딩합니다(절대 규칙 #2).
+struct MemberManagementProfileDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let id: String
+    let name: String
+    let nickname: String
+    let schoolName: String
+    let profileImageURL: String?
+    let roles: [MemberManagementRoleDTO]
+    let challengerRecords: [MemberManagementChallengerRecordDTO]
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case nickname
+        case schoolName
+        case profileImageURL = "profileImageLink"
+        case roles
+        case challengerRecords
+    }
+
+    // MARK: - Init
+
+    init(
+        id: String,
+        name: String,
+        nickname: String,
+        schoolName: String,
+        profileImageURL: String?,
+        roles: [MemberManagementRoleDTO],
+        challengerRecords: [MemberManagementChallengerRecordDTO]
+    ) {
+        self.id = id
+        self.name = name
+        self.nickname = nickname
+        self.schoolName = schoolName
+        self.profileImageURL = profileImageURL
+        self.roles = roles
+        self.challengerRecords = challengerRecords
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeFlexibleStringIfPresent(forKey: .id) ?? ""
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
+        schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
+        profileImageURL = try container.decodeIfPresent(String.self, forKey: .profileImageURL)
+        roles = try container.decodeIfPresent(
+            [MemberManagementRoleDTO].self,
+            forKey: .roles
+        ) ?? []
+        challengerRecords = try container.decodeIfPresent(
+            [MemberManagementChallengerRecordDTO].self,
+            forKey: .challengerRecords
+        ) ?? []
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(nickname, forKey: .nickname)
+        try container.encode(schoolName, forKey: .schoolName)
+        try container.encodeIfPresent(profileImageURL, forKey: .profileImageURL)
+        try container.encode(roles, forKey: .roles)
+        try container.encode(challengerRecords, forKey: .challengerRecords)
+    }
+}
+
+// MARK: - MemberManagementRoleDTO
+
+/// 멤버의 운영 역할 DTO
+struct MemberManagementRoleDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let challengerId: String?
+    let roleType: ManagementTeam
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerId
+        case roleType
+    }
+
+    // MARK: - Init
+
+    init(challengerId: String?, roleType: ManagementTeam) {
+        self.challengerId = challengerId
+        self.roleType = roleType
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        challengerId = try container.decodeFlexibleStringIfPresent(forKey: .challengerId)
+        // 미지의 역할 문자열은 디코딩을 실패시키지 않고 challenger 로 폴백한다(서버가 새 역할을
+        // 추가해도 안전). `decodeIfPresent(ManagementTeam.self)` 는 미지의 rawValue 에서 throw
+        // 하므로 raw String 으로 받아 매핑한다.
+        let rawRoleType = try container.decodeIfPresent(String.self, forKey: .roleType)
+        roleType = rawRoleType.flatMap(ManagementTeam.init(rawValue:)) ?? .challenger
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(challengerId, forKey: .challengerId)
+        try container.encode(roleType, forKey: .roleType)
+    }
+}
+
+// MARK: - MemberManagementChallengerRecordDTO
+
+/// 멤버의 기수별 챌린저 활동 레코드 DTO
+struct MemberManagementChallengerRecordDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let challengerId: String
+    let memberId: String
+    /// 기수 표시 번호(예: 9). 식별자가 아닌 표시·정렬용 수치라 `Int`.
+    let gisu: Int
+    let gisuId: String
+    let part: String
+    let challengerPoints: [MemberManagementPointDTO]
+    /// 서버가 `points` 키로 내려주는 폴백 포인트(챌린저 포인트가 비었을 때 사용).
+    let fallbackPoints: [MemberManagementPointDTO]
+
+    /// 챌린저 포인트가 비어 있으면 폴백 포인트를 사용합니다.
+    var resolvedPoints: [MemberManagementPointDTO] {
+        challengerPoints.isEmpty ? fallbackPoints : challengerPoints
+    }
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case challengerId
+        case memberId
+        case gisu
+        case gisuId
+        case part
+        case challengerPoints
+        case fallbackPoints = "points"
+    }
+
+    // MARK: - Init
+
+    init(
+        challengerId: String,
+        memberId: String,
+        gisu: Int,
+        gisuId: String,
+        part: String,
+        challengerPoints: [MemberManagementPointDTO],
+        fallbackPoints: [MemberManagementPointDTO]
+    ) {
+        self.challengerId = challengerId
+        self.memberId = memberId
+        self.gisu = gisu
+        self.gisuId = gisuId
+        self.part = part
+        self.challengerPoints = challengerPoints
+        self.fallbackPoints = fallbackPoints
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        challengerId = try container.decodeFlexibleStringIfPresent(forKey: .challengerId) ?? ""
+        memberId = try container.decodeFlexibleStringIfPresent(forKey: .memberId) ?? ""
+        gisu = try container.decodeIntFlexibleIfPresent(forKey: .gisu) ?? 0
+        gisuId = try container.decodeFlexibleStringIfPresent(forKey: .gisuId) ?? ""
+        part = try container.decodeIfPresent(String.self, forKey: .part) ?? ""
+        challengerPoints = try container.decodeIfPresent(
+            [MemberManagementPointDTO].self,
+            forKey: .challengerPoints
+        ) ?? []
+        fallbackPoints = try container.decodeIfPresent(
+            [MemberManagementPointDTO].self,
+            forKey: .fallbackPoints
+        ) ?? []
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(challengerId, forKey: .challengerId)
+        try container.encode(memberId, forKey: .memberId)
+        try container.encode(gisu, forKey: .gisu)
+        try container.encode(gisuId, forKey: .gisuId)
+        try container.encode(part, forKey: .part)
+        try container.encode(challengerPoints, forKey: .challengerPoints)
+        try container.encode(fallbackPoints, forKey: .fallbackPoints)
+    }
+}
+
+// MARK: - MemberManagementPointDTO
+
+/// 단일 상벌점 항목 DTO
+struct MemberManagementPointDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let id: String
+    let pointType: String
+    let point: Double
+    let description: String
+    let createdAt: String
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case pointType
+        case point
+        case description
+        case createdAt
+    }
+
+    // MARK: - Init
+
+    init(
+        id: String,
+        pointType: String,
+        point: Double,
+        description: String,
+        createdAt: String
+    ) {
+        self.id = id
+        self.pointType = pointType
+        self.point = point
+        self.description = description
+        self.createdAt = createdAt
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeFlexibleStringIfPresent(forKey: .id) ?? ""
+        pointType = try container.decodeIfPresent(String.self, forKey: .pointType) ?? ""
+        point = try container.decodeDoubleFlexibleIfPresent(forKey: .point) ?? 0
+        description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+        createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt) ?? ""
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(pointType, forKey: .pointType)
+        try container.encode(point, forKey: .point)
+        try container.encode(description, forKey: .description)
+        try container.encode(createdAt, forKey: .createdAt)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/MemberContextProviding.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/MemberContextProviding.swift
@@ -1,0 +1,82 @@
+//
+//  MemberContextProviding.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Foundation
+
+/// 멤버 관리 조회에 필요한 현재 사용자 컨텍스트 제공자.
+///
+/// ``MemberRepositoryProtocol`` 의 멤버 목록 조회는 학교 단위 오프셋 검색을 사용하므로
+/// `schoolId` 가 필요하고, 상벌점 히스토리 열람 권한 판별·기수 우선순위 해석을 위해
+/// `currentMemberId`·`gisuId` 가 필요합니다. Repository 는 이 추상화에서 값을 읽습니다.
+///
+/// - Note: ``StudyContextProviding`` 과 같은 이유로 비-`Sendable` 의존성으로 두고,
+///   Repository 가 `@unchecked Sendable` 로 감쌉니다. 운영 코드는
+///   ``UserDefaultsMemberContextProvider`` 를, 테스트는 가짜 구현을 주입합니다.
+protocol MemberContextProviding {
+
+    /// 현재 학교 식별자 — 서버 응답이므로 `String`. 미설정 시 `nil`.
+    var schoolId: String? { get }
+
+    /// 현재 로그인 멤버 식별자 — 서버 응답이므로 `String`. 미설정 시 `nil`.
+    var currentMemberId: String? { get }
+
+    /// 현재(우선) 기수 식별자 — 서버 응답이므로 `String`. 미설정 시 `nil`.
+    var gisuId: String? { get }
+}
+
+// MARK: - UserDefaultsMemberContextProvider
+
+/// `UserDefaults` 기반 기본 컨텍스트 제공자.
+///
+/// 레거시 `AppStorageKey` 와 동일한 키(`schoolId`, `memberId`, `gisuId`)를 읽어, 향후
+/// 세션 저장소가 도입되어도 같은 키를 공유하면 호환됩니다. 식별자는 `String` 우선으로 읽고,
+/// 레거시 `Int` 저장값(>0)이면 문자열로 변환합니다.
+struct UserDefaultsMemberContextProvider: MemberContextProviding {
+
+    // MARK: - Property
+
+    private let defaults: UserDefaults
+
+    // MARK: - Init
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    // MARK: - MemberContextProviding
+
+    var schoolId: String? {
+        resolvedIdentifier(forKey: Key.schoolId)
+    }
+
+    var currentMemberId: String? {
+        resolvedIdentifier(forKey: Key.memberId)
+    }
+
+    var gisuId: String? {
+        resolvedIdentifier(forKey: Key.gisuId)
+    }
+
+    // MARK: - Function
+
+    /// `String` 우선, 레거시 `Int` 저장값(>0) 폴백으로 식별자를 읽습니다.
+    private func resolvedIdentifier(forKey key: String) -> String? {
+        if let value = defaults.string(forKey: key), !value.isEmpty {
+            return value
+        }
+        let legacyInt = defaults.integer(forKey: key)
+        return legacyInt > 0 ? String(legacyInt) : nil
+    }
+
+    // MARK: - Storage Key
+
+    private enum Key {
+        static let schoolId = "schoolId"
+        static let memberId = "memberId"
+        static let gisuId = "gisuId"
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/MemberContextProviding.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/MemberContextProviding.swift
@@ -9,9 +9,9 @@ import Foundation
 
 /// 멤버 관리 조회에 필요한 현재 사용자 컨텍스트 제공자.
 ///
-/// ``MemberRepositoryProtocol`` 의 멤버 목록 조회는 학교 단위 오프셋 검색을 사용하므로
-/// `schoolId` 가 필요하고, 상벌점 히스토리 열람 권한 판별·기수 우선순위 해석을 위해
-/// `currentMemberId`·`gisuId` 가 필요합니다. Repository 는 이 추상화에서 값을 읽습니다.
+/// ``MemberRepositoryProtocol`` 의 멤버 목록 조회가 학교 단위 오프셋 검색이라 `schoolId` 가
+/// 있어야 하고, 상벌점 히스토리 열람 권한과 기수 우선순위를 따지려면 `currentMemberId`·
+/// `gisuId` 도 필요합니다. Repository 는 이 값들을 여기서 읽어옵니다.
 ///
 /// - Note: ``StudyContextProviding`` 과 같은 이유로 비-`Sendable` 의존성으로 두고,
 ///   Repository 가 `@unchecked Sendable` 로 감쌉니다. 운영 코드는

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/MemberRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/MemberRepository.swift
@@ -153,9 +153,9 @@ public final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendab
 
     /// 멤버의 기수별 상벌점 요약을 조회합니다.
     ///
-    /// - Note: 레거시는 기수별 챌린저 ID 마다 MyPage 챌린저 프로필을 병렬 조회했으나, 본 모듈은
-    ///   단일 멤버 프로필(`challengerRecords[].resolvedPoints`)에서 요약을 파생합니다 — MyPage
-    ///   모듈 의존 없이 동일 데이터를 활용합니다.
+    /// - Note: 레거시는 기수별 챌린저 ID 마다 MyPage 챌린저 프로필을 병렬로 조회했지만, 본 모듈은
+    ///   단일 멤버 프로필(`challengerRecords[].resolvedPoints`)에서 요약을 뽑습니다 — MyPage
+    ///   모듈에 기대지 않고 같은 데이터를 씁니다.
     public func fetchGenerationPointSummaries(
         memberId: String
     ) async throws -> [GenerationPointSummary] {

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/MemberRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/MemberRepository.swift
@@ -208,6 +208,7 @@ private extension MemberRepository {
         let memberId: String
         let challengerId: String?
         let name: String
+        let nickname: String
         let profileImageURL: String?
         let schoolName: String
         let generation: String
@@ -278,6 +279,7 @@ private extension MemberRepository {
                 memberId: item.memberId,
                 challengerId: item.challengerId.nonEmpty,
                 name: item.name,
+                nickname: item.nickname,
                 profileImageURL: item.profileImageURL,
                 schoolName: item.schoolName,
                 generation: generation,
@@ -360,7 +362,7 @@ private extension MemberRepository {
             challengerID: resolvedChallengerID(descriptor: descriptor, record: record),
             profile: profile?.profileImageURL ?? descriptor.profileImageURL,
             name: profile?.name.nonEmpty ?? descriptor.name,
-            nickname: profile?.nickname.nonEmpty ?? descriptor.name,
+            nickname: profile?.nickname.nonEmpty ?? descriptor.nickname,
             generation: allGenerationsText(from: profile, fallback: descriptor.generation),
             school: profile?.schoolName.nonEmpty ?? descriptor.schoolName,
             position: descriptor.position,

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/MemberRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/MemberRepository.swift
@@ -1,0 +1,566 @@
+//
+//  MemberRepository.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Foundation
+import ActivityDomain
+import CoreNetwork
+import UMCFoundation
+import Moya
+
+/// 운영진 멤버 관리 Repository 구현체
+///
+/// ``MemberRepositoryProtocol`` 전체를 채택한다. 멤버 목록은 학교 단위 오프셋 검색
+/// (``StudyRouter/searchChallengersOffset(query:)``)으로 수집한 뒤 멤버 프로필
+/// (``StudyRouter/getMemberProfile(memberId:)``)로 상벌점·역할을 보강한다. 상벌점 부여/삭제는
+/// 챌린저 포인트 엔드포인트로, 포인트 히스토리는 챌린저 프로필 엔드포인트
+/// (``StudyRouter/getChallengerProfile(challengerId:)``)로 처리한다. 출석 이력은
+/// ``AttendanceRouter/fetchAttendanceList(query:)`` 응답에서 멤버를 필터링한다.
+///
+/// - Note: 서버 식별자는 전 레이어 `String` 으로 통일된다(절대 규칙 #2). 멤버 조회에 필요한
+///   `schoolId`·`currentMemberId`·`gisuId` 는 ``MemberContextProviding`` 에서 읽는다(신규
+///   모듈에는 레거시 `AppStorageKey` 세션 저장소가 아직 없어 컨텍스트 제공자를 주입한다).
+/// - Note: 레거시는 오프셋 검색 실패(404/405) 시 스터디 그룹 전수 열거로 폴백했으나, 본 모듈은
+///   1차 경로(오프셋 검색)만 이식하고 폴백은 의도적으로 보류한다(후행 보강 대상). 따라서
+///   `schoolId` 가 없으면 ``UMCFoundation/DomainError/custom(message:)`` 를 던진다 —
+///   조용한 빈 배열 반환 대신 호출자에게 컨텍스트 부재를 명시적으로 알린다.
+public final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendable {
+
+    // MARK: - Property
+
+    private let networkRequesting: any NetworkRequesting
+    private let context: MemberContextProviding
+    private let decoder: JSONDecoder
+
+    // MARK: - Constants
+
+    private enum Constants {
+        /// 오프셋 검색 페이지당 항목 수.
+        static let searchPageSize = 20
+    }
+
+    // MARK: - Init
+
+    /// 운영(DI) 진입점.
+    ///
+    /// 인증 어댑터 ``CoreNetwork/MoyaNetworkAdapter`` 와 `UserDefaults` 기반 기본 컨텍스트
+    /// 제공자를 사용한다. 테스트는 ``init(networkRequesting:context:decoder:)`` 에 가짜
+    /// 구현을 주입한다.
+    public convenience init(
+        adapter: MoyaNetworkAdapter,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.init(
+            networkRequesting: adapter,
+            context: UserDefaultsMemberContextProvider(),
+            decoder: decoder
+        )
+    }
+
+    /// 의존성을 직접 주입하는 지정 이니셜라이저 (모듈 내부 · 테스트 전용).
+    init(
+        networkRequesting: any NetworkRequesting,
+        context: MemberContextProviding,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.networkRequesting = networkRequesting
+        self.context = context
+        self.decoder = decoder
+    }
+
+    // MARK: - 멤버 목록
+
+    public func fetchMembers() async throws -> [MemberManagementItem] {
+        let schoolId = try requireSchoolId()
+        let descriptors = try await fetchAllDescriptors(schoolId: schoolId)
+        guard !descriptors.isEmpty else { return [] }
+        return try await enrichDescriptors(descriptors)
+    }
+
+    public func fetchMembersPage(page: Int) async throws -> MemberPage {
+        let schoolId = try requireSchoolId()
+        let response = try await networkRequesting.request(
+            StudyRouter.searchChallengersOffset(
+                query: ChallengerSearchQuery(
+                    page: page,
+                    size: Constants.searchPageSize,
+                    schoolId: schoolId
+                )
+            )
+        )
+        let result = try decoder.decode(
+            APIResponse<ChallengerSearchOffsetResultDTO>.self,
+            from: response.data
+        ).unwrap()
+        let pageResult = result.page
+        let descriptors = makeDescriptors(from: pageResult.content)
+        let members = try await enrichDescriptors(descriptors)
+        return MemberPage(
+            members: members,
+            hasNext: pageResult.hasNext,
+            currentPage: pageResult.page
+        )
+    }
+
+    // MARK: - 상벌점 부여 / 삭제
+
+    public func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws {
+        try await performVoidRequest(
+            .createChallengerPoint(
+                challengerId: challengerId,
+                body: ChallengerPointCreateRequestDTO(
+                    pointType: pointType,
+                    pointValue: pointValue,
+                    description: description
+                )
+            )
+        )
+    }
+
+    public func deletePoint(challengerPointId: String) async throws {
+        try await performVoidRequest(
+            .deleteChallengerPoint(challengerPointId: challengerPointId)
+        )
+    }
+
+    public func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory] {
+        let response = try await networkRequesting.request(
+            StudyRouter.getChallengerProfile(challengerId: challengerId)
+        )
+        let profile = try decoder.decode(
+            APIResponse<ChallengerProfileDTO>.self,
+            from: response.data
+        ).unwrap()
+        return makePenaltyHistories(from: profile.challengerPoints, includeWarning: false)
+    }
+
+    // MARK: - 멤버 상세
+
+    public func fetchAllGenerations(memberId: String) async throws -> String {
+        let profile = try await fetchMemberProfile(memberId: memberId)
+        return allGenerationsText(from: profile, fallback: "")
+    }
+
+    /// 멤버의 기수별 상벌점 요약을 조회합니다.
+    ///
+    /// - Note: 레거시는 기수별 챌린저 ID 마다 MyPage 챌린저 프로필을 병렬 조회했으나, 본 모듈은
+    ///   단일 멤버 프로필(`challengerRecords[].resolvedPoints`)에서 요약을 파생합니다 — MyPage
+    ///   모듈 의존 없이 동일 데이터를 활용합니다.
+    public func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary] {
+        let profile = try await fetchMemberProfile(memberId: memberId)
+        return makeGenerationPointSummaries(from: profile, memberId: memberId)
+    }
+
+    /// 일정 출석 현황에서 특정 멤버의 출석 이력을 조회합니다.
+    ///
+    /// - Note: 전체 일정 응답에서 클라이언트 필터링합니다(레거시 동일). 데이터 규모가 커지면
+    ///   페이지네이션 또는 백엔드 멤버 필터 도입을 검토합니다.
+    public func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord] {
+        guard !memberId.isEmpty else { return [] }
+
+        let response = try await networkRequesting.request(
+            AttendanceRouter.fetchAttendanceList(
+                query: AttendanceListQuery(from: nil, to: nil, attendanceStatus: nil)
+            )
+        )
+        let schedules = try decoder.decode(
+            APIResponse<[ScheduleAttendanceInfoDTO]>.self,
+            from: response.data
+        ).unwrap()
+
+        let sorted = schedules.sorted { $0.startsAt < $1.startsAt }
+        return sorted.enumerated().compactMap { index, schedule in
+            guard let participant = schedule.participants.first(where: {
+                $0.memberId == memberId
+            }) else {
+                return nil
+            }
+            let rawStatus = participant.attendanceStatus ?? "PENDING"
+            return MemberAttendanceRecord(
+                sessionTitle: schedule.name,
+                week: index + 1,
+                status: AttendanceStatus(serverStatus: rawStatus)
+            )
+        }
+    }
+}
+
+// MARK: - Private Helper
+
+private extension MemberRepository {
+
+    /// 오프셋 검색 결과 + 프로필 보강에 사용하는 중간 표현.
+    struct MemberDescriptor: Hashable {
+        let memberId: String
+        let challengerId: String?
+        let name: String
+        let profileImageURL: String?
+        let schoolName: String
+        let generation: String
+        let part: UMCPartType
+        let position: String
+        let managementTeam: ManagementTeam
+        let fallbackPenalty: Double
+    }
+
+    /// 멤버 조회의 전제 조건인 `schoolId` 를 반환하거나, 없으면 도메인 에러를 던집니다.
+    func requireSchoolId() throws -> String {
+        guard let schoolId = context.schoolId, !schoolId.isEmpty else {
+            throw DomainError.custom(message: "학교 정보가 없어 멤버 목록을 조회할 수 없습니다.")
+        }
+        return schoolId
+    }
+
+    /// 오프셋 검색을 `hasNext` 가 끝날 때까지 순회하여 멤버 디스크립터를 수집합니다.
+    func fetchAllDescriptors(schoolId: String) async throws -> [MemberDescriptor] {
+        var page = 0
+        var descriptorsByMemberId: [String: MemberDescriptor] = [:]
+
+        while true {
+            let response = try await networkRequesting.request(
+                StudyRouter.searchChallengersOffset(
+                    query: ChallengerSearchQuery(
+                        page: page,
+                        size: Constants.searchPageSize,
+                        schoolId: schoolId
+                    )
+                )
+            )
+            let result = try decoder.decode(
+                APIResponse<ChallengerSearchOffsetResultDTO>.self,
+                from: response.data
+            ).unwrap()
+            let pageResult = result.page
+
+            // 빈 페이지는 더 수집할 항목이 없다는 신호다. `hasNext` 가 true 로 와도 여기서
+            // 중단해 무한 루프를 막는다(offset 페이지네이션의 진행 보장 가드 —
+            // ``StudyRepository`` 의 커서 누락 가드와 동일한 의도).
+            guard !pageResult.content.isEmpty else { break }
+
+            for descriptor in makeDescriptors(from: pageResult.content) {
+                descriptorsByMemberId[descriptor.memberId] = descriptor
+            }
+
+            guard pageResult.hasNext else { break }
+            page += 1
+        }
+
+        return descriptorsByMemberId.values.sorted { $0.memberId < $1.memberId }
+    }
+
+    func makeDescriptors(
+        from items: [ChallengerSearchOffsetItemDTO]
+    ) -> [MemberDescriptor] {
+        items.compactMap { item in
+            guard !item.memberId.isEmpty else { return nil }
+            let part = UMCPartType(apiValue: item.part) ?? .pm
+            let managementTeam = ManagementTeam.highestPriority(in: item.roleTypes)
+                ?? .challenger
+            let generation = resolvedGeneration(
+                generation: item.generation,
+                gisu: item.gisu
+            )
+            return MemberDescriptor(
+                memberId: item.memberId,
+                challengerId: item.challengerId.nonEmpty,
+                name: item.name,
+                profileImageURL: item.profileImageURL,
+                schoolName: item.schoolName,
+                generation: generation,
+                part: part,
+                position: managementTeam.korean,
+                managementTeam: managementTeam,
+                fallbackPenalty: max(0, item.pointSum)
+            )
+        }
+    }
+
+    /// 각 디스크립터의 멤버 프로필을 조회해 상벌점·역할을 보강하고 정렬합니다.
+    ///
+    /// - Note: 레거시는 프로필을 병렬(`withTaskGroup`)로 조회했으나, 본 모듈은 순차 조회합니다.
+    ///   테스트의 ``NetworkRequesting`` 가짜 구현이 FIFO 큐라 호출 순서가 결정론적이어야 하기
+    ///   때문이며, 멤버 수가 크게 늘면 병렬화를 재검토합니다.
+    /// - Note: 프로필 조회 실패는 전파합니다(`try await`). 레거시·`try?` 는 개별 실패를 흡수해
+    ///   검색 디스크립터 값만으로 구성했지만, 그러면 인증 만료·서버·디코딩 실패가 전 멤버에 걸쳐도
+    ///   목록을 폴백 데이터로 "성공"처럼 반환해 운영진이 잘못된 상벌점을 봅니다(silent failure).
+    ///   비-2xx 는 ``NetworkRequesting`` 이 throw 하므로 전파해 호출자가 명시적 실패로 처리합니다
+    ///   (`StudyRepository.resolveChallengerId` 와 동일 방침). 멤버별 부분 성공이 필요해지면
+    ///   404 등 recoverable 상태만 선별 흡수하도록 후속 보강합니다.
+    func enrichDescriptors(
+        _ descriptors: [MemberDescriptor]
+    ) async throws -> [MemberManagementItem] {
+        let preferredGisuId = context.gisuId
+        let currentMemberId = context.currentMemberId
+
+        var members: [MemberManagementItem] = []
+        members.reserveCapacity(descriptors.count)
+
+        for descriptor in descriptors {
+            let profile = try await fetchMemberProfile(memberId: descriptor.memberId)
+            let record = resolveRecord(
+                from: profile,
+                memberId: descriptor.memberId,
+                preferredGisuId: preferredGisuId
+            )
+            members.append(
+                makeMemberItem(
+                    descriptor: descriptor,
+                    profile: profile,
+                    record: record,
+                    currentMemberId: currentMemberId
+                )
+            )
+        }
+
+        return members.sorted { lhs, rhs in
+            if lhs.part.sortOrder == rhs.part.sortOrder {
+                return lhs.name < rhs.name
+            }
+            return lhs.part.sortOrder < rhs.part.sortOrder
+        }
+    }
+
+    func makeMemberItem(
+        descriptor: MemberDescriptor,
+        profile: MemberManagementProfileDTO?,
+        record: MemberManagementChallengerRecordDTO?,
+        currentMemberId: String?
+    ) -> MemberManagementItem {
+        let allPoints = record?.resolvedPoints ?? []
+        let penaltyPoints = allPoints.filter { !isReward(pointType: $0.pointType) }
+        let rewardPoints = allPoints.filter { isReward(pointType: $0.pointType) }
+
+        let totalPenalty: Double
+        let penaltyHistories: [OperatorMemberPenaltyHistory]
+        if penaltyPoints.isEmpty {
+            totalPenalty = descriptor.fallbackPenalty
+            penaltyHistories = []
+        } else {
+            totalPenalty = penaltyPoints.reduce(0) { $0 + abs($1.point) }
+            penaltyHistories = makePenaltyHistories(from: penaltyPoints, includeWarning: true)
+        }
+        let totalReward = rewardPoints.reduce(0) { $0 + abs($1.point) }
+
+        return MemberManagementItem(
+            memberID: descriptor.memberId,
+            challengerID: resolvedChallengerID(descriptor: descriptor, record: record),
+            profile: profile?.profileImageURL ?? descriptor.profileImageURL,
+            name: profile?.name.nonEmpty ?? descriptor.name,
+            nickname: profile?.nickname.nonEmpty ?? descriptor.name,
+            generation: allGenerationsText(from: profile, fallback: descriptor.generation),
+            school: profile?.schoolName.nonEmpty ?? descriptor.schoolName,
+            position: descriptor.position,
+            part: descriptor.part,
+            penalty: totalPenalty,
+            rewardPoints: totalReward,
+            badge: false,
+            managementTeam: resolvedManagementTeam(
+                profile: profile,
+                record: record,
+                fallback: descriptor.managementTeam
+            ),
+            attendanceRecords: [],
+            penaltyHistory: penaltyHistories,
+            canViewPenaltyHistory: descriptor.memberId == currentMemberId
+        )
+    }
+
+    /// 멤버 프로필을 조회합니다.
+    ///
+    /// - Note: 레거시는 본인 프로필일 때 MyPage `getMyProfile` 를 사용했으나, 본 모듈은 MyPage
+    ///   를 의존하지 않으므로 본인 포함 모든 멤버를 `getMemberProfile` 로 일관 조회합니다(같은
+    ///   `/api/v1/member/profile/{memberId}` 데이터).
+    func fetchMemberProfile(
+        memberId: String
+    ) async throws -> MemberManagementProfileDTO {
+        let response = try await networkRequesting.request(
+            StudyRouter.getMemberProfile(memberId: memberId)
+        )
+        return try decoder.decode(
+            APIResponse<MemberManagementProfileDTO>.self,
+            from: response.data
+        ).unwrap()
+    }
+
+    func resolveRecord(
+        from profile: MemberManagementProfileDTO,
+        memberId: String,
+        preferredGisuId: String?
+    ) -> MemberManagementChallengerRecordDTO? {
+        let matchedMemberRecords = profile.challengerRecords.filter {
+            $0.memberId == memberId
+        }
+
+        if let preferredGisuId {
+            if let matched = matchedMemberRecords.first(where: {
+                $0.gisuId == preferredGisuId
+            }) {
+                return matched
+            }
+            if let matched = profile.challengerRecords.first(where: {
+                $0.gisuId == preferredGisuId
+            }) {
+                return matched
+            }
+        }
+
+        return matchedMemberRecords.first ?? profile.challengerRecords.first
+    }
+
+    func resolvedChallengerID(
+        descriptor: MemberDescriptor,
+        record: MemberManagementChallengerRecordDTO?
+    ) -> String? {
+        if let challengerId = record?.challengerId, !challengerId.isEmpty {
+            return challengerId
+        }
+        return descriptor.challengerId
+    }
+
+    func resolvedManagementTeam(
+        profile: MemberManagementProfileDTO?,
+        record: MemberManagementChallengerRecordDTO?,
+        fallback: ManagementTeam
+    ) -> ManagementTeam {
+        guard let profile else { return fallback }
+
+        if let challengerId = record?.challengerId, !challengerId.isEmpty {
+            let matchedRoles = profile.roles
+                .filter { $0.challengerId == nil || $0.challengerId == challengerId }
+                .map(\.roleType)
+
+            if let highest = ManagementTeam.highestPriority(in: matchedRoles) {
+                return highest
+            }
+        }
+
+        return ManagementTeam.highestPriority(in: profile.roles.map(\.roleType))
+            ?? fallback
+    }
+
+    func resolvedGeneration(generation: Int?, gisu: Int?) -> String {
+        if let generation, generation > 0 {
+            return "\(generation)기"
+        }
+        if let gisu, gisu > 0 {
+            return "\(gisu)기"
+        }
+        return "-"
+    }
+
+    /// 프로필의 모든 `challengerRecords` 에서 중복 없는 기수 목록 텍스트를 반환합니다.
+    func allGenerationsText(
+        from profile: MemberManagementProfileDTO?,
+        fallback: String
+    ) -> String {
+        guard let records = profile?.challengerRecords, !records.isEmpty else {
+            return fallback
+        }
+        let uniqueGisu = Set(records.map(\.gisu)).filter { $0 > 0 }.sorted()
+        guard !uniqueGisu.isEmpty else { return fallback }
+        return uniqueGisu.map { "\($0)기" }.joined(separator: ", ")
+    }
+
+    func makeGenerationPointSummaries(
+        from profile: MemberManagementProfileDTO,
+        memberId: String
+    ) -> [GenerationPointSummary] {
+        let records = profile.challengerRecords.filter {
+            $0.memberId == memberId || $0.memberId.isEmpty
+        }
+        guard !records.isEmpty else { return [] }
+
+        return records.compactMap { record in
+            guard record.gisu > 0 else { return nil }
+            let allPoints = record.resolvedPoints
+            let reward = allPoints
+                .filter { isReward(pointType: $0.pointType) }
+                .reduce(0) { $0 + abs($1.point) }
+            let penalty = allPoints
+                .filter { !isReward(pointType: $0.pointType) }
+                .reduce(0) { $0 + abs($1.point) }
+            return GenerationPointSummary(
+                gisu: record.gisu,
+                reward: reward,
+                penalty: penalty
+            )
+        }
+        .sorted { $0.gisu < $1.gisu }
+    }
+
+    /// 포인트 항목을 상벌점 히스토리로 매핑합니다.
+    ///
+    /// - Parameter includeWarning: `false` 면 `WARNING` 유형을 제외합니다(포인트 히스토리 조회).
+    func makePenaltyHistories(
+        from points: [MemberManagementPointDTO],
+        includeWarning: Bool
+    ) -> [OperatorMemberPenaltyHistory] {
+        points
+            .filter { point in
+                guard !includeWarning else { return true }
+                return ChallengerPointType(rawValue: point.pointType.uppercased()) != .warning
+            }
+            .map { point in
+                let resolvedType = ChallengerPointType(
+                    rawValue: point.pointType.uppercased()
+                ) ?? .out
+                return OperatorMemberPenaltyHistory(
+                    challengerPointId: point.id.nonEmpty,
+                    date: ServerDateTimeConverter.parseUTCDateTimeOrTime(point.createdAt)
+                        ?? Date(),
+                    reason: point.description.nonEmpty ?? resolvedType.displayName,
+                    penaltyScore: abs(point.point),
+                    pointType: resolvedType
+                )
+            }
+            .sorted { $0.date > $1.date }
+    }
+
+    /// 포인트 유형 문자열이 상점(보상)인지 판별합니다(미지의 유형은 벌점으로 간주).
+    ///
+    /// - Note: 분류는 ``UMCFoundation/ChallengerPointType/isReward``(유형의 기본 배점 부호)에
+    ///   위임하므로, 레거시 호환으로 양수(1)인 `WARNING`/`OUT` 은 상점으로, 기본 배점 0 인
+    ///   `CUSTOM` 은 벌점으로 분류됩니다(레거시 동일 동작). 일반 부여 흐름은
+    ///   `availableTypes(for:)` 에서 `WARNING`/`OUT` 을 제외하므로 영향이 제한적입니다. 서버
+    ///   `point` 부호 기반 정밀 분류는 contract 확정 후 별도 보강합니다.
+    func isReward(pointType raw: String) -> Bool {
+        ChallengerPointType(rawValue: raw.uppercased())?.isReward == true
+    }
+
+    /// 결과 본문이 없는 변경(부여/삭제) 요청의 공통 호출·검증.
+    ///
+    /// ``StudyRepository`` 의 동명 헬퍼와 동일한 계약: 빈 본문 2xx 는 성공으로 처리하고, 본문이
+    /// 있으면 `APIResponse<EmptyResult>` 의 성공 여부만 검증한다.
+    func performVoidRequest(_ target: StudyRouter) async throws {
+        let response = try await networkRequesting.request(target)
+        guard !response.data.isEmpty else { return }
+        let apiResponse = try decoder.decode(
+            APIResponse<EmptyResult>.self,
+            from: response.data
+        )
+        try apiResponse.validateSuccess()
+    }
+}
+
+// MARK: - String + NonEmpty
+
+private extension String {
+    /// 빈 문자열이면 `nil`, 아니면 자기 자신.
+    var nonEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
@@ -12,8 +12,9 @@ internal import Alamofire
 
 /// Study(Activity) Feature API 라우터.
 ///
-/// 조회 계열(커리큘럼/운영 스터디 그룹/멤버 프로필)과 운영진 스터디 그룹 CRUD·일정 연결을
-/// 단일 enum 으로 묶어 표현합니다. 멤버·포인트 계열 case 는 9차 멤버 Data 레이어에서 확장합니다.
+/// 조회 계열(커리큘럼/운영 스터디 그룹/멤버 프로필)과 운영진 스터디 그룹 CRUD·일정 연결,
+/// 멤버·포인트 계열(오프셋 검색·상벌점 부여/삭제·챌린저 프로필)을 단일 enum 으로 묶어
+/// 표현합니다.
 ///
 /// 연관값(Query/Request DTO·식별자 String)이 모두 `Sendable` 이므로 라우터도 `Sendable`.
 /// 동시성 경계를 넘어 안전하게 전달되며, 테스트의 파라미터화(`@Test(arguments:)`)도 가능.
@@ -28,8 +29,19 @@ enum StudyRouter: Sendable {
     case getMyStudyGroups(query: MyStudyGroupsQuery)
     /// 단일 스터디 그룹 상세 조회 — `GET /api/v1/study-groups/{groupId}`
     case getStudyGroupDetail(groupId: String)
-    /// 멤버 프로필 조회 (resolveChallengerId 용) — `GET /api/v1/member/profile/{memberId}`
+    /// 멤버 프로필 조회 (resolveChallengerId · 멤버 관리 용) — `GET /api/v1/member/profile/{memberId}`
     case getMemberProfile(memberId: String)
+
+    // MARK: - 멤버 / 포인트
+
+    /// 학교 단위 챌린저 오프셋 검색 — `GET /api/v1/challenger/search/offset`
+    case searchChallengersOffset(query: ChallengerSearchQuery)
+    /// 챌린저 포인트 부여 — `POST /api/v1/challenger/{challengerId}/points`
+    case createChallengerPoint(challengerId: String, body: ChallengerPointCreateRequestDTO)
+    /// 챌린저 포인트 삭제 — `DELETE /api/v1/challenger/points/{challengerPointId}`
+    case deleteChallengerPoint(challengerPointId: String)
+    /// 챌린저 프로필 조회 (포인트 히스토리 용) — `GET /api/v1/challenger/{challengerId}`
+    case getChallengerProfile(challengerId: String)
 
     // MARK: - 운영진 스터디 그룹 CRUD / 일정 연결
 
@@ -65,6 +77,14 @@ extension StudyRouter: BaseTargetType {
             return "/api/v1/study-groups/\(groupId)"
         case .getMemberProfile(let memberId):
             return "/api/v1/member/profile/\(memberId)"
+        case .searchChallengersOffset:
+            return "/api/v1/challenger/search/offset"
+        case .createChallengerPoint(let challengerId, _):
+            return "/api/v1/challenger/\(challengerId)/points"
+        case .deleteChallengerPoint(let challengerPointId):
+            return "/api/v1/challenger/points/\(challengerPointId)"
+        case .getChallengerProfile(let challengerId):
+            return "/api/v1/challenger/\(challengerId)"
         case .createStudyGroup:
             return "/api/v1/study-groups"
         case .updateStudyGroup(let groupId, _):
@@ -89,10 +109,13 @@ extension StudyRouter: BaseTargetType {
         case .getCurriculum,
              .getMyStudyGroups,
              .getStudyGroupDetail,
-             .getMemberProfile:
+             .getMemberProfile,
+             .searchChallengersOffset,
+             .getChallengerProfile:
             return .get
         case .createStudyGroup,
-             .linkStudyGroupSchedule:
+             .linkStudyGroupSchedule,
+             .createChallengerPoint:
             return .post
         case .updateStudyGroup,
              .addStudyGroupMember,
@@ -100,7 +123,8 @@ extension StudyRouter: BaseTargetType {
             return .patch
         case .deleteStudyGroup,
              .removeStudyGroupMember,
-             .removeStudyGroupMentor:
+             .removeStudyGroupMentor,
+             .deleteChallengerPoint:
             return .delete
         }
     }
@@ -119,19 +143,28 @@ extension StudyRouter: BaseTargetType {
                 parameters: query.toParameters,
                 encoding: URLEncoding.queryString
             )
+        case .searchChallengersOffset(let query):
+            return .requestParameters(
+                parameters: query.toParameters,
+                encoding: URLEncoding.queryString
+            )
         case .createStudyGroup(let body):
             return .requestJSONEncodable(body)
         case .updateStudyGroup(_, let body):
             return .requestJSONEncodable(body)
         case .linkStudyGroupSchedule(let body):
             return .requestJSONEncodable(body)
+        case .createChallengerPoint(_, let body):
+            return .requestJSONEncodable(body)
         case .getStudyGroupDetail,
              .getMemberProfile,
+             .getChallengerProfile,
              .deleteStudyGroup,
              .addStudyGroupMember,
              .removeStudyGroupMember,
              .addStudyGroupMentor,
-             .removeStudyGroupMentor:
+             .removeStudyGroupMentor,
+             .deleteChallengerPoint:
             return .requestPlain
         }
     }

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/ChallengerSearchOffsetDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/ChallengerSearchOffsetDTOTests.swift
@@ -1,0 +1,89 @@
+//
+//  ChallengerSearchOffsetDTOTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Testing
+import Foundation
+import UMCFoundation
+@testable import ActivityData
+
+// MARK: - Suite: 챌린저 오프셋 검색 디코딩 계약
+
+@Suite("ChallengerSearchOffsetDTO — 디코딩 매핑 (서버 contract)")
+struct ChallengerSearchOffsetDTODecodingTests {
+
+    private func decode(_ json: String) throws -> ChallengerSearchOffsetResultDTO {
+        try JSONDecoder().decode(
+            ChallengerSearchOffsetResultDTO.self,
+            from: Data(json.utf8)
+        )
+    }
+
+    @Test("숫자 식별자를 String 으로 통일하고 profileImageLink·roleTypes 를 매핑한다")
+    func decodesIdentifiersAsStringAndMapsRoles() throws {
+        let json = """
+        {
+          "page": {
+            "content": [
+              {
+                "challengerId": 7, "memberId": 100, "gisuId": 70,
+                "generation": 9, "gisu": 9, "part": "IOS", "name": "홍길동",
+                "nickname": "길동", "schoolName": "한성대", "pointSum": 3,
+                "profileImageLink": "https://img/1.png",
+                "roleTypes": ["CHALLENGER", "BRAND_NEW_ROLE"]
+              }
+            ],
+            "page": 0, "size": 20, "totalElements": 1, "totalPages": 1,
+            "hasNext": false, "hasPrevious": false
+          }
+        }
+        """
+
+        let result = try decode(json)
+        let item = try #require(result.page.content.first)
+
+        #expect(item.challengerId == "7")
+        #expect(item.memberId == "100")
+        #expect(item.gisuId == "70")
+        #expect(item.generation == 9)              // 표시 수치는 Int 유지
+        #expect(item.profileImageURL == "https://img/1.png")
+        #expect(item.roleTypes == [.challenger])   // 미지의 역할은 제외
+    }
+
+    @Test("page 필드가 없으면 빈 페이지로 폴백한다")
+    func missingPageFallsBackToEmpty() throws {
+        let dto = try decode("{}")
+
+        #expect(dto.page.content.isEmpty)
+        #expect(dto.page.hasNext == false)
+    }
+
+    @Test("generation/gisu 가 없으면 nil 로 디코딩한다")
+    func optionalGenerationDecodesNil() throws {
+        let json = """
+        {
+          "page": {
+            "content": [
+              {
+                "challengerId": "7", "memberId": "100", "gisuId": "70",
+                "part": "IOS", "name": "홍길동", "nickname": "길동",
+                "schoolName": "한성대", "pointSum": 0, "roleTypes": []
+              }
+            ],
+            "page": 0, "size": 20, "totalElements": 1, "totalPages": 1,
+            "hasNext": false, "hasPrevious": false
+          }
+        }
+        """
+
+        let result = try decode(json)
+        let item = try #require(result.page.content.first)
+
+        #expect(item.generation == nil)
+        #expect(item.gisu == nil)
+        #expect(item.profileImageURL == nil)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/MemberManagementProfileDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/MemberManagementProfileDTOTests.swift
@@ -1,0 +1,130 @@
+//
+//  MemberManagementProfileDTOTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Testing
+import Foundation
+import UMCFoundation
+@testable import ActivityData
+
+// MARK: - Suite: 멤버 관리 프로필 디코딩 계약
+
+@Suite("MemberManagementProfileDTO — 디코딩 매핑 (서버 contract)")
+struct MemberManagementProfileDTODecodingTests {
+
+    private func decode(_ json: String) throws -> MemberManagementProfileDTO {
+        try JSONDecoder().decode(
+            MemberManagementProfileDTO.self,
+            from: Data(json.utf8)
+        )
+    }
+
+    @Test("숫자/문자 혼재 식별자를 String 으로 통일하고 profileImageLink 를 매핑한다")
+    func decodesIdentifiersAsStringAndMapsImageKey() throws {
+        let json = """
+        {
+          "id": 100, "name": "홍길동", "nickname": "길동", "schoolName": "한성대",
+          "profileImageLink": "https://img/1.png",
+          "roles": [{ "challengerId": 7, "roleType": "SCHOOL_PART_LEADER" }],
+          "challengerRecords": [
+            {
+              "challengerId": "C100", "memberId": 100, "gisu": 7, "gisuId": 70,
+              "part": "IOS", "challengerPoints": [], "points": []
+            }
+          ]
+        }
+        """
+
+        let dto = try decode(json)
+
+        #expect(dto.id == "100")
+        #expect(dto.profileImageURL == "https://img/1.png")
+        #expect(dto.roles.first?.challengerId == "7")
+        #expect(dto.roles.first?.roleType == .schoolPartLeader)
+        #expect(dto.challengerRecords.first?.memberId == "100")
+        #expect(dto.challengerRecords.first?.gisuId == "70")
+        #expect(dto.challengerRecords.first?.gisu == 7)   // 기수 표시 수치는 Int 유지
+    }
+
+    @Test("roleType 이 미지의 값이면 challenger 로 폴백한다")
+    func unknownRoleTypeFallsBackToChallenger() throws {
+        let json = """
+        {
+          "id": "1", "name": "", "nickname": "", "schoolName": "",
+          "roles": [{ "challengerId": null, "roleType": "BRAND_NEW_ROLE" }],
+          "challengerRecords": []
+        }
+        """
+
+        let dto = try decode(json)
+
+        #expect(dto.roles.first?.roleType == .challenger)
+        #expect(dto.roles.first?.challengerId == nil)
+    }
+
+    @Test("resolvedPoints — challengerPoints 가 비면 points 폴백을 사용한다")
+    func resolvedPointsFallsBackToPoints() throws {
+        let json = """
+        {
+          "id": "1", "name": "", "nickname": "", "schoolName": "",
+          "roles": [],
+          "challengerRecords": [
+            {
+              "challengerId": "C1", "memberId": "1", "gisu": 7, "gisuId": "70",
+              "part": "IOS", "challengerPoints": [],
+              "points": [
+                {
+                  "id": "9", "pointType": "STUDY_LATE", "point": -2,
+                  "description": "지각", "createdAt": "2026-06-01T09:00:00.000Z"
+                }
+              ]
+            }
+          ]
+        }
+        """
+
+        let dto = try decode(json)
+        let record = try #require(dto.challengerRecords.first)
+
+        #expect(record.challengerPoints.isEmpty)
+        #expect(record.resolvedPoints.count == 1)
+        #expect(record.resolvedPoints.first?.id == "9")
+        #expect(record.resolvedPoints.first?.point == -2)
+    }
+
+    @Test("resolvedPoints — challengerPoints 가 있으면 그것을 우선한다")
+    func resolvedPointsPrefersChallengerPoints() throws {
+        let json = """
+        {
+          "id": "1", "name": "", "nickname": "", "schoolName": "",
+          "roles": [],
+          "challengerRecords": [
+            {
+              "challengerId": "C1", "memberId": "1", "gisu": 7, "gisuId": "70",
+              "part": "IOS",
+              "challengerPoints": [
+                {
+                  "id": "1", "pointType": "BLOG_CHALLENGE", "point": 3,
+                  "description": "", "createdAt": "2026-06-01T09:00:00.000Z"
+                }
+              ],
+              "points": [
+                {
+                  "id": "2", "pointType": "STUDY_LATE", "point": -2,
+                  "description": "", "createdAt": "2026-06-01T09:00:00.000Z"
+                }
+              ]
+            }
+          ]
+        }
+        """
+
+        let dto = try decode(json)
+        let record = try #require(dto.challengerRecords.first)
+
+        #expect(record.resolvedPoints.map(\.id) == ["1"])
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/MemberRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/MemberRepositoryTests.swift
@@ -1,0 +1,618 @@
+//
+//  MemberRepositoryTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Testing
+import Foundation
+import Moya
+import ActivityDomain
+import UMCFoundation
+@testable import ActivityData
+
+#if DEBUG
+
+// MARK: - Test Double
+
+/// ``NetworkRequesting`` 가짜 구현 (FIFO outcome 큐).
+///
+/// 멤버 조회는 오프셋 검색 후 멤버별 프로필을 순차 호출하므로, 미리 설정한 결과를 순서대로
+/// 반환하고 호출된 라우터의 경로·메서드를 기록해 엔드포인트 계약을 검증합니다.
+private final class StubNetworkRequesting: NetworkRequesting, @unchecked Sendable {
+
+    enum Outcome {
+        case success(Data)
+        case failure(Error)
+    }
+
+    enum StubError: Error {
+        case noOutcomeQueued
+    }
+
+    private var outcomes: [Outcome]
+    private(set) var requestedPaths: [String] = []
+    private(set) var requestedMethods: [Moya.Method] = []
+
+    var requestCount: Int { requestedPaths.count }
+    var lastPath: String? { requestedPaths.last }
+    var lastMethod: Moya.Method? { requestedMethods.last }
+
+    init(_ outcomes: [Outcome]) {
+        self.outcomes = outcomes
+    }
+
+    func request<T: TargetType>(_ target: T) async throws -> Response {
+        requestedPaths.append(target.path)
+        requestedMethods.append(target.method)
+        guard !outcomes.isEmpty else {
+            throw StubError.noOutcomeQueued
+        }
+        switch outcomes.removeFirst() {
+        case .success(let data):
+            return Response(statusCode: 200, data: data)
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+/// 네트워크 실패 전파 검증용 테스트 에러.
+private enum TestError: Error, Equatable {
+    case network
+}
+
+/// ``MemberContextProviding`` 가짜 구현 — 학교·멤버·기수 식별자를 직접 지정합니다.
+private struct StubMemberContext: MemberContextProviding {
+    var schoolId: String?
+    var currentMemberId: String?
+    var gisuId: String?
+
+    init(
+        schoolId: String? = "5",
+        currentMemberId: String? = "100",
+        gisuId: String? = "70"
+    ) {
+        self.schoolId = schoolId
+        self.currentMemberId = currentMemberId
+        self.gisuId = gisuId
+    }
+}
+
+// MARK: - Fixtures
+
+private enum Fixture {
+
+    /// 오프셋 검색 단일 항목.
+    static func offsetItem(
+        memberId: String,
+        challengerId: String = "C100",
+        part: String = "IOS",
+        name: String = "홍길동",
+        gisu: Int = 7,
+        pointSum: Double = 3,
+        roleTypes: [String] = ["CHALLENGER"]
+    ) -> String {
+        let roles = roleTypes.map { "\"\($0)\"" }.joined(separator: ",")
+        return """
+        {
+          "challengerId": "\(challengerId)", "memberId": "\(memberId)", "gisuId": "70",
+          "generation": \(gisu), "gisu": \(gisu), "part": "\(part)", "name": "\(name)",
+          "nickname": "닉", "schoolName": "한성대", "pointSum": \(pointSum),
+          "profileImageLink": null, "roleTypes": [\(roles)]
+        }
+        """
+    }
+
+    /// 오프셋 검색 결과 페이지.
+    static func offsetPage(
+        items: [String],
+        page: Int = 0,
+        hasNext: Bool = false
+    ) -> String {
+        """
+        {
+          "page": {
+            "content": [\(items.joined(separator: ","))],
+            "page": \(page), "size": 20, "totalElements": \(items.count),
+            "totalPages": 1, "hasNext": \(hasNext), "hasPrevious": false
+          }
+        }
+        """
+    }
+
+    /// 단일 상벌점 항목.
+    static func point(
+        id: String,
+        pointType: String,
+        point: Double,
+        createdAt: String,
+        description: String = ""
+    ) -> String {
+        """
+        {
+          "id": "\(id)", "pointType": "\(pointType)", "point": \(point),
+          "description": "\(description)", "createdAt": "\(createdAt)"
+        }
+        """
+    }
+
+    /// 챌린저 활동 레코드.
+    static func record(
+        memberId: String = "100",
+        challengerId: String = "C100",
+        gisu: Int,
+        points: [String]
+    ) -> String {
+        """
+        {
+          "challengerId": "\(challengerId)", "memberId": "\(memberId)", "gisu": \(gisu),
+          "gisuId": "70", "part": "IOS",
+          "challengerPoints": [\(points.joined(separator: ","))], "points": []
+        }
+        """
+    }
+
+    /// 멤버 관리 프로필.
+    static func memberProfile(
+        id: String = "100",
+        name: String = "홍길동",
+        roleType: String = "SCHOOL_PART_LEADER",
+        records: [String]
+    ) -> String {
+        """
+        {
+          "id": "\(id)", "name": "\(name)", "nickname": "닉", "schoolName": "한성대",
+          "profileImageLink": null,
+          "roles": [{ "challengerId": "C100", "roleType": "\(roleType)" }],
+          "challengerRecords": [\(records.joined(separator: ","))]
+        }
+        """
+    }
+
+    /// 챌린저 프로필(포인트 히스토리 전용).
+    static func challengerProfile(points: [String]) -> String {
+        "{ \"challengerPoints\": [\(points.joined(separator: ","))] }"
+    }
+
+    /// 출석 현황 단일 일정.
+    static func schedule(
+        scheduleId: String,
+        name: String,
+        startsAt: String,
+        participantMemberId: String,
+        status: String
+    ) -> String {
+        """
+        {
+          "scheduleId": "\(scheduleId)", "name": "\(name)", "description": "",
+          "startsAt": "\(startsAt)", "endsAt": "\(startsAt)", "isOnline": false,
+          "location": null, "authorMemberId": "7", "attendancePolicy": null, "tags": [],
+          "participants": [
+            {
+              "memberId": "\(participantMemberId)", "name": "참가자", "nickname": "닉",
+              "profileImageUrl": null, "schoolId": "5", "schoolName": "한성대",
+              "attendanceStatus": "\(status)", "isLocationVerified": true, "excuseReason": ""
+            }
+          ]
+        }
+        """
+    }
+
+    static func success(_ resultJSON: String) -> Data {
+        Data("""
+        { "success": true, "code": "200", "message": "성공", "result": \(resultJSON) }
+        """.utf8)
+    }
+
+    static func successArray(_ objects: [String]) -> Data {
+        success("[\(objects.joined(separator: ","))]")
+    }
+
+    static func failureBody(code: String?, message: String?) -> Data {
+        var fields: [String] = ["\"success\": false"]
+        if let code { fields.append("\"code\": \"\(code)\"") }
+        if let message { fields.append("\"message\": \"\(message)\"") }
+        return Data("{ \(fields.joined(separator: ", ")) }".utf8)
+    }
+}
+
+private typealias RepositoryPair = (MemberRepository, StubNetworkRequesting)
+
+private func makeRepository(
+    _ outcomes: [StubNetworkRequesting.Outcome],
+    context: MemberContextProviding = StubMemberContext()
+) -> RepositoryPair {
+    let stub = StubNetworkRequesting(outcomes)
+    let repository = MemberRepository(networkRequesting: stub, context: context)
+    return (repository, stub)
+}
+
+private func makeRepository(
+    _ outcome: StubNetworkRequesting.Outcome,
+    context: MemberContextProviding = StubMemberContext()
+) -> RepositoryPair {
+    makeRepository([outcome], context: context)
+}
+
+// MARK: - Suite: 멤버 목록 조회 계약
+
+@Suite("MemberRepository — 멤버 목록 조회 (도메인 규칙)")
+struct MemberRepositoryListTests {
+
+    @Test("fetchMembersPage — 오프셋 검색 후 프로필을 보강하고 페이지 메타를 매핑한다")
+    func fetchMembersPageMapsAndEnriches() async throws {
+        let page = Fixture.offsetPage(items: [Fixture.offsetItem(memberId: "100")])
+        let profile = Fixture.memberProfile(
+            records: [Fixture.record(gisu: 7, points: [])]
+        )
+        let (sut, stub) = makeRepository([
+            .success(Fixture.success(page)),
+            .success(Fixture.success(profile))
+        ])
+
+        let result = try await sut.fetchMembersPage(page: 0)
+
+        #expect(result.members.count == 1)
+        #expect(result.members.first?.memberID == "100")
+        #expect(result.members.first?.name == "홍길동")
+        #expect(result.hasNext == false)
+        #expect(result.currentPage == 0)
+        #expect(stub.requestedPaths.first == "/api/v1/challenger/search/offset")
+        #expect(stub.requestedPaths.last == "/api/v1/member/profile/100")
+    }
+
+    @Test("fetchMembers — schoolId 가 없으면 네트워크 호출 없이 도메인 에러를 던진다")
+    func fetchMembersThrowsWhenNoSchool() async {
+        let (sut, stub) = makeRepository([], context: StubMemberContext(schoolId: nil))
+
+        await #expect(throws: DomainError.self) {
+            try await sut.fetchMembers()
+        }
+        #expect(stub.requestCount == 0)
+    }
+
+    @Test("fetchMembers — hasNext 가 끝날 때까지 오프셋 페이지를 누적한다")
+    func fetchMembersAccumulatesPages() async throws {
+        let page0 = Fixture.offsetPage(
+            items: [Fixture.offsetItem(memberId: "10")], page: 0, hasNext: true
+        )
+        let page1 = Fixture.offsetPage(
+            items: [Fixture.offsetItem(memberId: "20")], page: 1, hasNext: false
+        )
+        let profile = Fixture.memberProfile(records: [Fixture.record(gisu: 7, points: [])])
+        let (sut, stub) = makeRepository([
+            .success(Fixture.success(page0)),
+            .success(Fixture.success(page1)),
+            .success(Fixture.success(profile)),
+            .success(Fixture.success(profile))
+        ])
+
+        let members = try await sut.fetchMembers()
+
+        #expect(members.count == 2)
+        #expect(stub.requestCount == 4)        // 검색 2회 + 프로필 2회
+    }
+
+    @Test("fetchMembers — 빈 페이지가 hasNext:true 여도 무한 루프 없이 중단한다")
+    func fetchMembersStopsOnEmptyPage() async throws {
+        let emptyPage = Fixture.offsetPage(items: [], hasNext: true)
+        let (sut, stub) = makeRepository(.success(Fixture.success(emptyPage)))
+
+        let members = try await sut.fetchMembers()
+
+        #expect(members.isEmpty)
+        #expect(stub.requestCount == 1)        // 두 번째 페이지를 요청하지 않음
+    }
+
+    @Test("fetchMembersPage — 벌점 항목이 있으면 누적 벌점/상점을 분리 집계한다")
+    func fetchMembersPageAggregatesPoints() async throws {
+        let page = Fixture.offsetPage(items: [Fixture.offsetItem(memberId: "100")])
+        let record = Fixture.record(
+            gisu: 7,
+            points: [
+                Fixture.point(id: "1", pointType: "STUDY_LATE", point: -2,
+                              createdAt: "2026-06-01T09:00:00.000Z"),
+                Fixture.point(id: "2", pointType: "BLOG_CHALLENGE", point: 3,
+                              createdAt: "2026-06-02T09:00:00.000Z")
+            ]
+        )
+        let (sut, _) = makeRepository([
+            .success(Fixture.success(page)),
+            .success(Fixture.success(Fixture.memberProfile(records: [record])))
+        ])
+
+        let result = try await sut.fetchMembersPage(page: 0)
+        let member = try #require(result.members.first)
+
+        #expect(member.penalty == 2)            // abs(-2)
+        #expect(member.rewardPoints == 3)       // abs(3)
+        #expect(member.penaltyHistory.count == 1)
+    }
+
+    @Test("fetchMembersPage — 벌점 항목이 없으면 검색 pointSum 을 폴백 벌점으로 사용한다")
+    func fetchMembersPageUsesFallbackPenalty() async throws {
+        let page = Fixture.offsetPage(
+            items: [Fixture.offsetItem(memberId: "100", pointSum: 5)]
+        )
+        let profile = Fixture.memberProfile(records: [Fixture.record(gisu: 7, points: [])])
+        let (sut, _) = makeRepository([
+            .success(Fixture.success(page)),
+            .success(Fixture.success(profile))
+        ])
+
+        let result = try await sut.fetchMembersPage(page: 0)
+        let member = try #require(result.members.first)
+
+        #expect(member.penalty == 5)
+        #expect(member.penaltyHistory.isEmpty)
+    }
+
+    // 프로필 조회 실패 모드 두 가지 — 서버 거부(success:false)와 스키마 깨짐(malformed JSON).
+    // 두 경우 모두 목록이 폴백 데이터로 "조용히 성공" 하지 않고 에러를 전파해야 한다(silent-failure 회귀 잠금).
+    @Test(
+        "fetchMembers — 프로필 조회 실패는 목록을 조용히 성공시키지 않고 전파한다",
+        arguments: [
+            Fixture.failureBody(code: "MEMBER401", message: "인증 만료"),
+            Data("{ broken".utf8)
+        ]
+    )
+    func fetchMembersPropagatesProfileFailure(_ profileFailure: Data) async {
+        let page = Fixture.offsetPage(items: [Fixture.offsetItem(memberId: "100")])
+        let (sut, _) = makeRepository([
+            .success(Fixture.success(page)),
+            .success(profileFailure)
+        ])
+
+        await #expect(throws: (any Error).self) {
+            try await sut.fetchMembers()
+        }
+    }
+}
+
+// MARK: - Suite: 상벌점 부여 / 삭제 계약
+
+@Suite("MemberRepository — 상벌점 부여/삭제 (도메인 규칙)")
+struct MemberRepositoryPointMutationTests {
+
+    @Test("grantPoint — 챌린저 포인트 엔드포인트로 POST 한다")
+    func grantPointCallsEndpoint() async throws {
+        let (sut, stub) = makeRepository(.success(Fixture.success("null")))
+
+        try await sut.grantPoint(
+            challengerId: "7", pointType: .bestWorkbook, pointValue: 2, description: "굿"
+        )
+
+        #expect(stub.requestCount == 1)
+        #expect(stub.lastPath == "/api/v1/challenger/7/points")
+        #expect(stub.lastMethod == .post)
+    }
+
+    @Test("deletePoint — 챌린저 포인트 삭제 엔드포인트로 DELETE 한다")
+    func deletePointCallsEndpoint() async throws {
+        let (sut, stub) = makeRepository(.success(Fixture.success("null")))
+
+        try await sut.deletePoint(challengerPointId: "99")
+
+        #expect(stub.requestCount == 1)
+        #expect(stub.lastPath == "/api/v1/challenger/points/99")
+        #expect(stub.lastMethod == .delete)
+    }
+
+    @Test("grantPoint — 본문 없는 2xx(빈 본문)도 성공으로 처리한다")
+    func grantPointSucceedsOnEmptyBody() async throws {
+        let (sut, stub) = makeRepository(.success(Data()))
+
+        try await sut.grantPoint(
+            challengerId: "7", pointType: .custom, pointValue: 1, description: "x"
+        )
+
+        #expect(stub.requestCount == 1)
+    }
+
+    @Test("grantPoint — success:false 면 serverError 를 던진다")
+    func grantPointThrowsServerError() async {
+        let (sut, _) = makeRepository(
+            .success(Fixture.failureBody(code: "PT403", message: "권한 없음"))
+        )
+
+        await #expect(
+            throws: RepositoryError.serverError(code: "PT403", message: "권한 없음")
+        ) {
+            try await sut.grantPoint(
+                challengerId: "7", pointType: .out, pointValue: 1, description: "x"
+            )
+        }
+    }
+
+    @Test("deletePoint — success:false 면 serverError 를 던진다")
+    func deletePointThrowsServerError() async {
+        let (sut, _) = makeRepository(
+            .success(Fixture.failureBody(code: "PT404", message: "포인트 없음"))
+        )
+
+        await #expect(
+            throws: RepositoryError.serverError(code: "PT404", message: "포인트 없음")
+        ) {
+            try await sut.deletePoint(challengerPointId: "99")
+        }
+    }
+}
+
+// MARK: - Suite: 포인트 히스토리 / 기수 요약 계약
+
+@Suite("MemberRepository — 포인트 히스토리·기수 요약 (도메인 규칙)")
+struct MemberRepositoryHistoryTests {
+
+    @Test("fetchPointHistory — WARNING 을 제외하고 최신순으로 매핑한다")
+    func fetchPointHistoryExcludesWarningAndSorts() async throws {
+        let profile = Fixture.challengerProfile(points: [
+            Fixture.point(id: "1", pointType: "WARNING", point: 1,
+                          createdAt: "2026-06-01T09:00:00.000Z"),
+            Fixture.point(id: "2", pointType: "OUT", point: 1,
+                          createdAt: "2026-06-03T09:00:00.000Z"),
+            Fixture.point(id: "3", pointType: "BLOG_CHALLENGE", point: 3,
+                          createdAt: "2026-06-02T09:00:00.000Z")
+        ])
+        let (sut, stub) = makeRepository(.success(Fixture.success(profile)))
+
+        let history = try await sut.fetchPointHistory(challengerId: "7")
+
+        #expect(history.count == 2)                       // WARNING 제외
+        #expect(history.map(\.challengerPointId) == ["2", "3"])   // 최신순
+        #expect(history.first?.pointType == .out)
+        #expect(history.first?.penaltyScore == 1)
+        #expect(stub.lastPath == "/api/v1/challenger/7")
+    }
+
+    @Test("fetchPointHistory — challengerPoints 가 없으면 루트 points 폴백을 사용한다")
+    func fetchPointHistoryUsesPointsFallback() async throws {
+        // 서버가 challengerPoints 대신 루트 points 키로 내려주는 형식(레거시 폴백).
+        let pointsFallbackProfile = """
+        { "points": [
+          { "id": "5", "pointType": "STUDY_LATE", "point": -2,
+            "description": "지각", "createdAt": "2026-06-01T09:00:00.000Z" }
+        ] }
+        """
+        let (sut, _) = makeRepository(.success(Fixture.success(pointsFallbackProfile)))
+
+        let history = try await sut.fetchPointHistory(challengerId: "7")
+
+        #expect(history.count == 1)
+        #expect(history.first?.challengerPointId == "5")
+        #expect(history.first?.pointType == .studyLate)
+    }
+
+    @Test("fetchPointHistory — 네트워크 실패를 그대로 전파한다")
+    func fetchPointHistoryPropagatesFailure() async {
+        let (sut, _) = makeRepository(.failure(TestError.network))
+
+        await #expect(throws: TestError.network) {
+            try await sut.fetchPointHistory(challengerId: "7")
+        }
+    }
+
+    @Test("fetchGenerationPointSummaries — 기수별 상/벌점을 분리해 오름차순 정렬한다")
+    func fetchGenerationPointSummariesSplitsAndSorts() async throws {
+        let record7 = Fixture.record(gisu: 7, points: [
+            Fixture.point(id: "1", pointType: "BLOG_CHALLENGE", point: 3,
+                          createdAt: "2026-06-01T09:00:00.000Z"),
+            Fixture.point(id: "2", pointType: "STUDY_LATE", point: -2,
+                          createdAt: "2026-06-01T09:00:00.000Z")
+        ])
+        let record8 = Fixture.record(gisu: 8, points: [
+            Fixture.point(id: "3", pointType: "BEST_WORKBOOK", point: 2,
+                          createdAt: "2026-06-01T09:00:00.000Z")
+        ])
+        let profile = Fixture.memberProfile(records: [record8, record7])
+        let (sut, _) = makeRepository(.success(Fixture.success(profile)))
+
+        let summaries = try await sut.fetchGenerationPointSummaries(memberId: "100")
+
+        #expect(summaries.map(\.gisu) == [7, 8])
+        #expect(summaries.map(\.reward) == [3, 2])
+        #expect(summaries.map(\.penalty) == [2, 0])
+    }
+
+    @Test("fetchAllGenerations — 중복 없는 기수를 오름차순 텍스트로 결합한다")
+    func fetchAllGenerationsJoinsUniqueGisu() async throws {
+        let profile = Fixture.memberProfile(records: [
+            Fixture.record(gisu: 8, points: []),
+            Fixture.record(gisu: 7, points: [])
+        ])
+        let (sut, _) = makeRepository(.success(Fixture.success(profile)))
+
+        let text = try await sut.fetchAllGenerations(memberId: "100")
+
+        #expect(text == "7기, 8기")
+    }
+}
+
+// MARK: - Suite: 출석 이력 조회 계약
+
+@Suite("MemberRepository — 출석 이력 조회 (도메인 규칙)")
+struct MemberRepositoryAttendanceTests {
+
+    @Test("fetchAttendanceRecords — 일정을 시작시각 오름차순 주차로 매핑하고 멤버를 필터링한다")
+    func fetchAttendanceRecordsFiltersAndOrders() async throws {
+        let later = Fixture.schedule(
+            scheduleId: "2", name: "2주차", startsAt: "2026-06-08T09:00:00.000Z",
+            participantMemberId: "100", status: "PRESENT"
+        )
+        let earlier = Fixture.schedule(
+            scheduleId: "1", name: "1주차", startsAt: "2026-06-01T09:00:00.000Z",
+            participantMemberId: "100", status: "LATE"
+        )
+        let (sut, stub) = makeRepository(
+            .success(Fixture.successArray([later, earlier]))
+        )
+
+        let records = try await sut.fetchAttendanceRecords(memberId: "100")
+
+        #expect(records.map(\.sessionTitle) == ["1주차", "2주차"])   // startsAt 오름차순
+        #expect(records.map(\.week) == [1, 2])
+        #expect(records.first?.status == AttendanceStatus(serverStatus: "LATE"))
+        #expect(stub.lastPath == "/api/v2/schedules/attendance")
+    }
+
+    @Test("fetchAttendanceRecords — memberId 가 비면 네트워크 호출 없이 빈 배열을 반환한다")
+    func fetchAttendanceRecordsShortCircuitsOnEmptyId() async throws {
+        let (sut, stub) = makeRepository([])
+
+        let records = try await sut.fetchAttendanceRecords(memberId: "")
+
+        #expect(records.isEmpty)
+        #expect(stub.requestCount == 0)
+    }
+}
+
+// MARK: - Suite: UserDefaults 컨텍스트 제공자 계약
+
+@Suite("UserDefaultsMemberContextProvider — 식별자 해석 (도메인 규칙)")
+struct UserDefaultsMemberContextProviderTests {
+
+    /// 테스트마다 고유 suite 이름으로 격리해 잔여 값/병렬 실행 간섭을 차단합니다.
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "test.member.context.\(name)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test("String 저장값을 우선 사용한다")
+    func prefersStringValue() {
+        let defaults = makeDefaults("prefers")
+        defaults.set("42", forKey: "schoolId")
+        defaults.set("100", forKey: "memberId")
+        defaults.set("7", forKey: "gisuId")
+        let context = UserDefaultsMemberContextProvider(defaults: defaults)
+
+        #expect(context.schoolId == "42")
+        #expect(context.currentMemberId == "100")
+        #expect(context.gisuId == "7")
+    }
+
+    @Test("String 값이 없으면 레거시 Int 저장값을 문자열로 변환한다")
+    func fallsBackToLegacyInt() {
+        let defaults = makeDefaults("legacyInt")
+        defaults.set(42, forKey: "schoolId")
+        let context = UserDefaultsMemberContextProvider(defaults: defaults)
+
+        #expect(context.schoolId == "42")
+    }
+
+    @Test("키가 없으면 nil 을 반환한다")
+    func returnsNilWhenAbsent() {
+        // 미설정(키 부재)이 실제 '미설정' 상태다. `UserDefaults.string(forKey:)` 는 저장된
+        // 숫자를 문자열로 강제 변환하므로, 키 부재 케이스로 nil 분기를 검증한다.
+        let defaults = makeDefaults("nilCase")
+        let context = UserDefaultsMemberContextProvider(defaults: defaults)
+
+        #expect(context.schoolId == nil)
+        #expect(context.currentMemberId == nil)
+        #expect(context.gisuId == nil)
+    }
+}
+
+#endif

--- a/UMCApp/Features/Activity/Data/Tests/MemberRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/MemberRepositoryTests.swift
@@ -90,6 +90,7 @@ private enum Fixture {
         challengerId: String = "C100",
         part: String = "IOS",
         name: String = "홍길동",
+        nickname: String = "닉",
         gisu: Int = 7,
         pointSum: Double = 3,
         roleTypes: [String] = ["CHALLENGER"]
@@ -99,7 +100,7 @@ private enum Fixture {
         {
           "challengerId": "\(challengerId)", "memberId": "\(memberId)", "gisuId": "70",
           "generation": \(gisu), "gisu": \(gisu), "part": "\(part)", "name": "\(name)",
-          "nickname": "닉", "schoolName": "한성대", "pointSum": \(pointSum),
+          "nickname": "\(nickname)", "schoolName": "한성대", "pointSum": \(pointSum),
           "profileImageLink": null, "roleTypes": [\(roles)]
         }
         """
@@ -158,12 +159,13 @@ private enum Fixture {
     static func memberProfile(
         id: String = "100",
         name: String = "홍길동",
+        nickname: String = "닉",
         roleType: String = "SCHOOL_PART_LEADER",
         records: [String]
     ) -> String {
         """
         {
-          "id": "\(id)", "name": "\(name)", "nickname": "닉", "schoolName": "한성대",
+          "id": "\(id)", "name": "\(name)", "nickname": "\(nickname)", "schoolName": "한성대",
           "profileImageLink": null,
           "roles": [{ "challengerId": "C100", "roleType": "\(roleType)" }],
           "challengerRecords": [\(records.joined(separator: ","))]
@@ -347,6 +349,34 @@ struct MemberRepositoryListTests {
 
         #expect(member.penalty == 5)
         #expect(member.penaltyHistory.isEmpty)
+    }
+
+    // 검색 응답의 닉네임이 중간 모델에서 유실돼, 프로필 닉네임이 비면 '이름'이 닉네임 자리로 새던
+    // 회귀(리뷰 지적). 닉네임은 프로필 우선, 프로필이 비면 검색 닉네임으로 폴백해야 한다(이름 아님).
+    @Test(
+        "fetchMembersPage — 닉네임은 프로필 우선, 프로필이 비면 검색 닉네임으로 폴백한다",
+        arguments: [("프로필닉", "프로필닉"), ("", "검색닉")]
+    )
+    func fetchMembersPageResolvesNickname(
+        _ profileNickname: String,
+        _ expected: String
+    ) async throws {
+        let page = Fixture.offsetPage(
+            items: [Fixture.offsetItem(memberId: "100", name: "홍길동", nickname: "검색닉")]
+        )
+        let profile = Fixture.memberProfile(
+            name: "홍길동",
+            nickname: profileNickname,
+            records: [Fixture.record(gisu: 7, points: [])]
+        )
+        let (sut, _) = makeRepository([
+            .success(Fixture.success(page)),
+            .success(Fixture.success(profile))
+        ])
+
+        let member = try #require(try await sut.fetchMembersPage(page: 0).members.first)
+
+        #expect(member.nickname == expected)
     }
 
     // 프로필 조회 실패 모드 두 가지 — 서버 거부(success:false)와 스키마 깨짐(malformed JSON).

--- a/UMCApp/Features/Activity/Data/Tests/StudyRouterMemberPointTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRouterMemberPointTests.swift
@@ -1,0 +1,162 @@
+//
+//  StudyRouterMemberPointTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 6/28/26.
+//
+
+import Foundation
+import Testing
+import Moya
+import Alamofire
+import UMCFoundation
+@testable import ActivityData
+
+// MARK: - Helpers
+
+private func requestParameters(
+    of task: Moya.Task
+) -> (parameters: [String: Any], encoding: ParameterEncoding)? {
+    guard case let .requestParameters(parameters, encoding) = task else {
+        return nil
+    }
+    return (parameters, encoding)
+}
+
+private func makePointBody() -> ChallengerPointCreateRequestDTO {
+    ChallengerPointCreateRequestDTO(
+        pointType: .blogChallenge,
+        pointValue: 3,
+        description: "블로그 챌린지 완료"
+    )
+}
+
+// MARK: - Suite: 멤버/포인트 path·method 계약
+
+@Suite("StudyRouter — 멤버/포인트 엔드포인트 매핑 (API 계약)")
+struct StudyRouterMemberPointPathMethodTests {
+
+    @Test("각 멤버/포인트 case 는 명세된 path 로 매핑된다")
+    func pathMapsEachCase() {
+        let search = StudyRouter.searchChallengersOffset(
+            query: ChallengerSearchQuery(page: 0, size: 20, schoolId: "5")
+        )
+        let create = StudyRouter.createChallengerPoint(
+            challengerId: "7", body: makePointBody()
+        )
+        let delete = StudyRouter.deleteChallengerPoint(challengerPointId: "99")
+        let profile = StudyRouter.getChallengerProfile(challengerId: "7")
+
+        #expect(search.path == "/api/v1/challenger/search/offset")
+        #expect(create.path == "/api/v1/challenger/7/points")
+        #expect(delete.path == "/api/v1/challenger/points/99")
+        #expect(profile.path == "/api/v1/challenger/7")
+    }
+
+    @Test("searchChallengersOffset / getChallengerProfile 의 method 는 GET 이다")
+    func getMethods() {
+        let search = StudyRouter.searchChallengersOffset(
+            query: ChallengerSearchQuery(page: 0, size: 20, schoolId: "5")
+        )
+        let profile = StudyRouter.getChallengerProfile(challengerId: "7")
+
+        #expect(search.method == .get)
+        #expect(profile.method == .get)
+    }
+
+    @Test("createChallengerPoint 의 method 는 POST 이다")
+    func createMethodIsPost() {
+        let create = StudyRouter.createChallengerPoint(
+            challengerId: "7", body: makePointBody()
+        )
+        #expect(create.method == .post)
+    }
+
+    @Test("deleteChallengerPoint 의 method 는 DELETE 이다")
+    func deleteMethodIsDelete() {
+        let delete = StudyRouter.deleteChallengerPoint(challengerPointId: "99")
+        #expect(delete.method == .delete)
+    }
+}
+
+// MARK: - Suite: 멤버/포인트 task 형태 계약
+
+@Suite("StudyRouter — 멤버/포인트 task 형태 계약")
+struct StudyRouterMemberPointTaskTests {
+
+    @Test("searchChallengersOffset 는 query DTO 를 queryString 으로 인코딩한다")
+    func searchTaskEncodesQueryString() throws {
+        let router = StudyRouter.searchChallengersOffset(
+            query: ChallengerSearchQuery(page: 2, size: 20, schoolId: "5")
+        )
+
+        let extracted = try #require(requestParameters(of: router.task))
+
+        #expect(extracted.parameters["page"] as? Int == 2)
+        #expect(extracted.parameters["size"] as? Int == 20)
+        #expect(extracted.parameters["schoolId"] as? String == "5")
+        #expect((extracted.encoding as? URLEncoding)?.destination == .queryString)
+    }
+
+    @Test("createChallengerPoint 의 task 는 requestJSONEncodable 이다")
+    func createTaskIsJSONEncodable() {
+        let router = StudyRouter.createChallengerPoint(
+            challengerId: "7", body: makePointBody()
+        )
+        if case .requestJSONEncodable = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestJSONEncodable 여야 함 — 실제: \(router.task)")
+        }
+    }
+
+    @Test(
+        "조회/삭제 case 의 task 는 requestPlain 이다",
+        arguments: [
+            StudyRouter.deleteChallengerPoint(challengerPointId: "99"),
+            StudyRouter.getChallengerProfile(challengerId: "7")
+        ]
+    )
+    func plainTasks(router: StudyRouter) {
+        if case .requestPlain = router.task {
+            // 기대하는 case
+        } else {
+            Issue.record("task가 .requestPlain 여야 함 — 실제: \(router.task)")
+        }
+    }
+}
+
+// MARK: - Suite: ChallengerSearchQuery / Request DTO 인코딩 계약
+
+@Suite("ChallengerSearchQuery·ChallengerPointCreateRequestDTO — 인코딩 계약")
+struct ChallengerSearchAndPointDTOEncodingTests {
+
+    @Test("ChallengerSearchQuery — page/size 는 Int, schoolId 는 String 으로 캡슐화한다")
+    func searchQueryParameters() {
+        let query = ChallengerSearchQuery(page: 1, size: 20, schoolId: "5")
+
+        let parameters = query.toParameters
+
+        #expect(parameters.count == 3)
+        #expect(parameters["page"] as? Int == 1)
+        #expect(parameters["size"] as? Int == 20)
+        #expect(parameters["schoolId"] as? String == "5")
+        #expect(parameters["schoolId"] as? Int == nil)      // 식별자는 숫자가 아님
+    }
+
+    @Test("ChallengerPointCreateRequestDTO — pointType 은 서버 rawValue, 배점은 정수로 직렬화한다")
+    func pointCreateDTOEncoding() throws {
+        let dto = ChallengerPointCreateRequestDTO(
+            pointType: .blogChallenge, pointValue: 3, description: "완료"
+        )
+        let data = try JSONEncoder().encode(dto)
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        #expect(json["pointType"] as? String == "BLOG_CHALLENGE")
+        #expect(json["pointValue"] as? Int == 3)
+        #expect(json["description"] as? String == "완료")
+        #expect(json.keys.count == 3)
+    }
+}


### PR DESCRIPTION
resolves #893

## ✨ PR 유형

♻️ [Refactor] — 레거시 `AppProduct/` 의 MemberRepository 를 `UMCApp/Features/Activity/Data` (Tuist) 모듈로 이식하고 `MemberRepositoryProtocol` 을 채택합니다.

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="1012" alt="스크린샷 2026-07-11 오후 10 14 00" src="https://github.com/user-attachments/assets/b37ffd04-107d-4157-ad39-3b6b0cdca3d8" />
<img width="1512" height="1012" alt="스크린샷 2026-07-11 오후 10 14 14" src="https://github.com/user-attachments/assets/41236192-84f3-487d-b077-0092f8cca292" />



> ⚠️ **테스트 검증 캡쳐 첨부 예정** — `make test SCHEME=ActivityData` 전체 성공 화면 + 커버리지 (CI 미적용 한시 정책)

## 🛠️ 작업내용

- **StudyRouter** 에 챌린저 검색·포인트·프로필 case 4종 확장 (`searchChallengersOffset` / `createChallengerPoint` / `deleteChallengerPoint` / `getChallengerProfile`) — path·method·task 매핑, Query/Body DTO 캡슐화
- **멤버 관리 Response DTO** 이식 — custom `init(from:)`/`encode(to:)` + flexible 디코딩(서버 정수 `String` 통일), `profileImageLink`→`profileImageURL` 매핑, `roleType` 미인식 값 방어적 폴백
- **MemberRepository** 구현체 이식 — `MemberRepositoryProtocol` 메서드 실구현, offset 페이지네이션(빈 페이지 가드), 멤버 프로필 보강, 포인트 상/벌점 분리
- **MyPage 모듈 의존 제거** — challenger 프로필 엔드포인트 로컬 이식(`ChallengerProfileDTO`)으로 모듈 간 결합 차단
- 접근제어: Router/DTO `internal` + Repository 구현체 `public`
- **단위 테스트** — Repository / Router 계약 / DTO 디코딩 (Swift Testing)

## 📋 추후 진행 상황

- MyPage 의존: 로컬 이식으로 해소. 공용 challenger-profile 엔드포인트 Core 승격 시 통합 검토
- 멤버 프로필 순차 조회 → `withTaskGroup` 병렬화(성능) 별도 티켓
- `ChallengerPointType.warning/.out` 의 reward 분류 quirk → explicit classification policy 별도 티켓

## 📌 리뷰 포인트

- `Data/Sources/Routers/StudyRouter.swift` — 추가 4개 case 의 path/method/task 및 Query·Body DTO 캡슐화(인라인 딕셔너리 금지 준수)
- `Data/Sources/Repositories/MemberRepository.swift` — 멤버 프로필 보강 실패를 **삼키지 않고 전파**(silent-failure 방지, 형제 `StudyRepository` 와 동일 정책) + offset 빈 페이지 가드. 회귀 테스트 2건으로 고정
- `Data/Sources/DTOs/*` — Response DTO custom Codable + 서버 정수 `String` 통일 + `profileImageLink` 키 매핑

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
