### PR TITLE
✨ [Feat] 홈 - 최근 공지 섹션 이식 (Home 슬라이스 3)

### DIFF
--- a/UMCApp/Features/Home/Domain/Sources/UseCases/FetchRecentNoticesUseCaseProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/FetchRecentNoticesUseCaseProtocol.swift
@@ -1,0 +1,8 @@
+import NoticeDomain
+
+/// 홈 화면 내 최근 공지 조회 UseCase 인터페이스
+public protocol FetchRecentNoticesUseCaseProtocol {
+    /// - Parameter gisuId: 최신 기수 식별자 (서버 정수를 String으로 보존, 절대규칙 #2)
+    /// - Returns: 최신순 최근 공지 목록 (상위 5건)
+    func execute(gisuId: String) async throws -> [NoticeItemModel]
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchRecentNoticesUseCase.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchRecentNoticesUseCase.swift
@@ -1,0 +1,41 @@
+import NoticeDomain
+
+/// 홈 화면 최근 공지 조회 UseCase 구현체
+///
+/// 최신 기수의 공지사항을 최신순으로 조회해 상위 5건만 반환한다.
+/// 목록/상세 조회 파이프라인은 `NoticeDomain`/`NoticeData`에 이미 이식되어 있어
+/// 그대로 재사용하고, "최근 5건" 조합 로직만 홈 전용으로 추가한다.
+public final class FetchRecentNoticesUseCase: FetchRecentNoticesUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: NoticeRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: NoticeRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(gisuId: String) async throws -> [NoticeItemModel] {
+        let request = NoticeListRequest(
+            gisuId: gisuId,
+            chapterId: nil,
+            schoolId: nil,
+            part: nil,
+            page: Constants.firstPage,
+            size: Constants.recentNoticeCount,
+            sort: Constants.sortByCreatedAtDescending
+        )
+        let page = try await repository.getAllNotices(request: request)
+        return Array(page.items.prefix(Constants.recentNoticeCount))
+    }
+}
+
+private enum Constants {
+    static let firstPage = 0
+    static let recentNoticeCount = 5
+    static let sortByCreatedAtDescending = ["createdAt,DESC"]
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/RecentNoticeCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/RecentNoticeCard.swift
@@ -1,0 +1,137 @@
+import CoreDesignSystem
+import NoticeDomain
+import SwiftUI
+import UMCFoundation
+
+/// 홈 화면 최근 공지 카드 — 공지 출처 아이콘, 제목, 상대 시간을 한 행에 표시한다.
+struct RecentNoticeCard: View {
+
+    // MARK: - Property
+
+    let notice: NoticeItemModel
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let iconSize: CGFloat = 36
+        static let iconPadding: CGFloat = 8
+        static let iconCornerRadius: CGFloat = 24
+        static let rowPadding = EdgeInsets(top: 20, leading: 16, bottom: 20, trailing: 16)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            icon
+            info
+            Spacer(minLength: 0)
+            relativeDate
+        }
+        .padding(Constants.rowPadding)
+        .glassEffect(
+            .regular,
+            in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
+        )
+    }
+
+    // MARK: - Component
+
+    private var icon: some View {
+        Image(systemName: scopeIcon)
+            .font(.title2)
+            .foregroundStyle(scopeColor)
+            .frame(width: Constants.iconSize, height: Constants.iconSize)
+            .padding(Constants.iconPadding)
+            .background {
+                RoundedRectangle(cornerRadius: Constants.iconCornerRadius)
+                    .fill(scopeColor.opacity(0.4))
+            }
+            .glassEffect(.clear, in: .rect(cornerRadius: Constants.iconCornerRadius))
+    }
+
+    private var info: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+            Text(scopeLabel)
+                .appFont(.caption1, weight: .semibold, color: .grey500)
+            Text(notice.title)
+                .appFont(.subheadline, weight: .semibold, color: .grey900)
+                .lineLimit(1)
+        }
+    }
+
+    private var relativeDate: some View {
+        Text(notice.date.timeAgoText)
+            .appFont(.caption1, color: .grey500)
+    }
+
+    // MARK: - Function
+
+    /// 공지 출처(scope)별 아이콘. Notice 목록의 태그 색상 체계(`.orange500`/`.green500`)와 일관되게 맞춘다.
+    private var scopeIcon: String {
+        switch notice.scope {
+        case .central: "megaphone.fill"
+        case .branch: "network"
+        case .campus: "graduationcap.fill"
+        }
+    }
+
+    private var scopeColor: Color {
+        switch notice.scope {
+        case .central: .indigo500
+        case .branch: .orange500
+        case .campus: .green500
+        }
+    }
+
+    private var scopeLabel: String {
+        switch notice.scope {
+        case .central:
+            return "중앙운영사무국"
+        case .branch:
+            let displayName = notice.scopeDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return displayName.isEmpty ? "지부" : displayName
+        case .campus:
+            return "학교"
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    VStack(spacing: DefaultSpacing.spacing12) {
+        RecentNoticeCard(notice: NoticeItemModel(
+            generation: "12",
+            scope: .central,
+            category: .general,
+            mustRead: true,
+            isAlert: false,
+            date: Date(timeIntervalSinceNow: -3600),
+            title: "12기 중앙 해커톤 일정 안내",
+            content: "",
+            writer: "운영진",
+            links: [],
+            images: [],
+            vote: nil,
+            viewCount: "32"
+        ))
+        RecentNoticeCard(notice: NoticeItemModel(
+            generation: "12",
+            scope: .branch,
+            category: .general,
+            mustRead: false,
+            isAlert: false,
+            date: Date(timeIntervalSinceNow: -86400),
+            title: "서울 지부 스터디 모집 공지",
+            content: "",
+            writer: "지부장",
+            links: [],
+            images: [],
+            vote: nil,
+            viewCount: "12",
+            scopeDisplayName: "서울"
+        ))
+    }
+    .padding()
+}

--- a/UMCApp/Features/Home/Presentation/Sources/HomeFeatureView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/HomeFeatureView.swift
@@ -1,4 +1,5 @@
 import CoreDI
+import NoticeDomain
 import SwiftUI
 
 /// 홈 탭 진입점 — 루트 탭 셸의 `NavigationStack` 안에서 홈 대시보드를 표시한다.
@@ -7,14 +8,20 @@ public struct HomeFeatureView: View {
     // MARK: - Property
 
     @Environment(\.di) private var di
+    private let onNoticeSelected: (NoticeDetail) -> Void
 
     // MARK: - Init
 
-    public init() {}
+    /// - Parameter onNoticeSelected: 최근 공지 카드 탭 시 상세 화면 이동을 상위(App)에 위임하는 콜백.
+    ///   Home Feature는 App 타깃의 전역 `NavigationDestination`을 참조할 수 없어(Feature → App 의존
+    ///   방향 금지) 실제 push는 호출부(`RootTabView`)에서 수행한다.
+    public init(onNoticeSelected: @escaping (NoticeDetail) -> Void) {
+        self.onNoticeSelected = onNoticeSelected
+    }
 
     // MARK: - Body
 
     public var body: some View {
-        HomeView(container: di)
+        HomeView(container: di, onNoticeSelected: onNoticeSelected)
     }
 }

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
@@ -1,9 +1,10 @@
 import CoreDI
 import Foundation
 import HomeDomain
+import NoticeDomain
 import UMCFoundation
 
-/// 홈 화면(시즌/세대 카드) ViewModel
+/// 홈 화면(시즌/세대 카드/최근 공지) ViewModel
 @Observable
 @MainActor
 public final class HomeViewModel {
@@ -12,13 +13,16 @@ public final class HomeViewModel {
 
     public private(set) var seasonState: Loadable<[SeasonType]> = .idle
     public private(set) var generationState: Loadable<[HomeGeneration]> = .idle
+    public private(set) var recentNoticeState: Loadable<[NoticeItemModel]> = .idle
 
     private let fetchMyProfileUseCase: FetchHomeProfileUseCaseProtocol
+    private let fetchRecentNoticesUseCase: FetchRecentNoticesUseCaseProtocol
 
     // MARK: - Init
 
     public init(container: DIContainer) {
         fetchMyProfileUseCase = container.resolve(FetchHomeProfileUseCaseProtocol.self)
+        fetchRecentNoticesUseCase = container.resolve(FetchRecentNoticesUseCaseProtocol.self)
     }
 
     // MARK: - Function
@@ -30,6 +34,7 @@ public final class HomeViewModel {
     }
 
     /// 내 프로필을 조회해 시즌/세대 카드 상태를 갱신한다. 실패 시 인라인 `.failed` 상태로 표시한다.
+    /// 세대 조회가 성공하면 최신 기수를 기준으로 최근 공지도 함께 조회한다.
     public func fetchProfile() async {
         if seasonState.isLoading { return }
 
@@ -40,8 +45,10 @@ public final class HomeViewModel {
 
         do {
             let profile = try await fetchMyProfileUseCase.execute()
+            let sortedGenerations = sortedByGenerationDescending(profile.generations)
             seasonState = .loaded(profile.seasonTypes)
-            generationState = .loaded(sortedByGenerationDescending(profile.generations))
+            generationState = .loaded(sortedGenerations)
+            await fetchRecentNotices(latestGisuId: sortedGenerations.first?.gisuId)
         } catch is CancellationError {
             seasonState = previousSeasonState
             generationState = previousGenerationState
@@ -58,9 +65,35 @@ public final class HomeViewModel {
 
     // MARK: - Private Function
 
+    /// 최신 기수의 최근 공지 5건을 조회한다. 소속 기수가 없으면 빈 목록으로 처리한다.
+    private func fetchRecentNotices(latestGisuId: String?) async {
+        guard let gisuId = latestGisuId, !gisuId.isEmpty else {
+            recentNoticeState = .loaded([])
+            return
+        }
+
+        recentNoticeState = .loading
+
+        do {
+            let notices = try await fetchRecentNoticesUseCase.execute(gisuId: gisuId)
+            recentNoticeState = .loaded(notices)
+        } catch is CancellationError {
+            recentNoticeState = .idle
+        } catch let error as RepositoryError {
+            recentNoticeState = .failed(.repository(error))
+        } catch let error as NetworkError {
+            recentNoticeState = .failed(.network(error))
+        } catch let error as AppError {
+            recentNoticeState = .failed(error)
+        } catch {
+            recentNoticeState = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
     private func setFailed(_ error: AppError) {
         seasonState = .failed(error)
         generationState = .failed(error)
+        recentNoticeState = .failed(error)
     }
 
     /// 기수(`gen`)는 서버 정수를 `String`으로 보존하므로 정렬 시점에만 `Int`로 환원한다.

--- a/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
@@ -2,25 +2,28 @@ import CoreDesignSystem
 import CoreDI
 import CoreUIComponents
 import HomeDomain
+import NoticeDomain
 import SwiftUI
 import UMCFoundation
 
 /// 홈 대시보드 메인 화면.
 ///
-/// 슬라이스 1(#913) 범위: 진입 시 프로필을 로드해 시즌 카드와 세대별 상벌점 카드를
-/// 표시한다. 캘린더/최근 공지 등 나머지 섹션은 후속 슬라이스에서 추가된다.
+/// 슬라이스 1(#913) 범위: 진입 시 프로필을 로드해 시즌 카드와 세대별 상벌점 카드를 표시한다.
+/// 슬라이스 3(#915) 범위: 최신 기수의 최근 공지 5건을 표시하고, 탭 시 상세 화면으로 이동한다.
 /// `NavigationStack`은 루트 탭 셸이 소유하므로 이 뷰는 콘텐츠만 구성한다.
 struct HomeView: View {
 
     // MARK: - Property
 
     @State private var viewModel: HomeViewModel
+    private let onNoticeSelected: (NoticeDetail) -> Void
 
     // MARK: - Constants
 
     fileprivate enum Constants {
         static let seasonPlaceholderHeight: CGFloat = 120
         static let penaltyPlaceholderHeight: CGFloat = 240
+        static let recentNoticePlaceholderHeight: CGFloat = 280
     }
 
     // MARK: - Init
@@ -28,8 +31,14 @@ struct HomeView: View {
     /// - Parameters:
     ///   - container: UseCase를 resolve할 DI 컨테이너
     ///   - viewModel: 프리뷰/테스트용 주입 지점 (기본값: container로 생성)
-    init(container: DIContainer, viewModel: HomeViewModel? = nil) {
+    ///   - onNoticeSelected: 최근 공지 카드 탭 시 상세 화면 이동을 위임하는 콜백
+    init(
+        container: DIContainer,
+        viewModel: HomeViewModel? = nil,
+        onNoticeSelected: @escaping (NoticeDetail) -> Void = { _ in }
+    ) {
         _viewModel = State(initialValue: viewModel ?? HomeViewModel(container: container))
+        self.onNoticeSelected = onNoticeSelected
     }
 
     // MARK: - Body
@@ -39,6 +48,7 @@ struct HomeView: View {
             LazyVStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
                 seasonSection
                 generationSection
+                recentNoticeSection
             }
             .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
         }
@@ -115,6 +125,52 @@ struct HomeView: View {
         }
     }
 
+    // MARK: - Recent Notice Section
+
+    /// 최근 공지 섹션. 프로필 조회에 종속되므로 실패 안내는 `seasonSection`이 대표한다.
+    @ViewBuilder
+    private var recentNoticeSection: some View {
+        switch viewModel.recentNoticeState {
+        case .idle, .loading:
+            loadingPlaceholder(height: Constants.recentNoticePlaceholderHeight)
+        case .loaded(let notices):
+            recentNoticeLoaded(notices)
+        case .failed:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func recentNoticeLoaded(_ notices: [NoticeItemModel]) -> some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text("최근 공지")
+                .appFont(.title3, weight: .semibold, color: .grey900)
+
+            if notices.isEmpty {
+                ContentUnavailableView(
+                    "최근 공지가 없습니다.",
+                    systemImage: "bell.slash",
+                    description: Text("아직 등록된 공지사항이 없습니다.")
+                )
+                .glassEffect(
+                    .regular,
+                    in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
+                )
+            } else {
+                VStack(spacing: DefaultSpacing.spacing12) {
+                    ForEach(notices) { notice in
+                        Button {
+                            onNoticeSelected(notice.toNoticeDetail())
+                        } label: {
+                            RecentNoticeCard(notice: notice)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+
     // MARK: - Component
 
     private func loadingPlaceholder(height: CGFloat) -> some View {
@@ -153,9 +209,49 @@ private struct PreviewFetchHomeProfileUseCase: FetchHomeProfileUseCaseProtocol {
     }
 }
 
+/// 네트워크 없이 최근 공지 화면을 확인하기 위한 프리뷰 전용 UseCase (절대규칙 #5)
+private struct PreviewFetchRecentNoticesUseCase: FetchRecentNoticesUseCaseProtocol {
+    func execute(gisuId: String) async throws -> [NoticeItemModel] {
+        [
+            NoticeItemModel(
+                generation: "12",
+                scope: .central,
+                category: .general,
+                mustRead: true,
+                isAlert: false,
+                date: Date(timeIntervalSinceNow: -3600),
+                title: "12기 중앙 해커톤 일정 안내",
+                content: "",
+                writer: "운영진",
+                links: [],
+                images: [],
+                vote: nil,
+                viewCount: "32"
+            ),
+            NoticeItemModel(
+                generation: "12",
+                scope: .branch,
+                category: .general,
+                mustRead: false,
+                isAlert: false,
+                date: Date(timeIntervalSinceNow: -86400),
+                title: "서울 지부 스터디 모집 공지",
+                content: "",
+                writer: "지부장",
+                links: [],
+                images: [],
+                vote: nil,
+                viewCount: "12",
+                scopeDisplayName: "서울"
+            ),
+        ]
+    }
+}
+
 #Preview {
     let container = DIContainer()
     container.register(FetchHomeProfileUseCaseProtocol.self) { PreviewFetchHomeProfileUseCase() }
+    container.register(FetchRecentNoticesUseCaseProtocol.self) { PreviewFetchRecentNoticesUseCase() }
     return NavigationStack {
         HomeView(container: container)
     }

--- a/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
+++ b/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
@@ -1,6 +1,7 @@
 import CoreDI
 import Foundation
 import HomeDomain
+import NoticeDomain
 import Testing
 import UMCFoundation
 @testable import HomePresentation
@@ -105,10 +106,15 @@ struct HomeViewModelTests {
 private struct DummyError: Error {}
 
 @MainActor
-private func makeViewModel(useCase: FetchHomeProfileUseCaseProtocol? = nil) -> HomeViewModel {
+private func makeViewModel(
+    useCase: FetchHomeProfileUseCaseProtocol? = nil,
+    recentNoticesUseCase: FetchRecentNoticesUseCaseProtocol? = nil
+) -> HomeViewModel {
     let useCase = useCase ?? MockFetchHomeProfileUseCase()
+    let recentNoticesUseCase = recentNoticesUseCase ?? MockFetchRecentNoticesUseCase()
     let container = DIContainer()
     container.register(FetchHomeProfileUseCaseProtocol.self) { useCase }
+    container.register(FetchRecentNoticesUseCaseProtocol.self) { recentNoticesUseCase }
     return HomeViewModel(container: container)
 }
 
@@ -141,5 +147,13 @@ private final class MockFetchHomeProfileUseCase: FetchHomeProfileUseCaseProtocol
             try await Task.sleep(nanoseconds: delayNanoseconds)
         }
         return try result.get()
+    }
+}
+
+private final class MockFetchRecentNoticesUseCase: FetchRecentNoticesUseCaseProtocol, @unchecked Sendable {
+    var result: Result<[NoticeItemModel], Error> = .success([])
+
+    func execute(gisuId: String) async throws -> [NoticeItemModel] {
+        try result.get()
     }
 }

--- a/UMCApp/Features/Home/Project.swift
+++ b/UMCApp/Features/Home/Project.swift
@@ -3,6 +3,10 @@ import ProjectDescriptionHelpers
 
 let project = featureProject(
     name: "Home",
+    domainExtraDependencies: [
+        // 최근 공지(#915)가 NoticeDomain의 조회 파이프라인(NoticeItemModel/NoticeListRequest 등)을 재사용한다.
+        .project(target: "NoticeDomain", path: .relativeToRoot("Features/Notice")),
+    ],
     dataExtraDependencies: [
         .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
     ],
@@ -10,6 +14,7 @@ let project = featureProject(
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
+        .project(target: "NoticeDomain", path: .relativeToRoot("Features/Notice")),
     ],
     includesDomainTests: true,
     domainTestDependencies: [
@@ -27,6 +32,7 @@ let project = featureProject(
     presentationTestDependencies: [
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
+        .project(target: "NoticeDomain", path: .relativeToRoot("Features/Notice")),
         .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
     ]
 )

--- a/UMCApp/UMCApp/Sources/DIContainer+Home.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Home.swift
@@ -3,6 +3,7 @@ import CoreDomain
 import CoreNetwork
 import HomeData
 import HomeDomain
+import NoticeDomain
 
 extension DIContainer {
     func registerHomeDependencies() {
@@ -14,6 +15,9 @@ extension DIContainer {
         }
         register(FetchHomeProfileUseCaseProtocol.self) {
             FetchHomeProfileUseCase(repository: self.resolve(HomeRepositoryProtocol.self))
+        }
+        register(FetchRecentNoticesUseCaseProtocol.self) {
+            FetchRecentNoticesUseCase(repository: self.resolve(NoticeRepositoryProtocol.self))
         }
     }
 }

--- a/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
+++ b/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
@@ -66,7 +66,9 @@ struct RootTabView: View {
     private func tabContent(_ tab: TabCase) -> some View {
         switch tab {
         case .home:
-            HomeFeatureView()
+            HomeFeatureView { detailItem in
+                pathStore.homePath.append(.notice(.detail(detailItem: detailItem)))
+            }
         case .notice:
             // TODO: NoticePresentation의 실제 NoticeView 연결 (Notice 탭 실연결 후속 이슈)
             NoticeFeatureView()


### PR DESCRIPTION
## ✨ PR 유형

Feature — 홈 대시보드 최근 공지 섹션 이식 (`AppProduct` → `UMCApp` 마이그레이션, Phase 2 홈 슬라이스 3)

Resolves #915

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 관련 작업이라면 영상으로 올려주세요
그 외에는 스크린샷으로 올려도 무방합니다.
어떤 작업을 하였는지 시각적으로 바로 확인 가능하게 해주세요! -->

## 🛠️ 작업내용

- **재사용 검토**: Notice 모듈(NoticeDomain/NoticeData)의 조회 파이프라인을 100% 재사용 — `NoticeRepositoryProtocol.getAllNotices(request:)`, `NoticeListRequest`, `NoticePage`, `NoticeItemModel`, 기존 `toNoticeDetail()` 확장 활용. 신규 Response DTO 없음
- **Domain**: `FetchRecentNoticesUseCaseProtocol` + 구현체 추가 — 최신 기수 기준 최근 5건 조합 로직만 담은 얇은 UseCase. 거대 `NoticeUseCaseProtocol` 대신 좁은 `NoticeRepositoryProtocol`에 직접 의존 (ISP)
- **Presentation**: `RecentNoticeCard` 컴포넌트 추가 (아이콘/scope 라벨/제목/상대시간, 기존 글래스 카드 컨벤션 준수)
- **HomeViewModel**: `recentNoticeState: Loadable<[NoticeItemModel]>` 추가, 프로필 조회 성공 시 최신 기수 `gisuId`로 최근 공지 연쇄 조회
- **HomeView**: `recentNoticeSection` 추가 (로딩/빈 상태/카드 리스트), 프리뷰용 Mock UseCase 추가
- **네비게이션**: 카드 탭 → `onNoticeSelected(notice.toNoticeDetail())` 콜백 → `RootTabView`에서 `pathStore.homePath.append(.notice(.detail(detailItem:)))` — 기존 `NavigationRoutingView` 라우팅 그대로 활용 (앱 레벨 라우팅 신규 코드 없음)
- **Tuist**: `Home/Project.swift`에 `NoticeDomain` 크로스피처 의존성 추가 (Auth→MyPageDomain 선례 준용), `DIContainer+Home`에 UseCase 등록
- **테스트**: `HomeViewModelTests`의 `makeViewModel` 헬퍼에 신규 UseCase DI 등록 보강

## 📋 추후 진행 상황

- 홈 대시보드 나머지 슬라이스 이식 (출석/일정 등 후속 섹션)
- 최근 공지 섹션 실기기/시뮬레이터 UI 확인 및 스크린샷 첨부

## 📌 리뷰 포인트

- `UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchRecentNoticesUseCase.swift` - 최신 기수 판별 + 상위 5건 슬라이싱 로직, `NoticeRepositoryProtocol` 직접 의존 설계
- `UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift` - 프로필 로드 성공 → 최근 공지 연쇄 조회 흐름과 `Loadable` 상태 전이
- `UMCApp/Features/Home/Presentation/Sources/Components/RecentNoticeCard.swift` - 디자인 토큰/글래스 카드 컨벤션 준수 여부
- `UMCApp/UMCApp/Sources/RootTab/RootTabView.swift` - 콜백 기반 공지 상세 push 배선 (Feature→App 의존 없이 기존 라우팅 재사용)
- `UMCApp/Features/Home/Project.swift` - `NoticeDomain` 크로스피처 의존성 추가 방식

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)