### PR TITLE
♻️ [Refactor] OperatorAttendanceViewModel 이식 (List/Detail 단일 통합)

### DIFF
--- a/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceInfo.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Operator/ScheduleAttendanceInfo.swift
@@ -103,4 +103,11 @@ public struct ScheduleAttendanceInfo: Equatable, Sendable, Identifiable {
         guard totalCount > 0 else { return 0.0 }
         return Double(presentCount) / Double(totalCount)
     }
+
+    /// 일정이 진행 중인지 (`startsAt...endsAt` 경계 포함)
+    ///
+    /// 목록·상세 폴링 트리거가 같은 판정을 공유하도록 모델에 둡니다.
+    public func isOngoing(at now: Date = Date()) -> Bool {
+        now >= startsAt && now <= endsAt
+    }
 }

--- a/UMCApp/Features/Activity/Domain/Tests/Operator/ScheduleAttendanceInfoTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/Operator/ScheduleAttendanceInfoTests.swift
@@ -46,7 +46,7 @@ private func makeInfo(participants: [ParticipantAttendance]) -> ScheduleAttendan
 
 // MARK: - Suite
 
-@Suite("ScheduleAttendanceInfo — 카운팅 / 출석률 도메인 규칙")
+@Suite("ScheduleAttendanceInfo — 카운팅 / 출석률 / 진행 판정 (도메인 규칙)")
 struct ScheduleAttendanceInfoTests {
 
     // MARK: - presentCount
@@ -164,5 +164,29 @@ struct ScheduleAttendanceInfoTests {
 
         // Then
         #expect(rate == 1.0)
+    }
+
+    // MARK: - isOngoing (경계값 포함)
+
+    // makeInfo 고정 범위: startsAt 1_736_942_400 ... endsAt 1_736_949_600
+    @Test(
+        "isOngoing 은 startsAt...endsAt 경계를 포함해 판정한다",
+        arguments: [
+            (timestamp: 1_736_942_399.0, expected: false),  // 시작 1초 전
+            (timestamp: 1_736_942_400.0, expected: true),   // 시작 시각 (경계)
+            (timestamp: 1_736_946_000.0, expected: true),   // 진행 중
+            (timestamp: 1_736_949_600.0, expected: true),   // 종료 시각 (경계)
+            (timestamp: 1_736_949_601.0, expected: false)   // 종료 1초 후
+        ]
+    )
+    func isOngoingIncludesBoundaries(testCase: (timestamp: Double, expected: Bool)) {
+        // Given
+        let info = makeInfo(participants: [])
+
+        // When
+        let result = info.isOngoing(at: Date(timeIntervalSince1970: testCase.timestamp))
+
+        // Then
+        #expect(result == testCase.expected)
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Enums/AttendancePeriodPreset.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Enums/AttendancePeriodPreset.swift
@@ -1,0 +1,71 @@
+//
+//  AttendancePeriodPreset.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/14/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - AttendancePeriodPreset
+
+/// 운영진 출석 현황 기간 필터 프리셋
+///
+/// 목록 조회의 `from`/`to` 범위를 프리셋 단위로 제공합니다. `.custom` 은
+/// 사용자가 날짜를 직접 지정하므로 ``dateRange`` 가 `nil` 입니다.
+///
+/// - SeeAlso: ``OperatorAttendanceViewModel``
+enum AttendancePeriodPreset: String, CaseIterable, Identifiable {
+    case oneWeek     = "oneWeek"
+    case oneMonth    = "oneMonth"
+    case threeMonths = "threeMonths"
+    case custom      = "custom"
+
+    var id: String { rawValue }
+
+    /// 필터 칩에 표시할 한국어 라벨
+    var label: String {
+        switch self {
+        case .oneWeek:     return "최근 1주"
+        case .oneMonth:    return "최근 1개월"
+        case .threeMonths: return "최근 3개월"
+        case .custom:      return "직접 입력"
+        }
+    }
+
+    /// 필터 칩에 표시할 SF Symbol 이름
+    var iconName: String {
+        switch self {
+        case .oneWeek, .oneMonth, .threeMonths: return "calendar"
+        case .custom:                           return "calendar.badge.plus"
+        }
+    }
+
+    // MARK: - Date Range
+
+    /// 프리셋에 해당하는 `(fromDate, toDate)` 쌍.
+    ///
+    /// - `.custom` 은 날짜를 직접 지정하므로 `nil` 반환.
+    /// - `toDate` 는 조회 시점 기준 +24시간으로 고정해 진행 중인 일정도 포함합니다.
+    var dateRange: (fromDate: Date, toDate: Date)? {
+        guard self != .custom else { return nil }
+        let now = Date()
+        let toDate = now.addingTimeInterval(24 * 60 * 60)
+        let fromDate: Date
+        switch self {
+        case .oneWeek:
+            fromDate = Calendar.kstGregorian.date(byAdding: .day, value: -7, to: now)
+                ?? now.addingTimeInterval(-7 * 24 * 60 * 60)
+        case .oneMonth:
+            fromDate = Calendar.kstGregorian.date(byAdding: .month, value: -1, to: now)
+                ?? now.addingTimeInterval(-30 * 24 * 60 * 60)
+        case .threeMonths:
+            fromDate = Calendar.kstGregorian.date(byAdding: .month, value: -3, to: now)
+                ?? now.addingTimeInterval(-90 * 24 * 60 * 60)
+        case .custom:
+            return nil
+        }
+        return (fromDate, toDate)
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Support/PollingLoop.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Support/PollingLoop.swift
@@ -1,0 +1,42 @@
+//
+//  PollingLoop.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/20/26.
+//
+
+import Foundation
+
+/// 화면 폴링 공용 루프 (sleep-first)
+///
+/// 매 주기 `predicate 평가 → 간격 대기 → 취소 확인 → refresh` 순서로 반복하고,
+/// predicate 가 거짓이 되거나 Task 가 취소되면 종료합니다.
+/// `.task` 에서 호출하면 뷰 소멸 시 자동 취소됩니다.
+///
+/// - 첫 refresh 는 한 주기 뒤에 실행됩니다. 진입 즉시 1회 갱신(refresh-first)이 필요하면
+///   루프 시작 전에 refresh 를 직접 1회 실행합니다(`ChallengerAttendanceViewModel` 방식) —
+///   순서 조합으로 표현하므로 별도 플래그 파라미터를 두지 않습니다.
+/// - 대기 중 predicate 가 거짓으로 바뀌면 종료 전에 refresh 가 1회 더 실행될 수 있습니다.
+///   호출부 refresh 는 배경 갱신(실패 무시·latest-wins)이어야 안전합니다.
+enum PollingLoop {
+
+    /// 폴링 루프를 시작합니다.
+    ///
+    /// - Parameters:
+    ///   - intervalSeconds: 갱신 간격 (초)
+    ///   - predicate: 매 주기 시작 시 평가해 거짓이면 루프를 종료한다.
+    ///   - refresh: 주기마다 실행할 배경 갱신.
+    @MainActor
+    static func run(
+        intervalSeconds: Int,
+        while predicate: () -> Bool,
+        refresh: () async -> Void
+    ) async {
+        while !Task.isCancelled {
+            guard predicate() else { return }
+            try? await Task.sleep(for: .seconds(intervalSeconds))
+            guard !Task.isCancelled else { return }
+            await refresh()
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
@@ -153,14 +153,19 @@ final class ChallengerAttendanceViewModel {
     /// `.task` 모디파이어에서 호출하면 뷰 사라질 때 자동 취소됩니다.
     /// 세션 시간 기반으로 진행 중 여부를 판단합니다.
     func startPollingIfNeeded(sessions: [Session]) async {
-        while !Task.isCancelled {
-            guard hasActiveSession(in: sessions) else { return }
-            await refreshAvailableSchedules()
-            await refreshMyHistory()
-            try? await Task.sleep(for: .seconds(
-                PollingConfig.intervalSeconds
-            ))
-        }
+        // 공용 루프는 sleep-first 라, 문서화된 refresh-first 동작(진입 직후 대기 구간 없음)은
+        // 루프 시작 전 1회 갱신으로 표현한다.
+        guard !Task.isCancelled, hasActiveSession(in: sessions) else { return }
+        await refreshAvailableSchedules()
+        await refreshMyHistory()
+        await PollingLoop.run(
+            intervalSeconds: PollingConfig.intervalSeconds,
+            while: { hasActiveSession(in: sessions) },
+            refresh: {
+                await refreshAvailableSchedules()
+                await refreshMyHistory()
+            }
+        )
     }
 
     /// 진행 중인 세션이 하나라도 있는지 확인

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorAttendanceViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorAttendanceViewModel.swift
@@ -1,0 +1,666 @@
+//
+//  OperatorAttendanceViewModel.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/14/26.
+//
+
+import ActivityDomain
+import Foundation
+import UMCFoundation
+
+/// 운영진 출석 관리 화면(단일 통합, Direction A)의 상태·액션을 관리하는 ViewModel.
+///
+/// 레거시 `AttendanceListViewModel` + `AttendanceDetailViewModel` 을 단일 화면 기준으로
+/// 통합 이식했습니다. 출석 현황 목록 조회·단일 일정 상세 조회·일괄 승인/반려·위치 변경을
+/// 모두 `OperatorAttendanceUseCaseProtocol` 에만 의존해 처리합니다(Repository 직접 의존 금지).
+///
+/// - 모든 서버 식별자는 `String` 으로 통일됩니다.
+/// - `.task` 라이프사이클 취소(`CancellationError`)는 실패가 아니므로 이전 상태로 롤백합니다
+///   (형제 `MemberListViewModel`/`ChallengerStudyViewModel` house 패턴).
+///
+/// > Note: 레거시 위치 변경 시트(`OperatorLocationChangeSheetView`)와 `PlaceSearchInfo` 는
+///   아직 이식 전이라, 위치 변경은 검증된 원시 좌표 파라미터를 받는
+///   ``changeLocation(name:latitude:longitude:)`` 로 노출합니다.
+@MainActor
+@Observable
+final class OperatorAttendanceViewModel {
+
+    // MARK: - Polling Config
+
+    private enum PollingConfig {
+        static let intervalSeconds: Int = 15
+    }
+
+    // MARK: - Dependency
+
+    private let errorHandler: ErrorHandler
+    private let useCase: OperatorAttendanceUseCaseProtocol
+
+    // MARK: - Request Tokens
+
+    /// 목록·상세 요청 순번. 응답을 적용할 때 토큰이 최신인지 확인해 최신 요청만 상태에
+    /// 반영한다(latest-wins).
+    ///
+    /// 병합 VM 은 가변 식별자(`selectedScheduleId`)·필터(`selectedListFilter`/기간)를 갖고
+    /// 그 값이 요청 도중 바뀔 수 있다. 형제 `MemberListViewModel` 의 단순 재진입 가드
+    /// (`if state.isLoading { return }`)는 이 가변 식별자를 몰라서 진행 중 스케줄 전환을
+    /// 통째로 막거나(요청 유실) 오래된 응답이 새 식별자에 바인딩되는 문제가 생긴다. 토큰은
+    /// 이 둘을 함께 풀고 롤백 기준을 비-`.loading` 으로 잡아 stuck-loading 까지 막는다.
+    @ObservationIgnored private var listRequestID = 0
+    @ObservationIgnored private var detailRequestID = 0
+
+    // MARK: - List State
+
+    /// 출석 현황 목록 로드 상태
+    private(set) var listState: Loadable<[ScheduleAttendanceInfo]> = .idle
+
+    /// 목록 상태 필터 (`nil` = 전체)
+    private(set) var selectedListFilter: ParticipantAttendanceStatus?
+
+    /// 필터 칩 후보 (`.unknown` 제외)
+    let filterableStatuses: [ParticipantAttendanceStatus] =
+        ParticipantAttendanceStatus.filterableCases
+
+    /// 선택된 기간 프리셋 (기본값: 최근 1개월)
+    private(set) var periodPreset: AttendancePeriodPreset = .oneMonth
+
+    /// 조회 시작 일시 (기본값: 현재 -1개월)
+    var fromDate: Date = {
+        Calendar.kstGregorian.date(byAdding: .month, value: -1, to: Date())
+            ?? Date().addingTimeInterval(-30 * 24 * 60 * 60)
+    }()
+
+    /// 조회 종료 일시 (기본값: 현재 +24시간, 진행 중 일정 포함)
+    var toDate: Date = Date().addingTimeInterval(24 * 60 * 60)
+
+    // MARK: - Detail State
+
+    /// 현재 상세 조회 대상 일정 식별자 (서버 응답 `String`)
+    private(set) var selectedScheduleId: String?
+
+    /// 단일 일정 출석 현황 로드 상태
+    private(set) var detailState: Loadable<ScheduleAttendanceInfo> = .idle
+
+    /// 상세 화면 상태 필터 (`nil` = 전체, 클라이언트 측 필터링)
+    private(set) var selectedDetailFilter: ParticipantAttendanceStatus?
+
+    /// 상세 진입 후 일정이 삭제됐는지 여부 (SCHEDULE-0009 감지)
+    private(set) var isScheduleDeleted: Bool = false
+
+    /// 확인/에러 다이얼로그
+    var alertPrompt: AlertPrompt?
+
+    /// 승인/반려 처리 중인 멤버 ID Set (개별 행 ProgressView 표시용)
+    private(set) var processingMemberIds: Set<String> = []
+
+    // MARK: - Init
+
+    init(
+        errorHandler: ErrorHandler,
+        useCase: OperatorAttendanceUseCaseProtocol
+    ) {
+        self.errorHandler = errorHandler
+        self.useCase = useCase
+    }
+
+    // MARK: - List Derived State
+
+    /// 전체 승인 대기 건수 (`.loaded` 상태에서만 집계)
+    var totalPendingCount: Int {
+        guard case .loaded(let infos) = listState else { return 0 }
+        return infos.map(\.pendingCount).reduce(0, +)
+    }
+
+    /// 승인 대기가 1건 이상인 첫 번째 일정의 scheduleId
+    var firstPendingScheduleId: String? {
+        guard case .loaded(let infos) = listState else { return nil }
+        return infos.first(where: { $0.pendingCount > 0 })?.scheduleId
+    }
+
+    /// 접근 권한 거부 상태 여부 (HTTP 403) — 권한 전용 UI 노출 분기용
+    var isPermissionDenied: Bool {
+        guard case .failed(let error) = listState else { return false }
+        return Self.isPermissionDenied(error)
+    }
+
+    /// 진행 중인 세션이 하나라도 있는지 (KST 기준, 폴링 트리거용)
+    private var hasActiveSession: Bool {
+        guard case .loaded(let infos) = listState else { return false }
+        let now = Date()
+        return infos.contains { now >= $0.startsAt && now <= $0.endsAt }
+    }
+
+    // MARK: - List Fetch
+
+    /// 출석 현황 목록 조회 (스피너 전환).
+    func fetchList() async {
+        await loadList(showLoading: true)
+    }
+
+    /// 배경 갱신 — `.loading` 전환 없이 성공 시에만 상태 교체(실패 시 기존 데이터 유지).
+    func refreshList() async {
+        guard listState.isComplete else { return }
+        await loadList(showLoading: false)
+    }
+
+    /// 목록 조회 코어.
+    ///
+    /// 요청 토큰으로 최신 요청만 상태에 반영해 필터/기간이 요청 도중 바뀌어도 오래된 응답이
+    /// 새 필터 상태를 덮어쓰지 못하게 한다. 취소는 실패가 아니므로 스피너 전환일 때만 롤백한다.
+    /// - Parameter showLoading: `true` = 사용자 트리거(스피너·에러 노출), `false` = 배경 갱신
+    ///   (에러를 삼켜 기존 데이터 유지 — 레거시 `refreshList` 동작).
+    private func loadList(showLoading: Bool) async {
+        listRequestID &+= 1
+        let requestID = listRequestID
+        // 롤백 기준: 진행 중(.loading) 상태는 복원 대상이 아니므로 .idle 로 대체(stuck-loading 방지).
+        let restore: Loadable<[ScheduleAttendanceInfo]> = listState.isComplete ? listState : .idle
+        // 요청 파라미터를 시작 시점에 고정 — 응답 적용은 토큰이 최신일 때만 이뤄진다.
+        let from = fromDate
+        let to = toDate
+        let filter = selectedListFilter
+        if showLoading { listState = .loading }
+        do {
+            let list = try await useCase.fetchAttendanceList(
+                from: from,
+                to: to,
+                attendanceStatus: filter
+            )
+            guard requestID == listRequestID else { return }
+            listState = .loaded(list)
+        } catch is CancellationError {
+            guard requestID == listRequestID, showLoading else { return }
+            listState = restore
+        } catch let error as NSError
+            where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+            guard requestID == listRequestID, showLoading else { return }
+            listState = restore
+        } catch let error as AppError {
+            guard requestID == listRequestID, showLoading else { return }
+            listState = .failed(error)
+        } catch let error as DomainError {
+            guard requestID == listRequestID, showLoading else { return }
+            listState = .failed(.domain(error))
+        } catch let error as NetworkError {
+            guard requestID == listRequestID, showLoading else { return }
+            listState = .failed(.network(error))
+        } catch let error as RepositoryError {
+            guard requestID == listRequestID, showLoading else { return }
+            listState = .failed(.repository(error))
+        } catch {
+            guard requestID == listRequestID, showLoading else { return }
+            listState = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    /// 진행 중인 세션이 있을 때 15초 주기로 배경 갱신.
+    ///
+    /// `.task` 에서 호출하면 뷰 소멸 시 자동 취소됩니다.
+    func startListPollingIfNeeded() async {
+        guard listState.isComplete else { return }
+        while !Task.isCancelled {
+            guard hasActiveSession else { return }
+            try? await Task.sleep(for: .seconds(PollingConfig.intervalSeconds))
+            guard !Task.isCancelled else { break }
+            await refreshList()
+        }
+    }
+
+    // MARK: - List Filter
+
+    /// 상태 필터 칩 탭 — 같은 필터를 다시 누르면 해제. 변경 즉시 재조회.
+    func listFilterButtonTapped(_ status: ParticipantAttendanceStatus) async {
+        selectedListFilter = (selectedListFilter == status) ? nil : status
+        await fetchList()
+    }
+
+    /// "전체" 선택 — 이미 전체면 재조회하지 않음.
+    func clearListFilter() async {
+        guard selectedListFilter != nil else { return }
+        selectedListFilter = nil
+        await fetchList()
+    }
+
+    /// 기간 프리셋 선택 — `.custom` 은 from/to 를 유지하고 사용자가 직접 조정.
+    func presetSelected(_ preset: AttendancePeriodPreset) async {
+        periodPreset = preset
+        if let range = preset.dateRange {
+            fromDate = range.fromDate
+            toDate = range.toDate
+        }
+        await fetchList()
+    }
+
+    // MARK: - Detail Fetch
+
+    /// 단일 일정 상세 조회 대상 선택 + 즉시 조회.
+    func selectSchedule(_ scheduleId: String) async {
+        selectedScheduleId = scheduleId
+        selectedDetailFilter = nil
+        await loadDetail(showLoading: true)
+    }
+
+    /// 선택된 일정의 출석 현황 상세 재조회 (스피너 전환).
+    func fetchDetail() async {
+        await loadDetail(showLoading: true)
+    }
+
+    /// 상세 배경 갱신 — 실패해도 기존 상태 유지.
+    func refreshDetail() async {
+        guard selectedScheduleId != nil, detailState.isComplete else { return }
+        await loadDetail(showLoading: false)
+    }
+
+    /// 상세 조회 코어.
+    ///
+    /// 요청 토큰으로 최신 요청만 반영해, 스케줄 전환 중 오래된 응답이 새 `selectedScheduleId` 에
+    /// 옛 데이터를 바인딩하지 않게 한다. 진입 후 일정이 삭제된 경우(SCHEDULE-0009)
+    /// ``isScheduleDeleted`` 를 세운다.
+    /// - Parameter showLoading: `true` = 사용자 트리거(스피너·에러 노출), `false` = 배경 갱신.
+    private func loadDetail(showLoading: Bool) async {
+        guard let scheduleId = selectedScheduleId else { return }
+        detailRequestID &+= 1
+        let requestID = detailRequestID
+        let restore: Loadable<ScheduleAttendanceInfo> =
+            detailState.isComplete ? detailState : .idle
+        if showLoading {
+            detailState = .loading
+            isScheduleDeleted = false
+        }
+        do {
+            let info = try await useCase.fetchAttendanceDetail(
+                scheduleId: scheduleId,
+                attendanceStatus: nil
+            )
+            guard requestID == detailRequestID else { return }
+            detailState = .loaded(info)
+        } catch is CancellationError {
+            guard requestID == detailRequestID, showLoading else { return }
+            detailState = restore
+        } catch let error as NSError
+            where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+            guard requestID == detailRequestID, showLoading else { return }
+            detailState = restore
+        } catch let error as AppError {
+            guard requestID == detailRequestID, showLoading else { return }
+            detailState = .failed(error)
+        } catch let error as DomainError {
+            guard requestID == detailRequestID, showLoading else { return }
+            detailState = .failed(.domain(error))
+        } catch let error as NetworkError {
+            guard requestID == detailRequestID, showLoading else { return }
+            detailState = .failed(.network(error))
+        } catch let error as RepositoryError {
+            guard requestID == detailRequestID, showLoading else { return }
+            if case .serverError(let code, _) = error, code == "SCHEDULE-0009" {
+                isScheduleDeleted = true
+            }
+            detailState = .failed(.repository(error))
+        } catch {
+            guard requestID == detailRequestID, showLoading else { return }
+            detailState = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    /// 진행 중인 일정일 때만 15초 폴링.
+    func startDetailPollingIfNeeded() async {
+        guard detailState.isComplete else { return }
+        while !Task.isCancelled {
+            guard isCurrentlyActive else { return }
+            try? await Task.sleep(for: .seconds(PollingConfig.intervalSeconds))
+            guard !Task.isCancelled else { break }
+            await refreshDetail()
+        }
+    }
+
+    // MARK: - Detail Filter
+
+    /// 상세 필터 칩 탭 (클라이언트 측 필터링, 재조회 없음).
+    func detailFilterButtonTapped(_ status: ParticipantAttendanceStatus) {
+        selectedDetailFilter = (selectedDetailFilter == status) ? nil : status
+    }
+
+    /// 현재 필터를 적용한 참여자 목록.
+    var filteredParticipants: [ParticipantAttendance] {
+        guard case .loaded(let info) = detailState else { return [] }
+        guard let filter = selectedDetailFilter else { return info.participants }
+        return info.participants.filter { $0.attendanceStatus == filter }
+    }
+
+    // MARK: - Approval Button (AlertPrompt)
+
+    /// 개별 승인 버튼 탭 (확인 AlertPrompt 표시).
+    func approveButtonTapped(participant: ParticipantAttendance) {
+        alertPrompt = AlertPrompt(
+            title: "출석 승인",
+            message: "\(participant.name)님의 출석을 승인하시겠습니까?",
+            positiveBtnTitle: "승인",
+            positiveBtnAction: { [weak self] in
+                Task { await self?.decideAttendance(participant: participant, isApproved: true) }
+            },
+            negativeBtnTitle: "취소"
+        )
+    }
+
+    /// 개별 반려 버튼 탭 (확인 AlertPrompt 표시).
+    func rejectButtonTapped(participant: ParticipantAttendance) {
+        alertPrompt = AlertPrompt(
+            title: "출석 반려",
+            message: "\(participant.name)님의 출석을 반려하시겠습니까?",
+            positiveBtnTitle: "반려",
+            positiveBtnAction: { [weak self] in
+                Task { await self?.decideAttendance(participant: participant, isApproved: false) }
+            },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    /// 전체 승인 버튼 탭.
+    func approveAllButtonTapped() {
+        alertPrompt = AlertPrompt(
+            title: "전체 승인",
+            message: "모든 승인 대기 출석을 승인하시겠습니까?",
+            positiveBtnTitle: "전체 승인",
+            positiveBtnAction: { [weak self] in
+                Task { await self?.decideAllAttendances(isApproved: true) }
+            },
+            negativeBtnTitle: "취소"
+        )
+    }
+
+    /// 전체 반려 버튼 탭.
+    func rejectAllButtonTapped() {
+        alertPrompt = AlertPrompt(
+            title: "전체 거절",
+            message: "모든 승인 대기 출석을 거절하시겠습니까?",
+            positiveBtnTitle: "전체 거절",
+            positiveBtnAction: { [weak self] in
+                Task { await self?.decideAllAttendances(isApproved: false) }
+            },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    /// 선택 승인 버튼 탭.
+    func approveSelectedButtonTapped(participants: [ParticipantAttendance]) {
+        guard !participants.isEmpty else { return }
+        alertPrompt = AlertPrompt(
+            title: "선택 승인",
+            message: "\(participants.count)명의 출석을 승인하시겠습니까?",
+            positiveBtnTitle: "승인",
+            positiveBtnAction: { [weak self] in
+                Task {
+                    await self?.decideSelectedAttendances(
+                        participants: participants,
+                        isApproved: true
+                    )
+                }
+            },
+            negativeBtnTitle: "취소"
+        )
+    }
+
+    /// 선택 반려 버튼 탭.
+    func rejectSelectedButtonTapped(participants: [ParticipantAttendance]) {
+        guard !participants.isEmpty else { return }
+        alertPrompt = AlertPrompt(
+            title: "선택 거절",
+            message: "\(participants.count)명의 출석을 거절하시겠습니까?",
+            positiveBtnTitle: "거절",
+            positiveBtnAction: { [weak self] in
+                Task {
+                    await self?.decideSelectedAttendances(
+                        participants: participants,
+                        isApproved: false
+                    )
+                }
+            },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    // MARK: - Decision (낙관적 갱신)
+
+    /// 단건 승인/반려 — 성공 시 pending → present/absent 로 낙관적 갱신.
+    func decideAttendance(
+        participant: ParticipantAttendance,
+        isApproved: Bool
+    ) async {
+        guard let scheduleId = selectedScheduleId else { return }
+        alertPrompt = nil
+        let memberId = participant.memberId
+        processingMemberIds.insert(memberId)
+        defer { processingMemberIds.remove(memberId) }
+
+        let decision = AttendanceDecisionInput(
+            isApproved: isApproved,
+            participantMemberId: memberId,
+            reason: ""
+        )
+        do {
+            _ = try await useCase.decideAttendances(
+                scheduleId: scheduleId,
+                decisions: [decision]
+            )
+            updateParticipants(memberIds: [memberId], isApproved: isApproved)
+        } catch {
+            await handleDecisionError(
+                error,
+                action: isApproved ? "approveAttendance" : "rejectAttendance"
+            )
+        }
+    }
+
+    /// 전체 승인 대기 일괄 처리.
+    func decideAllAttendances(isApproved: Bool) async {
+        guard let scheduleId = selectedScheduleId else { return }
+        alertPrompt = nil
+        guard case .loaded(let info) = detailState else { return }
+
+        let pending = info.participants.filter(\.attendanceStatus.isPending)
+        guard !pending.isEmpty else { return }
+
+        let decisions = pending.map {
+            AttendanceDecisionInput(
+                isApproved: isApproved,
+                participantMemberId: $0.memberId,
+                reason: ""
+            )
+        }
+        do {
+            _ = try await useCase.decideAttendances(
+                scheduleId: scheduleId,
+                decisions: decisions
+            )
+            updateParticipants(
+                memberIds: Set(pending.map(\.memberId)),
+                isApproved: isApproved
+            )
+        } catch {
+            await handleDecisionError(
+                error,
+                action: isApproved ? "approveAllAttendances" : "rejectAllAttendances"
+            )
+        }
+    }
+
+    /// 선택 참여자 일괄 처리.
+    func decideSelectedAttendances(
+        participants: [ParticipantAttendance],
+        isApproved: Bool
+    ) async {
+        guard let scheduleId = selectedScheduleId else { return }
+        alertPrompt = nil
+        guard !participants.isEmpty else { return }
+
+        let decisions = participants.map {
+            AttendanceDecisionInput(
+                isApproved: isApproved,
+                participantMemberId: $0.memberId,
+                reason: ""
+            )
+        }
+        do {
+            _ = try await useCase.decideAttendances(
+                scheduleId: scheduleId,
+                decisions: decisions
+            )
+            updateParticipants(
+                memberIds: Set(participants.map(\.memberId)),
+                isApproved: isApproved
+            )
+        } catch {
+            await handleDecisionError(
+                error,
+                action: isApproved ? "approveSelectedAttendances" : "rejectSelectedAttendances"
+            )
+        }
+    }
+
+    // MARK: - Location
+
+    /// 세션 출석 위치 변경.
+    ///
+    /// 좌표 유효성(유한값·위경도 범위)을 검증한 뒤 UseCase 에 위임합니다. 성공하면 `true`.
+    /// - Note: 레거시 `PlaceSearchInfo` 커플링을 제거하고 검증된 원시 좌표를 받습니다.
+    func changeLocation(
+        name: String,
+        latitude: Double,
+        longitude: Double
+    ) async -> Bool {
+        guard let scheduleId = selectedScheduleId else { return false }
+
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            presentAlert(title: "위치 변경 실패", message: "변경할 위치를 선택해 주세요.")
+            return false
+        }
+
+        guard latitude.isFinite, longitude.isFinite,
+              (-90.0...90.0).contains(latitude),
+              (-180.0...180.0).contains(longitude) else {
+            presentAlert(title: "위치 변경 실패", message: "유효한 위치 좌표를 선택해 주세요.")
+            return false
+        }
+
+        do {
+            try await useCase.updateScheduleLocation(
+                scheduleId: scheduleId,
+                locationName: trimmedName,
+                latitude: latitude,
+                longitude: longitude
+            )
+            return true
+        } catch {
+            errorHandler.handle(error, context: ErrorContext(
+                feature: "Activity",
+                action: "updateScheduleLocation"
+            ))
+            return false
+        }
+    }
+
+    // MARK: - Private (Error)
+
+    private func handleDecisionError(_ error: Error, action: String) async {
+        if Self.isPermissionDenied(error) {
+            presentAlert(
+                title: "권한이 없어요",
+                message: "출석을 처리할 권한이 없습니다. 운영진 권한을 확인해 주세요."
+            )
+            await refreshDetail()
+            return
+        }
+        errorHandler.handle(error, context: ErrorContext(
+            feature: "Activity",
+            action: action
+        ))
+    }
+
+    /// HTTP 403 여부 판별 — `AppError` 로 정규화됐거나 원본 `NetworkError` 둘 다 커버.
+    private static func isPermissionDenied(_ error: Error) -> Bool {
+        if let networkError = error as? NetworkError,
+           case .requestFailed(let status, _) = networkError, status == 403 {
+            return true
+        }
+        if let appError = error as? AppError,
+           case .network(let networkError) = appError,
+           case .requestFailed(let status, _) = networkError, status == 403 {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Private (낙관적 갱신)
+
+    /// 지정한 멤버들을 pending → present/absent 로 낙관적 갱신.
+    ///
+    /// 단건·전체·선택 결정이 동일 규칙을 공유하므로 대상 memberId 집합만 달리해 재사용합니다.
+    private func updateParticipants(memberIds: Set<String>, isApproved: Bool) {
+        guard case .loaded(let info) = detailState else { return }
+        let newStatus: ParticipantAttendanceStatus = isApproved ? .present : .absent
+        let updated = info.participants.map { participant -> ParticipantAttendance in
+            guard memberIds.contains(participant.memberId),
+                  participant.attendanceStatus.isPending else {
+                return participant
+            }
+            return ParticipantAttendance(
+                memberId: participant.memberId,
+                name: participant.name,
+                nickname: participant.nickname,
+                profileImageURL: participant.profileImageURL,
+                schoolId: participant.schoolId,
+                schoolName: participant.schoolName,
+                attendanceStatus: newStatus,
+                isLocationVerified: participant.isLocationVerified,
+                excuseReason: participant.excuseReason
+            )
+        }
+        detailState = .loaded(rebuild(info, participants: updated))
+        notifySharedSessionChange()
+    }
+
+    private func rebuild(
+        _ info: ScheduleAttendanceInfo,
+        participants: [ParticipantAttendance]
+    ) -> ScheduleAttendanceInfo {
+        ScheduleAttendanceInfo(
+            scheduleId: info.scheduleId,
+            name: info.name,
+            description: info.description,
+            startsAt: info.startsAt,
+            endsAt: info.endsAt,
+            location: info.location,
+            isOnline: info.isOnline,
+            authorMemberId: info.authorMemberId,
+            attendancePolicy: info.attendancePolicy,
+            tags: info.tags,
+            participants: participants
+        )
+    }
+
+    // MARK: - Private (Helper)
+
+    /// 일정이 현재 진행 중인지 (KST 기준, 폴링용).
+    private var isCurrentlyActive: Bool {
+        guard case .loaded(let info) = detailState else { return false }
+        let now = Date()
+        return now >= info.startsAt && now <= info.endsAt
+    }
+
+    /// 챌린저 뷰를 실시간 갱신하도록 Notification 발송.
+    private func notifySharedSessionChange() {
+        NotificationCenter.default.post(name: .attendanceStatusChanged, object: nil)
+    }
+
+    private func presentAlert(title: String, message: String) {
+        alertPrompt = AlertPrompt(
+            title: title,
+            message: message,
+            positiveBtnTitle: "확인"
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorAttendanceViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorAttendanceViewModel.swift
@@ -47,6 +47,10 @@ final class OperatorAttendanceViewModel {
     /// (`if state.isLoading { return }`)는 이 가변 식별자를 몰라서 진행 중 스케줄 전환을
     /// 통째로 막거나(요청 유실) 오래된 응답이 새 식별자에 바인딩되는 문제가 생긴다. 토큰은
     /// 이 둘을 함께 풀고 롤백 기준을 비-`.loading` 으로 잡아 stuck-loading 까지 막는다.
+    ///
+    /// mutation(결정·위치 변경) 경로는 토큰 대신 진입 시점에 캡처한 `scheduleId` 로 대상
+    /// 일정을 고정하고, 성공 시 `detailRequestID` 를 올려 변경 이전 스냅샷을 실은
+    /// in-flight 폴 응답이 결과를 되돌리지 못하게 한다.
     @ObservationIgnored private var listRequestID = 0
     @ObservationIgnored private var detailRequestID = 0
 
@@ -124,11 +128,10 @@ final class OperatorAttendanceViewModel {
         return Self.isPermissionDenied(error)
     }
 
-    /// 진행 중인 세션이 하나라도 있는지 (KST 기준, 폴링 트리거용)
+    /// 진행 중인 세션이 하나라도 있는지 (폴링 트리거용)
     private var hasActiveSession: Bool {
         guard case .loaded(let infos) = listState else { return false }
-        let now = Date()
-        return infos.contains { now >= $0.startsAt && now <= $0.endsAt }
+        return infos.contains { $0.isOngoing() }
     }
 
     // MARK: - List Fetch
@@ -155,6 +158,12 @@ final class OperatorAttendanceViewModel {
         let requestID = listRequestID
         // 롤백 기준: 진행 중(.loading) 상태는 복원 대상이 아니므로 .idle 로 대체(stuck-loading 방지).
         let restore: Loadable<[ScheduleAttendanceInfo]> = listState.isComplete ? listState : .idle
+        // 프리셋 범위는 조회 시점 기준으로 재계산 — VM 이 오래 살아도 창이 init 시점에 고정되지
+        // 않는다. `.custom` 은 dateRange 가 nil 이라 사용자가 지정한 from/to 를 그대로 쓴다.
+        if let range = periodPreset.dateRange {
+            fromDate = range.fromDate
+            toDate = range.toDate
+        }
         // 요청 파라미터를 시작 시점에 고정 — 응답 적용은 토큰이 최신일 때만 이뤄진다.
         let from = fromDate
         let to = toDate
@@ -198,12 +207,7 @@ final class OperatorAttendanceViewModel {
     /// `.task` 에서 호출하면 뷰 소멸 시 자동 취소됩니다.
     func startListPollingIfNeeded() async {
         guard listState.isComplete else { return }
-        while !Task.isCancelled {
-            guard hasActiveSession else { return }
-            try? await Task.sleep(for: .seconds(PollingConfig.intervalSeconds))
-            guard !Task.isCancelled else { break }
-            await refreshList()
-        }
+        await poll(while: { hasActiveSession }, refresh: { await refreshList() })
     }
 
     // MARK: - List Filter
@@ -221,22 +225,26 @@ final class OperatorAttendanceViewModel {
         await fetchList()
     }
 
-    /// 기간 프리셋 선택 — `.custom` 은 from/to 를 유지하고 사용자가 직접 조정.
+    /// 기간 프리셋 선택 — 변경 즉시 재조회 (범위는 조회 시점에 재계산).
+    ///
+    /// `.custom` 은 표시 중인 from/to 가 그대로라 즉시 재조회하면 동일 범위 중복 조회만
+    /// 발생하므로, 사용자가 날짜를 조정한 뒤 조회한다.
     func presetSelected(_ preset: AttendancePeriodPreset) async {
         periodPreset = preset
-        if let range = preset.dateRange {
-            fromDate = range.fromDate
-            toDate = range.toDate
-        }
+        guard preset != .custom else { return }
         await fetchList()
     }
 
     // MARK: - Detail Fetch
 
     /// 단일 일정 상세 조회 대상 선택 + 즉시 조회.
+    ///
+    /// 이전 일정 기준으로 띄운 확인 다이얼로그가 새 일정 위에서 실행되지 않도록
+    /// `alertPrompt` 를 함께 닫는다.
     func selectSchedule(_ scheduleId: String) async {
         selectedScheduleId = scheduleId
         selectedDetailFilter = nil
+        alertPrompt = nil
         await loadDetail(showLoading: true)
     }
 
@@ -263,6 +271,8 @@ final class OperatorAttendanceViewModel {
         let requestID = detailRequestID
         let restore: Loadable<ScheduleAttendanceInfo> =
             detailState.isComplete ? detailState : .idle
+        // 취소 롤백 시 상태와 페어로 복원해야 하므로 리셋 전에 함께 캡처한다.
+        let restoreScheduleDeleted = isScheduleDeleted
         if showLoading {
             detailState = .loading
             isScheduleDeleted = false
@@ -277,10 +287,12 @@ final class OperatorAttendanceViewModel {
         } catch is CancellationError {
             guard requestID == detailRequestID, showLoading else { return }
             detailState = restore
+            isScheduleDeleted = restoreScheduleDeleted
         } catch let error as NSError
             where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
             guard requestID == detailRequestID, showLoading else { return }
             detailState = restore
+            isScheduleDeleted = restoreScheduleDeleted
         } catch let error as AppError {
             guard requestID == detailRequestID, showLoading else { return }
             detailState = .failed(error)
@@ -291,10 +303,15 @@ final class OperatorAttendanceViewModel {
             guard requestID == detailRequestID, showLoading else { return }
             detailState = .failed(.network(error))
         } catch let error as RepositoryError {
-            guard requestID == detailRequestID, showLoading else { return }
+            guard requestID == detailRequestID else { return }
+            // 일정 삭제는 배경 갱신에서도 감지해야 하는 터미널 상태 —
+            // showLoading 가드보다 먼저 판정한다. 진입 후 삭제의 현실적 트리거가 폴링이다.
             if case .serverError(let code, _) = error, code == "SCHEDULE-0009" {
                 isScheduleDeleted = true
+                detailState = .failed(.repository(error))
+                return
             }
+            guard showLoading else { return }
             detailState = .failed(.repository(error))
         } catch {
             guard requestID == detailRequestID, showLoading else { return }
@@ -305,12 +322,7 @@ final class OperatorAttendanceViewModel {
     /// 진행 중인 일정일 때만 15초 폴링.
     func startDetailPollingIfNeeded() async {
         guard detailState.isComplete else { return }
-        while !Task.isCancelled {
-            guard isCurrentlyActive else { return }
-            try? await Task.sleep(for: .seconds(PollingConfig.intervalSeconds))
-            guard !Task.isCancelled else { break }
-            await refreshDetail()
-        }
+        await poll(while: { isCurrentlyActive }, refresh: { await refreshDetail() })
     }
 
     // MARK: - Detail Filter
@@ -329,14 +341,26 @@ final class OperatorAttendanceViewModel {
 
     // MARK: - Approval Button (AlertPrompt)
 
+    // 확인 Alert 액션은 실행 시점의 `selectedScheduleId` 를 재해석하지 않도록, 탭 시점에
+    // 캡처한 scheduleId(전체 결정은 대상 목록까지)를 클로저에 고정해 결정 코어로 전달한다.
+    // Alert 가 떠 있는 동안 선택 일정이 바뀌어도 결정은 탭한 화면의 일정으로만 전송된다.
+
     /// 개별 승인 버튼 탭 (확인 AlertPrompt 표시).
     func approveButtonTapped(participant: ParticipantAttendance) {
+        guard let scheduleId = selectedScheduleId else { return }
         alertPrompt = AlertPrompt(
             title: "출석 승인",
             message: "\(participant.name)님의 출석을 승인하시겠습니까?",
             positiveBtnTitle: "승인",
             positiveBtnAction: { [weak self] in
-                Task { await self?.decideAttendance(participant: participant, isApproved: true) }
+                Task {
+                    await self?.decide(
+                        scheduleId: scheduleId,
+                        participants: [participant],
+                        isApproved: true,
+                        action: "approveAttendance"
+                    )
+                }
             },
             negativeBtnTitle: "취소"
         )
@@ -344,39 +368,69 @@ final class OperatorAttendanceViewModel {
 
     /// 개별 반려 버튼 탭 (확인 AlertPrompt 표시).
     func rejectButtonTapped(participant: ParticipantAttendance) {
+        guard let scheduleId = selectedScheduleId else { return }
         alertPrompt = AlertPrompt(
             title: "출석 반려",
             message: "\(participant.name)님의 출석을 반려하시겠습니까?",
             positiveBtnTitle: "반려",
             positiveBtnAction: { [weak self] in
-                Task { await self?.decideAttendance(participant: participant, isApproved: false) }
+                Task {
+                    await self?.decide(
+                        scheduleId: scheduleId,
+                        participants: [participant],
+                        isApproved: false,
+                        action: "rejectAttendance"
+                    )
+                }
             },
             negativeBtnTitle: "취소",
             isPositiveBtnDestructive: true
         )
     }
 
-    /// 전체 승인 버튼 탭.
+    /// 전체 승인 버튼 탭 — 승인 대기 대상도 탭 시점 기준으로 캡처한다.
     func approveAllButtonTapped() {
+        guard let scheduleId = selectedScheduleId,
+              case .loaded(let info) = detailState else { return }
+        let pending = info.participants.filter(\.attendanceStatus.isPending)
+        guard !pending.isEmpty else { return }
         alertPrompt = AlertPrompt(
             title: "전체 승인",
             message: "모든 승인 대기 출석을 승인하시겠습니까?",
             positiveBtnTitle: "전체 승인",
             positiveBtnAction: { [weak self] in
-                Task { await self?.decideAllAttendances(isApproved: true) }
+                Task {
+                    await self?.decide(
+                        scheduleId: scheduleId,
+                        participants: pending,
+                        isApproved: true,
+                        action: "approveAllAttendances"
+                    )
+                }
             },
             negativeBtnTitle: "취소"
         )
     }
 
-    /// 전체 반려 버튼 탭.
+    /// 전체 반려 버튼 탭 — 승인 대기 대상도 탭 시점 기준으로 캡처한다.
     func rejectAllButtonTapped() {
+        guard let scheduleId = selectedScheduleId,
+              case .loaded(let info) = detailState else { return }
+        let pending = info.participants.filter(\.attendanceStatus.isPending)
+        guard !pending.isEmpty else { return }
         alertPrompt = AlertPrompt(
             title: "전체 거절",
             message: "모든 승인 대기 출석을 거절하시겠습니까?",
             positiveBtnTitle: "전체 거절",
             positiveBtnAction: { [weak self] in
-                Task { await self?.decideAllAttendances(isApproved: false) }
+                Task {
+                    await self?.decide(
+                        scheduleId: scheduleId,
+                        participants: pending,
+                        isApproved: false,
+                        action: "rejectAllAttendances"
+                    )
+                }
             },
             negativeBtnTitle: "취소",
             isPositiveBtnDestructive: true
@@ -385,16 +439,18 @@ final class OperatorAttendanceViewModel {
 
     /// 선택 승인 버튼 탭.
     func approveSelectedButtonTapped(participants: [ParticipantAttendance]) {
-        guard !participants.isEmpty else { return }
+        guard let scheduleId = selectedScheduleId, !participants.isEmpty else { return }
         alertPrompt = AlertPrompt(
             title: "선택 승인",
             message: "\(participants.count)명의 출석을 승인하시겠습니까?",
             positiveBtnTitle: "승인",
             positiveBtnAction: { [weak self] in
                 Task {
-                    await self?.decideSelectedAttendances(
+                    await self?.decide(
+                        scheduleId: scheduleId,
                         participants: participants,
-                        isApproved: true
+                        isApproved: true,
+                        action: "approveSelectedAttendances"
                     )
                 }
             },
@@ -404,16 +460,18 @@ final class OperatorAttendanceViewModel {
 
     /// 선택 반려 버튼 탭.
     func rejectSelectedButtonTapped(participants: [ParticipantAttendance]) {
-        guard !participants.isEmpty else { return }
+        guard let scheduleId = selectedScheduleId, !participants.isEmpty else { return }
         alertPrompt = AlertPrompt(
             title: "선택 거절",
             message: "\(participants.count)명의 출석을 거절하시겠습니까?",
             positiveBtnTitle: "거절",
             positiveBtnAction: { [weak self] in
                 Task {
-                    await self?.decideSelectedAttendances(
+                    await self?.decide(
+                        scheduleId: scheduleId,
                         participants: participants,
-                        isApproved: false
+                        isApproved: false,
+                        action: "rejectSelectedAttendances"
                     )
                 }
             },
@@ -424,77 +482,70 @@ final class OperatorAttendanceViewModel {
 
     // MARK: - Decision (낙관적 갱신)
 
-    /// 단건 승인/반려 — 성공 시 pending → present/absent 로 낙관적 갱신.
+    /// 단건 승인/반려 — 호출 시점의 선택 일정 기준.
     func decideAttendance(
         participant: ParticipantAttendance,
         isApproved: Bool
     ) async {
         guard let scheduleId = selectedScheduleId else { return }
-        alertPrompt = nil
-        let memberId = participant.memberId
-        processingMemberIds.insert(memberId)
-        defer { processingMemberIds.remove(memberId) }
-
-        let decision = AttendanceDecisionInput(
+        await decide(
+            scheduleId: scheduleId,
+            participants: [participant],
             isApproved: isApproved,
-            participantMemberId: memberId,
-            reason: ""
+            action: isApproved ? "approveAttendance" : "rejectAttendance"
         )
-        do {
-            _ = try await useCase.decideAttendances(
-                scheduleId: scheduleId,
-                decisions: [decision]
-            )
-            updateParticipants(memberIds: [memberId], isApproved: isApproved)
-        } catch {
-            await handleDecisionError(
-                error,
-                action: isApproved ? "approveAttendance" : "rejectAttendance"
-            )
-        }
     }
 
-    /// 전체 승인 대기 일괄 처리.
+    /// 전체 승인 대기 일괄 처리 — 호출 시점의 선택 일정·승인 대기 목록 기준.
     func decideAllAttendances(isApproved: Bool) async {
-        guard let scheduleId = selectedScheduleId else { return }
-        alertPrompt = nil
-        guard case .loaded(let info) = detailState else { return }
-
+        guard let scheduleId = selectedScheduleId,
+              case .loaded(let info) = detailState else { return }
         let pending = info.participants.filter(\.attendanceStatus.isPending)
         guard !pending.isEmpty else { return }
-
-        let decisions = pending.map {
-            AttendanceDecisionInput(
-                isApproved: isApproved,
-                participantMemberId: $0.memberId,
-                reason: ""
-            )
-        }
-        do {
-            _ = try await useCase.decideAttendances(
-                scheduleId: scheduleId,
-                decisions: decisions
-            )
-            updateParticipants(
-                memberIds: Set(pending.map(\.memberId)),
-                isApproved: isApproved
-            )
-        } catch {
-            await handleDecisionError(
-                error,
-                action: isApproved ? "approveAllAttendances" : "rejectAllAttendances"
-            )
-        }
+        await decide(
+            scheduleId: scheduleId,
+            participants: pending,
+            isApproved: isApproved,
+            action: isApproved ? "approveAllAttendances" : "rejectAllAttendances"
+        )
     }
 
-    /// 선택 참여자 일괄 처리.
+    /// 선택 참여자 일괄 처리 — 호출 시점의 선택 일정 기준.
     func decideSelectedAttendances(
         participants: [ParticipantAttendance],
         isApproved: Bool
     ) async {
-        guard let scheduleId = selectedScheduleId else { return }
+        guard let scheduleId = selectedScheduleId, !participants.isEmpty else { return }
+        await decide(
+            scheduleId: scheduleId,
+            participants: participants,
+            isApproved: isApproved,
+            action: isApproved ? "approveSelectedAttendances" : "rejectSelectedAttendances"
+        )
+    }
+
+    /// 결정 공용 코어 — 단건/전체/선택 진입점과 확인 Alert 액션이 공유한다.
+    ///
+    /// - `scheduleId` 는 진입 시점 값으로 고정된다. 요청 진행 중 다른 일정으로 전환되면
+    ///   낙관적 갱신이 전환된 화면으로 새지 않는다(일정-정체성 가드는 반영 단계에서 수행).
+    /// - 성공 시 상세/목록 요청 토큰을 올려, 결정 이전 스냅샷을 실은 in-flight 배경 폴
+    ///   응답이 낙관적 갱신을 되돌리지 못하게 한다. 스피너 로드(`.loading`)가 진행 중이면
+    ///   bump 가 그 정당한 응답까지 폐기해 stuck-loading 이 되므로 건너뛴다
+    ///   (배경 폴은 complete 상태에서만 돌아 그 창에는 존재하지 않는다).
+    /// - 대상 전원을 `processingMemberIds` 에 등록해 배치 진행 중 행별 버튼의 중복 결정과
+    ///   in-flight 대상 재결정을 막는다.
+    private func decide(
+        scheduleId: String,
+        participants: [ParticipantAttendance],
+        isApproved: Bool,
+        action: String
+    ) async {
         alertPrompt = nil
-        guard !participants.isEmpty else { return }
+        let memberIds = Set(participants.map(\.memberId))
+        // 같은 대상 결정이 in-flight 면 무시 — 중복 전송 + defer 조기 해제 방지.
+        guard processingMemberIds.isDisjoint(with: memberIds) else { return }
+        processingMemberIds.formUnion(memberIds)
+        defer { processingMemberIds.subtract(memberIds) }
 
         let decisions = participants.map {
             AttendanceDecisionInput(
@@ -508,15 +559,19 @@ final class OperatorAttendanceViewModel {
                 scheduleId: scheduleId,
                 decisions: decisions
             )
+            if selectedScheduleId == scheduleId, !detailState.isLoading {
+                detailRequestID &+= 1
+            }
+            if !listState.isLoading {
+                listRequestID &+= 1
+            }
             updateParticipants(
-                memberIds: Set(participants.map(\.memberId)),
+                scheduleId: scheduleId,
+                memberIds: memberIds,
                 isApproved: isApproved
             )
         } catch {
-            await handleDecisionError(
-                error,
-                action: isApproved ? "approveSelectedAttendances" : "rejectSelectedAttendances"
-            )
+            await handleDecisionError(error, action: action, scheduleId: scheduleId)
         }
     }
 
@@ -553,6 +608,14 @@ final class OperatorAttendanceViewModel {
                 latitude: latitude,
                 longitude: longitude
             )
+            applyLocationChange(
+                scheduleId: scheduleId,
+                location: ScheduleLocation(
+                    latitude: latitude,
+                    longitude: longitude,
+                    locationName: trimmedName
+                )
+            )
             return true
         } catch {
             errorHandler.handle(error, context: ErrorContext(
@@ -563,15 +626,38 @@ final class OperatorAttendanceViewModel {
         }
     }
 
+    /// 위치 변경 성공을 화면 상태에 즉시 반영한다.
+    ///
+    /// 시작 전 일정은 폴링이 돌지 않아 재조회 없이는 옛 위치가 계속 남으므로 직접 교체한다.
+    /// 변경 이전 위치를 실은 in-flight 폴 응답은 토큰으로 무효화한다(결정 경로와 동일 규칙).
+    /// bump 는 해당 일정이 `.loaded` 일 때만 도달하므로 진행 중 스피너 로드를 폐기해
+    /// stuck-loading 을 만들 위험이 없다.
+    private func applyLocationChange(scheduleId: String, location: ScheduleLocation) {
+        guard case .loaded(let info) = detailState, info.scheduleId == scheduleId else { return }
+        if selectedScheduleId == scheduleId {
+            detailRequestID &+= 1
+        }
+        detailState = .loaded(
+            rebuild(info, participants: info.participants, location: location)
+        )
+    }
+
     // MARK: - Private (Error)
 
-    private func handleDecisionError(_ error: Error, action: String) async {
+    private func handleDecisionError(
+        _ error: Error,
+        action: String,
+        scheduleId: String
+    ) async {
         if Self.isPermissionDenied(error) {
             presentAlert(
                 title: "권한이 없어요",
                 message: "출석을 처리할 권한이 없습니다. 운영진 권한을 확인해 주세요."
             )
-            await refreshDetail()
+            // 결정을 보낸 일정을 여전히 보고 있을 때만 재조회한다 (일정-정체성 가드).
+            if selectedScheduleId == scheduleId {
+                await refreshDetail()
+            }
             return
         }
         errorHandler.handle(error, context: ErrorContext(
@@ -596,12 +682,36 @@ final class OperatorAttendanceViewModel {
 
     // MARK: - Private (낙관적 갱신)
 
-    /// 지정한 멤버들을 pending → present/absent 로 낙관적 갱신.
+    /// 결정 성공 결과를 화면 상태에 반영한다.
     ///
-    /// 단건·전체·선택 결정이 동일 규칙을 공유하므로 대상 memberId 집합만 달리해 재사용합니다.
-    private func updateParticipants(memberIds: Set<String>, isApproved: Bool) {
-        guard case .loaded(let info) = detailState else { return }
-        let newStatus: ParticipantAttendanceStatus = isApproved ? .present : .absent
+    /// 상세는 결정을 보낸 일정이 그대로 로드돼 있을 때만 갱신하고(일정-정체성 가드),
+    /// 목록은 같은 scheduleId 항목만 갱신해 per-card 승인 대기 배지(`pendingCount`)가
+    /// 수동 재조회 없이 결정 결과를 즉시 반영하게 한다.
+    private func updateParticipants(
+        scheduleId: String,
+        memberIds: Set<String>,
+        isApproved: Bool
+    ) {
+        if case .loaded(let info) = detailState, info.scheduleId == scheduleId {
+            detailState = .loaded(
+                applyingDecision(to: info, memberIds: memberIds, isApproved: isApproved)
+            )
+        }
+        if case .loaded(let infos) = listState {
+            listState = .loaded(infos.map { info in
+                guard info.scheduleId == scheduleId else { return info }
+                return applyingDecision(to: info, memberIds: memberIds, isApproved: isApproved)
+            })
+        }
+        notifySharedSessionChange()
+    }
+
+    /// 지정한 멤버들의 승인 대기 상태를 결정 확정 상태로 치환한 사본을 만든다.
+    private func applyingDecision(
+        to info: ScheduleAttendanceInfo,
+        memberIds: Set<String>,
+        isApproved: Bool
+    ) -> ScheduleAttendanceInfo {
         let updated = info.participants.map { participant -> ParticipantAttendance in
             guard memberIds.contains(participant.memberId),
                   participant.attendanceStatus.isPending else {
@@ -614,18 +724,37 @@ final class OperatorAttendanceViewModel {
                 profileImageURL: participant.profileImageURL,
                 schoolId: participant.schoolId,
                 schoolName: participant.schoolName,
-                attendanceStatus: newStatus,
+                attendanceStatus: decidedStatus(
+                    from: participant.attendanceStatus,
+                    isApproved: isApproved
+                ),
                 isLocationVerified: participant.isLocationVerified,
                 excuseReason: participant.excuseReason
             )
         }
-        detailState = .loaded(rebuild(info, participants: updated))
-        notifySharedSessionChange()
+        return rebuild(info, participants: updated, location: info.location)
+    }
+
+    /// pending 종류별 확정 상태 매핑 — 서버 확정 규칙과 동일하게 승인은 대기 종류를 보존한다.
+    ///
+    /// 지각/사유 승인을 일괄 `.present` 로 뭉개면 배지·presentCount·상세 필터 소속이
+    /// 서버 확정값과 어긋난다. 반려는 종류와 무관하게 일괄 `.absent`.
+    private func decidedStatus(
+        from pendingStatus: ParticipantAttendanceStatus,
+        isApproved: Bool
+    ) -> ParticipantAttendanceStatus {
+        guard isApproved else { return .absent }
+        switch pendingStatus {
+        case .latePending: return .late
+        case .excusedPending: return .excused
+        default: return .present
+        }
     }
 
     private func rebuild(
         _ info: ScheduleAttendanceInfo,
-        participants: [ParticipantAttendance]
+        participants: [ParticipantAttendance],
+        location: ScheduleLocation?
     ) -> ScheduleAttendanceInfo {
         ScheduleAttendanceInfo(
             scheduleId: info.scheduleId,
@@ -633,7 +762,7 @@ final class OperatorAttendanceViewModel {
             description: info.description,
             startsAt: info.startsAt,
             endsAt: info.endsAt,
-            location: info.location,
+            location: location,
             isOnline: info.isOnline,
             authorMemberId: info.authorMemberId,
             attendancePolicy: info.attendancePolicy,
@@ -644,11 +773,27 @@ final class OperatorAttendanceViewModel {
 
     // MARK: - Private (Helper)
 
-    /// 일정이 현재 진행 중인지 (KST 기준, 폴링용).
+    /// 일정이 현재 진행 중인지 (폴링용).
     private var isCurrentlyActive: Bool {
         guard case .loaded(let info) = detailState else { return false }
-        let now = Date()
-        return now >= info.startsAt && now <= info.endsAt
+        return info.isOngoing()
+    }
+
+    /// 공용 폴링 루프 — 목록·상세가 주기·취소 처리를 공유한다.
+    ///
+    /// - Parameters:
+    ///   - predicate: 매 주기 시작 시 평가해 거짓이면 루프를 종료한다.
+    ///   - refresh: 주기마다 실행할 배경 갱신.
+    private func poll(
+        while predicate: () -> Bool,
+        refresh: () async -> Void
+    ) async {
+        while !Task.isCancelled {
+            guard predicate() else { return }
+            try? await Task.sleep(for: .seconds(PollingConfig.intervalSeconds))
+            guard !Task.isCancelled else { return }
+            await refresh()
+        }
     }
 
     /// 챌린저 뷰를 실시간 갱신하도록 Notification 발송.

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorAttendanceViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorAttendanceViewModel.swift
@@ -207,7 +207,11 @@ final class OperatorAttendanceViewModel {
     /// `.task` 에서 호출하면 뷰 소멸 시 자동 취소됩니다.
     func startListPollingIfNeeded() async {
         guard listState.isComplete else { return }
-        await poll(while: { hasActiveSession }, refresh: { await refreshList() })
+        await PollingLoop.run(
+            intervalSeconds: PollingConfig.intervalSeconds,
+            while: { hasActiveSession },
+            refresh: { await refreshList() }
+        )
     }
 
     // MARK: - List Filter
@@ -322,7 +326,11 @@ final class OperatorAttendanceViewModel {
     /// 진행 중인 일정일 때만 15초 폴링.
     func startDetailPollingIfNeeded() async {
         guard detailState.isComplete else { return }
-        await poll(while: { isCurrentlyActive }, refresh: { await refreshDetail() })
+        await PollingLoop.run(
+            intervalSeconds: PollingConfig.intervalSeconds,
+            while: { isCurrentlyActive },
+            refresh: { await refreshDetail() }
+        )
     }
 
     // MARK: - Detail Filter
@@ -777,23 +785,6 @@ final class OperatorAttendanceViewModel {
     private var isCurrentlyActive: Bool {
         guard case .loaded(let info) = detailState else { return false }
         return info.isOngoing()
-    }
-
-    /// 공용 폴링 루프 — 목록·상세가 주기·취소 처리를 공유한다.
-    ///
-    /// - Parameters:
-    ///   - predicate: 매 주기 시작 시 평가해 거짓이면 루프를 종료한다.
-    ///   - refresh: 주기마다 실행할 배경 갱신.
-    private func poll(
-        while predicate: () -> Bool,
-        refresh: () async -> Void
-    ) async {
-        while !Task.isCancelled {
-            guard predicate() else { return }
-            try? await Task.sleep(for: .seconds(PollingConfig.intervalSeconds))
-            guard !Task.isCancelled else { return }
-            await refresh()
-        }
     }
 
     /// 챌린저 뷰를 실시간 갱신하도록 Notification 발송.

--- a/UMCApp/Features/Activity/Presentation/Tests/OperatorAttendanceViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/OperatorAttendanceViewModelTests.swift
@@ -70,17 +70,7 @@ private enum TestError: Error, Equatable {
     case boom
 }
 
-/// 조건이 만족될 때까지 MainActor 를 양보하며 대기한다(무한 루프 방지 상한 포함).
-///
-/// 게이트로 suspend 된 fetch 가 mock 의 호출 기록을 남길 때까지 기다리는 용도.
-@MainActor
-private func drainUntil(maxYields: Int = 10_000, _ condition: () -> Bool) async {
-    var yields = 0
-    while !condition(), yields < maxYields {
-        await Task.yield()
-        yields += 1
-    }
-}
+// drainUntil 은 Tests 타깃 공용 `ConcurrencyTestSupport.swift` 의 헬퍼를 사용한다.
 
 // MARK: - Mock
 
@@ -106,11 +96,13 @@ private final class MockOperatorAttendanceUseCase: OperatorAttendanceUseCaseProt
     var decideError: Error?
     var updateLocationError: Error?
 
-    // MARK: 게이트 (동시성 테스트용) — true 면 해당 fetch 가 release 될 때까지 suspend
+    // MARK: 게이트 (동시성 테스트용) — true 면 해당 요청이 release 될 때까지 suspend
     var gateList = false
     var gateDetail = false
+    var gateDecide = false
     private var listWaiters: [CheckedContinuation<Void, Never>] = []
     private var detailWaiters: [String: CheckedContinuation<Void, Never>] = [:]
+    private var decideWaiters: [CheckedContinuation<Void, Never>] = []
 
     // MARK: 호출 기록
     private(set) var fetchListCalls: [(
@@ -167,6 +159,9 @@ private final class MockOperatorAttendanceUseCase: OperatorAttendanceUseCaseProt
         decisions: [AttendanceDecisionInput]
     ) async throws -> [AttendanceDecisionResult] {
         decideCalls.append((scheduleId, decisions))
+        if gateDecide {
+            await withCheckedContinuation { decideWaiters.append($0) }
+        }
         if let decideError { throw decideError }
         return decideResult
     }
@@ -193,6 +188,13 @@ private final class MockOperatorAttendanceUseCase: OperatorAttendanceUseCaseProt
     /// 지정한 scheduleId 의 상세 fetch 를 방출한다.
     func releaseDetail(_ scheduleId: String) {
         detailWaiters.removeValue(forKey: scheduleId)?.resume()
+    }
+
+    /// 대기 중인 모든 결정 요청을 방출한다.
+    func releaseDecide() {
+        let waiters = decideWaiters
+        decideWaiters.removeAll()
+        waiters.forEach { $0.resume() }
     }
 }
 
@@ -229,6 +231,21 @@ struct OperatorAttendanceViewModelListTests {
 
         // 취소는 실패로 표시되지 않고 직전 loaded 상태를 유지한다.
         #expect(viewModel.listState == .loaded(first))
+    }
+
+    @Test("목록 배경 갱신 실패 → 에러를 삼키고 기존 데이터 유지")
+    func backgroundListRefreshKeepsDataOnFailure() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let loaded = [makeScheduleInfo(scheduleId: "7")]
+        useCase.fetchListResult = loaded
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchList()
+
+        useCase.fetchListError = TestError.boom
+        await viewModel.refreshList()
+
+        // 배경 경로(showLoading=false)는 실패해도 화면을 에러로 전이시키지 않는다.
+        #expect(viewModel.listState == .loaded(loaded))
     }
 
     @Test("목록 조회 실패(DomainError) → failed(.domain) 전이")
@@ -277,7 +294,7 @@ struct OperatorAttendanceViewModelListTests {
         #expect(useCase.fetchListCalls.isEmpty)
     }
 
-    @Test("기간 프리셋 선택 → periodPreset 갱신 + 재조회, custom 은 날짜 유지")
+    @Test("기간 프리셋 선택 → periodPreset 갱신 + 재조회, custom 은 날짜 유지·재조회 없음")
     func presetSelectionUpdatesAndRefetches() async {
         let useCase = MockOperatorAttendanceUseCase()
         let viewModel = makeViewModel(useCase: useCase)
@@ -287,11 +304,12 @@ struct OperatorAttendanceViewModelListTests {
         #expect(useCase.fetchListCalls.count == 1)
         #expect(viewModel.fromDate < viewModel.toDate)
 
+        // .custom 은 범위가 그대로라 동일 조건 재조회를 만들지 않는다 (사용자 조정 후 조회).
         let keptFrom = viewModel.fromDate
         await viewModel.presetSelected(.custom)
         #expect(viewModel.periodPreset == .custom)
         #expect(viewModel.fromDate == keptFrom)
-        #expect(useCase.fetchListCalls.count == 2)
+        #expect(useCase.fetchListCalls.count == 1)
     }
 
     @Test("승인 대기 파생 상태 — totalPendingCount 합산 + firstPendingScheduleId")
@@ -370,6 +388,58 @@ struct OperatorAttendanceViewModelDetailTests {
         #expect(viewModel.detailState == .loaded(loaded))
     }
 
+    @Test("배경 갱신 중 일정 삭제(SCHEDULE-0009) → isScheduleDeleted 감지")
+    func backgroundRefreshDetectsDeletedSchedule() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchDetailResult = makeScheduleInfo(scheduleId: "42")
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+
+        // 폴링과 같은 배경 경로(refreshDetail)에서도 삭제가 감지돼야 stale 화면이 남지 않는다.
+        useCase.fetchDetailError = RepositoryError.serverError(
+            code: "SCHEDULE-0009",
+            message: "삭제된 일정"
+        )
+        await viewModel.refreshDetail()
+
+        #expect(viewModel.isScheduleDeleted == true)
+        #expect(viewModel.detailState.error != nil)
+    }
+
+    @Test("삭제 상태에서 재조회가 취소되면 isScheduleDeleted 도 페어로 복원된다")
+    func cancellationRestoresScheduleDeletedFlag() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchDetailError = RepositoryError.serverError(
+            code: "SCHEDULE-0009",
+            message: "삭제된 일정"
+        )
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+        #expect(viewModel.isScheduleDeleted == true)
+
+        useCase.fetchDetailError = CancellationError()
+        await viewModel.fetchDetail()
+
+        // 취소는 실패가 아니므로 상태와 삭제 플래그가 함께 이전 값으로 돌아온다.
+        #expect(viewModel.isScheduleDeleted == true)
+        #expect(viewModel.detailState.error != nil)
+    }
+
+    @Test("일정 전환 → 이전 일정 기준 확인 다이얼로그가 닫힌다")
+    func selectScheduleDismissesAlertPrompt() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pending = makeParticipant(memberId: "1", status: .presentPending)
+        useCase.fetchDetailResult = makeScheduleInfo(scheduleId: "A", participants: [pending])
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("A")
+
+        viewModel.approveButtonTapped(participant: pending)
+        #expect(viewModel.alertPrompt != nil)
+
+        await viewModel.selectSchedule("B")
+        #expect(viewModel.alertPrompt == nil)
+    }
+
     @Test("상세 상태 필터 → 클라이언트 측 필터링, 재탭 시 해제")
     func detailFilterFiltersClientSide() async {
         let useCase = MockOperatorAttendanceUseCase()
@@ -429,7 +499,7 @@ struct OperatorAttendanceViewModelDecisionTests {
         #expect(useCase.decideCalls.first?.decisions.first?.participantMemberId == "1")
     }
 
-    @Test("전체 승인 → 승인 대기 전원 present 로 갱신 (확정 상태는 미변경)")
+    @Test("전체 승인 → 승인 대기 전원만 대기 종류를 보존해 갱신 (확정 상태는 미변경)")
     func decideAllApprovesPendingOnly() async {
         let useCase = MockOperatorAttendanceUseCase()
         let pendingA = makeParticipant(memberId: "1", status: .presentPending)
@@ -442,10 +512,60 @@ struct OperatorAttendanceViewModelDecisionTests {
 
         await viewModel.decideAllAttendances(isApproved: true)
 
+        // 지각 승인 대기는 '지각' 으로 확정된다 (일괄 present 로 뭉개지 않음).
         let statuses = (viewModel.detailState.value?.participants ?? [])
             .map(\.attendanceStatus)
-        #expect(statuses == [.present, .present, .absent])
+        #expect(statuses == [.present, .late, .absent])
         #expect(useCase.decideCalls.first?.decisions.count == 2)
+    }
+
+    @Test(
+        "승인 확정 상태는 대기 종류를 보존하고, 반려는 일괄 absent 로 확정한다",
+        arguments: [
+            (pending: ParticipantAttendanceStatus.presentPending, isApproved: true,
+             expected: ParticipantAttendanceStatus.present),
+            (pending: .latePending, isApproved: true, expected: .late),
+            (pending: .excusedPending, isApproved: true, expected: .excused),
+            (pending: .presentPending, isApproved: false, expected: .absent),
+            (pending: .latePending, isApproved: false, expected: .absent),
+            (pending: .excusedPending, isApproved: false, expected: .absent)
+        ]
+    )
+    func decidedStatusPreservesPendingKind(
+        testCase: (
+            pending: ParticipantAttendanceStatus,
+            isApproved: Bool,
+            expected: ParticipantAttendanceStatus
+        )
+    ) async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let target = makeParticipant(memberId: "1", status: testCase.pending)
+        let viewModel = await loadedViewModel(useCase: useCase, participants: [target])
+
+        await viewModel.decideAttendance(participant: target, isApproved: testCase.isApproved)
+
+        let status = viewModel.detailState.value?.participants.first?.attendanceStatus
+        #expect(status == testCase.expected)
+    }
+
+    @Test("결정 성공 → 목록의 같은 일정 항목도 갱신 (승인 대기 배지 즉시 반영)")
+    func decideUpdatesMatchingListEntry() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pending = makeParticipant(memberId: "1", status: .presentPending)
+        let schedule = makeScheduleInfo(scheduleId: "42", participants: [pending])
+        useCase.fetchListResult = [schedule, makeScheduleInfo(scheduleId: "43", pendingCount: 1)]
+        useCase.fetchDetailResult = schedule
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchList()
+        await viewModel.selectSchedule("42")
+
+        await viewModel.decideAttendance(participant: pending, isApproved: true)
+
+        // 결정한 일정의 배지만 줄고 다른 일정 항목은 그대로 유지된다.
+        let entries = viewModel.listState.value ?? []
+        #expect(entries.first { $0.scheduleId == "42" }?.pendingCount == 0)
+        #expect(entries.first { $0.scheduleId == "43" }?.pendingCount == 1)
+        #expect(viewModel.totalPendingCount == 1)
     }
 
     @Test("선택 결정 → 선택한 참여자만 갱신")
@@ -604,6 +724,24 @@ struct OperatorAttendanceViewModelLocationTests {
         #expect(call?.longitude == 127.010)
     }
 
+    @Test("위치 변경 성공 → 상세 화면 위치가 재조회 없이 즉시 교체된다")
+    func changeLocationUpdatesDetailState() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = await selectedViewModel(useCase: useCase)
+
+        let result = await viewModel.changeLocation(
+            name: "한성대 상상관",
+            latitude: 37.582,
+            longitude: 127.010
+        )
+
+        #expect(result == true)
+        let location = viewModel.detailState.value?.location
+        #expect(location?.locationName == "한성대 상상관")
+        #expect(location?.latitude == 37.582)
+        #expect(location?.longitude == 127.010)
+    }
+
     @Test("위치 변경 에러 → false 반환 (errorHandler 경로)")
     func changeLocationForwardsErrorReturnsFalse() async {
         let useCase = MockOperatorAttendanceUseCase()
@@ -702,6 +840,199 @@ struct OperatorAttendanceViewModelRequestTokenTests {
         #expect(viewModel.selectedListFilter == .presentPending)
         #expect(viewModel.listState == .loaded(filtered))
         #expect(useCase.fetchListCalls.last?.attendanceStatus == .presentPending)
+    }
+}
+
+// MARK: - 일정 정체성 가드 (mutation 동시성)
+
+@MainActor
+@Suite("OperatorAttendanceViewModel — 일정 정체성 가드 (도메인 규칙)")
+struct OperatorAttendanceViewModelScheduleIdentityTests {
+
+    @Test("결정 진행 중 일정 전환 → 낙관적 갱신이 전환된 일정으로 새지 않는다")
+    func decideDuringScheduleSwitchDoesNotLeak() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pendingA = makeParticipant(memberId: "1", status: .presentPending)
+        let pendingB = makeParticipant(memberId: "1", status: .presentPending)
+        useCase.fetchDetailResultByScheduleId = [
+            "A": makeScheduleInfo(scheduleId: "A", participants: [pendingA]),
+            "B": makeScheduleInfo(scheduleId: "B", participants: [pendingB])
+        ]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("A")
+
+        // A 에 대한 결정을 게이트로 붙잡은 상태에서 B 로 전환한다.
+        useCase.gateDecide = true
+        let decision = Task {
+            await viewModel.decideAttendance(participant: pendingA, isApproved: true)
+        }
+        await drainUntil { useCase.decideCalls.count == 1 }
+        await viewModel.selectSchedule("B")
+
+        useCase.releaseDecide()
+        await decision.value
+
+        // 결정은 A 엔드포인트로 나갔고, B 화면의 같은 memberId 는 여전히 승인 대기다.
+        #expect(useCase.decideCalls.first?.scheduleId == "A")
+        #expect(viewModel.detailState.value?.scheduleId == "B")
+        let status = viewModel.detailState.value?.participants.first?.attendanceStatus
+        #expect(status == .presentPending)
+    }
+
+    @Test("결정 성공 → in-flight 폴 응답(결정 이전 스냅샷)이 낙관적 갱신을 되돌리지 못한다")
+    func decideInvalidatesInFlightPollResponse() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pending = makeParticipant(memberId: "1", status: .presentPending)
+        useCase.fetchDetailResult = makeScheduleInfo(scheduleId: "42", participants: [pending])
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+
+        // 폴 fetch 를 게이트로 붙잡아 in-flight 로 만든다 (응답은 결정 이전 스냅샷).
+        useCase.gateDetail = true
+        let poll = Task { await viewModel.refreshDetail() }
+        await drainUntil { useCase.fetchDetailCalls.count == 2 }
+
+        await viewModel.decideAttendance(participant: pending, isApproved: true)
+        useCase.releaseDetail("42")
+        await poll.value
+
+        // 폴 응답이 pending 스냅샷으로 되돌리지 않고 낙관적 갱신이 살아남는다.
+        let status = viewModel.detailState.value?.participants.first?.attendanceStatus
+        #expect(status == .present)
+    }
+
+    @Test("전체 승인 Alert — 실행 시점이 아니라 탭 시점의 일정·대상으로 결정을 보낸다")
+    func approveAllCapturesScheduleAtTapTime() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchDetailResultByScheduleId = [
+            "A": makeScheduleInfo(
+                scheduleId: "A",
+                participants: [makeParticipant(memberId: "a1", status: .presentPending)]
+            ),
+            "B": makeScheduleInfo(
+                scheduleId: "B",
+                participants: [makeParticipant(memberId: "b1", status: .presentPending)]
+            )
+        ]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("A")
+
+        // A 화면에서 Alert 를 띄운 뒤(액션 캡처) B 로 전환하고 나서 확인 액션을 실행한다.
+        viewModel.approveAllButtonTapped()
+        let confirmAction = viewModel.alertPrompt?.positiveBtnAction
+        await viewModel.selectSchedule("B")
+
+        confirmAction?()
+        await drainUntil { useCase.decideCalls.count == 1 }
+        await drainUntil { viewModel.processingMemberIds.isEmpty }
+
+        // 결정은 탭 시점의 A 일정·A 대상에게 전송되고, B 화면은 건드리지 않는다.
+        #expect(useCase.decideCalls.first?.scheduleId == "A")
+        #expect(useCase.decideCalls.first?.decisions.map(\.participantMemberId) == ["a1"])
+        let status = viewModel.detailState.value?.participants.first?.attendanceStatus
+        #expect(status == .presentPending)
+    }
+
+    @Test("결정 성공 — 같은 일정의 스피너 로드가 진행 중이면 토큰을 올리지 않아 로드가 살아남는다")
+    func decideDoesNotOrphanInFlightSpinnerLoad() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pending = makeParticipant(memberId: "1", status: .presentPending)
+        useCase.fetchDetailResultByScheduleId = [
+            "A": makeScheduleInfo(scheduleId: "A", participants: [pending])
+        ]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("A")
+
+        // 결정을 게이트로 붙잡은 채, 같은 일정 A 를 다시 선택해 스피너 로드를 in-flight 로 만든다.
+        useCase.gateDecide = true
+        let decision = Task {
+            await viewModel.decideAttendance(participant: pending, isApproved: true)
+        }
+        await drainUntil { useCase.decideCalls.count == 1 }
+        useCase.gateDetail = true
+        let reload = Task { await viewModel.selectSchedule("A") }
+        await drainUntil { useCase.fetchDetailCalls.count == 2 }
+        #expect(viewModel.detailState.isLoading)
+
+        // 결정이 먼저 성공해도 .loading 중에는 토큰을 올리지 않아 로드 응답이 반영된다.
+        useCase.releaseDecide()
+        await decision.value
+        useCase.releaseDetail("A")
+        await reload.value
+
+        #expect(viewModel.detailState.value != nil)
+        #expect(viewModel.detailState.isLoading == false)
+    }
+
+    @Test("결정 성공 → in-flight 목록 폴 응답이 배지 낙관적 갱신을 되돌리지 못한다")
+    func decideInvalidatesInFlightListPollResponse() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pending = makeParticipant(memberId: "1", status: .presentPending)
+        let preDecision = [makeScheduleInfo(scheduleId: "42", participants: [pending])]
+        useCase.fetchListResultQueue = [preDecision, preDecision]
+        useCase.fetchDetailResult = preDecision[0]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchList()
+        await viewModel.selectSchedule("42")
+
+        // 목록 배경 폴을 게이트로 붙잡아 in-flight 로 만든다 (응답은 결정 이전 스냅샷).
+        useCase.gateList = true
+        let poll = Task { await viewModel.refreshList() }
+        await drainUntil { useCase.fetchListCalls.count == 2 }
+
+        await viewModel.decideAttendance(participant: pending, isApproved: true)
+        useCase.releaseList()
+        await poll.value
+
+        // 폴 응답이 배지를 '승인 대기 1건' 으로 되돌리지 않는다.
+        let entry = viewModel.listState.value?.first { $0.scheduleId == "42" }
+        #expect(entry?.pendingCount == 0)
+        #expect(viewModel.totalPendingCount == 0)
+    }
+
+    @Test("in-flight 대상에 대한 재결정은 무시된다 (중복 전송 방지)")
+    func duplicateDecisionForInFlightMemberIsIgnored() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pending = makeParticipant(memberId: "1", status: .presentPending)
+        useCase.fetchDetailResult = makeScheduleInfo(scheduleId: "42", participants: [pending])
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+
+        useCase.gateDecide = true
+        let first = Task { await viewModel.decideAttendance(participant: pending, isApproved: true) }
+        await drainUntil { useCase.decideCalls.count == 1 }
+
+        // 같은 멤버에 대한 두 번째 결정은 서버로 나가지 않는다.
+        await viewModel.decideAttendance(participant: pending, isApproved: false)
+        #expect(useCase.decideCalls.count == 1)
+
+        useCase.releaseDecide()
+        await first.value
+        #expect(viewModel.processingMemberIds.isEmpty)
+    }
+
+    @Test("배치 결정 진행 중 대상 전원이 processingMemberIds 에 등록·해제된다")
+    func batchDecisionTracksProcessingMembers() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let first = makeParticipant(memberId: "1", status: .presentPending)
+        let second = makeParticipant(memberId: "2", status: .latePending)
+        useCase.fetchDetailResult = makeScheduleInfo(
+            scheduleId: "42",
+            participants: [first, second]
+        )
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+
+        useCase.gateDecide = true
+        let decision = Task { await viewModel.decideAllAttendances(isApproved: true) }
+        await drainUntil { useCase.decideCalls.count == 1 }
+
+        // 진행 중에는 대상 전원이 처리 중으로 표시돼 행별 버튼의 중복 결정을 막는다.
+        #expect(viewModel.processingMemberIds == ["1", "2"])
+
+        useCase.releaseDecide()
+        await decision.value
+        #expect(viewModel.processingMemberIds.isEmpty)
     }
 }
 

--- a/UMCApp/Features/Activity/Presentation/Tests/OperatorAttendanceViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/OperatorAttendanceViewModelTests.swift
@@ -1,0 +1,708 @@
+//
+//  OperatorAttendanceViewModelTests.swift
+//  ActivityPresentationTests
+//
+//  Created by jaewon Lee on 7/14/26.
+//
+
+import Foundation
+import Testing
+import ActivityDomain
+import UMCFoundation
+@testable import ActivityPresentation
+
+#if DEBUG
+
+// MARK: - Helpers
+
+private func makeParticipant(
+    memberId: String = "1",
+    name: String = "김미주",
+    status: ParticipantAttendanceStatus = .present
+) -> ParticipantAttendance {
+    ParticipantAttendance(
+        memberId: memberId,
+        name: name,
+        nickname: name,
+        profileImageURL: "",
+        schoolId: "1",
+        schoolName: "한성대학교",
+        attendanceStatus: status,
+        isLocationVerified: true,
+        excuseReason: nil
+    )
+}
+
+private func makeScheduleInfo(
+    scheduleId: String = "100",
+    pendingCount: Int = 0,
+    participants: [ParticipantAttendance] = []
+) -> ScheduleAttendanceInfo {
+    let filled: [ParticipantAttendance] = participants.isEmpty
+        ? (0..<pendingCount).map {
+            makeParticipant(memberId: "p\($0)", status: .presentPending)
+        }
+        : participants
+    return ScheduleAttendanceInfo(
+        scheduleId: scheduleId,
+        name: "정기 세션",
+        description: "",
+        startsAt: Date(timeIntervalSince1970: 1_000),
+        endsAt: Date(timeIntervalSince1970: 8_000),
+        location: nil,
+        isOnline: true,
+        authorMemberId: "1",
+        attendancePolicy: nil,
+        tags: [],
+        participants: filled
+    )
+}
+
+@MainActor
+private func makeViewModel(
+    useCase: MockOperatorAttendanceUseCase,
+    errorHandler: ErrorHandler = ErrorHandler()
+) -> OperatorAttendanceViewModel {
+    OperatorAttendanceViewModel(errorHandler: errorHandler, useCase: useCase)
+}
+
+private enum TestError: Error, Equatable {
+    case boom
+}
+
+/// 조건이 만족될 때까지 MainActor 를 양보하며 대기한다(무한 루프 방지 상한 포함).
+///
+/// 게이트로 suspend 된 fetch 가 mock 의 호출 기록을 남길 때까지 기다리는 용도.
+@MainActor
+private func drainUntil(maxYields: Int = 10_000, _ condition: () -> Bool) async {
+    var yields = 0
+    while !condition(), yields < maxYields {
+        await Task.yield()
+        yields += 1
+    }
+}
+
+// MARK: - Mock
+
+/// 운영진 출석 UseCase Mock.
+///
+/// `@MainActor` — VM(@MainActor)이 프로토콜 메서드를 호출할 때 액터 홉 없이 실행돼 호출 기록과
+/// 게이트 continuation 접근이 메인 액터에서 직렬화된다(동시성 테스트의 데이터 레이스 방지).
+@MainActor
+private final class MockOperatorAttendanceUseCase: OperatorAttendanceUseCaseProtocol {
+
+    // MARK: 스텁 결과
+    var fetchListResult: [ScheduleAttendanceInfo] = []
+    /// 호출 순서대로 소비하는 목록 결과(없으면 `fetchListResult` 폴백).
+    var fetchListResultQueue: [[ScheduleAttendanceInfo]] = []
+    var fetchDetailResult: ScheduleAttendanceInfo = makeScheduleInfo()
+    /// scheduleId 별 상세 결과(없으면 `fetchDetailResult` 폴백).
+    var fetchDetailResultByScheduleId: [String: ScheduleAttendanceInfo] = [:]
+    var decideResult: [AttendanceDecisionResult] = []
+
+    // MARK: 메서드별 에러
+    var fetchListError: Error?
+    var fetchDetailError: Error?
+    var decideError: Error?
+    var updateLocationError: Error?
+
+    // MARK: 게이트 (동시성 테스트용) — true 면 해당 fetch 가 release 될 때까지 suspend
+    var gateList = false
+    var gateDetail = false
+    private var listWaiters: [CheckedContinuation<Void, Never>] = []
+    private var detailWaiters: [String: CheckedContinuation<Void, Never>] = [:]
+
+    // MARK: 호출 기록
+    private(set) var fetchListCalls: [(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: ParticipantAttendanceStatus?
+    )] = []
+    private(set) var fetchDetailCalls: [(
+        scheduleId: String,
+        attendanceStatus: ParticipantAttendanceStatus?
+    )] = []
+    private(set) var decideCalls: [(
+        scheduleId: String,
+        decisions: [AttendanceDecisionInput]
+    )] = []
+    private(set) var updateLocationCalls: [(
+        scheduleId: String,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    )] = []
+    private var listCallIndex = 0
+
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> [ScheduleAttendanceInfo] {
+        // 결과 인덱스는 게이트 대기 전에 고정 — release 순서와 무관하게 결정론적.
+        let index = listCallIndex
+        listCallIndex += 1
+        fetchListCalls.append((from, to, attendanceStatus))
+        if gateList {
+            await withCheckedContinuation { listWaiters.append($0) }
+        }
+        if let fetchListError { throw fetchListError }
+        return index < fetchListResultQueue.count ? fetchListResultQueue[index] : fetchListResult
+    }
+
+    func fetchAttendanceDetail(
+        scheduleId: String,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> ScheduleAttendanceInfo {
+        fetchDetailCalls.append((scheduleId, attendanceStatus))
+        if gateDetail {
+            await withCheckedContinuation { detailWaiters[scheduleId] = $0 }
+        }
+        if let fetchDetailError { throw fetchDetailError }
+        return fetchDetailResultByScheduleId[scheduleId] ?? fetchDetailResult
+    }
+
+    func decideAttendances(
+        scheduleId: String,
+        decisions: [AttendanceDecisionInput]
+    ) async throws -> [AttendanceDecisionResult] {
+        decideCalls.append((scheduleId, decisions))
+        if let decideError { throw decideError }
+        return decideResult
+    }
+
+    func updateScheduleLocation(
+        scheduleId: String,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    ) async throws {
+        updateLocationCalls.append((scheduleId, locationName, latitude, longitude))
+        if let updateLocationError { throw updateLocationError }
+    }
+
+    // MARK: 게이트 해제
+
+    /// 대기 중인 모든 목록 fetch 를 방출한다.
+    func releaseList() {
+        let waiters = listWaiters
+        listWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    /// 지정한 scheduleId 의 상세 fetch 를 방출한다.
+    func releaseDetail(_ scheduleId: String) {
+        detailWaiters.removeValue(forKey: scheduleId)?.resume()
+    }
+}
+
+// MARK: - 목록 조회 / 필터 / 기간
+
+@MainActor
+@Suite("OperatorAttendanceViewModel — 목록 조회 (도메인 규칙)")
+struct OperatorAttendanceViewModelListTests {
+
+    @Test("목록 조회 성공 → loaded 전이 + 기간/필터 인자 그대로 위임")
+    func fetchListSucceedsAndDelegates() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let expected = [makeScheduleInfo(scheduleId: "7"), makeScheduleInfo(scheduleId: "8")]
+        useCase.fetchListResult = expected
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchList()
+
+        #expect(viewModel.listState == .loaded(expected))
+        #expect(useCase.fetchListCalls.count == 1)
+        #expect(useCase.fetchListCalls.first?.attendanceStatus == nil)
+    }
+
+    @Test("목록 조회 취소(CancellationError) → 이전 상태로 롤백 (실패 아님)")
+    func fetchListForwardsCancellation() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let first = [makeScheduleInfo(scheduleId: "7")]
+        useCase.fetchListResult = first
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.fetchList()
+
+        useCase.fetchListError = CancellationError()
+        await viewModel.fetchList()
+
+        // 취소는 실패로 표시되지 않고 직전 loaded 상태를 유지한다.
+        #expect(viewModel.listState == .loaded(first))
+    }
+
+    @Test("목록 조회 실패(DomainError) → failed(.domain) 전이")
+    func fetchListFailsWithDomainError() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchListError = DomainError.custom(message: "실패")
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchList()
+
+        #expect(viewModel.listState == .failed(.domain(.custom(message: "실패"))))
+    }
+
+    @Test("목록 조회 403 → failed(.network) + isPermissionDenied == true")
+    func fetchListPermissionDeniedOn403() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchListError = NetworkError.requestFailed(statusCode: 403, data: nil)
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchList()
+
+        #expect(viewModel.isPermissionDenied == true)
+    }
+
+    @Test("상태 필터 탭 → 필터 설정 + 재조회, 같은 필터 재탭 → 해제")
+    func listFilterTogglesAndRefetches() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.listFilterButtonTapped(.presentPending)
+        #expect(viewModel.selectedListFilter == .presentPending)
+        #expect(useCase.fetchListCalls.last?.attendanceStatus == .presentPending)
+
+        await viewModel.listFilterButtonTapped(.presentPending)
+        #expect(viewModel.selectedListFilter == nil)
+        #expect(useCase.fetchListCalls.count == 2)
+    }
+
+    @Test("전체 필터 초기화 — 이미 전체면 재조회하지 않음")
+    func clearListFilterSkipsWhenAlreadyAll() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.clearListFilter()
+
+        #expect(useCase.fetchListCalls.isEmpty)
+    }
+
+    @Test("기간 프리셋 선택 → periodPreset 갱신 + 재조회, custom 은 날짜 유지")
+    func presetSelectionUpdatesAndRefetches() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.presetSelected(.oneWeek)
+        #expect(viewModel.periodPreset == .oneWeek)
+        #expect(useCase.fetchListCalls.count == 1)
+        #expect(viewModel.fromDate < viewModel.toDate)
+
+        let keptFrom = viewModel.fromDate
+        await viewModel.presetSelected(.custom)
+        #expect(viewModel.periodPreset == .custom)
+        #expect(viewModel.fromDate == keptFrom)
+        #expect(useCase.fetchListCalls.count == 2)
+    }
+
+    @Test("승인 대기 파생 상태 — totalPendingCount 합산 + firstPendingScheduleId")
+    func pendingDerivedState() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchListResult = [
+            makeScheduleInfo(scheduleId: "10", pendingCount: 0),
+            makeScheduleInfo(scheduleId: "11", pendingCount: 2),
+            makeScheduleInfo(scheduleId: "12", pendingCount: 3)
+        ]
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchList()
+
+        #expect(viewModel.totalPendingCount == 5)
+        #expect(viewModel.firstPendingScheduleId == "11")
+    }
+}
+
+// MARK: - 상세 조회 / 필터
+
+@MainActor
+@Suite("OperatorAttendanceViewModel — 상세 조회 (도메인 규칙)")
+struct OperatorAttendanceViewModelDetailTests {
+
+    @Test("일정 선택 → scheduleId 지정 + 상세 조회 위임")
+    func selectScheduleFetchesDetail() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchDetailResult = makeScheduleInfo(scheduleId: "42")
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.selectSchedule("42")
+
+        #expect(viewModel.selectedScheduleId == "42")
+        #expect(useCase.fetchDetailCalls.first?.scheduleId == "42")
+        #expect(viewModel.detailState == .loaded(makeScheduleInfo(scheduleId: "42")))
+    }
+
+    @Test("선택 없이 상세 조회 → 아무 동작 없음")
+    func fetchDetailWithoutSelectionIsNoOp() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.fetchDetail()
+
+        #expect(useCase.fetchDetailCalls.isEmpty)
+        #expect(viewModel.detailState == .idle)
+    }
+
+    @Test("상세 조회 중 일정 삭제(SCHEDULE-0009) → isScheduleDeleted + failed(.repository)")
+    func fetchDetailDetectsDeletedSchedule() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchDetailError = RepositoryError.serverError(
+            code: "SCHEDULE-0009",
+            message: "삭제된 일정"
+        )
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.selectSchedule("42")
+
+        #expect(viewModel.isScheduleDeleted == true)
+        #expect(viewModel.detailState.error != nil)
+    }
+
+    @Test("상세 조회 취소 → 이전 상태로 롤백")
+    func fetchDetailForwardsCancellation() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let loaded = makeScheduleInfo(scheduleId: "42")
+        useCase.fetchDetailResult = loaded
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+
+        useCase.fetchDetailError = CancellationError()
+        await viewModel.fetchDetail()
+
+        #expect(viewModel.detailState == .loaded(loaded))
+    }
+
+    @Test("상세 상태 필터 → 클라이언트 측 필터링, 재탭 시 해제")
+    func detailFilterFiltersClientSide() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchDetailResult = makeScheduleInfo(
+            scheduleId: "42",
+            participants: [
+                makeParticipant(memberId: "1", status: .present),
+                makeParticipant(memberId: "2", status: .absent),
+                makeParticipant(memberId: "3", status: .present)
+            ]
+        )
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+
+        viewModel.detailFilterButtonTapped(.present)
+        #expect(viewModel.filteredParticipants.map(\.memberId) == ["1", "3"])
+
+        viewModel.detailFilterButtonTapped(.present)
+        #expect(viewModel.filteredParticipants.count == 3)
+    }
+}
+
+// MARK: - 승인 / 반려 (낙관적 갱신)
+
+@MainActor
+@Suite("OperatorAttendanceViewModel — 승인/반려 (도메인 규칙)")
+struct OperatorAttendanceViewModelDecisionTests {
+
+    private func loadedViewModel(
+        useCase: MockOperatorAttendanceUseCase,
+        participants: [ParticipantAttendance]
+    ) async -> OperatorAttendanceViewModel {
+        useCase.fetchDetailResult = makeScheduleInfo(scheduleId: "42", participants: participants)
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+        return viewModel
+    }
+
+    @Test(
+        "단건 결정 성공 → 대상만 낙관적 갱신 (승인=present / 반려=absent)",
+        arguments: [true, false]
+    )
+    func decideSingleUpdatesTargetOptimistically(isApproved: Bool) async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let target = makeParticipant(memberId: "1", status: .presentPending)
+        let other = makeParticipant(memberId: "2", status: .presentPending)
+        let viewModel = await loadedViewModel(useCase: useCase, participants: [target, other])
+
+        await viewModel.decideAttendance(participant: target, isApproved: isApproved)
+
+        let participants = viewModel.detailState.value?.participants ?? []
+        let updated = participants.first { $0.memberId == "1" }
+        let untouched = participants.first { $0.memberId == "2" }
+        #expect(updated?.attendanceStatus == (isApproved ? .present : .absent))
+        #expect(untouched?.attendanceStatus == .presentPending)
+        #expect(useCase.decideCalls.first?.scheduleId == "42")
+        #expect(useCase.decideCalls.first?.decisions.first?.participantMemberId == "1")
+    }
+
+    @Test("전체 승인 → 승인 대기 전원 present 로 갱신 (확정 상태는 미변경)")
+    func decideAllApprovesPendingOnly() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pendingA = makeParticipant(memberId: "1", status: .presentPending)
+        let pendingB = makeParticipant(memberId: "2", status: .latePending)
+        let confirmed = makeParticipant(memberId: "3", status: .absent)
+        let viewModel = await loadedViewModel(
+            useCase: useCase,
+            participants: [pendingA, pendingB, confirmed]
+        )
+
+        await viewModel.decideAllAttendances(isApproved: true)
+
+        let statuses = (viewModel.detailState.value?.participants ?? [])
+            .map(\.attendanceStatus)
+        #expect(statuses == [.present, .present, .absent])
+        #expect(useCase.decideCalls.first?.decisions.count == 2)
+    }
+
+    @Test("선택 결정 → 선택한 참여자만 갱신")
+    func decideSelectedUpdatesOnlySelected() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let a = makeParticipant(memberId: "1", status: .presentPending)
+        let b = makeParticipant(memberId: "2", status: .presentPending)
+        let c = makeParticipant(memberId: "3", status: .presentPending)
+        let viewModel = await loadedViewModel(useCase: useCase, participants: [a, b, c])
+
+        await viewModel.decideSelectedAttendances(participants: [a, c], isApproved: true)
+
+        let byId = Dictionary(
+            uniqueKeysWithValues: (viewModel.detailState.value?.participants ?? [])
+                .map { ($0.memberId, $0.attendanceStatus) }
+        )
+        #expect(byId["1"] == .present)
+        #expect(byId["2"] == .presentPending)
+        #expect(byId["3"] == .present)
+    }
+
+    @Test("결정 403 → 권한 Alert + 상세 재조회, 낙관적 갱신 미적용")
+    func decidePermissionDeniedShowsAlertAndRefreshes() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let target = makeParticipant(memberId: "1", status: .presentPending)
+        let viewModel = await loadedViewModel(useCase: useCase, participants: [target])
+        useCase.decideError = NetworkError.requestFailed(statusCode: 403, data: nil)
+
+        await viewModel.decideAttendance(participant: target, isApproved: true)
+
+        #expect(viewModel.alertPrompt?.title == "권한이 없어요")
+        // 초기 선택 조회 1회 + 실패 후 refreshDetail 1회 = 2회
+        #expect(useCase.fetchDetailCalls.count == 2)
+        let status = viewModel.detailState.value?.participants.first?.attendanceStatus
+        #expect(status == .presentPending)
+    }
+
+    @Test("결정 비-권한 에러 → errorHandler 경로 (Alert 없음, 갱신 미적용)")
+    func decideNonPermissionErrorRoutesToHandler() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let target = makeParticipant(memberId: "1", status: .presentPending)
+        let viewModel = await loadedViewModel(useCase: useCase, participants: [target])
+        useCase.decideError = TestError.boom
+
+        await viewModel.decideAttendance(participant: target, isApproved: true)
+
+        #expect(viewModel.alertPrompt == nil)
+        #expect(useCase.fetchDetailCalls.count == 1)
+        let status = viewModel.detailState.value?.participants.first?.attendanceStatus
+        #expect(status == .presentPending)
+    }
+
+    @Test("전체 결정 403 → 권한 Alert (단건과 동일 에러 경로, 형제 대칭)")
+    func decideAllPermissionDeniedShowsAlert() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pending = makeParticipant(memberId: "1", status: .presentPending)
+        let viewModel = await loadedViewModel(useCase: useCase, participants: [pending])
+        useCase.decideError = NetworkError.requestFailed(statusCode: 403, data: nil)
+
+        await viewModel.decideAllAttendances(isApproved: true)
+
+        #expect(viewModel.alertPrompt?.title == "권한이 없어요")
+        let status = viewModel.detailState.value?.participants.first?.attendanceStatus
+        #expect(status == .presentPending)
+    }
+
+    @Test("선택 결정 403 → 권한 Alert (단건과 동일 에러 경로, 형제 대칭)")
+    func decideSelectedPermissionDeniedShowsAlert() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pending = makeParticipant(memberId: "1", status: .presentPending)
+        let viewModel = await loadedViewModel(useCase: useCase, participants: [pending])
+        useCase.decideError = NetworkError.requestFailed(statusCode: 403, data: nil)
+
+        await viewModel.decideSelectedAttendances(participants: [pending], isApproved: true)
+
+        #expect(viewModel.alertPrompt?.title == "권한이 없어요")
+        let status = viewModel.detailState.value?.participants.first?.attendanceStatus
+        #expect(status == .presentPending)
+    }
+
+    @Test("선택 없이 결정 → UseCase 미호출")
+    func decideWithoutSelectionIsNoOp() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.decideAttendance(
+            participant: makeParticipant(memberId: "1"),
+            isApproved: true
+        )
+
+        #expect(useCase.decideCalls.isEmpty)
+    }
+}
+
+// MARK: - 위치 변경
+
+@MainActor
+@Suite("OperatorAttendanceViewModel — 위치 변경 (도메인 규칙)")
+struct OperatorAttendanceViewModelLocationTests {
+
+    private func selectedViewModel(
+        useCase: MockOperatorAttendanceUseCase
+    ) async -> OperatorAttendanceViewModel {
+        useCase.fetchDetailResult = makeScheduleInfo(scheduleId: "42")
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+        return viewModel
+    }
+
+    @Test("위치 변경 — 빈 이름은 거부 + Alert, UseCase 미호출")
+    func changeLocationRejectsEmptyName() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = await selectedViewModel(useCase: useCase)
+
+        let result = await viewModel.changeLocation(name: "   ", latitude: 37.5, longitude: 127.0)
+
+        #expect(result == false)
+        #expect(viewModel.alertPrompt != nil)
+        #expect(useCase.updateLocationCalls.isEmpty)
+    }
+
+    @Test(
+        "위치 변경 — 유효하지 않은 좌표는 거부",
+        arguments: [
+            (lat: 91.0, lng: 127.0),
+            (lat: 37.5, lng: 181.0),
+            (lat: Double.nan, lng: 127.0)
+        ]
+    )
+    func changeLocationRejectsInvalidCoordinate(lat: Double, lng: Double) async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = await selectedViewModel(useCase: useCase)
+
+        let result = await viewModel.changeLocation(name: "한성대", latitude: lat, longitude: lng)
+
+        #expect(result == false)
+        #expect(useCase.updateLocationCalls.isEmpty)
+    }
+
+    @Test("위치 변경 성공 → 이름 트림 + 좌표 그대로 위임")
+    func changeLocationSucceedsAndDelegates() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = await selectedViewModel(useCase: useCase)
+
+        let result = await viewModel.changeLocation(
+            name: "  한성대 상상관  ",
+            latitude: 37.582,
+            longitude: 127.010
+        )
+
+        #expect(result == true)
+        let call = useCase.updateLocationCalls.first
+        #expect(call?.scheduleId == "42")
+        #expect(call?.locationName == "한성대 상상관")
+        #expect(call?.latitude == 37.582)
+        #expect(call?.longitude == 127.010)
+    }
+
+    @Test("위치 변경 에러 → false 반환 (errorHandler 경로)")
+    func changeLocationForwardsErrorReturnsFalse() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = await selectedViewModel(useCase: useCase)
+        useCase.updateLocationError = TestError.boom
+
+        let result = await viewModel.changeLocation(
+            name: "한성대",
+            latitude: 37.5,
+            longitude: 127.0
+        )
+
+        #expect(result == false)
+    }
+
+    @Test("선택 없이 위치 변경 → false + UseCase 미호출")
+    func changeLocationWithoutSelectionReturnsFalse() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let viewModel = makeViewModel(useCase: useCase)
+
+        let result = await viewModel.changeLocation(
+            name: "한성대",
+            latitude: 37.5,
+            longitude: 127.0
+        )
+
+        #expect(result == false)
+        #expect(useCase.updateLocationCalls.isEmpty)
+    }
+}
+
+// MARK: - 요청 토큰 latest-wins (동시성)
+
+@MainActor
+@Suite("OperatorAttendanceViewModel — 요청 토큰 latest-wins (도메인 규칙)")
+struct OperatorAttendanceViewModelRequestTokenTests {
+
+    @Test("상세 스케줄 전환 — 진행 중 이전 스케줄 응답이 새 식별자에 바인딩되지 않는다")
+    func detailScheduleSwitchDiscardsStaleResponse() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.gateDetail = true
+        useCase.fetchDetailResultByScheduleId = [
+            "A": makeScheduleInfo(
+                scheduleId: "A",
+                participants: [makeParticipant(memberId: "a1")]
+            ),
+            "B": makeScheduleInfo(
+                scheduleId: "B",
+                participants: [makeParticipant(memberId: "b1")]
+            )
+        ]
+        let viewModel = makeViewModel(useCase: useCase)
+
+        // A 상세 조회 시작 → 게이트에서 대기
+        let selectA = Task { await viewModel.selectSchedule("A") }
+        await drainUntil { useCase.fetchDetailCalls.contains { $0.scheduleId == "A" } }
+
+        // B 로 전환 → 게이트에서 대기 (재진입 가드였다면 여기서 유실됐을 요청)
+        let selectB = Task { await viewModel.selectSchedule("B") }
+        await drainUntil { useCase.fetchDetailCalls.contains { $0.scheduleId == "B" } }
+
+        // 오래된 A 응답을 먼저 방출 → 토큰 불일치로 폐기돼야 함
+        useCase.releaseDetail("A")
+        await selectA.value
+        // 최신 B 응답 방출 → 반영
+        useCase.releaseDetail("B")
+        await selectB.value
+
+        #expect(viewModel.selectedScheduleId == "B")
+        #expect(viewModel.detailState.value?.scheduleId == "B")
+        #expect(viewModel.detailState.value?.participants.map(\.memberId) == ["b1"])
+    }
+
+    @Test("목록 필터 변경 — 진행 중 언필터 응답이 필터 상태를 덮어쓰지 않는다")
+    func listFilterChangeDiscardsStaleResponse() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.gateList = true
+        let unfiltered = [makeScheduleInfo(scheduleId: "1"), makeScheduleInfo(scheduleId: "2")]
+        let filtered = [makeScheduleInfo(scheduleId: "1")]
+        useCase.fetchListResultQueue = [unfiltered, filtered]
+        let viewModel = makeViewModel(useCase: useCase)
+
+        // 초기(언필터) 조회 시작 → 게이트 대기
+        let initial = Task { await viewModel.fetchList() }
+        await drainUntil { useCase.fetchListCalls.count == 1 }
+
+        // 필터 변경 → 두 번째(필터) 조회 시작, 게이트 대기
+        let filterTap = Task { await viewModel.listFilterButtonTapped(.presentPending) }
+        await drainUntil { useCase.fetchListCalls.count == 2 }
+
+        // 두 응답 모두 방출 → 오래된 언필터 응답은 토큰으로 폐기
+        useCase.releaseList()
+        await initial.value
+        await filterTap.value
+
+        #expect(viewModel.selectedListFilter == .presentPending)
+        #expect(viewModel.listState == .loaded(filtered))
+        #expect(useCase.fetchListCalls.last?.attendanceStatus == .presentPending)
+    }
+}
+
+#endif

--- a/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
@@ -90,20 +90,7 @@ private func makeViewModel(
     )
 }
 
-/// 백그라운드 새로고침처럼 fire-and-forget `Task` 가 완료될 때까지 조건을 폴링한다.
-/// mock 은 실제 I/O 지연이 없어 몇 번의 yield 로 끝난다. `maxYields` 는 무한 루프 방지 상한.
-@MainActor
-private func drainUntil(
-    _ viewModel: OperatorStudyManagementViewModel,
-    maxYields: Int = 10_000,
-    _ condition: (OperatorStudyManagementViewModel) -> Bool
-) async {
-    var yields = 0
-    while !condition(viewModel), yields < maxYields {
-        await Task.yield()
-        yields += 1
-    }
-}
+// drainUntil 은 Tests 타깃 공용 `ConcurrencyTestSupport.swift` 의 헬퍼를 사용한다.
 
 private struct DummyError: Error {}
 
@@ -305,8 +292,8 @@ struct OperatorStudyManagementViewModelLoadTests {
         #expect(created == true)
 
         // 새로고침 Task 가 placeholder 를 서버 데이터로 교체할 때까지 대기
-        await drainUntil(viewModel) { vm in
-            !vm.studyGroupDetails.contains { $0.serverID.hasPrefix("new_") }
+        await drainUntil {
+            !viewModel.studyGroupDetails.contains { $0.serverID.hasPrefix("new_") }
         }
 
         // 첫 페이지(20)로 잘리지 않고 로드 윈도우(40)가 복원돼야 한다.

--- a/UMCApp/Features/Activity/Presentation/Tests/Support/ConcurrencyTestSupport.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/Support/ConcurrencyTestSupport.swift
@@ -1,0 +1,26 @@
+//
+//  ConcurrencyTestSupport.swift
+//  ActivityPresentationTests
+//
+//  Created by jaewon Lee on 7/19/26.
+//
+
+import Foundation
+
+#if DEBUG
+
+/// 조건이 만족될 때까지 MainActor 를 양보하며 대기한다(무한 루프 방지 상한 포함).
+///
+/// mock 은 실제 I/O 지연이 없어 몇 번의 yield 로 끝난다. 게이트로 suspend 된 요청이
+/// mock 호출 기록을 남기거나, fire-and-forget `Task` 가 완료될 때까지 기다리는 용도.
+/// 동시성 스위트가 공유하는 test-support 헬퍼로, 파일별 사본을 만들지 않는다.
+@MainActor
+func drainUntil(maxYields: Int = 10_000, _ condition: () -> Bool) async {
+    var yields = 0
+    while !condition(), yields < maxYields {
+        await Task.yield()
+        yields += 1
+    }
+}
+
+#endif


### PR DESCRIPTION
resolves #876

## ✨ PR 유형

♻️ 리팩토링 — 레거시 출석 관리 ViewModel 2종을 Tuist `ActivityPresentation` 모듈로 단일 통합 이식

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="984" alt="스크린샷 2026-07-15 오후 1 39 46" src="https://github.com/user-attachments/assets/d294db38-be4b-44c8-bf74-3309fc825e45" />
<img width="1512" height="984" alt="스크린샷 2026-07-15 오후 1 40 02" src="https://github.com/user-attachments/assets/ec5d939d-e5a4-4704-a126-7c29e9e6ce4e" />


## 🛠️ 작업내용

레거시 `AttendanceListViewModel` + `AttendanceDetailViewModel` 을 단일 통합 화면 기준으로 `OperatorAttendanceViewModel` 하나로 병합 이식.

- 4개 UseCase 경로 전부 `OperatorAttendanceUseCaseProtocol` 에 연결 — 명단 조회 · 상세 조회 · 일괄 승인/반려 · 위치 변경
- `@Observable` 상태 관리 · 서버 식별자 전 레이어 `String` 통일 · `ParticipantAttendanceStatus` 사용
- fetch 계열: 취소(`CancellationError`) house 패턴 + 요청 토큰(latest-wins)으로 stale 응답 차단
- 승인/반려 낙관적 갱신(pending → present/absent) · 위치 변경 좌표 검증
- 기간 필터 프리셋(`AttendancePeriodPreset`) 이식
- Swift Testing 단위 테스트 5 Suite / 26 케이스

## 📋 추후 진행 상황

- 단일 통합 화면 View 이식 티켓에서 목록 ↔ 상세 갱신 연동
- 커버리지 리포트 수집 (Tuist 스킴 `-enableCodeCoverage` 활성화)

## 📌 리뷰 포인트

- **요청 토큰(latest-wins)** — 병합 VM이 가변 식별자(`selectedScheduleId`)·필터를 갖게 되면서, 단순 재진입 가드로는 스케줄 전환 중 stale 응답이 새 식별자에 바인딩(잘못된 승인 대상)되거나 필터 변경이 유실되는 문제가 생김. `loadList`/`loadDetail` 이 토큰으로 최신 요청만 반영
- 취소 롤백 기준을 비-`.loading`(`.idle`)으로 잡아 stuck-loading 방지
- 위치 변경은 미이식 `PlaceSearchInfo`/시트 커플링을 제거하고 검증된 원시 좌표(`changeLocation(name:latitude:longitude:)`)로 노출

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
