### PR TITLE
♻️ [Refactor] 네비게이션 타이틀 enum을 피처 단위 중첩 enum으로 상세화

### DIFF
--- a/UMCApp/Core/UIComponents/Sources/Utilities/NavigationModifier.swift
+++ b/UMCApp/Core/UIComponents/Sources/Utilities/NavigationModifier.swift
@@ -10,47 +10,20 @@ import SwiftUI
 
 /// 네비게이션 바의 타이틀과 표시 모드를 설정하는 커스텀 ViewModifier입니다.
 ///
-/// `Navititle` 열거형을 통해 앱 내에서 사용되는 타이틀을 중앙 관리합니다.
+/// `NavigationTitle` 네임스페이스의 피처별 타이틀을 통해 중앙 관리합니다.
 public struct NavigationModifier: ViewModifier {
-    public let naviTitle: Navititle
+    public let title: String
     public let displayMode: NavigationBarItem.TitleDisplayMode
 
-    /// 앱 전체에서 사용되는 네비게이션 타이틀 목록 정의
-    public enum Navititle: String {
-        case signUp = "회원가입"
-        case noticeAlarmType = "알림 보관"
-        case communityDetail = "게시글"
-        case placeSearch = "어느 위치를 찾고 있나요?"
-        case tag = "태그"
-        case challenger = "초대할 챌린저 추가"
-        case searchChallenger = "챌린저 검색"
-        case registration = "일정 추가"
-        case registrationEdit = "일정 수정"
-        case myProfile = "프로필"
-        case myPage = "마이 페이지"
-        case productTeam = "UMC PRODUCT"
-        case myWrittenPosts = "내가 쓴 글"
-        case myCommentedPosts = "댓글 단 글"
-        case myScrappedPosts = "스크랩"
-        case communityPost = "게시글 생성"
-        case voteCreate = "투표 만들기"
-        case voteEdit = "투표 수정하기"
-        case participant = "초대할 챌린저"
-        case adminPannel = "관리자 패널"
-        case branchSelection = "지부 선택"
-        case schoolSelection = "학교 선택"
-        case partSelection = "파트 선택"
-        case noticeDetail = "공지사항"
-        case noticeReadStatus = "공지 열람 현황"
-        case detailSchedule = "일정 상세"
-        case studyScheduleRegistration = "스터디 일정 등록"
-        case communityPostEdit = "게시글 수정"
-        case resetPassword = "비밀번호 재설정"
+    public init(naviTitle: some NavigationTitleRepresentable,
+                displayMode: NavigationBarItem.TitleDisplayMode) {
+        self.title = naviTitle.rawValue
+        self.displayMode = displayMode
     }
 
     public func body(content: Content) -> some View {
         content
-            .navigationTitle(naviTitle.rawValue)
+            .navigationTitle(title)
             .navigationBarTitleDisplayMode(displayMode)
     }
 }
@@ -59,10 +32,11 @@ extension View {
     /// 네비게이션 타이틀과 디스플레이 모드를 간편하게 설정하는 메서드입니다.
     ///
     /// - Parameters:
-    ///   - naviTitle: 미리 정의된 `Navititle` 열거형 값
+    ///   - naviTitle: `NavigationTitle` 네임스페이스의 피처별 타이틀 값
     ///   - displayMode: 타이틀 표시 모드 (.inline, .large 등)
     /// - Returns: NavigationModifier가 적용된 View
-    public func navigation(naviTitle: NavigationModifier.Navititle, displayMode: NavigationBarItem.TitleDisplayMode) -> some View {
+    public func navigation(naviTitle: some NavigationTitleRepresentable,
+                           displayMode: NavigationBarItem.TitleDisplayMode) -> some View {
         modifier(NavigationModifier(naviTitle: naviTitle, displayMode: displayMode))
     }
 }

--- a/UMCApp/Core/UIComponents/Sources/Utilities/NavigationTitle.swift
+++ b/UMCApp/Core/UIComponents/Sources/Utilities/NavigationTitle.swift
@@ -1,0 +1,83 @@
+//
+//  NavigationTitle.swift
+//  CoreUIComponents
+//
+//  Created by 이예지 on 6/1/26.
+//
+
+import Foundation
+
+// MARK: - Protocol
+
+/// 네비게이션 타이틀로 사용할 수 있는 타입이 채택하는 프로토콜입니다.
+///
+/// `String` raw enum이 채택하면 `rawValue`를 자동으로 획득하므로 선언만으로 충족됩니다.
+public protocol NavigationTitleRepresentable {
+    var rawValue: String { get }
+}
+
+// MARK: - Namespace
+
+/// 앱 전체 네비게이션 타이틀을 피처 단위로 그룹화한 네임스페이스입니다.
+///
+/// 각 피처가 모듈로 이식될 때 해당 중첩 enum을 그대로 들어내기 쉽도록
+/// 그룹명을 피처 모듈명과 일치시킵니다.
+public enum NavigationTitle {
+
+    /// 인증/온보딩 화면용 타이틀
+    public enum Auth: String, NavigationTitleRepresentable {
+        case signUp = "회원가입"
+        case resetPassword = "비밀번호 재설정"
+    }
+
+    /// 공지사항 화면용 타이틀
+    public enum Notice: String, NavigationTitleRepresentable {
+        case detail = "공지사항"
+        case readStatus = "공지 열람 현황"
+        case alarmArchive = "알림 보관"
+    }
+
+    /// 커뮤니티 화면용 타이틀
+    public enum Community: String, NavigationTitleRepresentable {
+        case postDetail = "게시글"
+        case createPost = "게시글 생성"
+        case editPost = "게시글 수정"
+        case tag = "태그"
+        case createVote = "투표 만들기"
+        case editVote = "투표 수정하기"
+    }
+
+    /// 스터디/활동 화면용 타이틀
+    public enum Activity: String, NavigationTitleRepresentable {
+        case challenger = "초대할 챌린저 추가"
+        case searchChallenger = "챌린저 검색"
+        case participant = "초대할 챌린저"
+        case addSchedule = "일정 추가"
+        case editSchedule = "일정 수정"
+        case scheduleDetail = "일정 상세"
+        case studyScheduleRegistration = "스터디 일정 등록"
+    }
+
+    /// 마이페이지 화면용 타이틀
+    public enum MyPage: String, NavigationTitleRepresentable {
+        case root = "마이 페이지"
+        case profile = "프로필"
+        case writtenPosts = "내가 쓴 글"
+        case commentedPosts = "댓글 단 글"
+        case scrappedPosts = "스크랩"
+        case productTeam = "UMC PRODUCT"
+    }
+
+    /// 운영/관리자 화면용 타이틀
+    public enum Maintenance: String, NavigationTitleRepresentable {
+        case adminPanel = "관리자 패널"
+    }
+
+    /// 여러 피처에서 공통으로 쓰이는 선택 화면용 타이틀
+    public enum Shared: String, NavigationTitleRepresentable {
+        case branch = "지부 선택"
+        case school = "학교 선택"
+        case part = "파트 선택"
+        case placeSearch = "어느 위치를 찾고 있나요?"
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/ResetPasswordView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/ResetPasswordView.swift
@@ -8,6 +8,7 @@
 import AuthDomain
 import CoreDesignSystem
 import CoreDI
+import CoreUIComponents
 import SwiftUI
 import UMCFoundation
 
@@ -88,7 +89,7 @@ public struct ResetPasswordView: View {
                 .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
             }
             .scrollDismissesKeyboard(.interactively)
-            .navigation(naviTitle: .resetPassword, displayMode: .inline)
+            .navigation(naviTitle: NavigationTitle.Auth.resetPassword, displayMode: .inline)
             .safeAreaInset(edge: .bottom) {
                 submitButton
             }

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpByIdPwView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpByIdPwView.swift
@@ -8,6 +8,7 @@
 import AuthDomain
 import CoreDesignSystem
 import CoreDI
+import CoreUIComponents
 import SwiftUI
 import UMCFoundation
 
@@ -117,7 +118,7 @@ public struct SignUpByIdPwView: View {
                 .safeAreaPadding(.vertical, DefaultConstant.defaultContentTopMargins)
                 .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
             }
-            .navigation(naviTitle: .signUp, displayMode: .large)
+            .navigation(naviTitle: NavigationTitle.Auth.signUp, displayMode: .large)
             .navigationSubtitle(Constants.naviSubtitle)
             .safeAreaInset(edge: .bottom) {
                 submitButton

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/SignUpView.swift
@@ -8,6 +8,7 @@
 import AuthDomain
 import CoreDesignSystem
 import CoreDI
+import CoreUIComponents
 import SwiftUI
 import UMCFoundation
 
@@ -104,7 +105,7 @@ public struct SignUpView: View {
                 .safeAreaPadding(.vertical, DefaultConstant.defaultContentTopMargins)
                 .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
             }
-            .navigation(naviTitle: .signUp, displayMode: .large)
+            .navigation(naviTitle: NavigationTitle.Auth.signUp, displayMode: .large)
             .navigationSubtitle(Constants.naviSubtitle)
             .safeAreaInset(edge: .bottom) {
                 submitButton

--- a/UMCApp/Features/Notice/Presentation/Sources/Views/NoticeDetail/NoticeDetailView.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Views/NoticeDetail/NoticeDetailView.swift
@@ -68,7 +68,7 @@ public struct NoticeDetailView: View {
 
     public var body: some View {
         content
-            .navigation(naviTitle: .noticeDetail, displayMode: .inline)
+            .navigation(naviTitle: NavigationTitle.Notice.detail, displayMode: .inline)
             .navigationSubtitle(noticeTypeSubtitle)
             .toolbar { toolbarContent }
             .safeAreaBar(edge: .bottom, alignment: .center, content: expandedReadStatusInset)

--- a/UMCApp/Features/Notice/Presentation/Sources/Views/NoticeDetail/NoticeReadStatusSheet.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Views/NoticeDetail/NoticeReadStatusSheet.swift
@@ -42,7 +42,7 @@ public struct NoticeReadStatusSheet: View {
                     failedSection(error: error)
                 }
             }
-            .navigation(naviTitle: .noticeReadStatus, displayMode: .inline)
+            .navigation(naviTitle: NavigationTitle.Notice.readStatus, displayMode: .inline)
             .toolbar {
                 ToolBarCollection.CancelBtn(action: {})
                 


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 네비게이션 타이틀을 관리하던 flat `NavigationModifier.Navititle`(29 case)을 피처 단위 중첩 enum으로 상세화한 순수 리팩터입니다. 동작/표시 변경 없음.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 — 모든 rawValue(화면 표시 타이틀 문자열)를 한 글자도 변경하지 않아 표시 결과는 리팩터 전후 동일합니다.

## 🛠️ 작업내용

- flat `Navititle`(29 case, 서로 다른 피처가 혼재)을 `NavigationTitle` 네임스페이스 + **피처별 중첩 `String` enum 7개**로 분리
  - `Auth`(2) · `Notice`(3) · `Community`(6) · `Activity`(7) · `MyPage`(6) · `Maintenance`(1) · `Shared`(4)
  - `Shared` = 여러 피처 공통 선택 화면(지부/학교/파트 선택, 위치 검색)
- `NavigationTitleRepresentable` 프로토콜 도입 — 각 중첩 `String` enum이 채택(rawValue 자동 충족)
- `NavigationModifier`는 내부적으로 rawValue(`String`)만 저장하도록 변경, 시그니처를 `some NavigationTitleRepresentable`로 전환
- case명에서 중복 접두어 제거(`noticeDetail` → `Notice.detail`), 오타 수정(`adminPannel` → `Maintenance.adminPanel`)
- `NavigationTitle.swift`(신규) / `NavigationModifier.swift`(modifier+extension) 로 파일 분리
- 호출부 5곳을 `NavigationTitle.Feature.case` 경로로 갱신 (Auth 뷰 3곳은 명시적 타입 참조를 위해 `import CoreUIComponents` 추가)

## 📋 추후 진행 상황

- 미이식 피처(Community/Activity/MyPage/Maintenance 등)가 `UMCApp`으로 이식될 때, 준비된 그룹에 case를 채우거나 해당 중첩 enum을 피처 모듈로 그대로 이동

## 📌 리뷰 포인트

- `UMCApp/Core/UIComponents/Sources/Utilities/NavigationTitle.swift` - 그룹 분류(7개)와 case↔rawValue 매핑이 기존 값과 일치하는지, `Shared` 그룹 배치가 적절한지
- `UMCApp/Core/UIComponents/Sources/Utilities/NavigationModifier.swift` - `some NavigationTitleRepresentable` 시그니처와 rawValue 저장 방식
- `UMCApp/Features/Auth/Presentation/Sources/Views/*` - `import CoreUIComponents` 추가 및 `NavigationTitle.Auth.*` 호출 경로
- `UMCApp/Features/Notice/Presentation/Sources/Views/NoticeDetail/*` - `NavigationTitle.Notice.*` 호출 경로

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)