### PR TITLE
♻️ [Refactor] StaffNotice 화면 계층 및 Notice 요청 noticeTab 파라미터 이관 (#1006)

### DIFF
--- a/UMCApp/Features/Notice/Data/Sources/DTOs/NoticeRequestFactory.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/NoticeRequestFactory.swift
@@ -12,7 +12,7 @@ import NoticeDomain
 // MARK: - NoticeRequestFactory
 /// 공지 목록/검색 요청 DTO를 생성합니다.
 enum NoticeRequestFactory {
-    /// 메인필터에 따라 적절한 NoticeListRequestDTO를 생성합니다.
+    /// 메인필터에 따라 적절한 NoticeListRequest를 생성합니다.
     ///
     /// - Parameters:
     ///   - gisuId: 조회할 기수 ID
@@ -36,6 +36,7 @@ enum NoticeRequestFactory {
         let requestChapterId: String?
         let requestSchoolId: String?
         let requestPart: UMCPartType?
+        let requestNoticeTab = ManagementTeam.challenger.rawValue
 
         switch selectedMainFilter {
         case .all, .central:
@@ -65,6 +66,7 @@ enum NoticeRequestFactory {
             chapterId: requestChapterId,
             schoolId: requestSchoolId,
             part: requestPart,
+            noticeTab: requestNoticeTab,
             page: page,
             size: pageSize,
             sort: sort

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/NoticeRequestFactory.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/NoticeRequestFactory.swift
@@ -36,7 +36,6 @@ enum NoticeRequestFactory {
         let requestChapterId: String?
         let requestSchoolId: String?
         let requestPart: UMCPartType?
-        let requestNoticeTab = ManagementTeam.challenger.rawValue
 
         switch selectedMainFilter {
         case .all, .central:
@@ -66,7 +65,7 @@ enum NoticeRequestFactory {
             chapterId: requestChapterId,
             schoolId: requestSchoolId,
             part: requestPart,
-            noticeTab: requestNoticeTab,
+            noticeTab: ManagementTeam.challenger.rawValue,
             page: page,
             size: pageSize,
             sort: sort

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeListQuery.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeListQuery.swift
@@ -46,6 +46,7 @@ public struct NoticeListQuery: Encodable {
     public var toParameters: [String: Any] {
         var params: [String: Any] = [
             "gisuId": gisuId,
+            "noticeTab": noticeTab,
             "page": page,
             "size": size,
         ]

--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeListQuery.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Request/NoticeListQuery.swift
@@ -18,6 +18,7 @@ public struct NoticeListQuery: Encodable {
     public let chapterId: String?
     public let schoolId: String?
     public let part: UMCPartType?
+    public let noticeTab: String
     public let page: Int
     public let size: Int
     public let sort: [String]
@@ -27,6 +28,7 @@ public struct NoticeListQuery: Encodable {
         chapterId: String?,
         schoolId: String?,
         part: UMCPartType?,
+        noticeTab: String,
         page: Int,
         size: Int,
         sort: [String]
@@ -35,6 +37,7 @@ public struct NoticeListQuery: Encodable {
         self.chapterId = chapterId
         self.schoolId = schoolId
         self.part = part
+        self.noticeTab = noticeTab
         self.page = page
         self.size = size
         self.sort = sort
@@ -76,6 +79,7 @@ extension NoticeListQuery {
             chapterId: request.chapterId,
             schoolId: request.schoolId,
             part: request.part,
+            noticeTab: request.noticeTab,
             page: request.page,
             size: request.size,
             sort: request.sort

--- a/UMCApp/Features/Notice/Data/Tests/NoticeListQueryTests.swift
+++ b/UMCApp/Features/Notice/Data/Tests/NoticeListQueryTests.swift
@@ -1,0 +1,131 @@
+//
+//  NoticeListQueryTests.swift
+//  NoticeDataTests
+//
+//  Created by JEONG on 8/7/26.
+//
+
+import Testing
+import Foundation
+import UMCFoundation
+import NoticeDomain
+@testable import NoticeData
+
+@Suite("NoticeListQuery — 쿼리 파라미터 직렬화 (Router가 실제로 전송하는 값)")
+struct NoticeListQueryTests {
+
+    // MARK: - Helper
+
+    private func makeQuery(
+        chapterId: String? = nil,
+        schoolId: String? = nil,
+        part: UMCPartType? = nil,
+        noticeTab: String = ManagementTeam.challenger.rawValue,
+        sort: [String] = ["createdAt,DESC"]
+    ) -> NoticeListQuery {
+        NoticeListQuery(
+            gisuId: "7",
+            chapterId: chapterId,
+            schoolId: schoolId,
+            part: part,
+            noticeTab: noticeTab,
+            page: 0,
+            size: 20,
+            sort: sort
+        )
+    }
+
+    // MARK: - Required Parameters
+
+    @Test("필수 파라미터(gisuId·noticeTab·page·size)는 항상 전송된다")
+    func emitsRequiredParameters() {
+        let params = makeQuery().toParameters
+
+        #expect(params["gisuId"] as? String == "7")
+        #expect(params["noticeTab"] as? String == "CHALLENGER")
+        #expect(params["page"] as? Int == 0)
+        #expect(params["size"] as? Int == 20)
+    }
+
+    /// `NoticeListQuery`에 필드를 추가하고 `toParameters` 갱신을 잊으면 서버로 값이 전달되지
+    /// 않는다. 운영진 공지 탭(`noticeTab`)이 실제로 이 회귀를 겪었으므로 탭 값별로 고정한다.
+    @Test(
+        "운영진 공지 탭 값이 noticeTab 파라미터로 그대로 전송된다",
+        arguments: StaffNoticeTab.allCases
+    )
+    func emitsStaffNoticeTabRawValue(_ tab: StaffNoticeTab) {
+        let params = makeQuery(noticeTab: tab.rawValue).toParameters
+
+        #expect(params["noticeTab"] as? String == tab.rawValue)
+    }
+
+    @Test("검색 파라미터에도 noticeTab이 유지된 채 keyword가 더해진다")
+    func keepsNoticeTabWhenAddingKeyword() {
+        let params = makeQuery(noticeTab: StaffNoticeTab.schoolCore.rawValue)
+            .toParameters(addingKeyword: "정기모임")
+
+        #expect(params["noticeTab"] as? String == "SCHOOL_CORE")
+        #expect(params["keyword"] as? String == "정기모임")
+    }
+
+    // MARK: - Optional Parameters
+
+    @Test("nil인 선택 파라미터는 쿼리에서 생략된다")
+    func omitsNilOptionalParameters() {
+        let params = makeQuery().toParameters
+
+        #expect(params["chapterId"] == nil)
+        #expect(params["schoolId"] == nil)
+        #expect(params["part"] == nil)
+    }
+
+    @Test("값이 있는 선택 파라미터는 전송되고 part는 apiValue로 변환된다")
+    func emitsPresentOptionalParameters() {
+        let params = makeQuery(chapterId: "3", schoolId: "900", part: .front(type: .ios))
+            .toParameters
+
+        #expect(params["chapterId"] as? String == "3")
+        #expect(params["schoolId"] as? String == "900")
+        #expect(params["part"] as? String == UMCPartType.front(type: .ios).apiValue)
+    }
+
+    @Test("sort가 비어 있으면 파라미터에서 제외된다")
+    func omitsEmptySort() {
+        #expect(makeQuery(sort: []).toParameters["sort"] == nil)
+        #expect(makeQuery().toParameters["sort"] as? [String] == ["createdAt,DESC"])
+    }
+
+    // MARK: - Domain → Query 변환
+
+    @Test("NoticeListRequest의 noticeTab이 Query로 그대로 전달된다")
+    func carriesNoticeTabFromDomainRequest() {
+        let request = NoticeListRequest(
+            gisuId: "7",
+            chapterId: nil,
+            schoolId: "900",
+            part: nil,
+            noticeTab: StaffNoticeTab.schoolPartLeader.rawValue,
+            page: 1,
+            size: 20,
+            sort: ["createdAt,DESC"]
+        )
+
+        #expect(NoticeListQuery(from: request).toParameters["noticeTab"] as? String
+                == "SCHOOL_PART_LEADER")
+    }
+
+    @Test("noticeTab을 생략한 요청은 CHALLENGER로 조회한다")
+    func defaultsToChallengerTab() {
+        let request = NoticeListRequest(
+            gisuId: "7",
+            chapterId: nil,
+            schoolId: nil,
+            part: nil,
+            page: 0,
+            size: 20,
+            sort: []
+        )
+
+        #expect(NoticeListQuery(from: request).toParameters["noticeTab"] as? String == "CHALLENGER")
+    }
+}

--- a/UMCApp/Features/Notice/Domain/Sources/Requests/NoticeListRequest.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Requests/NoticeListRequest.swift
@@ -13,6 +13,7 @@ public struct NoticeListRequest {
     public let chapterId: String?
     public let schoolId: String?
     public let part: UMCPartType?
+    public let noticeTab: String
     public let page: Int
     public let size: Int
     public let sort: [String]
@@ -22,6 +23,7 @@ public struct NoticeListRequest {
         chapterId: String?,
         schoolId: String?,
         part: UMCPartType?,
+        noticeTab: String = ManagementTeam.challenger.rawValue,
         page: Int,
         size: Int,
         sort: [String]
@@ -30,6 +32,7 @@ public struct NoticeListRequest {
         self.chapterId = chapterId
         self.schoolId = schoolId
         self.part = part
+        self.noticeTab = noticeTab
         self.page = page
         self.size = size
         self.sort = sort

--- a/UMCApp/Features/Notice/Presentation/Sources/Navigation/NoticeNavigation.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Navigation/NoticeNavigation.swift
@@ -31,7 +31,7 @@ public enum NavigationDestination: Hashable {
 public enum NoticeDestination: Hashable {
     case detail(detailItem: NoticeDetail)
     case staffNotice
-    case editor(mode: NoticeEditorMode, selectedGisuId: String?)
+    case editor(mode: NoticeEditorMode, selectedGisuId: String?, initialCategory: EditorMainCategory? = nil)
 }
 
 public struct NavigationRoutingView: View {

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -309,7 +309,7 @@ extension NoticeViewModel {
         error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled
     }
 
-    /// NoticeListRequestDTO 생성
+    /// NoticeListRequest 생성
     private func buildNoticeListRequest(gisuId: String, page: Int) -> NoticeListRequest {
         let myChapterId: String? = chapterId.isEmpty || chapterId == "0"
         ? nil : chapterId

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/StaffNotice/StaffNoticeViewModel.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/StaffNotice/StaffNoticeViewModel.swift
@@ -1,0 +1,314 @@
+//
+//  StaffNoticeViewModel.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 7/22/26.
+//
+
+import Foundation
+import SwiftUI
+import UMCFoundation
+import CoreDI
+import NoticeDomain
+
+// MARK: - StaffNoticeViewModel
+/// 운영진 공지 전용 ViewModel
+///
+/// `NoticeViewModel`과 책임을 분리하여 챌린저/운영진 상태를 격리합니다.
+/// 역할 기반 탭 가시성, 탭별 `noticeTab` + `schoolId` 매핑, 페이지네이션을 담당합니다.
+@Observable
+final class StaffNoticeViewModel {
+
+    // MARK: - Property
+
+    private let container: DIContainer
+
+    private var noticeUseCase: NoticeUseCaseProtocol {
+        container.resolve(NoticeUseCaseProtocol.self)
+    }
+
+    private var noticeReadRepository: NoticeReadRepositoryProtocol {
+        container.resolve(NoticeReadRepositoryProtocol.self)
+    }
+
+    private(set) var memberRole: ManagementTeam?
+    private(set) var schoolId: String = ""
+    private(set) var gisuId: String = ""
+
+    private(set) var accessibleTabs: [StaffNoticeTab] = []
+    var selectedTab: StaffNoticeTab?
+
+    var noticeItems: Loadable<[NoticeItemModel]> = .idle
+    var pagingState = NoticePagingState()
+    var hasNoAccessFromServer: Bool = false
+
+    var isSearchMode: Bool = false
+    var searchQuery: String = ""
+
+    let errorHandler: ErrorHandler
+
+    private var isFetchingFirstPage: Bool = false
+
+    private enum Pagination {
+        static let pageSize: Int = 20
+        static let sort: [String] = ["createdAt,DESC"]
+    }
+
+    var isLoadingMore: Bool {
+        pagingState.isLoadingMore
+    }
+
+    // MARK: - Lifecycle
+
+    init(container: DIContainer, errorHandler: ErrorHandler) {
+        self.container = container
+        self.errorHandler = errorHandler
+    }
+
+    // MARK: - Context
+
+    func applyUserContext(
+        memberRoleRawValue: String,
+        schoolId: String,
+        gisuId: String
+    ) {
+        self.memberRole = ManagementTeam(rawValue: memberRoleRawValue)
+        self.schoolId = schoolId
+        self.gisuId = gisuId
+        self.accessibleTabs = StaffNoticeTab.accessibleTabs(for: memberRole)
+
+        if let selectedTab, !accessibleTabs.contains(selectedTab) {
+            self.selectedTab = accessibleTabs.first
+        } else if selectedTab == nil {
+            self.selectedTab = accessibleTabs.first
+        }
+    }
+
+    // MARK: - Tab Selection
+
+    func selectTab(_ tab: StaffNoticeTab) {
+        guard accessibleTabs.contains(tab) else { return }
+        selectedTab = tab
+        isSearchMode = false
+        searchQuery = ""
+        if hasNoAccessFromServer {
+            hasNoAccessFromServer = false
+            noticeItems = .loading
+        }
+        Task {
+            await fetchNotices()
+        }
+    }
+
+    // MARK: - Fetch
+
+    @MainActor
+    func fetchNotices(page: Int = 0) async {
+        guard let selectedTab else { return }
+
+        if page == 0, hasNoAccessFromServer {
+            hasNoAccessFromServer = false
+            noticeItems = .loading
+        }
+
+        await performPagedFetch(page: page, tab: selectedTab) { request in
+            try await self.noticeUseCase.getAllNotices(request: request)
+        }
+    }
+
+    @MainActor
+    func searchNotices(keyword: String, page: Int = 0) async {
+        guard !keyword.trimmingCharacters(in: .whitespaces).isEmpty else {
+            isSearchMode = false
+            await fetchNotices()
+            return
+        }
+
+        guard let selectedTab else { return }
+
+        isSearchMode = true
+        searchQuery = keyword
+        await performPagedFetch(page: page, tab: selectedTab) { request in
+            try await self.noticeUseCase.searchNotice(keyword: keyword, request: request)
+        }
+    }
+
+    @MainActor
+    func clearSearch() async {
+        searchQuery = ""
+        isSearchMode = false
+        await fetchNotices()
+    }
+
+    @MainActor
+    func retryCurrentRequest() async {
+        if isSearchMode, !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            await searchNotices(keyword: searchQuery)
+        } else {
+            await fetchNotices()
+        }
+    }
+
+    @MainActor
+    func loadNextPageIfNeeded(currentItem: NoticeItemModel) async {
+        guard case .loaded(let items) = noticeItems,
+              let last = items.last,
+              currentItem.id == last.id,
+              pagingState.hasNextPage,
+              !pagingState.isLoadingMore else {
+            return
+        }
+
+        let nextPage = pagingState.nextPage
+        if isSearchMode {
+            await searchNotices(keyword: searchQuery, page: nextPage)
+        } else {
+            await fetchNotices(page: nextPage)
+        }
+    }
+
+    // MARK: - Private
+
+    @MainActor
+    private func performPagedFetch(
+        page: Int,
+        tab: StaffNoticeTab,
+        requestAction: (NoticeListRequest) async throws -> NoticePage
+    ) async {
+        if page == 0 {
+            guard !isFetchingFirstPage else { return }
+            isFetchingFirstPage = true
+        }
+        defer {
+            if page == 0 {
+                isFetchingFirstPage = false
+            }
+        }
+
+        let previousState = noticeItems
+        if page == 0, noticeItems.value == nil {
+            noticeItems = .loading
+        }
+
+        guard pagingState.begin(page: page) else { return }
+
+        let request = buildRequest(tab: tab, page: page)
+
+        do {
+            let response = try await requestAction(request)
+            applyPagedResponse(response, page: page)
+        } catch is CancellationError {
+            handleCancelledFetch(page: page, previousState: previousState)
+        } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+            handleCancelledFetch(page: page, previousState: previousState)
+        } catch let error as RepositoryError {
+            handleFetchError(.repository(error), page: page, action: "staffFetchNotices", failure: error)
+        } catch let error as DomainError {
+            handleFetchError(.domain(error), page: page, action: "staffFetchNotices", failure: error)
+        } catch let error as NetworkError {
+            handleFetchError(.network(error), page: page, action: "staffFetchNotices", failure: error)
+        } catch {
+            handleFetchError(
+                .unknown(message: error.localizedDescription),
+                page: page,
+                action: "staffFetchNotices",
+                failure: error
+            )
+        }
+    }
+
+    private func buildRequest(tab: StaffNoticeTab, page: Int) -> NoticeListRequest {
+        let resolvedSchoolId: String? = if tab.requiresSchoolId, memberRole != .chapterPresident, let schoolIdValue = Int(schoolId), schoolIdValue > 0 {
+            schoolId
+        } else {
+            nil
+        }
+        
+        return NoticeListRequest(
+            gisuId: gisuId,
+            chapterId: nil,
+            schoolId: resolvedSchoolId,
+            part: nil,
+            noticeTab: tab.rawValue,
+            page: page,
+            size: Pagination.pageSize,
+            sort: Pagination.sort
+        )
+    }
+
+    @MainActor
+    private func applyPagedResponse(_ response: NoticePage, page: Int) {
+        let readNoticeIDs = resolvedReadNoticeIDs()
+        let items = response.items.map { item -> NoticeItemModel in
+            guard readNoticeIDs.contains(item.noticeId) else { return item }
+            return NoticeItemModel(
+                noticeId: item.noticeId,
+                generation: item.generation,
+                scope: item.scope,
+                category: item.category,
+                mustRead: item.mustRead,
+                isAlert: item.isAlert,
+                date: item.date,
+                title: item.title,
+                content: item.content,
+                writer: item.writer,
+                authorNickname: item.authorNickname,
+                authorName: item.authorName,
+                links: item.links,
+                images: item.images,
+                vote: item.vote,
+                viewCount: item.viewCount,
+                scopeDisplayName: item.scopeDisplayName,
+                targetsAllGenerations: item.targetsAllGenerations,
+                parts: item.parts,
+                isRead: true
+            )
+        }
+        pagingState.applySuccess(page: page, hasNextPage: response.hasNext)
+
+        if page == 0 {
+            noticeItems = .loaded(items)
+        } else {
+            let mergedItems = (noticeItems.value ?? []) + items
+            noticeItems = .loaded(mergedItems)
+        }
+    }
+
+    private func resolvedReadNoticeIDs() -> Set<String> {
+        let memberId = AppStorageKey.legacyMemberIdInt()
+        guard memberId > 0 else { return [] }
+        return (try? noticeReadRepository.fetchReadNoticeIDs(memberId: String(memberId))) ?? []
+    }
+
+    @MainActor
+    private func handleFetchError(_ error: AppError, page: Int, action: String, failure: Error) {
+        if case .network(.requestFailed(let statusCode, _)) = error, statusCode == 403 {
+            hasNoAccessFromServer = true
+            if page == 0 {
+                noticeItems = .loaded([])
+            }
+            pagingState.applyFailure()
+            return
+        }
+
+        if page == 0 {
+            noticeItems = .failed(error)
+        }
+        pagingState.applyFailure()
+
+        if case .domain = error { return }
+
+        errorHandler.handle(
+            failure,
+            context: ErrorContext(feature: "StaffNotice", action: action)
+        )
+    }
+
+    @MainActor
+    private func handleCancelledFetch(page: Int, previousState: Loadable<[NoticeItemModel]>) {
+        if page == 0 {
+            noticeItems = previousState
+        }
+        pagingState.applyFailure()
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/StaffNotice/StaffNoticeViewModel.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/StaffNotice/StaffNoticeViewModel.swift
@@ -48,6 +48,7 @@ final class StaffNoticeViewModel {
     let errorHandler: ErrorHandler
 
     private var isFetchingFirstPage: Bool = false
+    private var tabSwitchTask: Task<Void, Never>?
 
     private enum Pagination {
         static let pageSize: Int = 20
@@ -87,7 +88,7 @@ final class StaffNoticeViewModel {
     // MARK: - Tab Selection
 
     func selectTab(_ tab: StaffNoticeTab) {
-        guard accessibleTabs.contains(tab) else { return }
+        guard accessibleTabs.contains(tab), tab != selectedTab else { return }
         selectedTab = tab
         isSearchMode = false
         searchQuery = ""
@@ -95,8 +96,14 @@ final class StaffNoticeViewModel {
             hasNoAccessFromServer = false
             noticeItems = .loading
         }
-        Task {
-            await fetchNotices()
+
+        // 이전 탭 요청이 끝나기 전에 새 탭을 누르면 `isFetchingFirstPage` 가드에 막혀
+        // 새 요청이 통째로 버려지고 이전 탭 목록이 남는다. 취소 후 완료를 기다렸다가 이어간다.
+        let previousTask = tabSwitchTask
+        tabSwitchTask = Task { [weak self] in
+            previousTask?.cancel()
+            _ = await previousTask?.value
+            await self?.fetchNotices()
         }
     }
 
@@ -199,14 +206,21 @@ final class StaffNoticeViewModel {
             applyPagedResponse(response, page: page)
         } catch is CancellationError {
             handleCancelledFetch(page: page, previousState: previousState)
-        } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+        } catch let error as NSError where error.domain == NSURLErrorDomain
+            && error.code == NSURLErrorCancelled {
             handleCancelledFetch(page: page, previousState: previousState)
         } catch let error as RepositoryError {
-            handleFetchError(.repository(error), page: page, action: "staffFetchNotices", failure: error)
+            handleFetchError(
+                .repository(error), page: page, action: "staffFetchNotices", failure: error
+            )
         } catch let error as DomainError {
-            handleFetchError(.domain(error), page: page, action: "staffFetchNotices", failure: error)
+            handleFetchError(
+                .domain(error), page: page, action: "staffFetchNotices", failure: error
+            )
         } catch let error as NetworkError {
-            handleFetchError(.network(error), page: page, action: "staffFetchNotices", failure: error)
+            handleFetchError(
+                .network(error), page: page, action: "staffFetchNotices", failure: error
+            )
         } catch {
             handleFetchError(
                 .unknown(message: error.localizedDescription),
@@ -218,12 +232,11 @@ final class StaffNoticeViewModel {
     }
 
     private func buildRequest(tab: StaffNoticeTab, page: Int) -> NoticeListRequest {
-        let resolvedSchoolId: String? = if tab.requiresSchoolId, memberRole != .chapterPresident, let schoolIdValue = Int(schoolId), schoolIdValue > 0 {
-            schoolId
-        } else {
-            nil
-        }
-        
+        // 지부장은 SCHOOL_CORE viewerRole로 매핑되어 학교 단위 필터 없이 조회한다.
+        let needsSchoolId = tab.requiresSchoolId && memberRole != .chapterPresident
+        let hasValidSchoolId = (Int(schoolId) ?? 0) > 0
+        let resolvedSchoolId: String? = needsSchoolId && hasValidSchoolId ? schoolId : nil
+
         return NoticeListRequest(
             gisuId: gisuId,
             chapterId: nil,

--- a/UMCApp/Features/Notice/Presentation/Sources/Views/Components/NoAccessContentView.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Views/Components/NoAccessContentView.swift
@@ -1,0 +1,55 @@
+//
+//  NoAccessContentView.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 7/20/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+
+// MARK: - NoAccessContentView
+
+struct NoAccessContentView: View {
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let iconSystemName: String = "person.badge.shield.checkmark"
+        static let iconSize: CGFloat = 56
+        static let title: String = "접근 권한이 없어요"
+        static let description: String = "이 공지는 특정 운영진에게만 보여요.\n권한이 바뀌었다면 잠시 후 다시 확인해 주세요."
+        static let accessibilityCombinedLabel: String = "접근 권한이 없어요. 이 공지는 특정 운영진에게만 보입니다."
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            lockIcon
+            Spacer().frame(height: DefaultSpacing.spacing16)
+            Text(Constants.title)
+                .appFont(.callout, weight: .semibold)
+                .multilineTextAlignment(.center)
+            Spacer().frame(height: DefaultSpacing.spacing8)
+            Text(Constants.description)
+                .appFont(.subheadline)
+                .foregroundStyle(Color.grey600)
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+        }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Constants.accessibilityCombinedLabel)
+    }
+
+    // MARK: - Sub Views
+
+    private var lockIcon: some View {
+        Image(systemName: Constants.iconSystemName)
+            .font(.system(size: Constants.iconSize))
+            .foregroundStyle(Color.grey400)
+            .accessibilityHidden(true)
+    }
+}

--- a/UMCApp/Features/Notice/Presentation/Sources/Views/StaffNotice/StaffNoticeView.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Views/StaffNotice/StaffNoticeView.swift
@@ -230,7 +230,11 @@ public struct StaffNoticeView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     pathStore.noticePath.append(
-                        .notice(.editor(mode: .create, selectedGisuId: gisuId, initialCategory: category))
+                        .notice(.editor(
+                            mode: .create,
+                            selectedGisuId: gisuId,
+                            initialCategory: category
+                        ))
                     )
                 } label: {
                     Image(systemName: "square.and.pencil")
@@ -255,11 +259,6 @@ public struct StaffNoticeView: View {
         default:
             return nil
         }
-    }
-
-    /// 지부장은 운영진 공지 작성 불가 (읽기 전용)
-    private var isReadOnlyStaffAccess: Bool {
-        viewModel.memberRole == .chapterPresident
     }
 
     // MARK: - User Context

--- a/UMCApp/Features/Notice/Presentation/Sources/Views/StaffNotice/StaffNoticeView.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Views/StaffNotice/StaffNoticeView.swift
@@ -1,0 +1,321 @@
+//
+//  StaffNoticeView.swift
+//  NoticePresentation
+//
+//  Created by 이예지 on 7/22/26.
+//
+
+import SwiftUI
+import UMCFoundation
+import CoreDI
+import CoreDesignSystem
+import CoreUIComponents
+import NoticeDomain
+
+// MARK: - StaffNoticeView
+/// 운영진 공지 전용 화면 (안 B: 별도 분리)
+///
+/// `NoticeView`와 독립된 화면으로, `canAccessStaffNotice` 사용자에게만
+/// 툴바 아이콘을 통해 진입점이 노출됩니다.
+public struct StaffNoticeView: View {
+
+    // MARK: - Properties
+
+    @Environment(\.di) private var di
+    @Environment(ErrorHandler.self) private var errorHandler
+    @AppStorage(AppStorageKey.memberRole) private var memberRoleRaw: String = ""
+    @AppStorage(AppStorageKey.schoolId) private var schoolId: String = ""
+    @AppStorage(AppStorageKey.gisuId) private var gisuId: String = ""
+    @State private var viewModel: StaffNoticeViewModel
+    @State private var search: String = ""
+    @State private var searchTask: Task<Void, Never>?
+    @State private var isRetryingNotices: Bool = false
+
+    private var pathStore: PathStore {
+        di.resolve(PathStore.self)
+    }
+
+    // MARK: - Initializer
+
+    public init(container: DIContainer, errorHandler: ErrorHandler) {
+        _viewModel = State(
+            initialValue: StaffNoticeViewModel(container: container, errorHandler: errorHandler)
+        )
+    }
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let searchPlaceholder: String = "제목, 내용 검색"
+        static let loadingMessage: String = "공지를 불러오고 있어요"
+        static let emptyTitle: String = "아직 등록된 공지사항이 없어요"
+        static let emptySystemImage: String = "exclamationmark.triangle.text.page"
+        static let emptyDescription: String = "운영진 공지사항이 등록되면 이곳에 표시됩니다"
+        static let failedTitle: String = "불러오지 못했어요"
+        static let failedSystemImage: String = "exclamationmark.triangle"
+        static let failedDescription: String = "공지사항을 불러오지 못했습니다. 잠시 후 다시 시도해주세요."
+        static let retryTitle: String = "다시 시도"
+        static let retryMinimumWidth: CGFloat = 72
+        static let retryMinimumHeight: CGFloat = 20
+        static let loadingMoreBottomPadding: CGFloat = DefaultSpacing.spacing16
+        static let chipSpacing: CGFloat = DefaultSpacing.spacing8
+        static let defaultNavigationTitle: String = "운영진 공지"
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Group {
+            if viewModel.accessibleTabs.isEmpty {
+                noAccessContent
+            } else {
+                mainContent
+            }
+        }
+        .navigationTitle(viewModel.selectedTab?.labelText ?? Constants.defaultNavigationTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar { staffToolbarContent }
+        .task {
+            applyUserContext()
+            await viewModel.fetchNotices()
+        }
+        .onChange(of: staffContextSignature) { _, _ in
+            applyUserContext()
+        }
+        .onDisappear {
+            searchTask?.cancel()
+        }
+        .umcDefaultBackground()
+    }
+
+    // MARK: - Main Content
+
+    @ViewBuilder
+    private var mainContent: some View {
+        VStack(spacing: 0) {
+            staffTabChips
+            content
+        }
+        .searchable(text: $search, prompt: Constants.searchPlaceholder)
+        .searchToolbarBehavior(.minimize)
+        .onChange(of: search) { _, newValue in
+            handleSearchChanged(newValue)
+        }
+    }
+
+    // MARK: - Staff Tab Chips
+
+    private var staffTabChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Constants.chipSpacing) {
+                ForEach(viewModel.accessibleTabs) { tab in
+                    ChipButton(
+                        tab.labelText,
+                        isSelected: viewModel.selectedTab == tab
+                    ) {
+                        viewModel.selectTab(tab)
+                    }
+                    .buttonSize(.medium)
+                    .accessibilityLabel("\(tab.labelText) 탭")
+                    .accessibilityAddTraits(viewModel.selectedTab == tab ? .isSelected : [])
+                }
+            }
+            .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+            .padding(.vertical, DefaultSpacing.spacing8)
+        }
+    }
+
+    // MARK: - Content Rendering
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.hasNoAccessFromServer {
+            noAccessContent
+        } else {
+            switch viewModel.noticeItems {
+            case .idle, .loading:
+                progressContent
+            case .loaded(let items):
+                noticeContent(items)
+            case .failed:
+                failedContent()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func noticeContent(_ data: [NoticeItemModel]) -> some View {
+        if data.isEmpty {
+            unavailableContent
+        } else {
+            availableContent(data)
+        }
+    }
+
+    private var progressContent: some View {
+        VStack {
+            Spacer()
+            Progress(message: Constants.loadingMessage)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func availableContent(_ data: [NoticeItemModel]) -> some View {
+        List(data) { item in
+            noticeRow(item)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(DefaultConstant.defaultListPadding)
+        }
+        .overlay(alignment: .bottom) {
+            if viewModel.isLoadingMore {
+                ProgressView()
+                    .padding(.bottom, Constants.loadingMoreBottomPadding)
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .tint(.indigo500)
+        .refreshable {
+            await reloadWithMinimumDuration()
+        }
+    }
+
+    private func failedContent() -> some View {
+        RetryContentUnavailableView(
+            title: Constants.failedTitle,
+            systemImage: Constants.failedSystemImage,
+            description: Constants.failedDescription,
+            retryTitle: Constants.retryTitle,
+            isRetrying: isRetryingNotices,
+            minRetryButtonWidth: Constants.retryMinimumWidth,
+            minRetryButtonHeight: Constants.retryMinimumHeight
+        ) {
+            await retryNotices()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+
+    private var unavailableContent: some View {
+        ContentUnavailableView(
+            Constants.emptyTitle,
+            systemImage: Constants.emptySystemImage,
+            description: Text(Constants.emptyDescription)
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+
+    private var noAccessContent: some View {
+        NoAccessContentView()
+    }
+
+    // MARK: - Row
+
+    private func noticeRow(_ item: NoticeItemModel) -> some View {
+        NoticeItem(model: item) {
+            let noticeDetail = item.toNoticeDetail()
+            pathStore.noticePath.append(.notice(.detail(detailItem: noticeDetail)))
+        }
+        .task(id: item.id) {
+            await viewModel.loadNextPageIfNeeded(currentItem: item)
+        }
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var staffToolbarContent: some ToolbarContent {
+        if let category = writableCategoryForSelectedTab {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    pathStore.noticePath.append(
+                        .notice(.editor(mode: .create, selectedGisuId: gisuId, initialCategory: category))
+                    )
+                } label: {
+                    Image(systemName: "square.and.pencil")
+                        .imageScale(.medium)
+                }
+                .accessibilityLabel("운영진 공지 작성")
+            }
+        }
+    }
+
+    private var writableCategoryForSelectedTab: EditorMainCategory? {
+        guard let tab = viewModel.selectedTab,
+              let role = viewModel.memberRole else { return nil }
+
+        switch tab {
+        case .centralMember where role.canWriteCentralAllNotice:
+            return .management(.centralAll)
+        case .schoolCore where role.canWriteSchoolCoreNotice:
+            return .management(.schoolCore)
+        case .schoolPartLeader where role.canWriteSchoolPartLeaderNotice:
+            return .management(.schoolPartLeader)
+        default:
+            return nil
+        }
+    }
+
+    /// 지부장은 운영진 공지 작성 불가 (읽기 전용)
+    private var isReadOnlyStaffAccess: Bool {
+        viewModel.memberRole == .chapterPresident
+    }
+
+    // MARK: - User Context
+
+    private func applyUserContext() {
+        viewModel.applyUserContext(
+            memberRoleRawValue: memberRoleRaw,
+            schoolId: schoolId,
+            gisuId: gisuId
+        )
+    }
+
+    private var staffContextSignature: String {
+        "\(memberRoleRaw)|\(schoolId)|\(gisuId)"
+    }
+
+    // MARK: - Retry / Reload
+
+    @MainActor
+    private func retryNotices() async {
+        guard !isRetryingNotices else { return }
+        isRetryingNotices = true
+        defer { isRetryingNotices = false }
+        await viewModel.retryCurrentRequest()
+    }
+
+    @MainActor
+    private func reloadWithMinimumDuration() async {
+        async let reloadTask: Void = reloadCurrentList()
+        async let delayTask: Void = { try? await Task.sleep(for: .seconds(2)) }()
+        _ = await (reloadTask, delayTask)
+    }
+
+    @MainActor
+    private func reloadCurrentList() async {
+        if viewModel.isSearchMode,
+           !viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            await viewModel.searchNotices(keyword: viewModel.searchQuery)
+        } else {
+            await viewModel.fetchNotices()
+        }
+    }
+
+    // MARK: - Search
+
+    private func handleSearchChanged(_ newValue: String) {
+        searchTask?.cancel()
+        let keyword = search.trimmingCharacters(in: .whitespacesAndNewlines)
+        searchTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled else { return }
+            if keyword.isEmpty {
+                await viewModel.clearSearch()
+            } else {
+                await viewModel.searchNotices(keyword: keyword)
+            }
+        }
+    }
+}

--- a/UMCApp/Features/Notice/Project.swift
+++ b/UMCApp/Features/Notice/Project.swift
@@ -7,4 +7,9 @@ let project = featureProject(
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         // `UserSessionManager`(#957 후속으로 CoreDomain에 승격)를 사용한다.
         .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
+    ],
+    includesDataTests: true,
+    dataTestDependencies: [
+        .target(name: "NoticeDomain"),
+        .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
     ])

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationDestination.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationDestination.swift
@@ -26,6 +26,6 @@ enum NavigationDestination: Hashable {
     enum Notice: Hashable {
         case detail(detailItem: NoticeDetail)
         case staffNotice
-        case editor(mode: NoticeEditorMode, selectedGisuId: String?)
+        case editor(mode: NoticeEditorMode, selectedGisuId: String?, initialCategory: EditorMainCategory? = nil)
     }
 }

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
@@ -47,7 +47,9 @@ private extension NavigationRoutingView {
         case .detail(let detailItem):
             NoticeDetailView(container: di, errorHandler: errorHandler, model: detailItem)
         case .staffNotice, .editor:
-            // StaffNoticeView / NoticeEditorView는 아직 NoticePresentation에 이식되지 않았다.
+            // StaffNoticeView / NoticeEditorView 자체는 NoticePresentation에 이식됐지만,
+            // 두 화면은 로컬 `NoticeNavigation.PathStore`로 push되므로 이 라우터를 타지 않는다.
+            // Notice 탭 실연결 후속 이슈에서 목적지 타입을 일원화하며 함께 연결한다.
             Text("아직 지원하지 않는 화면입니다")
         }
     }


### PR DESCRIPTION
## ✨ PR 유형

리팩터링 (♻️ Refactor) — StaffNotice(운영진 공지) 화면 계층 AppProduct → UMCApp 이관

## 🛠️ 작업내용

- ♻️ Notice 목록/검색 요청 확장: `NoticeListRequest`/`NoticeListQuery`에 `noticeTab` 필드 추가(기본값 `CHALLENGER`), `NoticeRequestFactory`도 고정값으로 초기화
- ♻️ StaffNoticeViewModel 이관: 운영진 공지 탭 가시성·페이지네이션·요청 빌드 로직을 도메인 타입(String) 기준으로 재작성
- ♻️ StaffNoticeView 이관: 운영진 공지 화면, 탭 칩, 검색, 작성 버튼
- ♻️ NoAccessContentView 이관: 접근 권한 없음 안내 컴포넌트
- ♻️ NoticeDestination/NavigationDestination: `editor` 케이스에 `initialCategory` 파라미터 추가 (StaffNoticeView 작성 버튼 대응)

## 📋 추후 진행 상황

- Notice 탭 실제 네비게이션 연결(로컬 `NavigationRoutingView` 구현 및 App 레벨 `RootTabView` 연결)은 별도 브랜치/이슈에서 진행 예정

## 📌 리뷰 포인트

- `Notice/Domain/Sources/Requests/NoticeListRequest.swift`, `Notice/Data/Sources/DTOs/Request/NoticeListQuery.swift` — `noticeTab` 기본값이 기존 챌린저 목록 호출부에 영향 없는지
- `Notice/Presentation/Sources/ViewModels/StaffNotice/StaffNoticeViewModel.swift` — `buildRequest`의 `schoolId` 노출 조건(`tab.requiresSchoolId` / `chapterPresident` 예외)
- `Notice/Presentation/Sources/Views/StaffNotice/StaffNoticeView.swift` — `AppStorage(AppStorageKey.schoolId/gisuId)` 타입(String) 일치 여부

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?