### PR TITLE
✨ [Feat] 프로필 강제 갱신(forceRefresh) 경로 Home/MyPage 관통 및 홈 대시보드 당겨서 새로고침 연결

### DIFF
--- a/UMCApp/Features/Home/Data/Sources/Repositories/HomeRepository.swift
+++ b/UMCApp/Features/Home/Data/Sources/Repositories/HomeRepository.swift
@@ -38,8 +38,8 @@ public final class HomeRepository: HomeRepositoryProtocol, @unchecked Sendable {
 
     // MARK: - Function
 
-    public func fetchMyProfile() async throws -> HomeProfileResult {
-        let profile = try await memberProfileRepository.fetchMyProfile()
+    public func fetchMyProfile(forceRefresh: Bool) async throws -> HomeProfileResult {
+        let profile = try await memberProfileRepository.fetchMyProfile(forceRefresh: forceRefresh)
         let generations = profile.toHomeGenerations()
         let seasonTypes = try await makeSeasonTypes(profile: profile)
 

--- a/UMCApp/Features/Home/Data/Tests/HomeRepositoryTests.swift
+++ b/UMCApp/Features/Home/Data/Tests/HomeRepositoryTests.swift
@@ -12,6 +12,7 @@ import Foundation
 import Testing
 import Moya
 import CoreDomain
+import CoreNetwork
 import UMCFoundation
 import HomeDomain
 @testable import HomeData
@@ -64,10 +65,36 @@ private final class MockMemberProfileRepository:
 
     var result: Result<Profile, Error> = .failure(MockError.notStubbed)
     private(set) var fetchMyProfileCallCount = 0
+    private(set) var lastForceRefresh: Bool?
 
     func fetchMyProfile() async throws -> Profile {
+        try await fetchMyProfile(forceRefresh: false)
+    }
+
+    func fetchMyProfile(forceRefresh: Bool) async throws -> Profile {
         fetchMyProfileCallCount += 1
+        lastForceRefresh = forceRefresh
         return try result.get()
+    }
+}
+
+/// 캐시 합성 검증용 원격 스텁 — 호출 횟수를 기록하고 호출 시점의 `profileToReturn`을 반환한다.
+private actor FakeRemoteMemberProfileRepository: MemberProfileRepositoryProtocol {
+
+    private(set) var callCount = 0
+    private var profileToReturn: Profile
+
+    init(profile: Profile) {
+        self.profileToReturn = profile
+    }
+
+    func updateProfile(_ profile: Profile) {
+        profileToReturn = profile
+    }
+
+    func fetchMyProfile() async throws -> Profile {
+        callCount += 1
+        return profileToReturn
     }
 }
 
@@ -83,6 +110,18 @@ private enum Fixture {
           "result": { "gisuId": "\(gisuId)", "startAt": "\(startAt)" }
         }
         """.utf8)
+    }
+
+    /// 기수 기록이 없어 기수 상세 네트워크 호출이 발생하지 않는 최소 프로필
+    static func minimalProfile(memberId: String) -> Profile {
+        Profile(
+            memberId: memberId,
+            name: "홍길동",
+            nickname: "길동",
+            generations: [],
+            roles: [],
+            challengerRecords: []
+        )
     }
 }
 
@@ -291,5 +330,55 @@ struct HomeRepositoryTests {
         await #expect(throws: MockMemberProfileRepository.MockError.notStubbed) {
             _ = try await repository.fetchMyProfile()
         }
+    }
+
+    @Test("fetchMyProfile(forceRefresh:)가 정본 프로필 리포지토리에 플래그를 그대로 전달한다")
+    func fetchMyProfilePassesForceRefreshToMemberProfileRepository() async throws {
+        let memberProfileRepository = MockMemberProfileRepository()
+        memberProfileRepository.result = .success(Fixture.minimalProfile(memberId: "1"))
+        let network = StubHomeNetwork(.failure(MockMemberProfileRepository.MockError.notStubbed))
+        let repository = HomeRepository(
+            networkRequesting: network,
+            memberProfileRepository: memberProfileRepository
+        )
+
+        _ = try await repository.fetchMyProfile(forceRefresh: true)
+        #expect(memberProfileRepository.lastForceRefresh == true)
+
+        _ = try await repository.fetchMyProfile()
+        #expect(memberProfileRepository.lastForceRefresh == false)
+    }
+
+    @Test("forceRefresh는 캐시를 우회해 서버를 재조회하고, 이후 일반 조회는 갱신된 스냅샷을 반환한다")
+    func forceRefreshBypassesCacheAndSubsequentFetchReturnsUpdatedSnapshot() async throws {
+        let remote = FakeRemoteMemberProfileRepository(
+            profile: Fixture.minimalProfile(memberId: "1")
+        )
+        let cached = CachedMemberProfileRepository(remote: remote)
+        let network = StubHomeNetwork(.failure(MockMemberProfileRepository.MockError.notStubbed))
+        let repository = HomeRepository(
+            networkRequesting: network,
+            memberProfileRepository: cached
+        )
+
+        let first = try await repository.fetchMyProfile()
+        #expect(first.memberId == "1")
+
+        await remote.updateProfile(Fixture.minimalProfile(memberId: "2"))
+
+        let cachedHit = try await repository.fetchMyProfile()
+        var remoteCallCount = await remote.callCount
+        #expect(cachedHit.memberId == "1", "일반 조회는 캐시 히트 — 이전 스냅샷 유지")
+        #expect(remoteCallCount == 1)
+
+        let refreshed = try await repository.fetchMyProfile(forceRefresh: true)
+        remoteCallCount = await remote.callCount
+        #expect(refreshed.memberId == "2", "forceRefresh는 캐시를 우회해 서버 최신을 반환")
+        #expect(remoteCallCount == 2)
+
+        let afterRefresh = try await repository.fetchMyProfile()
+        remoteCallCount = await remote.callCount
+        #expect(afterRefresh.memberId == "2", "이후 일반 조회도 갱신된 스냅샷을 반환")
+        #expect(remoteCallCount == 2, "갱신된 캐시에 히트 — 추가 원격 호출 없음")
     }
 }

--- a/UMCApp/Features/Home/Domain/Sources/Interfaces/HomeRepositoryProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Interfaces/HomeRepositoryProtocol.swift
@@ -2,5 +2,14 @@
 public protocol HomeRepositoryProtocol {
 
     /// 홈 화면(시즌/세대 카드) 구성에 필요한 내 프로필을 조회한다.
-    func fetchMyProfile() async throws -> HomeProfileResult
+    /// - Parameter forceRefresh: `true`이면 세션 프로필 캐시를 우회해 서버에서 새로 조회한다.
+    func fetchMyProfile(forceRefresh: Bool) async throws -> HomeProfileResult
+}
+
+extension HomeRepositoryProtocol {
+
+    /// 홈 화면(시즌/세대 카드) 구성에 필요한 내 프로필을 조회한다 (캐시 허용 기본 경로).
+    public func fetchMyProfile() async throws -> HomeProfileResult {
+        try await fetchMyProfile(forceRefresh: false)
+    }
 }

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/FetchHomeProfileUseCaseProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/FetchHomeProfileUseCaseProtocol.swift
@@ -1,5 +1,16 @@
 /// 홈 화면 내 프로필 조회 UseCase 인터페이스
 public protocol FetchHomeProfileUseCaseProtocol {
+
+    /// 홈 화면(시즌/세대 카드) 구성에 필요한 내 프로필을 조회한다.
+    /// - Parameter forceRefresh: `true`이면 세션 프로필 캐시를 우회해 서버에서 새로 조회한다.
     /// - Returns: 시즌/세대 카드 구성에 필요한 내 프로필 정보
-    func execute() async throws -> HomeProfileResult
+    func execute(forceRefresh: Bool) async throws -> HomeProfileResult
+}
+
+extension FetchHomeProfileUseCaseProtocol {
+
+    /// 내 프로필을 조회한다 (캐시 허용 기본 경로, `forceRefresh: false`와 동일).
+    public func execute() async throws -> HomeProfileResult {
+        try await execute(forceRefresh: false)
+    }
 }

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchHomeProfileUseCase.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchHomeProfileUseCase.swift
@@ -13,7 +13,7 @@ public final class FetchHomeProfileUseCase: FetchHomeProfileUseCaseProtocol {
 
     // MARK: - Function
 
-    public func execute() async throws -> HomeProfileResult {
-        try await repository.fetchMyProfile()
+    public func execute(forceRefresh: Bool) async throws -> HomeProfileResult {
+        try await repository.fetchMyProfile(forceRefresh: forceRefresh)
     }
 }

--- a/UMCApp/Features/Home/Domain/Tests/Support/MockHomeRepository.swift
+++ b/UMCApp/Features/Home/Domain/Tests/Support/MockHomeRepository.swift
@@ -21,9 +21,11 @@ final class MockHomeRepository: HomeRepositoryProtocol, @unchecked Sendable {
 
     var fetchMyProfileResult: Result<HomeProfileResult, Error> = .failure(MockError.notStubbed)
     private(set) var fetchMyProfileCallCount = 0
+    private(set) var fetchMyProfileReceivedForceRefresh: Bool?
 
-    func fetchMyProfile() async throws -> HomeProfileResult {
+    func fetchMyProfile(forceRefresh: Bool) async throws -> HomeProfileResult {
         fetchMyProfileCallCount += 1
+        fetchMyProfileReceivedForceRefresh = forceRefresh
         return try fetchMyProfileResult.get()
     }
 }

--- a/UMCApp/Features/Home/Domain/Tests/UseCases/FetchHomeProfileUseCaseTests.swift
+++ b/UMCApp/Features/Home/Domain/Tests/UseCases/FetchHomeProfileUseCaseTests.swift
@@ -21,6 +21,7 @@ struct FetchHomeProfileUseCaseTests {
 
         #expect(result == expected)
         #expect(repository.fetchMyProfileCallCount == 1)
+        #expect(repository.fetchMyProfileReceivedForceRefresh == false)
     }
 
     @Test("repository.fetchMyProfile()이 에러를 던지면 그대로 전파한다")
@@ -32,5 +33,18 @@ struct FetchHomeProfileUseCaseTests {
         await #expect(throws: HomeTestError.boom) {
             _ = try await useCase.execute()
         }
+    }
+
+    @Test("execute(forceRefresh: true)는 forceRefresh를 repository에 그대로 관통시킨다")
+    func executePassesForceRefreshThrough() async throws {
+        let repository = MockHomeRepository()
+        let expected = HomeProfileResult(memberId: "1", seasonTypes: [.days(1)], generations: [])
+        repository.fetchMyProfileResult = .success(expected)
+        let useCase = FetchHomeProfileUseCase(repository: repository)
+
+        let result = try await useCase.execute(forceRefresh: true)
+
+        #expect(result == expected)
+        #expect(repository.fetchMyProfileReceivedForceRefresh == true)
     }
 }

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
@@ -48,7 +48,9 @@ public final class HomeViewModel {
 
     /// 내 프로필을 조회해 시즌/세대 카드 상태를 갱신한다. 실패 시 인라인 `.failed` 상태로 표시한다.
     /// 세대 조회가 성공하면 최신 기수를 기준으로 최근 공지도 함께 조회한다.
-    public func fetchProfile() async {
+    /// - Parameter forceRefresh: `true`이면 세션 프로필 캐시를 우회해 서버 최신으로 갱신한다
+    ///   (당겨서 새로고침 경로).
+    public func fetchProfile(forceRefresh: Bool = false) async {
         if seasonState.isLoading { return }
 
         let previousSeasonState = seasonState
@@ -57,7 +59,7 @@ public final class HomeViewModel {
         generationState = .loading
 
         do {
-            let profile = try await fetchMyProfileUseCase.execute()
+            let profile = try await fetchMyProfileUseCase.execute(forceRefresh: forceRefresh)
             let sortedGenerations = sortedByGenerationDescending(profile.generations)
             seasonState = .loaded(profile.seasonTypes)
             generationState = .loaded(sortedGenerations)

--- a/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
@@ -57,6 +57,9 @@ struct HomeView: View {
             .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
         }
         .contentMargins(.bottom, DefaultConstant.defaultContentBottomMargins, for: .scrollContent)
+        .refreshable {
+            await viewModel.fetchProfile(forceRefresh: true)
+        }
         .umcDefaultBackground()
         .task {
             await viewModel.fetchProfileIfNeeded()
@@ -241,7 +244,7 @@ struct HomeView: View {
 #if DEBUG
 /// 네트워크 없이 화면을 확인하기 위한 프리뷰 전용 UseCase (절대규칙 #5)
 private struct PreviewFetchHomeProfileUseCase: FetchHomeProfileUseCaseProtocol {
-    func execute() async throws -> HomeProfileResult {
+    func execute(forceRefresh: Bool) async throws -> HomeProfileResult {
         HomeProfileResult(
             memberId: "1",
             seasonTypes: [.gens(["11", "12"]), .days(128)],

--- a/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
+++ b/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
@@ -99,6 +99,28 @@ struct HomeViewModelTests {
 
         #expect(useCase.callCount == 1)
     }
+
+    @Test("fetchProfile(forceRefresh: true)는 UseCase에 forceRefresh를 그대로 전달한다")
+    func forceRefreshIsPassedThroughToUseCase() async {
+        let useCase = MockFetchHomeProfileUseCase()
+        useCase.result = .success(makeProfile(generationNumbers: ["11"]))
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchProfile(forceRefresh: true)
+
+        #expect(useCase.lastForceRefresh == true)
+    }
+
+    @Test("기본 fetchProfile()은 forceRefresh: false로 조회한다 (캐시 히트 유지)")
+    func defaultFetchUsesCacheAllowedPath() async {
+        let useCase = MockFetchHomeProfileUseCase()
+        useCase.result = .success(makeProfile(generationNumbers: ["11"]))
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchProfile()
+
+        #expect(useCase.lastForceRefresh == false)
+    }
 }
 
 // MARK: - Helpers
@@ -141,9 +163,11 @@ private final class MockFetchHomeProfileUseCase: FetchHomeProfileUseCaseProtocol
     /// 로딩 중 중복 호출 방지 검증용 인위적 지연 (기본값: 지연 없음)
     var delayNanoseconds: UInt64 = 0
     private(set) var callCount = 0
+    private(set) var lastForceRefresh: Bool?
 
-    func execute() async throws -> HomeProfileResult {
+    func execute(forceRefresh: Bool) async throws -> HomeProfileResult {
         callCount += 1
+        lastForceRefresh = forceRefresh
         if delayNanoseconds > 0 {
             try await Task.sleep(nanoseconds: delayNanoseconds)
         }

--- a/UMCApp/Features/MyPage/Data/Sources/Repository/MyPageRepository.swift
+++ b/UMCApp/Features/MyPage/Data/Sources/Repository/MyPageRepository.swift
@@ -62,8 +62,8 @@ public final class MyPageRepository: MyPageRepositoryProtocol, @unchecked Sendab
     ///
     /// 정본 프로필 조회 파이프라인(``CoreDomain/MemberProfileRepositoryProtocol``)에 위임한 뒤,
     /// `MyPageDomain`의 `Profile.toProfileData()` 확장으로 화면 전체 데이터를 구성합니다.
-    public func fetchMyProfile() async throws -> ProfileData {
-        let profile = try await memberProfileRepository.fetchMyProfile()
+    public func fetchMyProfile(forceRefresh: Bool) async throws -> ProfileData {
+        let profile = try await memberProfileRepository.fetchMyProfile(forceRefresh: forceRefresh)
         return profile.toProfileData()
     }
 

--- a/UMCApp/Features/MyPage/Data/Tests/MyPageRepositoryTests.swift
+++ b/UMCApp/Features/MyPage/Data/Tests/MyPageRepositoryTests.swift
@@ -89,15 +89,41 @@ private final class MockMemberProfileRepository:
     private(set) var fetchMyProfileCallCount = 0
     private(set) var primeCacheCallCount = 0
     private(set) var primedProfiles: [Profile] = []
+    private(set) var lastForceRefresh: Bool?
 
     func fetchMyProfile() async throws -> Profile {
+        try await fetchMyProfile(forceRefresh: false)
+    }
+
+    func fetchMyProfile(forceRefresh: Bool) async throws -> Profile {
         fetchMyProfileCallCount += 1
+        lastForceRefresh = forceRefresh
         return try result.get()
     }
 
     func primeCache(with profile: Profile) async {
         primeCacheCallCount += 1
         primedProfiles.append(profile)
+    }
+}
+
+/// 캐시 합성 검증용 원격 스텁 — 호출 횟수를 기록하고 호출 시점의 `profileToReturn`을 반환한다.
+private actor FakeRemoteMemberProfileRepository: MemberProfileRepositoryProtocol {
+
+    private(set) var callCount = 0
+    private var profileToReturn: Profile
+
+    init(profile: Profile) {
+        self.profileToReturn = profile
+    }
+
+    func updateProfile(_ profile: Profile) {
+        profileToReturn = profile
+    }
+
+    func fetchMyProfile() async throws -> Profile {
+        callCount += 1
+        return profileToReturn
     }
 }
 
@@ -195,6 +221,18 @@ private enum Fixture {
         if let message { fields.append("\"message\": \"\(message)\"") }
         fields.append("\"result\": null")
         return Data("{ \(fields.joined(separator: ", ")) }".utf8)
+    }
+
+    /// 캐시 합성 검증용 최소 Profile (기수 기록 없음)
+    static func minimalProfile(memberId: String) -> Profile {
+        Profile(
+            memberId: memberId,
+            name: "홍길동",
+            nickname: "길동",
+            generations: [],
+            roles: [],
+            challengerRecords: []
+        )
     }
 
     /// 프로필 result 본문 — 최신 챌린저 기록(challengerId 777, gisu 11, IOS)을 가진 멤버(id 42)
@@ -351,6 +389,50 @@ struct MyPageRepositoryProfileTests {
         await #expect(throws: RepositoryError.serverError(code: "M404", message: "회원 없음")) {
             _ = try await sut.fetchMyProfile()
         }
+    }
+
+    @Test("fetchMyProfile(forceRefresh:)가 정본 프로필 리포지토리에 플래그를 그대로 전달한다")
+    func fetchMyProfilePassesForceRefreshToMemberProfileRepository() async throws {
+        let memberProfileRepository = MockMemberProfileRepository()
+        memberProfileRepository.result = .success(Fixture.minimalProfile(memberId: "42"))
+        let (sut, _) = makeRepository(
+            .success(Fixture.successVoid()),
+            memberProfileRepository: memberProfileRepository
+        )
+
+        _ = try await sut.fetchMyProfile(forceRefresh: true)
+        #expect(memberProfileRepository.lastForceRefresh == true)
+
+        _ = try await sut.fetchMyProfile()
+        #expect(memberProfileRepository.lastForceRefresh == false)
+    }
+
+    @Test("forceRefresh는 캐시를 우회해 서버를 재조회하고, 이후 일반 조회는 캐시에 히트한다")
+    func forceRefreshBypassesCacheAndSubsequentFetchHitsRefreshedCache() async throws {
+        let remote = FakeRemoteMemberProfileRepository(
+            profile: Fixture.minimalProfile(memberId: "42")
+        )
+        let cached = CachedMemberProfileRepository(remote: remote)
+        let (sut, _) = makeRepository(
+            .success(Fixture.successVoid()),
+            memberProfileRepository: cached
+        )
+
+        _ = try await sut.fetchMyProfile()
+        var count = await remote.callCount
+        #expect(count == 1, "일반 조회 1회 — 캐시 적재")
+
+        _ = try await sut.fetchMyProfile()
+        count = await remote.callCount
+        #expect(count == 1, "일반 조회 1회 더 — 캐시 히트")
+
+        _ = try await sut.fetchMyProfile(forceRefresh: true)
+        count = await remote.callCount
+        #expect(count == 2, "forceRefresh — 캐시 우회")
+
+        _ = try await sut.fetchMyProfile()
+        count = await remote.callCount
+        #expect(count == 2, "일반 조회 1회 더 — 갱신된 캐시 히트")
     }
 
     @Test("fetchMemberProfile — APIResponse 래핑 응답을 MemberProfileSummary로 매핑하고 memberId를 path에 보간한다")

--- a/UMCApp/Features/MyPage/Domain/Sources/Interface/MyPageRepositoryProtocol.swift
+++ b/UMCApp/Features/MyPage/Domain/Sources/Interface/MyPageRepositoryProtocol.swift
@@ -12,7 +12,8 @@ import CoreDomain
 public protocol MyPageRepositoryProtocol: Sendable {
 
     /// 내 프로필 조회
-    func fetchMyProfile() async throws -> ProfileData
+    /// - Parameter forceRefresh: `true`이면 세션 프로필 캐시를 우회해 서버에서 새로 조회한다.
+    func fetchMyProfile(forceRefresh: Bool) async throws -> ProfileData
 
     /// 특정 멤버 프로필 조회
     func fetchMemberProfile(memberId: Int) async throws -> MemberProfileSummary
@@ -51,4 +52,12 @@ public protocol MyPageRepositoryProtocol: Sendable {
     func fetchTerms(termsType: String) async throws -> MyPageTerms
 
 
+}
+
+extension MyPageRepositoryProtocol {
+
+    /// 내 프로필 조회 (캐시 허용 기본 경로, `forceRefresh: false`와 동일).
+    public func fetchMyProfile() async throws -> ProfileData {
+        try await fetchMyProfile(forceRefresh: false)
+    }
 }

--- a/UMCApp/Features/MyPage/Domain/Sources/UseCases/FetchMyPageProfileUseCaseProtocol.swift
+++ b/UMCApp/Features/MyPage/Domain/Sources/UseCases/FetchMyPageProfileUseCaseProtocol.swift
@@ -10,5 +10,16 @@ import Foundation
 ///
 /// MyPage에서 내 프로필 정보를 조회합니다
 public protocol FetchMyPageProfileUseCaseProtocol {
-    func execute() async throws -> ProfileData
+
+    /// 내 프로필을 조회한다.
+    /// - Parameter forceRefresh: `true`이면 세션 프로필 캐시를 우회해 서버에서 새로 조회한다.
+    func execute(forceRefresh: Bool) async throws -> ProfileData
+}
+
+extension FetchMyPageProfileUseCaseProtocol {
+
+    /// 내 프로필을 조회한다 (캐시 허용 기본 경로, `forceRefresh: false`와 동일).
+    public func execute() async throws -> ProfileData {
+        try await execute(forceRefresh: false)
+    }
 }

--- a/UMCApp/Features/MyPage/Domain/Sources/UseCases/Implementations/FetchMyPageProfileUseCase.swift
+++ b/UMCApp/Features/MyPage/Domain/Sources/UseCases/Implementations/FetchMyPageProfileUseCase.swift
@@ -25,7 +25,7 @@ public final class FetchMyPageProfileUseCase: FetchMyPageProfileUseCaseProtocol 
 
     // MARK: - Function
 
-    public func execute() async throws -> ProfileData {
-        try await repository.fetchMyProfile()
+    public func execute(forceRefresh: Bool) async throws -> ProfileData {
+        try await repository.fetchMyProfile(forceRefresh: forceRefresh)
     }
 }

--- a/UMCApp/Features/MyPage/Domain/Tests/FetchMyPageProfileUseCaseTests.swift
+++ b/UMCApp/Features/MyPage/Domain/Tests/FetchMyPageProfileUseCaseTests.swift
@@ -23,6 +23,7 @@ struct FetchMyPageProfileUseCaseTests {
 
         #expect(result == expected)
         #expect(mock.fetchMyProfileCallCount == 1)
+        #expect(mock.fetchMyProfileReceivedForceRefresh == false)
     }
 
     @Test("repository가 에러를 던지면 그대로 전파한다")
@@ -34,5 +35,18 @@ struct FetchMyPageProfileUseCaseTests {
         await #expect(throws: MyPageTestError.boom) {
             _ = try await useCase.execute()
         }
+    }
+
+    @Test("execute(forceRefresh: true)는 forceRefresh를 repository에 그대로 관통시킨다")
+    func executePassesForceRefreshThrough() async throws {
+        let expected = makeStubProfileData(challengeId: 7)
+        let mock = MockMyPageRepository()
+        mock.fetchMyProfileResult = .success(expected)
+        let useCase = FetchMyPageProfileUseCase(repository: mock)
+
+        let result = try await useCase.execute(forceRefresh: true)
+
+        #expect(result == expected)
+        #expect(mock.fetchMyProfileReceivedForceRefresh == true)
     }
 }

--- a/UMCApp/Features/MyPage/Domain/Tests/Support/MockMyPageRepository.swift
+++ b/UMCApp/Features/MyPage/Domain/Tests/Support/MockMyPageRepository.swift
@@ -36,9 +36,11 @@ final class MockMyPageRepository: MyPageRepositoryProtocol, @unchecked Sendable 
 
     var fetchMyProfileResult: Result<ProfileData, Error> = .failure(MockError.notStubbed)
     private(set) var fetchMyProfileCallCount = 0
+    private(set) var fetchMyProfileReceivedForceRefresh: Bool?
 
-    func fetchMyProfile() async throws -> ProfileData {
+    func fetchMyProfile(forceRefresh: Bool) async throws -> ProfileData {
         fetchMyProfileCallCount += 1
+        fetchMyProfileReceivedForceRefresh = forceRefresh
         return try fetchMyProfileResult.get()
     }
 

--- a/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageViewModel.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageViewModel.swift
@@ -60,15 +60,19 @@ public final class MyPageViewModel {
     /// - Important: 본 PR은 `/member-oauth/me` 동기화를 호출하지 않으므로
     ///   `socialConnections`는 항상 빈 배열로 세팅됩니다. 소셜 연동 표시는
     ///   Auth UseCase 이식 후속 PR에서 복원합니다.
+    /// - Parameter forceRefresh: `true`이면 세션 프로필 캐시를 우회해 서버 최신으로 갱신한다.
+    ///   (#816 화면 조립 시 당겨서 새로고침 경로로 연결 예정)
     @MainActor
-    public func fetchProfile() async {
+    public func fetchProfile(forceRefresh: Bool = false) async {
         if profileData.isLoading { return }
 
         let previousState = profileData
         profileData = .loading
 
         do {
-            var profile = try await myPageProvider.fetchMyPageProfileUseCase.execute()
+            var profile = try await myPageProvider.fetchMyPageProfileUseCase.execute(
+                forceRefresh: forceRefresh
+            )
             // TODO: Auth UseCase 이식 후속 PR에서 syncConnectedSocials() 호출로 교체
             profile.socialConnections = []
             profileData = .loaded(profile)

--- a/UMCApp/Features/MyPage/Presentation/Tests/MyPageViewModelTests.swift
+++ b/UMCApp/Features/MyPage/Presentation/Tests/MyPageViewModelTests.swift
@@ -122,6 +122,26 @@ struct MyPageViewModelTests {
         #expect(repository.callCount == 1)
         #expect(viewModel.profileData.value?.challengeId == 1)
     }
+
+    @Test("fetchProfile(forceRefresh: true)는 repository까지 forceRefresh를 그대로 전달한다")
+    func forceRefreshIsPassedThroughToRepository() async {
+        let repository = StubRepository(result: .success(makeProfileData(challengeId: 1)))
+        let viewModel = makeViewModel(repository: repository)
+
+        await viewModel.fetchProfile(forceRefresh: true)
+
+        #expect(repository.lastForceRefresh == true)
+    }
+
+    @Test("기본 fetchProfile()은 forceRefresh: false로 조회한다 (캐시 히트 유지)")
+    func defaultFetchUsesCacheAllowedPath() async {
+        let repository = StubRepository(result: .success(makeProfileData(challengeId: 1)))
+        let viewModel = makeViewModel(repository: repository)
+
+        await viewModel.fetchProfile()
+
+        #expect(repository.lastForceRefresh == false)
+    }
 }
 
 // MARK: - Helpers
@@ -172,13 +192,15 @@ private func makeProfileData(
 
 private final class StubRepository: MyPageRepositoryProtocol, @unchecked Sendable {
     private let result: Result<ProfileData, AppError>
+    private(set) var lastForceRefresh: Bool?
 
     init(result: Result<ProfileData, AppError>) {
         self.result = result
     }
 
-    func fetchMyProfile() async throws -> ProfileData {
-        try result.get()
+    func fetchMyProfile(forceRefresh: Bool) async throws -> ProfileData {
+        lastForceRefresh = forceRefresh
+        return try result.get()
     }
 
     func fetchMemberProfile(memberId: Int) async throws -> MemberProfileSummary { fatalError("unused") }
@@ -199,7 +221,7 @@ private final class ThrowingRepository: MyPageRepositoryProtocol, @unchecked Sen
         self.error = error
     }
 
-    func fetchMyProfile() async throws -> ProfileData {
+    func fetchMyProfile(forceRefresh: Bool) async throws -> ProfileData {
         throw error
     }
 
@@ -230,7 +252,7 @@ private final class SlowStubRepository: MyPageRepositoryProtocol, @unchecked Sen
         self.delayNanoseconds = delayNanoseconds
     }
 
-    func fetchMyProfile() async throws -> ProfileData {
+    func fetchMyProfile(forceRefresh: Bool) async throws -> ProfileData {
         lock.lock()
         _callCount += 1
         lock.unlock()


### PR DESCRIPTION
## ✨ PR 유형

Feature — Resolves #974

#972(PR #973)에서 정본 캐시 리포지토리 `CachedMemberProfileRepository`에 도입된 `fetchMyProfile(forceRefresh:)` 경로를 Home/MyPage 소비부까지 관통시키고, 홈 대시보드에 당겨서 새로고침을 연결합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 홈 대시보드 당겨서 새로고침 동작 영상 추가 예정 -->

## 🛠️ 작업내용

**Home (전 구간 관통 + UI 연결)**
- `HomeRepositoryProtocol`·`FetchHomeProfileUseCaseProtocol`을 "단일 요구사항 `forceRefresh: Bool` + 무인자 편의 extension" 패턴으로 확장 — 기존 무인자 호출부는 소스 무변경으로 유지
- `HomeRepository` → 정본 `MemberProfileRepositoryProtocol.fetchMyProfile(forceRefresh:)`까지 인자 관통
- `HomeViewModel.fetchProfile(forceRefresh: Bool = false)` — 기본값으로 기존 호출부(최초 진입/재시도) 무변경
- `HomeView` ScrollView에 `.refreshable { await viewModel.fetchProfile(forceRefresh: true) }` 추가

**MyPage (ViewModel까지 관통, UI 연결은 #816으로 이연)**
- `MyPageRepositoryProtocol`·`FetchMyPageProfileUseCaseProtocol`·`MyPageRepository`·`MyPageViewModel`에 동일 패턴 적용
- `MyPageRepositoryProtocol`의 나머지 8개 메서드와 `primeCache` 프라이밍 로직은 무변경

**테스트 (신규 10건 + 기존 회귀 green)**
- 레이어별 forceRefresh 관통 테스트 (UseCase/Repository/ViewModel — Home·MyPage 각각)
- 실제 `CachedMemberProfileRepository`(actor) 합성 테스트: 캐시 적재 → 히트 → forceRefresh 우회(서버 재조회) → 이후 일반 조회가 갱신된 스냅샷에 히트(추가 원격 호출 없음)를 remote 호출 횟수로 검증
- 기본 경로가 `forceRefresh: false`(캐시 히트 유지)임을 단언하는 테스트 포함
- HomeDomain/HomeData/HomePresentation, MyPageDomain/MyPageData/MyPagePresentation, CoreNetwork(안전망) 스킴 전부 통과

## 📋 추후 진행 상황

- **MyPage `.refreshable`은 이 PR에서 의도적으로 미연결** — `MyPageFeatureView`가 아직 placeholder(`Text("MyPage Feature")`)라 붙일 실화면이 없습니다. #816 화면 조립 시 `.refreshable { await viewModel.fetchProfile(forceRefresh: true) }` 한 줄로 연결되도록 ViewModel 진입점을 준비해 두었습니다.
- 후속 제안: (a) 홈 당겨서 새로고침에 일정 섹션(`fetchSchedules`) 갱신 포함, (b) `Loadable` stale-while-reloading — 현재는 새로고침 중 기존 카드가 스켈레톤으로 교체됩니다(기존 상태 머신 유지 선택).

## 📌 리뷰 포인트

- `Features/Home/Domain/Sources/Interfaces/HomeRepositoryProtocol.swift` — 단일 요구사항 + 편의 extension 패턴 (구현체가 플래그를 조용히 무시할 수 없는 구조)
- `Features/Home/Data/Sources/Repositories/HomeRepository.swift` — 정본 리포지토리로의 forceRefresh 관통 지점
- `Features/Home/Presentation/Sources/Views/HomeView.swift` — `.refreshable` 연결 (프로필+최근 공지 갱신, 일정은 범위 외)
- `Features/Home/Data/Tests/HomeRepositoryTests.swift` · `Features/MyPage/Data/Tests/MyPageRepositoryTests.swift` — 실캐시 합성 테스트의 검증 시퀀스
- `Features/MyPage/Presentation/Sources/ViewModels/MyPageViewModel.swift` — #816에서 연결될 pull-to-refresh 진입점

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)