### PR TITLE
✨ [Feat] 홈 - 일정 캘린더 섹션 이식 (Home 슬라이스 2)

### DIFF
--- a/UMCApp/.gitignore
+++ b/UMCApp/.gitignore
@@ -4,8 +4,8 @@
 .AppleDouble
 .LSOverride
 
-# Icon must end with two
-Icon
+# Icon must end with two \r
+Icon
 
 # Thumbnails
 ._*

--- a/UMCApp/Core/UIComponents/Sources/Icon/CardIconImage.swift
+++ b/UMCApp/Core/UIComponents/Sources/Icon/CardIconImage.swift
@@ -1,0 +1,62 @@
+//
+//  CardIconImage.swift
+//  UMCApp
+//
+//  Created by JEONG on 7/11/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+
+/// 카드 좌측에 배치하는 원형 아이콘 이미지.
+///
+/// 홈 일정/공지 카드, 출석/커리큘럼 카드 등 여러 Feature가 공유하는 아이콘 래퍼입니다.
+/// `isLoading`이 `true`인 동안에는 아이콘 대신 진행 인디케이터를 표시합니다.
+public struct CardIconImage: View {
+
+    // MARK: - Property
+
+    private let image: String
+    private let color: Color
+    @Binding private var isLoading: Bool
+
+    // MARK: - Initializer
+
+    public init(image: String, color: Color, isLoading: Binding<Bool>) {
+        self.image = image
+        self.color = color
+        self._isLoading = isLoading
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+                    .tint(.black)
+            } else {
+                Image(systemName: image)
+                    .font(.title2)
+                    .foregroundStyle(color)
+            }
+        }
+        .frame(width: DefaultConstant.iconSize, height: DefaultConstant.iconSize)
+        .padding(DefaultConstant.iconPadding)
+        .background {
+            RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+                .fill(color.opacity(0.4))
+        }
+        .glassEffect(.clear, in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
+    }
+}
+
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    HStack {
+        CardIconImage(image: "calendar.badge", color: .indigo500, isLoading: .constant(false))
+        CardIconImage(image: "calendar.badge", color: .indigo500, isLoading: .constant(true))
+    }
+    .padding()
+}

--- a/UMCApp/Features/Home/Data/Sources/DTOs/Request/MySchedulesQuery.swift
+++ b/UMCApp/Features/Home/Data/Sources/DTOs/Request/MySchedulesQuery.swift
@@ -1,0 +1,24 @@
+import Foundation
+import UMCFoundation
+
+/// 내 일정 목록 조회 Query DTO
+///
+/// `GET /api/v2/schedules/me` 쿼리 파라미터. `from`/`to`는 서버가 UTC ISO8601 datetime
+/// 문자열을 기대하므로 ``UMCFoundation/ServerDateTimeConverter/toUTCDateTimeString(_:)`` 로 변환한다.
+struct MySchedulesQuery: Encodable {
+    /// 조회 시작 시각
+    let from: Date
+    /// 조회 종료 시각
+    let to: Date
+    /// 출석 필수 일정만 조회 여부
+    let isAttendanceRequired: Bool
+
+    /// Query Parameter Dictionary 변환
+    var toParameters: [String: Any] {
+        [
+            "from": ServerDateTimeConverter.toUTCDateTimeString(from),
+            "to": ServerDateTimeConverter.toUTCDateTimeString(to),
+            "isAttendanceRequired": isAttendanceRequired
+        ]
+    }
+}

--- a/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleDetailDTO.swift
+++ b/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleDetailDTO.swift
@@ -1,0 +1,81 @@
+import Foundation
+import HomeDomain
+import UMCFoundation
+
+/// 일정 목록/상세 응답 DTO (V2)
+///
+/// `GET /api/v2/schedules/me` 목록과 `GET /api/v2/schedules/{id}` 상세 응답이 동일한
+/// 형태로 내려오므로 단일 DTO로 처리한다. 슬라이스 2(#914)는 캘린더 표시에 필요한
+/// 필드만 다루며, 장소/참여자/출석 정책 등은 이후 슬라이스에서 확장한다.
+///
+/// - SeeAlso: ``ScheduleDetailData``
+public struct ScheduleDetailDTO: Codable {
+
+    // MARK: - Property
+
+    /// 일정 고유 식별자. 서버 정수를 절대 규칙 #2에 따라 `String`으로 보존한다.
+    public let scheduleId: String
+    public let name: String
+    public let description: String
+    public let tags: [String]
+    /// 시작 일시 (UTC ISO8601 문자열). 파싱은 호출부(Repository)에서 수행한다.
+    public let startsAt: String
+    /// 종료 일시 (UTC ISO8601 문자열)
+    public let endsAt: String
+    /// 현재 사용자의 참여 여부
+    public let isParticipant: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case scheduleId
+        case name
+        case description
+        case tags
+        case startsAt
+        case endsAt
+        case isParticipant
+    }
+
+    // MARK: - Init
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        scheduleId = try container.decodeFlexibleString(forKey: .scheduleId)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+        tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
+        startsAt = try container.decodeIfPresent(String.self, forKey: .startsAt) ?? ""
+        endsAt = try container.decodeIfPresent(String.self, forKey: .endsAt) ?? ""
+        isParticipant = try container.decodeBoolFlexibleIfPresent(forKey: .isParticipant) ?? false
+    }
+
+    // MARK: - Function
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(scheduleId, forKey: .scheduleId)
+        try container.encode(name, forKey: .name)
+        try container.encode(description, forKey: .description)
+        try container.encode(tags, forKey: .tags)
+        try container.encode(startsAt, forKey: .startsAt)
+        try container.encode(endsAt, forKey: .endsAt)
+        try container.encode(isParticipant, forKey: .isParticipant)
+    }
+}
+
+// MARK: - Domain 변환
+
+extension ScheduleDetailDTO {
+
+    /// DTO → `ScheduleDetailData` 변환. 날짜 파싱 실패 시 현재 시각으로 폴백한다.
+    func toDomain() -> ScheduleDetailData {
+        ScheduleDetailData(
+            scheduleId: scheduleId,
+            name: name,
+            description: description,
+            tags: tags,
+            startsAt: ServerDateTimeConverter.parseUTCDateTime(startsAt) ?? .now,
+            endsAt: ServerDateTimeConverter.parseUTCDateTime(endsAt) ?? .now,
+            isParticipant: isParticipant
+        )
+    }
+}

--- a/UMCApp/Features/Home/Data/Sources/Repositories/ScheduleRepository.swift
+++ b/UMCApp/Features/Home/Data/Sources/Repositories/ScheduleRepository.swift
@@ -1,0 +1,60 @@
+import CoreNetwork
+import Foundation
+import HomeDomain
+import UMCFoundation
+
+/// 홈 일정 캘린더 조회 Repository 구현체
+public final class ScheduleRepository: ScheduleRepositoryProtocol, @unchecked Sendable {
+
+    // MARK: - Property
+
+    private let networkRequesting: any HomeNetworkRequesting
+
+    // MARK: - Init
+
+    /// 운영(DI) 진입점.
+    public convenience init(adapter: MoyaNetworkAdapter) {
+        self.init(networkRequesting: adapter)
+    }
+
+    /// 네트워크 추상화를 직접 주입하는 지정 이니셜라이저 (모듈 내부 · 테스트 전용).
+    init(networkRequesting: any HomeNetworkRequesting) {
+        self.networkRequesting = networkRequesting
+    }
+
+    // MARK: - Function
+
+    /// 기간 내 일정을 조회하고 KST 자정 기준 날짜별로 그룹핑하여 반환한다.
+    public func fetchMySchedules(
+        from: Date,
+        to: Date,
+        isAttendanceRequired: Bool
+    ) async throws -> [Date: [ScheduleDetailData]] {
+        let response = try await networkRequesting.request(
+            ScheduleV2Router.getMySchedules(
+                query: MySchedulesQuery(
+                    from: from,
+                    to: to,
+                    isAttendanceRequired: isAttendanceRequired
+                )
+            )
+        )
+
+        let schedules: [ScheduleDetailData]
+        do {
+            let apiResponse = try JSONDecoder().decode(
+                APIResponse<[ScheduleDetailDTO]>.self,
+                from: response.data
+            )
+            schedules = try apiResponse.unwrap().map { $0.toDomain() }
+        } catch let decodingError as DecodingError {
+            #if DEBUG
+            print("[ScheduleRepository] fetchMySchedules decodingError=\(decodingError)")
+            #endif
+            throw RepositoryError.decodingError(detail: "\(decodingError)")
+        }
+
+        let calendar = Calendar.kstGregorian
+        return Dictionary(grouping: schedules) { calendar.startOfDay(for: $0.startsAt) }
+    }
+}

--- a/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
+++ b/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
@@ -1,0 +1,49 @@
+import CoreNetwork
+import Foundation
+internal import Alamofire
+import Moya
+
+/// 일정 V2 API 라우터
+///
+/// 슬라이스 2(#914)는 홈 일정 캘린더 표시에 필요한 목록 조회만 다룬다. 생성/수정/삭제·출석
+/// 관련 엔드포인트는 등록/출석 기능 이식 시 별도로 추가한다.
+///
+/// - Note: `URLEncoding`(Alamofire) 노출을 막기 위해 `internal import Alamofire`를 쓰므로,
+///   이 라우터와 멤버는 `HomeData` 모듈 내부(`ScheduleRepository`)에서만 사용하는 `internal`로 둔다.
+enum ScheduleV2Router: BaseTargetType {
+
+    // MARK: - Cases
+
+    /// 내 일정 목록 조회 (기간 + 출석 필수 필터)
+    case getMySchedules(query: MySchedulesQuery)
+
+    // MARK: - Path
+
+    var path: String {
+        switch self {
+        case .getMySchedules:
+            return "/api/v2/schedules/me"
+        }
+    }
+
+    // MARK: - Method
+
+    var method: Moya.Method {
+        switch self {
+        case .getMySchedules:
+            return .get
+        }
+    }
+
+    // MARK: - Task
+
+    var task: Moya.Task {
+        switch self {
+        case .getMySchedules(let query):
+            return .requestParameters(
+                parameters: query.toParameters,
+                encoding: URLEncoding.queryString
+            )
+        }
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleRepositoryProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleRepositoryProtocol.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// 홈 일정 캘린더 데이터 접근 계층 인터페이스.
+///
+/// 조회 전용이다. 일정 생성/수정/삭제·출석 관련 액션은 이 슬라이스(#914)의 범위 밖으로,
+/// 등록/출석 기능 이식 시 별도 Repository로 추가한다.
+public protocol ScheduleRepositoryProtocol {
+
+    /// 기간 내 내 일정을 조회해 KST 자정 기준 날짜별로 그룹핑한다.
+    ///
+    /// - Parameters:
+    ///   - from: 조회 시작 시각 (UTC ISO8601 송신, 통상 KST 월초 자정)
+    ///   - to: 조회 종료 시각 (UTC ISO8601 송신, 통상 KST 월말 23:59:59.999)
+    ///   - isAttendanceRequired: 출석 필수 일정만 조회할지 여부
+    func fetchMySchedules(
+        from: Date,
+        to: Date,
+        isAttendanceRequired: Bool
+    ) async throws -> [Date: [ScheduleDetailData]]
+}

--- a/UMCApp/Features/Home/Domain/Sources/Models/ScheduleDetailData.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/ScheduleDetailData.swift
@@ -1,0 +1,71 @@
+import Foundation
+import UMCFoundation
+
+/// 홈 일정 캘린더가 표시하는 일정 상세 모델.
+///
+/// 서버 V2 스키마는 목록/상세 응답이 동일한 형태이므로 단일 모델로 양쪽을 지원한다.
+/// 슬라이스 2(#914) 범위는 캘린더 표시에 필요한 필드만 다루며, 장소/참여자/출석 정책 등은
+/// 출석·등록 기능 이식 시 별도로 확장한다.
+public struct ScheduleDetailData: Equatable, Identifiable, Sendable {
+
+    // MARK: - Property
+
+    public var id: String { scheduleId }
+
+    public let scheduleId: String
+    public let name: String
+    public let description: String
+    public let tags: [String]
+    public let startsAt: Date
+    public let endsAt: Date
+    public let isParticipant: Bool
+
+    // MARK: - Init
+
+    public init(
+        scheduleId: String,
+        name: String,
+        description: String,
+        tags: [String],
+        startsAt: Date,
+        endsAt: Date,
+        isParticipant: Bool
+    ) {
+        self.scheduleId = scheduleId
+        self.name = name
+        self.description = description
+        self.tags = tags
+        self.startsAt = startsAt
+        self.endsAt = endsAt
+        self.isParticipant = isParticipant
+    }
+
+    // MARK: - Computed
+
+    /// KST 기준 오늘 자정과 일정 시작 자정의 일수 차. 양수는 미래, 음수는 과거, 0은 오늘.
+    public var dDay: Int {
+        let calendar = Calendar.kstGregorian
+        let today = calendar.startOfDay(for: .now)
+        let target = calendar.startOfDay(for: startsAt)
+        return calendar.dateComponents([.day], from: today, to: target).day ?? 0
+    }
+
+    /// `dDay` 부호 규칙에 맞춘 화면 표시용 문자열 (미래: `D-N`, 과거: `D+N`, 오늘: `D-Day`).
+    public var dDayText: String {
+        if dDay > 0 {
+            return "D-\(dDay)"
+        }
+        if dDay < 0 {
+            return "D+\(abs(dDay))"
+        }
+        return "D-Day"
+    }
+
+    /// 종료/참여 여부 기반 표시 텍스트. 종료된 일정이면 `"종료됨"`, 그 외에는 참여 여부를 표시한다.
+    public var participationStatusText: String {
+        if Date() > endsAt {
+            return "종료됨"
+        }
+        return isParticipant ? "참여 예정" : "참여 안 함"
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/FetchSchedulesUseCaseProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/FetchSchedulesUseCaseProtocol.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// 기간 내 내 일정 조회 UseCase 인터페이스
+public protocol FetchSchedulesUseCaseProtocol {
+
+    /// - Parameters:
+    ///   - from: 조회 시작 시각
+    ///   - to: 조회 종료 시각
+    ///   - isAttendanceRequired: 출석 필수 일정만 조회할지 여부
+    /// - Returns: KST 자정 기준 날짜별로 그룹핑된 일정 딕셔너리
+    func execute(
+        from: Date,
+        to: Date,
+        isAttendanceRequired: Bool
+    ) async throws -> [Date: [ScheduleDetailData]]
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchSchedulesUseCase.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchSchedulesUseCase.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// 기간 내 내 일정 조회 UseCase 구현체
+public final class FetchSchedulesUseCase: FetchSchedulesUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: ScheduleRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: ScheduleRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(
+        from: Date,
+        to: Date,
+        isAttendanceRequired: Bool
+    ) async throws -> [Date: [ScheduleDetailData]] {
+        try await repository.fetchMySchedules(
+            from: from,
+            to: to,
+            isAttendanceRequired: isAttendanceRequired
+        )
+    }
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleCard.swift
@@ -1,0 +1,287 @@
+import CoreDesignSystem
+import SwiftUI
+import UMCFoundation
+
+/// 홈 화면 일정 캘린더 카드 — 월별 그리드로 일정 유무를 표시한다.
+///
+/// 슬라이스 2(#914) 범위는 캘린더 그리드 표시만 다룬다. 가로 스크롤(리스트) 모드 전환은
+/// 후속 슬라이스에서 추가한다.
+struct ScheduleCard: View, Equatable {
+
+    // MARK: - Property
+
+    @Binding var selectedDate: Date
+    @Binding var currentMonth: Date
+    let scheduledDates: Set<Date>
+
+    @State private var showDatePicker = false
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let padding: CGFloat = 24
+        static let weekdayCount = 7
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.selectedDate == rhs.selectedDate &&
+        lhs.currentMonth == rhs.currentMonth &&
+        lhs.scheduledDates == rhs.scheduledDates
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing24) {
+            header
+            weekdayHeader
+            dateGrid
+        }
+        .padding(Constants.padding)
+        .glassEffect(
+            .regular,
+            in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
+        )
+        .sheet(isPresented: $showDatePicker) {
+            DateSheetPicker(month: $currentMonth, selectedDate: $selectedDate)
+                .presentationDetents([.height(300)])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Button {
+                showDatePicker = true
+            } label: {
+                Text(monthTitle)
+                    .appFont(.body, weight: .semibold, color: .grey900)
+            }
+            Spacer()
+            monthStepper
+        }
+    }
+
+    private var monthStepper: some View {
+        HStack(spacing: DefaultSpacing.spacing16) {
+            Button {
+                changeMonth(by: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+            }
+            Button {
+                changeMonth(by: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+            }
+        }
+        .foregroundStyle(Color.grey600)
+    }
+
+    private var monthTitle: String {
+        let calendar = Calendar.kstGregorian
+        let year = calendar.component(.year, from: currentMonth)
+        let month = calendar.component(.month, from: currentMonth)
+        return "\(year)년 \(month)월 일정"
+    }
+
+    private func changeMonth(by offset: Int) {
+        guard
+            let newMonth = Calendar.kstGregorian.date(byAdding: .month, value: offset, to: currentMonth)
+        else { return }
+
+        withAnimation(.smooth(duration: DefaultConstant.animationTime)) {
+            currentMonth = newMonth
+        }
+    }
+
+    // MARK: - Weekday Header
+
+    private var weekdayHeader: some View {
+        HStack(spacing: .zero) {
+            ForEach(Date.weekDaySymbols(), id: \.self) { symbol in
+                Text(symbol)
+                    .appFont(.subheadline, weight: .medium, color: .grey400)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    // MARK: - Date Grid
+
+    private var columns: [GridItem] {
+        Array(repeating: GridItem(.flexible(), spacing: DefaultSpacing.spacing8), count: Constants.weekdayCount)
+    }
+
+    private var dateGrid: some View {
+        LazyVGrid(columns: columns, spacing: DefaultSpacing.spacing8) {
+            ForEach(adjustedDates, id: \.self) { date in
+                if Calendar.kstGregorian.isDate(date, equalTo: currentMonth, toGranularity: .month) {
+                    ScheduleDateCell(
+                        date: date,
+                        isSelected: date.isSameDay(selectedDate),
+                        hasSchedule: hasSchedule(date),
+                        isToday: date.isSameDay(.now)
+                    )
+                    .onTapGesture {
+                        withAnimation(.easeInOut(duration: DefaultConstant.animationTime)) {
+                            selectedDate = date
+                        }
+                    }
+                } else {
+                    Color.clear
+                }
+            }
+        }
+    }
+
+    /// 표시 월의 날짜 앞/뒤에 인접 월의 날짜를 채워 7일 단위 그리드를 완성한다.
+    private var adjustedDates: [Date] {
+        let calendar = Calendar.kstGregorian
+        let datesInMonth = currentMonth.datesInMonth()
+        guard let firstDate = datesInMonth.first, let lastDate = datesInMonth.last else { return [] }
+
+        let firstWeekday = calendar.component(.weekday, from: firstDate)
+        let lastWeekday = calendar.component(.weekday, from: lastDate)
+
+        var dates: [Date] = []
+        let emptyDaysBefore = firstWeekday - 1
+        for offset in 0..<emptyDaysBefore {
+            if let date = calendar.date(byAdding: .day, value: -(emptyDaysBefore - offset), to: firstDate) {
+                dates.append(date)
+            }
+        }
+
+        dates.append(contentsOf: datesInMonth)
+
+        let emptyDaysAfter = Constants.weekdayCount - lastWeekday
+        if emptyDaysAfter > 0 {
+            for offset in 1...emptyDaysAfter {
+                if let date = calendar.date(byAdding: .day, value: offset, to: lastDate) {
+                    dates.append(date)
+                }
+            }
+        }
+
+        return dates
+    }
+
+    private func hasSchedule(_ date: Date) -> Bool {
+        scheduledDates.contains { $0.isSameDay(date) }
+    }
+}
+
+// MARK: - ScheduleDateCell
+
+/// 캘린더 그리드의 개별 날짜 셀.
+fileprivate struct ScheduleDateCell: View {
+
+    // MARK: - Property
+
+    let date: Date
+    let isSelected: Bool
+    let hasSchedule: Bool
+    let isToday: Bool
+
+    fileprivate enum Constants {
+        static let cellSize: CGFloat = 40
+        static let dotSize: CGFloat = 6
+        static let todayBorderWidth: CGFloat = 2
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing4) {
+            Text(dayText)
+                .appFont(.callout, color: isSelected ? .grey000 : .grey900)
+                .frame(maxWidth: .infinity)
+                .frame(height: Constants.cellSize)
+                .background {
+                    if isSelected {
+                        Color.indigo500.glassEffect(.regular.interactive(), in: .circle)
+                    }
+                }
+                .clipShape(.circle)
+                .overlay {
+                    if isToday && !isSelected {
+                        Circle().strokeBorder(Color.indigo500, lineWidth: Constants.todayBorderWidth)
+                    }
+                }
+
+            Circle()
+                .fill(hasSchedule ? dotColor : .clear)
+                .frame(width: Constants.dotSize, height: Constants.dotSize)
+        }
+    }
+
+    private var dayText: String {
+        "\(Calendar.kstGregorian.component(.day, from: date))"
+    }
+
+    private var dotColor: Color {
+        isSelected ? .grey000 : .red500
+    }
+}
+
+// MARK: - DateSheetPicker
+
+/// 연월 이동을 위한 휠 스타일 날짜 선택 시트.
+fileprivate struct DateSheetPicker: View {
+
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+    @Binding var month: Date
+    @Binding var selectedDate: Date
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing16) {
+            title
+            datePicker
+        }
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    private var title: some View {
+        HStack {
+            Spacer()
+            Text("날짜 선택")
+                .appFont(.body, weight: .semibold, color: .grey900)
+            Spacer()
+        }
+        .overlay(alignment: .trailing) {
+            Button(role: .confirm) {
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.indigo500)
+        }
+    }
+
+    private var datePicker: some View {
+        DatePicker("", selection: $selectedDate, displayedComponents: .date)
+            .datePickerStyle(.wheel)
+            .labelsHidden()
+            .onChange(of: selectedDate) { _, newDate in
+                month = newDate
+            }
+    }
+}
+
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    ScheduleCard(
+        selectedDate: .constant(.now),
+        currentMonth: .constant(.now),
+        scheduledDates: [.now, .now.addingTimeInterval(60 * 60 * 24 * 3)]
+    )
+    .padding()
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleListCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleListCard.swift
@@ -1,0 +1,96 @@
+import CoreDesignSystem
+import CoreUIComponents
+import HomeDomain
+import SwiftUI
+import UMCFoundation
+
+/// 선택한 날짜의 일정 한 건을 리스트 형태로 보여주는 카드.
+///
+/// - Note: 제목 기반 자동 카테고리 분류(ML)는 이 슬라이스(#914) 범위 밖으로, 항상
+///   ``ScheduleIconCategory/general`` 아이콘을 표시한다. 분류 기능은 후속 이슈에서 추가한다.
+struct ScheduleListCard: View, Equatable {
+
+    // MARK: - Property
+
+    let data: ScheduleDetailData
+
+    private let category: ScheduleIconCategory = .general
+
+    fileprivate enum Constants {
+        static let iconPadding: CGFloat = 8
+        static let padding = EdgeInsets(top: 20, leading: 16, bottom: 20, trailing: 16)
+        static let lineLimit = 1
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.data == rhs.data
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing24) {
+            CardIconImage(image: category.symbol, color: category.color, isLoading: .constant(false))
+            infoContent
+            Spacer()
+            chevron
+        }
+        .padding(Constants.padding)
+        .glassEffect(
+            .regular,
+            in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
+        )
+    }
+
+    // MARK: - Component
+
+    private var infoContent: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            Text(data.name)
+                .appFont(.callout, weight: .semibold, color: .grey900)
+                .lineLimit(Constants.lineLimit)
+            Text(statusText)
+                .appFont(.subheadline, color: .grey600)
+        }
+    }
+
+    private var statusText: String {
+        let status = data.participationStatusText
+        return status == "종료됨" ? status : "\(status) · \(data.dDayText)"
+    }
+
+    private var chevron: some View {
+        Image(systemName: DefaultConstant.chevronForwardImage)
+            .renderingMode(.template)
+            .foregroundStyle(Color.grey900)
+            .padding(Constants.iconPadding)
+    }
+}
+
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    VStack {
+        ScheduleListCard(data: ScheduleDetailData(
+            scheduleId: "1",
+            name: "컨퍼런스",
+            description: "",
+            tags: [],
+            startsAt: .now.addingTimeInterval(60 * 60 * 24 * 7),
+            endsAt: .now.addingTimeInterval(60 * 60 * 24 * 7 + 3600),
+            isParticipant: true
+        ))
+        ScheduleListCard(data: ScheduleDetailData(
+            scheduleId: "2",
+            name: "데모데이",
+            description: "",
+            tags: [],
+            startsAt: .now.addingTimeInterval(-60 * 60 * 24 * 14),
+            endsAt: .now.addingTimeInterval(-60 * 60 * 24 * 14 + 3600),
+            isParticipant: false
+        ))
+    }
+    .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+}

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
@@ -4,7 +4,7 @@ import HomeDomain
 import NoticeDomain
 import UMCFoundation
 
-/// 홈 화면(시즌/세대 카드/최근 공지) ViewModel
+/// 홈 화면(시즌/세대 카드/최근 공지/일정 캘린더) ViewModel
 @Observable
 @MainActor
 public final class HomeViewModel {
@@ -15,14 +15,27 @@ public final class HomeViewModel {
     public private(set) var generationState: Loadable<[HomeGeneration]> = .idle
     public private(set) var recentNoticeState: Loadable<[NoticeItemModel]> = .idle
 
+    /// 선택 월의 일정을 KST 자정 기준 날짜로 그룹핑한 딕셔너리.
+    ///
+    /// 캘린더는 조회 실패 시에도 화면 흐름을 막지 않아야 하므로 `Loadable`로 감싸지 않고,
+    /// 실패 시 빈 딕셔너리로 degrade한다 (원본 AppProduct와 동일한 정책).
+    public private(set) var scheduleByDates: [Date: [ScheduleDetailData]] = [:]
+
+    /// 일정이 있는 날짜 집합 (캘린더 그리드의 점 표시용).
+    public var scheduleDates: Set<Date> {
+        Set(scheduleByDates.keys)
+    }
+
     private let fetchMyProfileUseCase: FetchHomeProfileUseCaseProtocol
     private let fetchRecentNoticesUseCase: FetchRecentNoticesUseCaseProtocol
+    private let fetchMySchedulesUseCase: FetchSchedulesUseCaseProtocol
 
     // MARK: - Init
 
     public init(container: DIContainer) {
         fetchMyProfileUseCase = container.resolve(FetchHomeProfileUseCaseProtocol.self)
         fetchRecentNoticesUseCase = container.resolve(FetchRecentNoticesUseCaseProtocol.self)
+        fetchMySchedulesUseCase = container.resolve(FetchSchedulesUseCaseProtocol.self)
     }
 
     // MARK: - Function
@@ -61,6 +74,44 @@ public final class HomeViewModel {
         } catch {
             setFailed(.unknown(message: error.localizedDescription))
         }
+    }
+
+    /// 월별 일정 조회 (KST 기준 월초/월말로 변환해 V2 일정 목록 API를 호출한다).
+    ///
+    /// 캘린더는 출석 필수 여부와 무관한 모든 일정을 보여줘야 하므로
+    /// `isAttendanceRequired: false`로 고정 호출한다.
+    ///
+    /// - Parameters:
+    ///   - year: 조회 연도 (nil이면 현재 연도, KST 기준)
+    ///   - month: 조회 월 (nil이면 현재 월, KST 기준)
+    public func fetchSchedules(year: Int? = nil, month: Int? = nil) async {
+        let calendar = Calendar.kstGregorian
+        let now = Date()
+        let targetYear = year ?? calendar.component(.year, from: now)
+        let targetMonth = month ?? calendar.component(.month, from: now)
+
+        guard
+            let startOfMonth = calendar.date(from: DateComponents(year: targetYear, month: targetMonth, day: 1)),
+            let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth)
+        else {
+            scheduleByDates = [:]
+            return
+        }
+
+        do {
+            scheduleByDates = try await fetchMySchedulesUseCase.execute(
+                from: startOfMonth.kstStartOfDay,
+                to: endOfMonth.kstEndOfDay,
+                isAttendanceRequired: false
+            )
+        } catch {
+            scheduleByDates = [:]
+        }
+    }
+
+    /// 특정 날짜(KST 자정 기준 정규화)에 해당하는 일정 목록을 반환한다.
+    public func getSchedules(_ date: Date) -> [ScheduleDetailData] {
+        scheduleByDates[Calendar.kstGregorian.startOfDay(for: date)] ?? []
     }
 
     // MARK: - Private Function

--- a/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
@@ -9,6 +9,7 @@ import UMCFoundation
 /// 홈 대시보드 메인 화면.
 ///
 /// 슬라이스 1(#913) 범위: 진입 시 프로필을 로드해 시즌 카드와 세대별 상벌점 카드를 표시한다.
+/// 슬라이스 2(#914) 범위: 이번 달 일정 캘린더와 선택 날짜의 일정 리스트를 표시한다.
 /// 슬라이스 3(#915) 범위: 최신 기수의 최근 공지 5건을 표시하고, 탭 시 상세 화면으로 이동한다.
 /// `NavigationStack`은 루트 탭 셸이 소유하므로 이 뷰는 콘텐츠만 구성한다.
 struct HomeView: View {
@@ -16,6 +17,8 @@ struct HomeView: View {
     // MARK: - Property
 
     @State private var viewModel: HomeViewModel
+    @State private var selectedDate: Date = .now
+    @State private var currentMonth: Date = .now
     private let onNoticeSelected: (NoticeDetail) -> Void
 
     // MARK: - Constants
@@ -48,6 +51,7 @@ struct HomeView: View {
             LazyVStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
                 seasonSection
                 generationSection
+                scheduleSection
                 recentNoticeSection
             }
             .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
@@ -56,6 +60,18 @@ struct HomeView: View {
         .umcDefaultBackground()
         .task {
             await viewModel.fetchProfileIfNeeded()
+        }
+        .task {
+            await viewModel.fetchSchedules()
+        }
+        .onChange(of: currentMonth) { _, newMonth in
+            let calendar = Calendar.kstGregorian
+            Task {
+                await viewModel.fetchSchedules(
+                    year: calendar.component(.year, from: newMonth),
+                    month: calendar.component(.month, from: newMonth)
+                )
+            }
         }
     }
 
@@ -125,6 +141,22 @@ struct HomeView: View {
         }
     }
 
+    // MARK: - Schedule Section
+
+    /// 이번 달 일정 캘린더와 선택 날짜의 일정 리스트 섹션.
+    private var scheduleSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
+            ScheduleCard(
+                selectedDate: $selectedDate,
+                currentMonth: $currentMonth,
+                scheduledDates: viewModel.scheduleDates
+            )
+            .equatable()
+
+            scheduleList
+        }
+    }
+
     // MARK: - Recent Notice Section
 
     /// 최근 공지 섹션. 프로필 조회에 종속되므로 실패 안내는 `seasonSection`이 대표한다.
@@ -137,6 +169,27 @@ struct HomeView: View {
             recentNoticeLoaded(notices)
         case .failed:
             EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var scheduleList: some View {
+        let schedules = viewModel.getSchedules(selectedDate)
+        if schedules.isEmpty {
+            ContentUnavailableView(
+                "일정이 없습니다.",
+                systemImage: "calendar.badge.exclamationmark",
+                description: Text("선택한 날짜에 등록된 일정이 없습니다.")
+            )
+            .glassEffect(
+                .regular,
+                in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
+            )
+        } else {
+            ForEach(schedules) { schedule in
+                ScheduleListCard(data: schedule)
+                    .equatable()
+            }
         }
     }
 
@@ -248,10 +301,29 @@ private struct PreviewFetchRecentNoticesUseCase: FetchRecentNoticesUseCaseProtoc
     }
 }
 
+/// 네트워크 없이 일정 캘린더를 확인하기 위한 프리뷰 전용 UseCase (절대규칙 #5)
+private struct PreviewFetchSchedulesUseCase: FetchSchedulesUseCaseProtocol {
+    func execute(from: Date, to: Date, isAttendanceRequired: Bool) async throws -> [Date: [ScheduleDetailData]] {
+        let calendar = Calendar.kstGregorian
+        let today = calendar.startOfDay(for: .now)
+        let schedule = ScheduleDetailData(
+            scheduleId: "1",
+            name: "정기 세미나",
+            description: "",
+            tags: [],
+            startsAt: today,
+            endsAt: today.addingTimeInterval(3600),
+            isParticipant: true
+        )
+        return [today: [schedule]]
+    }
+}
+
 #Preview {
     let container = DIContainer()
     container.register(FetchHomeProfileUseCaseProtocol.self) { PreviewFetchHomeProfileUseCase() }
     container.register(FetchRecentNoticesUseCaseProtocol.self) { PreviewFetchRecentNoticesUseCase() }
+    container.register(FetchSchedulesUseCaseProtocol.self) { PreviewFetchSchedulesUseCase() }
     return NavigationStack {
         HomeView(container: container)
     }

--- a/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
+++ b/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
@@ -115,6 +115,7 @@ private func makeViewModel(
     let container = DIContainer()
     container.register(FetchHomeProfileUseCaseProtocol.self) { useCase }
     container.register(FetchRecentNoticesUseCaseProtocol.self) { recentNoticesUseCase }
+    container.register(FetchSchedulesUseCaseProtocol.self) { MockFetchSchedulesUseCase() }
     return HomeViewModel(container: container)
 }
 
@@ -155,5 +156,12 @@ private final class MockFetchRecentNoticesUseCase: FetchRecentNoticesUseCaseProt
 
     func execute(gisuId: String) async throws -> [NoticeItemModel] {
         try result.get()
+    }
+}
+
+/// 프로필 로딩 상태 전이 테스트는 일정 조회 결과와 무관하므로 빈 결과만 반환한다.
+private struct MockFetchSchedulesUseCase: FetchSchedulesUseCaseProtocol, Sendable {
+    func execute(from: Date, to: Date, isAttendanceRequired: Bool) async throws -> [Date: [ScheduleDetailData]] {
+        [:]
     }
 }

--- a/UMCApp/UMCApp/Sources/DIContainer+Home.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Home.swift
@@ -19,5 +19,11 @@ extension DIContainer {
         register(FetchRecentNoticesUseCaseProtocol.self) {
             FetchRecentNoticesUseCase(repository: self.resolve(NoticeRepositoryProtocol.self))
         }
+        register(ScheduleRepositoryProtocol.self) {
+            ScheduleRepository(adapter: self.resolve(MoyaNetworkAdapter.self))
+        }
+        register(FetchSchedulesUseCaseProtocol.self) {
+            FetchSchedulesUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
+        }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

✨ Feature — `AppProduct` → `UMCApp`(Tuist) 마이그레이션 Phase 2(홈) 2단계

close #914

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 시뮬레이터 확인 후 첨부 예정 — 빌드/Preview(mock 데이터) 수준으로 캘린더 그리드·일자별 리스트 렌더링 검증 완료 -->

## 🛠️ 작업내용

### HomeDomain
- `ScheduleDetailData` 모델 추가 — `public`, 서버 정수 `String` 통일(절대규칙 #2/#4), `dDay`/`dDayText`/`participationStatusText` 계산 프로퍼티
- `ScheduleRepositoryProtocol`, `FetchSchedulesUseCaseProtocol` + `FetchSchedulesUseCase` 구현체

### HomeData
- `ScheduleV2Router` (`GET /api/v2/schedules/me`) — 파라미터는 `MySchedulesQuery` DTO로 캡슐화(절대규칙 #6)
- `ScheduleDetailDTO` — custom `init(from:)`/`encode(to:)` + `decodeFlexibleString`/`decodeBoolFlexibleIfPresent`(절대규칙 #3)
- `ScheduleRepository` 구현체

### HomePresentation
- `ScheduleCard`(이번 달 캘린더 그리드) + `ScheduleListCard`(일자별 일정 행) 이식
- `HomeView`/`HomeViewModel`에 일정 섹션 연결 — 초기 `.task` 로드 + 월 변경 시 재조회 (KST 기준)

### 기타
- `CardIconImage`를 CoreUIComponents 공용 컴포넌트로 승격
- `DIContainer+Home`에 Repository/UseCase 등록
- **`.gitignore` 버그 수정**: bare `Icon` 패턴이 `Icon` 이름의 모든 디렉터리/파일을 무시하던 문제 → macOS 아이콘 마커 전용 원형(`Icon\r\r`)으로 복원

### 검증
- `tuist generate` + 시뮬레이터 빌드 **BUILD SUCCEEDED**
- 테스트 13/13 통과 (HomePresentation 7 · HomeData 4 · HomeDomain 2)
- `AppProduct/` 무변경 (절대규칙 #9)

## 📋 추후 진행 상황

- 일정 분류 ML(`ClassifyScheduleUseCase`) 이식 — 이슈 범위 외, 후속 이슈로 분리 (현재 `ScheduleListCard`는 `general` 카테고리 고정)
- 일정 상세 필드 확장(장소/참여자/출석 정책 등) — 출석·등록 기능 이식 슬라이스에서 진행
- Activity 피처 TODO(전용 Schedule Feature 모듈 분리) 추적

## 📌 리뷰 포인트

- `ScheduleV2Router`가 `public`이 아닌 `internal` — Alamofire `internal import` 환경에서 public enum이 `URLEncoding`/`Moya.Method`를 노출할 수 없어 기존 `AttendanceRouter` 선례를 따름
- `ScheduleDetailData.id`를 원본의 랜덤 UUID 대신 `scheduleId` 파생으로 변경 (원본의 잠재 버그 수정 — Identifiable 안정성)
- `ScheduleRepositoryProtocol`을 `HomeRepositoryProtocol`과 분리 (원본은 프로필 리포지토리에 혼재)
- `.gitignore` 수정이 의도대로인지 — macOS 아이콘 마커(`Icon\r`)는 계속 무시되고, `Icon/` 디렉터리는 추적됨을 `git check-ignore`로 검증함

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
