### PR TITLE
♻️ [Refactor] 챌린저 구성원 목록·상세 시트 뷰 + 멤버 관리 공유 컴포넌트 이식

### DIFF
--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Member/CoreMemberManagementList.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Member/CoreMemberManagementList.swift
@@ -1,0 +1,180 @@
+//
+//  CoreMemberManagementList.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+// MARK: - CoreMemberManagementList
+
+/// 구성원 목록의 리스트 아이템 뷰입니다.
+///
+/// 프로필 이미지, 이름·파트, 운영진 직책 배지를 가로로 배치합니다.
+/// 챌린저 구성원 목록과 운영진 멤버 관리 화면(후속 이슈)에서 공유합니다.
+struct CoreMemberManagementList: View {
+
+    // MARK: - Property
+
+    /// 표시할 멤버 정보
+    let memberManagementItem: MemberManagementItem
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack {
+            MemberImagePresenter(memberManagementItem: memberManagementItem)
+
+            CoreMemberTextPresenter(
+                name: memberManagementItem.name,
+                nickname: memberManagementItem.nickname,
+                part: memberManagementItem.part
+            )
+
+            Spacer()
+
+            ManagementTeamBadgePresenter(
+                managementTeam: memberManagementItem.managementTeam
+            )
+        }
+    }
+}
+
+// MARK: - CoreMemberTextPresenter
+
+/// 멤버의 닉네임·이름과 파트 배지를 표시합니다.
+struct CoreMemberTextPresenter: View {
+
+    /// 멤버 이름
+    let name: String
+
+    /// 멤버 닉네임
+    let nickname: String
+
+    /// 소속 파트
+    let part: UMCPartType
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Text("\(nickname)/\(name)")
+                .appFont(.callout, weight: .semibold, color: .black)
+
+            Text(part.name)
+                .appFont(.footnote, color: part.color)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background {
+                    Capsule()
+                        .fill(part.color.opacity(0.16))
+                }
+                .overlay {
+                    Capsule()
+                        .stroke(part.color.opacity(0.4), lineWidth: 1)
+                }
+        }
+    }
+}
+
+// MARK: - ManagementTeamBadgePresenter
+
+/// 운영진 직책 배지입니다. 일반 챌린저(`.challenger`)는 아무것도 표시하지 않습니다.
+struct ManagementTeamBadgePresenter: View {
+
+    /// 운영진 직책 타입
+    let managementTeam: ManagementTeam
+
+    private enum Constants {
+        static let verticalPadding: CGFloat = 6
+        static let horizontalPadding: CGFloat = 8
+    }
+
+    var body: some View {
+        Group {
+            if managementTeam != .challenger {
+                Text(managementTeam.korean)
+                    .font(.app(.footnote, weight: .regular))
+                    .foregroundStyle(managementTeam.textColor)
+                    .padding(.vertical, Constants.verticalPadding)
+                    .padding(.horizontal, Constants.horizontalPadding)
+                    .background {
+                        RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+                            .fill(managementTeam.backgroundColor)
+                    }
+            }
+        }
+    }
+}
+
+// MARK: - PenaltyBadgePresenter
+
+/// 운영진 화면에서 멤버의 벌점을 표시하는 배지입니다.
+struct PenaltyBadgePresenter: View {
+
+    let penalty: Double
+
+    private enum Constants {
+        static let verticalPadding: CGFloat = 6
+        static let horizontalPadding: CGFloat = 8
+        static let bgOpacity: Double = 0.2
+    }
+
+    var body: some View {
+        Text("벌점 \(String(format: "%.0f", penalty))")
+            .font(.app(.footnote, weight: .regular))
+            .foregroundStyle(.red)
+            .padding(.vertical, Constants.verticalPadding)
+            .padding(.horizontal, Constants.horizontalPadding)
+            .background {
+                RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+                    .fill(.red.opacity(Constants.bgOpacity))
+            }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview(traits: .sizeThatFitsLayout) {
+    VStack(spacing: 4) {
+        CoreMemberManagementList(
+            memberManagementItem: MemberManagementItem(
+                profile: nil,
+                name: "이예지",
+                nickname: "소피",
+                generation: "9기",
+                school: "가천대학교",
+                position: "Part Leader",
+                part: .front(type: .ios),
+                penalty: 0,
+                badge: false,
+                managementTeam: .schoolPartLeader,
+                attendanceRecords: [],
+                penaltyHistory: []
+            )
+        )
+
+        CoreMemberManagementList(
+            memberManagementItem: MemberManagementItem(
+                profile: nil,
+                name: "홍길동",
+                nickname: "라이언",
+                generation: "9기",
+                school: "가천대학교",
+                position: "Challenger",
+                part: .front(type: .ios),
+                penalty: 1,
+                badge: false,
+                managementTeam: .challenger,
+                attendanceRecords: [],
+                penaltyHistory: []
+            )
+        )
+    }
+    .padding()
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Member/CoreMemberManagementRow.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Member/CoreMemberManagementRow.swift
@@ -1,5 +1,5 @@
 //
-//  CoreMemberManagementList.swift
+//  CoreMemberManagementRow.swift
 //  ActivityPresentation
 //
 //  Created by jaewon Lee on 7/15/26.
@@ -11,13 +11,13 @@ import CoreUIComponents
 import SwiftUI
 import UMCFoundation
 
-// MARK: - CoreMemberManagementList
+// MARK: - CoreMemberManagementRow
 
-/// 구성원 목록의 리스트 아이템 뷰입니다.
+/// 구성원 목록의 리스트 아이템(행) 뷰입니다.
 ///
 /// 프로필 이미지, 이름·파트, 운영진 직책 배지를 가로로 배치합니다.
 /// 챌린저 구성원 목록과 운영진 멤버 관리 화면(후속 이슈)에서 공유합니다.
-struct CoreMemberManagementList: View {
+struct CoreMemberManagementRow: View {
 
     // MARK: - Property
 
@@ -110,38 +110,12 @@ struct ManagementTeamBadgePresenter: View {
     }
 }
 
-// MARK: - PenaltyBadgePresenter
-
-/// 운영진 화면에서 멤버의 벌점을 표시하는 배지입니다.
-struct PenaltyBadgePresenter: View {
-
-    let penalty: Double
-
-    private enum Constants {
-        static let verticalPadding: CGFloat = 6
-        static let horizontalPadding: CGFloat = 8
-        static let bgOpacity: Double = 0.2
-    }
-
-    var body: some View {
-        Text("벌점 \(String(format: "%.0f", penalty))")
-            .font(.app(.footnote, weight: .regular))
-            .foregroundStyle(.red)
-            .padding(.vertical, Constants.verticalPadding)
-            .padding(.horizontal, Constants.horizontalPadding)
-            .background {
-                RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
-                    .fill(.red.opacity(Constants.bgOpacity))
-            }
-    }
-}
-
 // MARK: - Preview
 
 #if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     VStack(spacing: 4) {
-        CoreMemberManagementList(
+        CoreMemberManagementRow(
             memberManagementItem: MemberManagementItem(
                 profile: nil,
                 name: "이예지",
@@ -158,7 +132,7 @@ struct PenaltyBadgePresenter: View {
             )
         )
 
-        CoreMemberManagementList(
+        CoreMemberManagementRow(
             memberManagementItem: MemberManagementItem(
                 profile: nil,
                 name: "홍길동",

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Member/CoreMemberManagementRow.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Member/CoreMemberManagementRow.swift
@@ -83,29 +83,21 @@ struct CoreMemberTextPresenter: View {
 // MARK: - ManagementTeamBadgePresenter
 
 /// 운영진 직책 배지입니다. 일반 챌린저(`.challenger`)는 아무것도 표시하지 않습니다.
+///
+/// 렌더링은 ``InfoBadge`` 에 위임해 앱 전역 배지 스타일(Glass Effect)을 따릅니다.
+/// 이 타입은 `.challenger` 를 걸러내는 도메인 규칙만 담당합니다.
 struct ManagementTeamBadgePresenter: View {
 
     /// 운영진 직책 타입
     let managementTeam: ManagementTeam
 
-    private enum Constants {
-        static let verticalPadding: CGFloat = 6
-        static let horizontalPadding: CGFloat = 8
-    }
-
     var body: some View {
-        Group {
-            if managementTeam != .challenger {
-                Text(managementTeam.korean)
-                    .font(.app(.footnote, weight: .regular))
-                    .foregroundStyle(managementTeam.textColor)
-                    .padding(.vertical, Constants.verticalPadding)
-                    .padding(.horizontal, Constants.horizontalPadding)
-                    .background {
-                        RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
-                            .fill(managementTeam.backgroundColor)
-                    }
-            }
+        if managementTeam != .challenger {
+            InfoBadge(
+                managementTeam.korean,
+                textColor: managementTeam.textColor,
+                tintColor: managementTeam.backgroundColor
+            )
         }
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Member/MemberManagementCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Member/MemberManagementCard.swift
@@ -13,10 +13,15 @@ import UMCFoundation
 
 // MARK: - MemberManagementCard
 
+// TODO: OperatorMemberManagementView 이식 시 이 카드 연결 (#898) - [26.07.29] 이재원
+
 /// 멤버 관리 리스트에서 사용하는 카드 뷰입니다.
 ///
 /// 프로필 이미지, 이름·기수·직책·파트, 상벌점 배지, chevron 을 가로로 배치합니다.
-/// 운영진 멤버 관리 화면(후속 이슈)에서 공유하는 컴포넌트입니다.
+///
+/// - Note: 현재 이 카드를 소비하는 화면은 없고 프리뷰에서만 렌더링됩니다.
+///   챌린저 구성원 목록은 행 높이가 낮은 ``CoreMemberManagementRow`` 를 사용하며,
+///   이 카드는 운영진 멤버 관리 화면이 이식될 때 첫 소비자가 생깁니다.
 struct MemberManagementCard: View, Equatable {
 
     // MARK: - Property
@@ -28,7 +33,7 @@ struct MemberManagementCard: View, Equatable {
     fileprivate enum Constants {
         static let hstackSpacing: CGFloat = 15
         static let chevronSize: CGSize = .init(width: 4, height: 8)
-        static let innerPadding: CGFloat = 16
+        static let innerPadding: CGFloat = DefaultSpacing.spacing16
         static let radius: CGFloat = 14
         static let strokeWidth: CGFloat = 1
     }
@@ -61,7 +66,7 @@ struct MemberManagementCard: View, Equatable {
 
 /// 프로필 사진과 선물 상자 배지를 표시합니다.
 ///
-/// ``CoreMemberManagementList`` 에서도 사용하는 공유 컴포넌트입니다.
+/// ``CoreMemberManagementRow`` 에서도 사용하는 공유 컴포넌트입니다.
 struct MemberImagePresenter: View, Equatable {
 
     // MARK: - Property
@@ -188,9 +193,9 @@ private struct MemberPenaltyPresenter: View, Equatable {
     // MARK: - Constants
 
     fileprivate enum Constants {
-        static let hstackSpacing: CGFloat = 4
-        static let horizonSpacing: CGFloat = 8
-        static let verticalSpacing: CGFloat = 4
+        static let hstackSpacing: CGFloat = DefaultSpacing.spacing4
+        static let horizonSpacing: CGFloat = DefaultSpacing.spacing8
+        static let verticalSpacing: CGFloat = DefaultSpacing.spacing4
         static let radius: CGFloat = 8
         static let strokeWidth: CGFloat = 0.5
     }
@@ -203,9 +208,9 @@ private struct MemberPenaltyPresenter: View, Equatable {
                 pointBadge(
                     label: "상점",
                     value: memberManagementItem.rewardPoints,
-                    fgColor: .green,
-                    bgColor: Color.green.opacity(0.1),
-                    borderColor: Color.green.opacity(0.3)
+                    fgColor: Color.green700,
+                    bgColor: Color.green100,
+                    borderColor: Color.green300
                 )
             }
             if memberManagementItem.penalty > 0 {

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Member/MemberManagementCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Member/MemberManagementCard.swift
@@ -1,0 +1,317 @@
+//
+//  MemberManagementCard.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+// MARK: - MemberManagementCard
+
+/// 멤버 관리 리스트에서 사용하는 카드 뷰입니다.
+///
+/// 프로필 이미지, 이름·기수·직책·파트, 상벌점 배지, chevron 을 가로로 배치합니다.
+/// 운영진 멤버 관리 화면(후속 이슈)에서 공유하는 컴포넌트입니다.
+struct MemberManagementCard: View, Equatable {
+
+    // MARK: - Property
+
+    let memberManagementItem: MemberManagementItem
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let hstackSpacing: CGFloat = 15
+        static let chevronSize: CGSize = .init(width: 4, height: 8)
+        static let innerPadding: CGFloat = 16
+        static let radius: CGFloat = 14
+        static let strokeWidth: CGFloat = 1
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: Constants.hstackSpacing) {
+            MemberImagePresenter(memberManagementItem: memberManagementItem)
+            MemberTextPresenter(memberManagementItem: memberManagementItem)
+            Spacer()
+            MemberPenaltyPresenter(memberManagementItem: memberManagementItem)
+            Image(systemName: "chevron.right")
+                .resizable()
+                .frame(
+                    width: Constants.chevronSize.width,
+                    height: Constants.chevronSize.height
+                )
+                .foregroundStyle(Color.grey400)
+        }
+        .padding(Constants.innerPadding)
+        .background {
+            RoundedRectangle(cornerRadius: Constants.radius)
+                .strokeBorder(Color.grey200, lineWidth: Constants.strokeWidth)
+        }
+    }
+}
+
+// MARK: - MemberImagePresenter
+
+/// 프로필 사진과 선물 상자 배지를 표시합니다.
+///
+/// ``CoreMemberManagementList`` 에서도 사용하는 공유 컴포넌트입니다.
+struct MemberImagePresenter: View, Equatable {
+
+    // MARK: - Property
+
+    let memberManagementItem: MemberManagementItem
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let imageSize: CGSize = .init(width: 40, height: 40)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        RemoteImage(
+            urlString: memberManagementItem.profile ?? "",
+            size: Constants.imageSize
+        )
+        .clipShape(Circle())
+        .aspectRatio(contentMode: .fit)
+        .overlay(alignment: .topTrailing) {
+            if memberManagementItem.badge {
+                MemberBadgePresenter()
+            }
+        }
+    }
+}
+
+// MARK: - MemberTextPresenter
+
+/// 멤버 이름·기수·직책·파트 텍스트를 세로로 배치합니다.
+private struct MemberTextPresenter: View, Equatable {
+
+    // MARK: - Property
+
+    let memberManagementItem: MemberManagementItem
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let vstackSpacing: CGFloat = 2
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Constants.vstackSpacing) {
+            MemberTopTextPresenter(memberManagementItem: memberManagementItem)
+            MemberBottomTextPresenter(memberManagementItem: memberManagementItem)
+        }
+    }
+}
+
+// MARK: - MemberTopTextPresenter
+
+/// 멤버 이름과 기수를 표시합니다.
+private struct MemberTopTextPresenter: View, Equatable {
+
+    // MARK: - Property
+
+    let memberManagementItem: MemberManagementItem
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let rectangleSize: CGSize = .init(width: 1, height: 16)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack {
+            Text(memberManagementItem.name)
+                .appFont(.callout, weight: .semibold)
+
+            Rectangle()
+                .frame(
+                    width: Constants.rectangleSize.width,
+                    height: Constants.rectangleSize.height
+                )
+                .foregroundStyle(Color.grey300)
+
+            Text(memberManagementItem.generation)
+                .font(.app(.subheadline, weight: .regular))
+                .foregroundStyle(Color.grey900)
+        }
+    }
+}
+
+// MARK: - MemberBottomTextPresenter
+
+/// 멤버 직책과 파트를 표시합니다.
+private struct MemberBottomTextPresenter: View, Equatable {
+
+    // MARK: - Property
+
+    let memberManagementItem: MemberManagementItem
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack {
+            Text(memberManagementItem.position)
+                .font(.app(.subheadline, weight: .regular))
+                .foregroundStyle(Color.grey500)
+
+            Text(memberManagementItem.part.name)
+                .font(.app(.subheadline, weight: .regular))
+                .foregroundStyle(Color.grey500)
+        }
+    }
+}
+
+// MARK: - MemberPenaltyPresenter
+
+/// 상점·벌점 배지를 표시합니다. 값이 0 이하인 배지는 숨깁니다.
+private struct MemberPenaltyPresenter: View, Equatable {
+
+    // MARK: - Property
+
+    let memberManagementItem: MemberManagementItem
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let hstackSpacing: CGFloat = 4
+        static let horizonSpacing: CGFloat = 8
+        static let verticalSpacing: CGFloat = 4
+        static let radius: CGFloat = 8
+        static let strokeWidth: CGFloat = 0.5
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: Constants.hstackSpacing) {
+            if memberManagementItem.rewardPoints > 0 {
+                pointBadge(
+                    label: "상점",
+                    value: memberManagementItem.rewardPoints,
+                    fgColor: .green,
+                    bgColor: Color.green.opacity(0.1),
+                    borderColor: Color.green.opacity(0.3)
+                )
+            }
+            if memberManagementItem.penalty > 0 {
+                pointBadge(
+                    label: "벌점",
+                    value: memberManagementItem.penalty,
+                    fgColor: Color.red700,
+                    bgColor: Color.red100,
+                    borderColor: Color.red300
+                )
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    private func pointBadge(
+        label: String,
+        value: Double,
+        fgColor: Color,
+        bgColor: Color,
+        borderColor: Color
+    ) -> some View {
+        HStack(spacing: 3) {
+            Text(label)
+            Text(String(format: "%.0f", value))
+        }
+        .appFont(.footnote, weight: .semibold)
+        .foregroundStyle(fgColor)
+        .padding(.horizontal, Constants.horizonSpacing)
+        .padding(.vertical, Constants.verticalSpacing)
+        .background {
+            RoundedRectangle(cornerRadius: Constants.radius)
+                .fill(bgColor)
+                .strokeBorder(borderColor, lineWidth: Constants.strokeWidth)
+        }
+    }
+}
+
+// MARK: - MemberBadgePresenter
+
+/// 선물 상자 배지입니다. 프로필 이미지 우상단에 겹쳐 표시합니다.
+private struct MemberBadgePresenter: View, Equatable {
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let imageSize: CGFloat = 10
+        static let innerPadding: CGFloat = 3
+        static let strokeWidth: CGFloat = 2
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Image(systemName: "gift")
+            .font(.system(size: Constants.imageSize))
+            .padding(Constants.innerPadding)
+            .background {
+                Circle()
+                    .fill(Color.yellow300)
+                    .stroke(Color.white, lineWidth: Constants.strokeWidth)
+            }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview(traits: .sizeThatFitsLayout) {
+    VStack {
+        MemberManagementCard(
+            memberManagementItem: MemberManagementItem(
+                profile: nil,
+                name: "이예지",
+                nickname: "소피",
+                generation: "8기",
+                school: "가천대학교",
+                position: "Challenger",
+                part: .front(type: .ios),
+                penalty: 0,
+                badge: true,
+                managementTeam: .challenger,
+                attendanceRecords: [],
+                penaltyHistory: []
+            )
+        )
+
+        MemberManagementCard(
+            memberManagementItem: MemberManagementItem(
+                profile: nil,
+                name: "이예지",
+                nickname: "소피",
+                generation: "8기",
+                school: "가천대학교",
+                position: "Challenger",
+                part: .front(type: .ios),
+                penalty: 2,
+                rewardPoints: 3,
+                badge: false,
+                managementTeam: .challenger,
+                attendanceRecords: [],
+                penaltyHistory: []
+            )
+        )
+    }
+    .padding()
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberDetailSheetView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberDetailSheetView.swift
@@ -19,7 +19,6 @@ struct ChallengerMemberDetailSheetView: View {
 
     // MARK: - Property
 
-    @Environment(\.dismiss) private var dismiss
     let member: MemberManagementItem
     @State private var selectedGisu: Int
 
@@ -33,7 +32,13 @@ struct ChallengerMemberDetailSheetView: View {
         static let partStrokeWidth: CGFloat = 1
         static let pointIconSize: CGFloat = 14
         static let dividerHeight: CGFloat = 44
-        static let detentHeight: CGFloat = 280
+
+        /// Apple HIG 최소 터치 타겟(44pt).
+        static let minimumTapTarget: CGFloat = 44
+
+        /// 기수 칩 탭 영역을 44pt 로 넓히면서 활동 기수 행이 약 21pt 높아져,
+        /// 기존 280pt 로는 여유가 10pt 남짓만 남는다. 여유를 되돌려 잡은 값.
+        static let detentHeight: CGFloat = 300
     }
 
     // MARK: - Init
@@ -47,11 +52,10 @@ struct ChallengerMemberDetailSheetView: View {
 
     // MARK: - Computed Property
 
+    /// 기수가 하나뿐인 멤버의 기수 문자열.
+    ///
+    /// - Note: 복수 기수 멤버는 ``generationChips`` 로 분기하므로 이 프로퍼티를 읽지 않습니다.
     private var currentGeneration: String {
-        if hasMultipleGenerations,
-           let lastGisu = uniqueGenerationPoints.map(\.gisu).max() {
-            return "\(lastGisu)기"
-        }
         let gens = member.generation
             .components(separatedBy: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
@@ -147,10 +151,15 @@ struct ChallengerMemberDetailSheetView: View {
             HStack {
                 Text("활동 기수")
                     .appFont(.subheadline, color: .grey700)
-                Spacer()
+
+                // 복수 기수일 때는 `Spacer` 를 두지 않는다. 칩 스크롤뷰가 남은 폭을
+                // 전부 차지해야 기수가 많아도 스크롤로 닿을 수 있고, 칩이 적을 때는
+                // `defaultScrollAnchor(.trailing)` 이 우측 정렬을 대신한다.
                 if hasMultipleGenerations {
                     generationChips
                 } else {
+                    Spacer()
+
                     Text(currentGeneration)
                         .appFont(.subheadline, weight: .semibold)
                         .contentTransition(.numericText())
@@ -162,10 +171,10 @@ struct ChallengerMemberDetailSheetView: View {
             HStack(spacing: .zero) {
                 pointColumn(
                     icon: "plus.circle.fill",
-                    iconColor: .green,
+                    iconColor: .green700,
                     label: "상점",
                     value: displayRewardPoints,
-                    valueColor: .green
+                    valueColor: .green700
                 )
 
                 Divider()
@@ -173,10 +182,10 @@ struct ChallengerMemberDetailSheetView: View {
 
                 pointColumn(
                     icon: "minus.circle.fill",
-                    iconColor: .red,
+                    iconColor: .red700,
                     label: "벌점",
                     value: displayPenaltyPoints,
-                    valueColor: .red
+                    valueColor: .red700
                 )
             }
         }
@@ -189,29 +198,37 @@ struct ChallengerMemberDetailSheetView: View {
     }
 
     private var generationChips: some View {
-        HStack(spacing: DefaultSpacing.spacing4) {
-            ForEach(uniqueGenerationPoints) { summary in
-                Button {
-                    withAnimation(.smooth(duration: 0.3)) {
-                        selectedGisu = summary.gisu
+        ScrollView(.horizontal) {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                ForEach(uniqueGenerationPoints) { summary in
+                    Button {
+                        withAnimation(.smooth(duration: 0.3)) {
+                            selectedGisu = summary.gisu
+                        }
+                    } label: {
+                        Text("\(summary.gisu)기")
+                            .appFont(
+                                .subheadline,
+                                weight: selectedGisu == summary.gisu ? .semibold : .regular,
+                                color: selectedGisu == summary.gisu ? .white : .grey700
+                            )
+                            .padding(Constants.tagPadding)
+                            .background(
+                                selectedGisu == summary.gisu
+                                    ? Color.accentColor : Color.grey200,
+                                in: Capsule()
+                            )
+                            // 캡슐 자체는 그대로 두고 탭 영역만 HIG 최소 높이까지 넓힌다.
+                            .frame(minHeight: Constants.minimumTapTarget)
+                            .contentShape(Rectangle())
                     }
-                } label: {
-                    Text("\(summary.gisu)기")
-                        .appFont(
-                            .subheadline,
-                            weight: selectedGisu == summary.gisu ? .semibold : .regular,
-                            color: selectedGisu == summary.gisu ? .white : .grey700
-                        )
-                        .padding(Constants.tagPadding)
-                        .background(
-                            selectedGisu == summary.gisu
-                                ? Color.accentColor : Color.grey200,
-                            in: Capsule()
-                        )
+                    .accessibilityLabel("\(summary.gisu)기 선택")
                 }
-                .accessibilityLabel("\(summary.gisu)기 선택")
             }
         }
+        .scrollIndicators(.hidden)
+        .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+        .defaultScrollAnchor(.trailing)
     }
 
     // MARK: - Function

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberDetailSheetView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberDetailSheetView.swift
@@ -1,0 +1,273 @@
+//
+//  ChallengerMemberDetailSheetView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 챌린저 멤버 상세 정보를 표시하는 바텀 시트 뷰
+///
+/// 프로필과 기수별 상벌점 요약을 표시합니다.
+/// 복수 기수 사용자의 경우 `Picker`를 통해 기수를 전환할 수 있습니다.
+struct ChallengerMemberDetailSheetView: View {
+
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+    let member: MemberManagementItem
+    @State private var selectedGisu: Int
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let tagPadding: EdgeInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
+        static let profileSize: CGSize = .init(width: 60, height: 60)
+        static let partTagOpacity: Double = 0.14
+        static let partStrokeOpacity: Double = 0.4
+        static let partStrokeWidth: CGFloat = 1
+        static let pointIconSize: CGFloat = 14
+        static let dividerHeight: CGFloat = 44
+        static let detentHeight: CGFloat = 280
+    }
+
+    // MARK: - Init
+
+    init(member: MemberManagementItem) {
+        self.member = member
+        _selectedGisu = State(
+            initialValue: member.generationPoints.map(\.gisu).max() ?? 0
+        )
+    }
+
+    // MARK: - Computed Property
+
+    private var currentGeneration: String {
+        if hasMultipleGenerations,
+           let lastGisu = uniqueGenerationPoints.map(\.gisu).max() {
+            return "\(lastGisu)기"
+        }
+        let gens = member.generation
+            .components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        return gens.last ?? member.generation
+    }
+
+    private var hasMultipleGenerations: Bool {
+        uniqueGenerationPoints.count > 1
+    }
+
+    private var uniqueGenerationPoints: [GenerationPointSummary] {
+        var seen = Set<Int>()
+        return member.generationPoints.filter { seen.insert($0.gisu).inserted }
+    }
+
+    private var selectedSummary: GenerationPointSummary? {
+        member.generationPoints.first { $0.gisu == selectedGisu }
+    }
+
+    private var displayRewardPoints: Double {
+        selectedSummary?.reward ?? member.rewardPoints
+    }
+
+    private var displayPenaltyPoints: Double {
+        selectedSummary?.penalty ?? member.penalty
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
+            memberInfoView
+            summaryCardView
+        }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .padding(.top, DefaultSpacing.spacing8)
+        .padding(.bottom, DefaultSpacing.spacing32)
+        .presentationDetents([.height(Constants.detentHeight)])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(.regularMaterial)
+    }
+
+    // MARK: - SubView
+
+    private var memberInfoView: some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            RemoteImage(urlString: member.profile ?? "", size: Constants.profileSize)
+
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+                Text("\(member.nickname)/\(member.name)")
+                    .appFont(.body, weight: .semibold)
+
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    partTag
+                    schoolTag
+                    if member.managementTeam != .challenger {
+                        ManagementTeamBadgePresenter(
+                            managementTeam: member.managementTeam
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private var partTag: some View {
+        Text(member.part.name)
+            .appFont(.callout, color: member.part.color)
+            .padding(Constants.tagPadding)
+            .background(
+                member.part.color.opacity(Constants.partTagOpacity),
+                in: Capsule()
+            )
+            .overlay {
+                Capsule()
+                    .stroke(
+                        member.part.color.opacity(Constants.partStrokeOpacity),
+                        lineWidth: Constants.partStrokeWidth
+                    )
+            }
+    }
+
+    private var schoolTag: some View {
+        Text(member.school)
+            .appFont(.callout, color: .grey700)
+            .padding(Constants.tagPadding)
+            .background(.regularMaterial, in: Capsule())
+    }
+
+    private var summaryCardView: some View {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            HStack {
+                Text("활동 기수")
+                    .appFont(.subheadline, color: .grey700)
+                Spacer()
+                if hasMultipleGenerations {
+                    generationChips
+                } else {
+                    Text(currentGeneration)
+                        .appFont(.subheadline, weight: .semibold)
+                        .contentTransition(.numericText())
+                }
+            }
+
+            Divider()
+
+            HStack(spacing: .zero) {
+                pointColumn(
+                    icon: "plus.circle.fill",
+                    iconColor: .green,
+                    label: "상점",
+                    value: displayRewardPoints,
+                    valueColor: .green
+                )
+
+                Divider()
+                    .frame(height: Constants.dividerHeight)
+
+                pointColumn(
+                    icon: "minus.circle.fill",
+                    iconColor: .red,
+                    label: "벌점",
+                    value: displayPenaltyPoints,
+                    valueColor: .red
+                )
+            }
+        }
+        .padding(DefaultSpacing.spacing16)
+        .background(
+            .ultraThinMaterial,
+            in: RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius)
+        )
+        .animation(.smooth(duration: 0.3), value: selectedGisu)
+    }
+
+    private var generationChips: some View {
+        HStack(spacing: DefaultSpacing.spacing4) {
+            ForEach(uniqueGenerationPoints) { summary in
+                Button {
+                    withAnimation(.smooth(duration: 0.3)) {
+                        selectedGisu = summary.gisu
+                    }
+                } label: {
+                    Text("\(summary.gisu)기")
+                        .appFont(
+                            .subheadline,
+                            weight: selectedGisu == summary.gisu ? .semibold : .regular,
+                            color: selectedGisu == summary.gisu ? .white : .grey700
+                        )
+                        .padding(Constants.tagPadding)
+                        .background(
+                            selectedGisu == summary.gisu
+                                ? Color.accentColor : Color.grey200,
+                            in: Capsule()
+                        )
+                }
+                .accessibilityLabel("\(summary.gisu)기 선택")
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    private func pointColumn(
+        icon: String,
+        iconColor: Color,
+        label: String,
+        value: Double,
+        valueColor: Color
+    ) -> some View {
+        VStack(spacing: DefaultSpacing.spacing4) {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Image(systemName: icon)
+                    .font(.system(size: Constants.pointIconSize))
+                    .foregroundStyle(iconColor)
+                Text(label)
+                    .appFont(.footnote, color: .grey700)
+            }
+
+            Text(String(format: "%.0f", value))
+                .appFont(.callout, weight: .semibold, color: valueColor)
+                .contentTransition(.numericText())
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview {
+    Text("Preview")
+        .sheet(isPresented: .constant(true)) {
+            ChallengerMemberDetailSheetView(
+                member: MemberManagementItem(
+                    profile: nil,
+                    name: "김미주",
+                    nickname: "마티",
+                    generation: "7기, 8기, 9기",
+                    school: "덕성여자대학교",
+                    position: "Challenger",
+                    part: .front(type: .ios),
+                    penalty: 2,
+                    rewardPoints: 3,
+                    badge: false,
+                    managementTeam: .schoolPartLeader,
+                    attendanceRecords: [],
+                    penaltyHistory: [],
+                    generationPoints: [
+                        GenerationPointSummary(gisu: 7, reward: 1, penalty: 0),
+                        GenerationPointSummary(gisu: 8, reward: 2, penalty: 1),
+                        GenerationPointSummary(gisu: 9, reward: 0, penalty: 1),
+                    ]
+                )
+            )
+        }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberListView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberListView.swift
@@ -125,7 +125,7 @@ struct ChallengerMemberListView: View {
                                 await viewModel.openChallengerMemberDetail(item)
                             }
                         } label: {
-                            CoreMemberManagementList(memberManagementItem: item)
+                            CoreMemberManagementRow(memberManagementItem: item)
                         }
                         .onAppear {
                             if item.id == group.members.last?.id,

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberListView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberListView.swift
@@ -127,6 +127,10 @@ struct ChallengerMemberListView: View {
                         } label: {
                             CoreMemberManagementRow(memberManagementItem: item)
                         }
+                        // 상세 조회가 진행 중이면 다른 행 탭을 막는다. 가드가 없으면 서로
+                        // 다른 멤버의 조회 Task 가 동시에 떠서 늦게 끝난 쪽이
+                        // `selectedMember` 를 덮어써 엉뚱한 멤버의 시트가 열린다.
+                        .disabled(viewModel.isLoadingMemberDetail)
                         .onAppear {
                             if item.id == group.members.last?.id,
                                group.part == viewModel.groupedMembers.last?.part {

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberListView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerMemberListView.swift
@@ -1,0 +1,267 @@
+//
+//  ChallengerMemberListView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreDI
+import CoreDomain
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 챌린저 모드의 구성원 목록 화면
+///
+/// 파트별로 그룹핑된 동아리 구성원을 무한 스크롤로 표시하고, 검색과 멤버 상세 시트를
+/// 제공합니다. 화면 소유의 `NavigationStack` 없이 콘텐츠만 구성하며, 상위(Activity 루트)의
+/// 네비게이션 컨텍스트 안에서 사용됩니다.
+struct ChallengerMemberListView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: MemberListViewModel
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let loadingOverlayRadius: CGFloat = 12
+    }
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - container: UseCase·세션을 resolve 할 DI 컨테이너
+    ///   - errorHandler: 흐름 중단형 전역 에러 처리기
+    ///   - viewModel: 프리뷰/테스트용 주입 지점 (기본값: container 로 생성)
+    init(
+        container: DIContainer,
+        errorHandler: ErrorHandler,
+        viewModel: MemberListViewModel? = nil
+    ) {
+        _viewModel = State(
+            initialValue: viewModel ?? MemberListViewModel(
+                fetchMembersUseCase: container.resolve(FetchMembersUseCaseProtocol.self),
+                errorHandler: errorHandler,
+                userSessionManager: container.resolve(UserSessionManager.self)
+            )
+        )
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            switch viewModel.membersState {
+            case .idle, .loading:
+                loadingView
+            case .loaded:
+                memberListContent
+            case .failed(let error):
+                RetryContentUnavailableView(
+                    title: "불러오지 못했어요",
+                    systemImage: "exclamationmark.triangle",
+                    description: error.userMessage,
+                    isRetrying: false
+                ) {
+                    await viewModel.fetchMembers()
+                }
+            }
+        }
+        .task {
+            await viewModel.fetchMembers()
+        }
+        .searchable(text: $viewModel.searchText)
+        .searchToolbarBehavior(.minimize)
+        .overlay {
+            if viewModel.isLoadingMemberDetail {
+                ProgressView()
+                    .controlSize(.regular)
+                    .padding()
+                    .background(
+                        .ultraThinMaterial,
+                        in: RoundedRectangle(cornerRadius: Constants.loadingOverlayRadius)
+                    )
+            }
+        }
+        .sheet(item: $viewModel.selectedMember) { member in
+            ChallengerMemberDetailSheetView(member: member)
+        }
+    }
+
+    // MARK: - SubView
+
+    private var loadingView: some View {
+        VStack(spacing: DefaultSpacing.spacing16) {
+            ProgressView()
+
+            Text("챌린저 목록 불러오는 중...")
+                .appFont(.subheadline, color: .grey500)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var memberListContent: some View {
+        Group {
+            if viewModel.groupedMembers.isEmpty && viewModel.searchText.isEmpty {
+                emptyMemberView
+            } else if viewModel.isSearchResultEmpty {
+                searchEmptyView
+            } else {
+                memberList
+            }
+        }
+    }
+
+    private var memberList: some View {
+        List {
+            ForEach(viewModel.groupedMembers, id: \.part) { group in
+                Section {
+                    ForEach(group.members) { item in
+                        Button {
+                            Task {
+                                await viewModel.openChallengerMemberDetail(item)
+                            }
+                        } label: {
+                            CoreMemberManagementList(memberManagementItem: item)
+                        }
+                        .onAppear {
+                            if item.id == group.members.last?.id,
+                               group.part == viewModel.groupedMembers.last?.part {
+                                Task { await viewModel.fetchNextPage() }
+                            }
+                        }
+                    }
+                } header: {
+                    Text(group.part.name)
+                        .appFont(.title3, weight: .semibold, color: .black)
+                }
+            }
+
+            if viewModel.isLoadingNextPage {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .listRowSeparator(.hidden)
+            }
+        }
+    }
+
+    private var searchEmptyView: some View {
+        ContentUnavailableView {
+            Label("검색 결과가 없습니다.", systemImage: "magnifyingglass")
+        } description: {
+            Text("'\(viewModel.searchText)'에 대한 결과가 없습니다")
+        }
+    }
+
+    private var emptyMemberView: some View {
+        ContentUnavailableView {
+            Label("구성원 관리", systemImage: "person.3")
+        } description: {
+            Text("구성원이 없습니다.")
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+/// 네트워크 없이 구성원 목록을 확인하기 위한 프리뷰 전용 UseCase (절대규칙 #5)
+private struct PreviewFetchMembersUseCase: FetchMembersUseCaseProtocol {
+    func execute() async throws -> [MemberManagementItem] {
+        previewMembers
+    }
+
+    func executePage(page: Int) async throws -> MemberPage {
+        MemberPage(members: previewMembers, hasNext: false, currentPage: page)
+    }
+
+    func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws {}
+
+    func deletePoint(challengerPointId: String) async throws {}
+
+    func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory] {
+        []
+    }
+
+    func fetchAllGenerations(memberId: String) async throws -> String {
+        "9기"
+    }
+
+    func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary] {
+        []
+    }
+
+    func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord] {
+        []
+    }
+
+    private var previewMembers: [MemberManagementItem] {
+        [
+            MemberManagementItem(
+                memberID: "1",
+                challengerID: "10",
+                profile: nil,
+                name: "이예지",
+                nickname: "소피",
+                generation: "9기",
+                school: "가천대학교",
+                position: "Part Leader",
+                part: .front(type: .ios),
+                penalty: 0,
+                badge: false,
+                managementTeam: .schoolPartLeader,
+                attendanceRecords: [],
+                penaltyHistory: []
+            ),
+            MemberManagementItem(
+                memberID: "2",
+                challengerID: "11",
+                profile: nil,
+                name: "홍길동",
+                nickname: "라이언",
+                generation: "9기",
+                school: "한성대학교",
+                position: "Challenger",
+                part: .front(type: .web),
+                penalty: 1,
+                badge: false,
+                managementTeam: .challenger,
+                attendanceRecords: [],
+                penaltyHistory: []
+            ),
+        ]
+    }
+}
+
+#Preview {
+    let viewModel = MemberListViewModel(
+        fetchMembersUseCase: PreviewFetchMembersUseCase(),
+        errorHandler: ErrorHandler(),
+        userSessionManager: UserSessionManager()
+    )
+    return NavigationStack {
+        ChallengerMemberListView(
+            container: DIContainer(),
+            errorHandler: ErrorHandler(),
+            viewModel: viewModel
+        )
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -9,6 +9,8 @@ let project = featureProject(
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
         // OperatorStudyManagementViewModel 이 멤버/멘토 선택 입력 타입(ChallengerInfo)을 사용.
         .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
+        // ChallengerMemberListView 가 DIContainer 로 UseCase·세션을 resolve (Home/Notice 동일 패턴).
+        .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
     ],
     includesDomainTests: true,
     includesDataTests: true,

--- a/docs/claude/tuist-file-mapping.md
+++ b/docs/claude/tuist-file-mapping.md
@@ -149,7 +149,7 @@
 | `Presentation/Components/CoreStudyManagementList.swift` | ActivityPresentation |
 | `Presentation/Components/Map/ActivityCompactMapView.swift` | ActivityPresentation |
 | `Presentation/Components/Map/BaseMapComponent.swift` | ActivityPresentation |
-| `Presentation/Components/Member/CoreMemberManagementList.swift` | ActivityPresentation |
+| `Presentation/Components/Member/CoreMemberManagementList.swift` | ActivityPresentation (이식 시 `CoreMemberManagementRow.swift` 로 개명 — 리스트가 아니라 행 뷰) |
 | `Presentation/Components/Member/MemberManagementCard.swift` | ActivityPresentation |
 | `Presentation/Components/Member/PointGrantFormSheet.swift` | ActivityPresentation |
 | `Presentation/Components/Operation/Attendance/OperatorLocationChangeSheetView.swift` | ActivityPresentation |


### PR DESCRIPTION
resolves #897

## ✨ PR 유형

♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="1512" height="984" alt="스크린샷 2026-07-20 오전 10 30 40" src="https://github.com/user-attachments/assets/13ebfc64-8c6b-4a62-836c-bed2cf32978b" />
<img width="1512" height="984" alt="스크린샷 2026-07-20 오전 10 30 50" src="https://github.com/user-attachments/assets/188c1036-3929-427a-a8a8-e297d640b0bb" />


## 🛠️ 작업내용

레거시 `AppProduct`에 있던 챌린저 구성원 화면과 멤버 관리 공유 컴포넌트를 `UMCApp/Features/Activity/Presentation`으로 옮겼습니다. ViewModel(#985)과 도메인 모델은 이미 넘어와 있어서, 이번엔 View 계층만 작업했습니다.

- **챌린저 구성원 목록 뷰**: 파트별 그룹핑, 검색, 무한 스크롤(마지막 항목에 닿으면 다음 페이지 요청), 멤버 상세 시트
- **챌린저 멤버 상세 시트**: 프로필과 기수별 상벌점 요약, 기수가 여러 개면 칩으로 전환
- **공유 컴포넌트** `MemberManagementCard`·`CoreMemberManagementList`: 다음 운영진 멤버 관리 화면에서도 쓸 거라 이번에 미리 확보
- `ActivityPresentation`에 `CoreDI` 의존성 추가: 목록 뷰가 `DIContainer`로 UseCase와 세션을 resolve

`make build SCHEME=ActivityPresentation`은 빌드, `make test SCHEME=ActivityPresentation`은 118개 테스트가 모두 통과합니다.

## 📋 추후 진행 상황

- Activity 탭 연결(#996·#997): 루트 `ActivityView`에서 이 뷰들을 띄우고 `FetchMembersUseCaseProtocol`을 DI에 등록
- 운영진 멤버 관리 화면 이식 때 이번 공유 컴포넌트 재사용
- 탭 연결 뒤 실제 렌더로 화면 확인

## 📌 리뷰 포인트

- **DI 구성 방식**: `ChallengerMemberListView`는 `NoticeView`처럼 `init(container:errorHandler:)`로 받아 `FetchMembersUseCaseProtocol`과 `UserSessionManager`를 resolve합니다. 등록 자체는 탭 연결(#997)에서 할 일이라 이 PR엔 없습니다. `Project.swift`에 `CoreDI`를 넣은 것도 이 때문이고, Home·Notice와 같은 방식입니다.
- **`CoreMemberManagementList`의 `mode` 파라미터 제거**: 레거시에서도 body가 이 값을 아예 안 써서 옮기면서 뺐습니다. 다음 운영진 화면이 모드별로 분기할 생각이었다면 되살려야 합니다.
- **강조 타이포 매핑**: 새 디자인 시스템엔 `.calloutEmphasis` 같은 Emphasis 케이스가 없어 `.appFont(.callout, weight: .semibold)` 형태로 바꿨습니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
