### PR TITLE
♻️ [Refactor] 운영진 스터디 관리 화면·카드/시트 컴포넌트 이식

### DIFF
--- a/UMCApp/Core/UIComponents/Sources/Badge/InfoBadge.swift
+++ b/UMCApp/Core/UIComponents/Sources/Badge/InfoBadge.swift
@@ -1,0 +1,95 @@
+//
+//  InfoBadge.swift
+//  CoreUIComponents
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+
+// MARK: - InfoBadge
+
+/// 텍스트 뱃지 컴포넌트
+///
+/// Glass Effect 기반의 간결한 정보 뱃지를 표시합니다.
+public struct InfoBadge: View, Equatable {
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let backgroundOpacity: Double = 0.15
+    }
+
+    // MARK: - Property
+
+    private let text: String
+    private let textColor: Color
+    private let tintColor: Color?
+    private let glassVariant: GlassVariant
+
+    /// Glass Effect 변형 타입
+    public enum GlassVariant: Equatable {
+        case regular
+        case clear
+    }
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - text: 뱃지에 표시할 텍스트
+    ///   - textColor: 텍스트 색상
+    ///   - tintColor: Glass Effect 틴트 색상
+    ///   - glassVariant: Glass Effect 변형 타입
+    public init(
+        _ text: String,
+        textColor: Color = .grey600,
+        tintColor: Color? = nil,
+        glassVariant: GlassVariant = .clear
+    ) {
+        self.text = text
+        self.textColor = textColor
+        self.tintColor = tintColor
+        self.glassVariant = glassVariant
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        switch (glassVariant, tintColor) {
+        case (.regular, let color?):
+            badgeText.glassEffect(
+                .regular.tint(color.opacity(Constants.backgroundOpacity))
+            )
+        case (.regular, nil):
+            badgeText.glassEffect(.regular)
+        case (.clear, let color?):
+            badgeText.glassEffect(
+                .clear.tint(color.opacity(Constants.backgroundOpacity))
+            )
+        case (.clear, nil):
+            badgeText.glassEffect(.clear)
+        }
+    }
+
+    // MARK: - View Components
+
+    private var badgeText: some View {
+        Text(text)
+            .appFont(.footnote, color: textColor)
+            .lineLimit(1)
+            .padding(DefaultConstant.iconPadding)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    HStack(spacing: DefaultSpacing.spacing8) {
+        InfoBadge("중앙대")
+        InfoBadge("Leader", tintColor: .gray)
+        InfoBadge("iOS", textColor: .indigo500, tintColor: .indigo)
+        InfoBadge("미디어 위", glassVariant: .clear)
+    }
+    .padding()
+}

--- a/UMCApp/Core/UIComponents/Sources/Layout/FlowLayout.swift
+++ b/UMCApp/Core/UIComponents/Sources/Layout/FlowLayout.swift
@@ -1,0 +1,89 @@
+//
+//  FlowLayout.swift
+//  CoreUIComponents
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import SwiftUI
+
+/// 자식 뷰를 가로로 배치하다가 폭을 넘으면 다음 줄로 넘기는 flow(wrap) 레이아웃입니다.
+///
+/// 태그·칩처럼 개수가 가변인 요소를 자연스럽게 줄바꿈 배치할 때 사용합니다.
+///
+/// - Note: 같은 `FlowLayout` 이 NoticePresentation 에도 로컬로 하나 더 있습니다.
+///   여러 피처가 함께 쓰는 순수 레이아웃이라, 앞으로 이 canonical 하나로 합치는 게 목표입니다.
+///   // TODO: NoticePresentation 로컬 FlowLayout 을 이 canonical 로 통합 - [26.07.15] 이재원
+public struct FlowLayout: Layout {
+    public var alignment: Alignment
+    public var spacing: CGFloat
+
+    // MARK: - Init
+
+    public init(
+        alignment: Alignment = .leading,
+        spacing: CGFloat = 10
+    ) {
+        self.alignment = alignment
+        self.spacing = spacing
+    }
+
+    public func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        let maxWidth = proposal.width ?? 0
+        var height: CGFloat = 0
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+
+            if x + size.width > maxWidth {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + spacing
+        }
+
+        height = y + rowHeight
+
+        return CGSize(width: maxWidth, height: height)
+    }
+
+    public func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        let maxWidth = bounds.width
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+
+            if x + size.width > maxWidth {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+
+            subview.place(
+                at: CGPoint(x: bounds.minX + x, y: bounds.minY + y),
+                proposal: .init(size)
+            )
+
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + spacing
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
@@ -6,11 +6,67 @@
 //
 
 import SwiftUI
+#if DEBUG
+import CoreDomain
+#endif
 
 public struct ActivityFeatureView: View {
     public init() {}
 
     public var body: some View {
+        #if DEBUG
+        debugOperatorStudyHarness
+        #else
         Text("Activity Feature")
+        #endif
     }
 }
+
+#if DEBUG
+extension ActivityFeatureView {
+    /// 운영진 스터디 관리 화면 DEBUG 하네스 진입점
+    @MainActor
+    fileprivate var debugOperatorStudyHarness: some View {
+        DebugOperatorStudyHarnessView()
+    }
+}
+
+/// 운영진 스터디 관리 화면의 DEBUG 전용 하네스
+///
+/// Activity 라우터·DI 배선 이식 전까지, 스텁 UseCase(PreviewSupport)로 이식 화면을
+/// 서버·로그인 없이 Activity 탭에서 직접 확인하기 위한 임시 진입점. 앱 타깃이 이
+/// 화면들을 참조해야 static 링크에 포함되므로, UMCApp 스킴의 Canvas 프리뷰 호스팅도
+/// 이 참조로 활성화된다. 생성 폼은 운영 화면에서 진입점이 게이팅("준비 중")된 상태라
+/// 하네스 전용 버튼으로 직접 진입한다. 상위 RootTabView가 탭별 NavigationStack을
+/// 제공하므로 여기서 스택을 만들지 않는다.
+/// // TODO: Activity 라우터·DIContainer 이식 후 실제 배선으로 교체 - [26.07.24] 이재원
+@MainActor
+private struct DebugOperatorStudyHarnessView: View {
+    @State private var viewModel: OperatorStudyManagementViewModel
+    @State private var userSession: UserSessionManager
+    @State private var showsCreateForm = false
+
+    init() {
+        _viewModel = State(wrappedValue: previewOperatorStudyManagementViewModel())
+        _userSession = State(wrappedValue: previewCreateCapableSession())
+    }
+
+    var body: some View {
+        OperatorStudyManagementView(
+            viewModel: viewModel,
+            userSession: userSession
+        )
+        .navigationTitle("스터디 관리")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("생성 폼") {
+                    showsCreateForm = true
+                }
+            }
+        }
+        .navigationDestination(isPresented: $showsCreateForm) {
+            OperatorStudyGroupCreateView(viewModel: viewModel)
+        }
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SelectedChallengerView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SelectedChallengerView.swift
@@ -1,0 +1,124 @@
+//
+//  SelectedChallengerView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import CoreDesignSystem
+import CoreDomain
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 선택된 챌린저(멘토/스터디원) 목록을 확인·삭제하는 최소 스텁 뷰.
+///
+/// 원본(`AppProduct`)의 `SelectedChallengerView` 는 `SearchChallengerView` 검색 서브시스템에
+/// 의존하는데, 해당 Home 서브시스템(검색 API 포함)이 아직 UMCApp 으로 이식되지 않았다.
+/// 그래서 이 스텁은 **이미 선택된 목록의 확인·삭제** 까지만 담당하고, "검색으로 추가" 진입은
+/// 검색 서브시스템 이식 시점에 결선한다(#894 범위 밖, 사용자 결정으로 최소 스텁 채택).
+/// // TODO: SearchChallengerView(챌린저 검색 서브시스템) 이식 후 검색-추가 결선 - [26.07.15] 이재원
+struct SelectedChallengerView: View {
+
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+
+    /// 상위 뷰와 공유하는 선택된 챌린저 목록
+    @Binding var challenger: [ChallengerInfo]
+
+    /// 검색-추가 미이식 안내 표시 여부
+    @State private var showSearchUnavailable = false
+
+    /// 현재 사용자의 memberId (본인은 삭제 방지)
+    private var myMemberIdSet: Set<String> {
+        guard let id = AppStorageKey.memberIdString() else { return [] }
+        return [id]
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(NavigationTitle.Activity.participant.rawValue)
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationSubtitle("총 \(challenger.count)명")
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button {
+                            dismiss()
+                        } label: {
+                            Image(systemName: "chevron.left")
+                        }
+                    }
+
+                    ToolBarCollection.AddBtn(action: {
+                        // 검색-추가는 검색 서브시스템 미이식으로 아직 결선되지 않았다.
+                        showSearchUnavailable = true
+                    })
+                }
+                .alert("준비 중", isPresented: $showSearchUnavailable) {
+                    Button("확인", role: .cancel) {}
+                } message: {
+                    Text("챌린저 검색·추가 기능은 검색 화면 이식 후 연결됩니다.")
+                }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if challenger.isEmpty {
+            ContentUnavailableView(
+                "선택된 챌린저가 없습니다",
+                systemImage: "person.3.fill",
+                description: Text("새로운 챌린저를 초대하여 함께 도전해보세요.")
+            )
+        } else {
+            List {
+                ForEach(challenger) { info in
+                    challengerRow(info)
+                }
+            }
+        }
+    }
+
+    private func challengerRow(_ info: ChallengerInfo) -> some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            RemoteImage(
+                urlString: info.profileImage ?? "",
+                size: CGSize(width: 40, height: 40),
+                cornerRadius: 0,
+                placeholderImage: "person.fill"
+            )
+            .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                Text("\(info.nickname)/\(info.name)")
+                    .appFont(.subheadline, weight: .semibold, color: .grey900)
+                Text(info.schoolName)
+                    .appFont(.footnote, color: .grey500)
+            }
+
+            Spacer()
+
+            if !myMemberIdSet.contains(info.memberId) {
+                Button(role: .destructive) {
+                    removeChallenger(info)
+                } label: {
+                    Image(systemName: "minus.circle.fill")
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    private func removeChallenger(_ info: ChallengerInfo) {
+        challenger.removeAll { $0.id == info.id }
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SelectedChallengerView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SelectedChallengerView.swift
@@ -122,3 +122,12 @@ struct SelectedChallengerView: View {
         challenger.removeAll { $0.id == info.id }
     }
 }
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("SelectedChallengerView") {
+    @Previewable @State var challengers = OperatorStudyPreviewData.challengers
+    SelectedChallengerView(challenger: $challengers)
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/OperatorStudyGroupEditSheet.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/OperatorStudyGroupEditSheet.swift
@@ -114,3 +114,11 @@ struct OperatorStudyGroupEditSheet: View {
         }
     }
 }
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("OperatorStudyGroupEditSheet") {
+    OperatorStudyGroupEditSheet(viewModel: previewEditingViewModel())
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/OperatorStudyGroupEditSheet.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/OperatorStudyGroupEditSheet.swift
@@ -1,0 +1,116 @@
+//
+//  OperatorStudyGroupEditSheet.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+
+/// 스터디 그룹 정보 수정 시트
+///
+/// 그룹 이름을 수정할 수 있는 시트입니다.
+struct OperatorStudyGroupEditSheet: View {
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var viewModel: OperatorStudyManagementViewModel
+    @State private var isSaving = false
+
+    fileprivate enum Constants {
+        static let sectionSpacing: CGFloat = 20
+        static let blockSpacing: CGFloat = 8
+        static let fieldHeight: CGFloat = 50
+        static let fieldHorizontalPadding: CGFloat = 16
+        static let contentHorizontalPadding: CGFloat = 20
+        static let contentTopPadding: CGFloat = 20
+    }
+
+    // MARK: - Initializer
+
+    /// - Parameter viewModel: 스터디 관리 ViewModel (`editingName`으로 상태를 관리합니다)
+    init(viewModel: OperatorStudyManagementViewModel) {
+        self.viewModel = viewModel
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Constants.sectionSpacing) {
+                    nameSection
+                }
+                .padding(.horizontal, Constants.contentHorizontalPadding)
+                .padding(.top, Constants.contentTopPadding)
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .navigationTitle("그룹 정보 수정")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolBarCollection.CancelBtn {}
+                ToolBarCollection.ConfirmBtn(
+                    action: submit,
+                    disable: isSaveDisabled || isSaving,
+                    isLoading: isSaving,
+                    dismissOnTap: false
+                )
+            }
+        }
+        .presentationDetents([.fraction(0.3)])
+        .presentationDragIndicator(.hidden)
+        .interactiveDismissDisabled()
+    }
+
+    // MARK: - Sections
+
+    private var nameSection: some View {
+        VStack(alignment: .leading, spacing: Constants.blockSpacing) {
+            Text("그룹 이름")
+                .appFont(.subheadline, color: .grey700)
+
+            TextField("그룹 이름 지정", text: $viewModel.editingName)
+                .multilineTextAlignment(.leading)
+                .autocorrectionDisabled(true)
+                .padding(.horizontal, Constants.fieldHorizontalPadding)
+                .frame(height: Constants.fieldHeight)
+                .background(
+                    ConcentricRectangle(
+                        corners: .concentric(minimum: DefaultConstant.concentricRadius)
+                    )
+                    .fill(Color.grey100)
+                )
+
+            Text("예시) React A팀")
+                .appFont(.footnote, color: .grey500)
+        }
+    }
+
+    // MARK: - Action
+
+    private var isSaveDisabled: Bool {
+        viewModel.editingName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func submit() {
+        guard !isSaving else { return }
+        isSaving = true
+
+        Task { @MainActor in
+            guard let groupID = viewModel.editingGroup?.id else {
+                isSaving = false
+                return
+            }
+            let isSuccess = await viewModel.updateGroup(
+                groupID: groupID,
+                name: viewModel.editingName.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            isSaving = false
+            if isSuccess {
+                dismiss()
+            }
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupCard.swift
@@ -462,3 +462,23 @@ struct StudyGroupCard: View, Equatable {
         .accessibilityLabel("멘토 추가")
     }
 }
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("StudyGroupCard") {
+    ScrollView {
+        StudyGroupCard(
+            detail: OperatorStudyPreviewData.groups[0],
+            onEdit: {},
+            onDelete: {},
+            onAddMember: {},
+            onAddMentor: {},
+            onSchedule: {},
+            onRemoveMember: { _ in },
+            onRemoveMentor: { _ in }
+        )
+        .padding()
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupCard.swift
@@ -1,0 +1,464 @@
+//
+//  StudyGroupCard.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+// MARK: - StudyGroupCard
+
+/// 스터디 그룹 상세 카드
+///
+/// 그룹명, 파트, 멘토(담당 파트장) 목록, 멤버 목록과 관리 액션을 표시합니다.
+struct StudyGroupCard: View, Equatable {
+
+    // MARK: - Property
+
+    @State private var deleteAlertPrompt: AlertPrompt?
+    /// 멘토/스터디원 섹션 펼침 상태
+    ///
+    /// 멘토가 N명 가능 + 멤버 많을수록 카드 길이가 빠르게 늘어남.
+    /// 기본 collapsed → 헤더만으로 빠른 스캔, 관심 카드만 펼침.
+    @State private var isExpanded: Bool = false
+
+    /// 펼침 콘텐츠(멘토+멤버 섹션)의 자연 높이.
+    ///
+    /// `fixedSize`로 클램프와 무관하게 측정한 natural height를 보관한다. `frame(height:)`를
+    /// 이 값↔0 으로 애니메이션해 콘텐츠를 카드 안에 가둔 채(clip) 펼침/접힘을 표현한다.
+    /// `if + .transition` 방식은 제거되는 뷰가 축소된 부모 밖으로 잔류 렌더되며 clip을 벗어나
+    /// 잔상이 생기는데(이번 이슈 영상 검증), 이 방식은 콘텐츠가 항상 클램프 프레임 안에 있어
+    /// 헤더 아래로 넘치지 않는다.
+    @State private var expandedSectionsHeight: CGFloat = 0
+
+    private let detail: StudyGroupInfo
+    private var onEdit: (() -> Void)?
+    private var onDelete: (() -> Void)?
+    private var onAddMember: (() -> Void)?
+    private var onAddMentor: (() -> Void)?
+    private var onSchedule: (() -> Void)?
+    private var onRemoveMember: ((StudyGroupMember) -> Void)?
+    private var onRemoveMentor: ((StudyGroupMember) -> Void)?
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - detail: 그룹 상세 정보
+    ///   - onEdit: 편집 버튼 탭 콜백
+    ///   - onDelete: 삭제 버튼 탭 콜백
+    ///   - onAddMember: 멤버 추가 버튼 탭 콜백
+    ///   - onAddMentor: 멘토 추가 버튼 탭 콜백
+    ///   - onSchedule: 일정 등록 버튼 탭 콜백
+    ///   - onRemoveMember: 멤버 칩 삭제 콜백
+    ///   - onRemoveMentor: 멘토 칩 삭제 콜백
+    init(
+        detail: StudyGroupInfo,
+        onEdit: (() -> Void)? = nil,
+        onDelete: (() -> Void)? = nil,
+        onAddMember: (() -> Void)? = nil,
+        onAddMentor: (() -> Void)? = nil,
+        onSchedule: (() -> Void)? = nil,
+        onRemoveMember: ((StudyGroupMember) -> Void)? = nil,
+        onRemoveMentor: ((StudyGroupMember) -> Void)? = nil
+    ) {
+        self.detail = detail
+        self.onEdit = onEdit
+        self.onDelete = onDelete
+        self.onAddMember = onAddMember
+        self.onAddMentor = onAddMentor
+        self.onSchedule = onSchedule
+        self.onRemoveMember = onRemoveMember
+        self.onRemoveMentor = onRemoveMentor
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.detail == rhs.detail
+    }
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        /// 카드 외곽 라운드 — Apple 가이드 권장 `.glassEffect(_:in:)` 패턴에서 사용
+        ///
+        /// `ConcentricRectangle`은 superview corner 상속에 의존하는데,
+        /// `GlassEffectContainer` 내부에서는 그 상속이 끊겨 의도와 다른 거대 round로
+        /// morphing되는 문제가 있어 명시 corner radius로 고정한다.
+        static let cardCornerRadius: CGFloat = 24
+        /// 좌측 파트 컬러 strip 너비
+        static let accentStripWidth: CGFloat = 4
+        /// strip 모서리 둥글기
+        static let accentStripCornerRadius: CGFloat = 2
+        /// sub-section(멘토/멤버) 내부 패딩
+        static let subSectionPadding: CGFloat = 12
+        /// sub-section Material 배경 라운드
+        static let subSectionCornerRadius: CGFloat = 14
+        /// HIG 권장 최소 터치 타겟
+        static let minTouchTarget: CGFloat = 44
+        /// metadataRow 배경 라운드
+        static let metadataRowCornerRadius: CGFloat = 10
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            accentStrip
+
+            VStack(alignment: .leading, spacing: 0) {
+                headerSection
+
+                // 펼침 콘텐츠는 항상 트리에 존재하고 `fixedSize`로 자연 높이를 측정한다.
+                // 표시 높이는 `frame(height:)`로 0↔측정값을 애니메이션하고 `clipped()`로 잘라,
+                // 콘텐츠가 헤더 아래로 빠져나오는 잔상 없이 카드 안에서만 열리고 닫힌다.
+                expandableSections
+                    .fixedSize(horizontal: false, vertical: true)
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.size.height
+                    } action: { newHeight in
+                        expandedSectionsHeight = newHeight
+                    }
+                    .frame(
+                        height: isExpanded ? expandedSectionsHeight : 0,
+                        alignment: .top
+                    )
+                    .opacity(isExpanded ? 1 : 0)
+                    .clipped()
+            }
+            .padding(DefaultConstant.defaultCardPadding)
+        }
+        // Apple 가이드 권장 패턴: View 자체에 `.glassEffect(_:in:)` 적용
+        // → GlassEffectContainer 내부 morphing/blending이 정상 동작
+        .glassEffect(
+            .regular,
+            in: .rect(cornerRadius: Constants.cardCornerRadius)
+        )
+        // 카드 외곽 라운드로 콘텐츠를 한 번 더 clip — 내부 섹션 clip과 더불어 어떤 자식도
+        // 카드 모서리를 넘지 않도록 보장한다.
+        .clipShape(.rect(cornerRadius: Constants.cardCornerRadius))
+        // 카드 전체를 펼침/접힘 탭 영역으로 만든다. 내부 Button/Menu(일정 등록·설정·추가)는
+        // 자체적으로 탭을 소비하므로 토글되지 않고, 빈 영역·타이틀·메타·파트장/멤버 행을
+        // 탭하면 펼침/접힘이 토글된다.
+        .contentShape(.rect(cornerRadius: Constants.cardCornerRadius))
+        .onTapGesture { toggleExpansion() }
+        .alertPrompt(item: $deleteAlertPrompt)
+    }
+
+    /// 펼침/접힘 토글 — `metadataRow`의 chevron과 카드 전체 탭이 공유하는 단일 진입점.
+    private func toggleExpansion() {
+        withAnimation(.smooth(duration: 0.3)) {
+            isExpanded.toggle()
+        }
+    }
+
+    /// 펼침 시 노출되는 멘토/멤버 섹션 묶음.
+    ///
+    /// 헤더와의 간격(spacing16)을 이 블록 상단 패딩으로 흡수해, 접힘 시 `frame(height: 0)`로
+    /// 갭까지 함께 사라지게 한다(외곽 VStack spacing은 0).
+    private var expandableSections: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+            mentorSection
+            membersSection
+        }
+        .padding(.top, DefaultSpacing.spacing16)
+    }
+
+    // MARK: - View Components
+
+    /// 카드 좌측 파트 컬러 accent strip
+    ///
+    /// `maxHeight: .infinity`로 카드 content 영역 전체 높이를 채워 파트 정체성을 강한 시각 단서로
+    /// 표현한다. 좌측만 leading 패딩을 두고, 카드 패딩과의 어색한 갭이 생기지 않도록 한다.
+    private var accentStrip: some View {
+        RoundedRectangle(cornerRadius: Constants.accentStripCornerRadius)
+            .fill(detail.part.color)
+            .frame(width: Constants.accentStripWidth)
+            .frame(maxHeight: .infinity)
+            .padding(.vertical, DefaultConstant.defaultCardPadding.top)
+            .padding(.leading, DefaultSpacing.spacing8)
+            .accessibilityHidden(true)
+    }
+
+    /// 헤더 — 2-row 구조로 식별/액션을 분리한다.
+    ///
+    /// Row 1 (Identity): 그룹명·파트 뱃지·오늘 미팅 — primary attention.
+    /// Row 2 (Meta + Actions): 멤버 수·생성일·펼침 토글 + 일정 등록·설정 — secondary.
+    ///
+    /// 그룹명에 `lineLimit(2) + fixedSize(vertical)`를 부여해 긴 이름이 truncate 되는 대신 줄바꿈된다.
+    @ViewBuilder
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            // Row 1: 식별 정보 (primary)
+            HStack(alignment: .firstTextBaseline, spacing: DefaultSpacing.spacing8) {
+                Text(detail.name)
+                    .appFont(.callout, weight: .semibold)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                InfoBadge(
+                    detail.part.name,
+                    textColor: detail.part.color,
+                    tintColor: detail.part.color
+                )
+
+                // "오늘 미팅" active 상태 뱃지 — UI hook만 준비, 산정 로직은 별도 이슈
+                // .tint(part.color)는 prominence 신호 보존을 위해 이 active 뱃지에만 한정한다.
+                if isMeetingToday {
+                    todayMeetingBadge
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            // Row 2: 메타/펼침 토글 + 액션 버튼
+            HStack(spacing: DefaultSpacing.spacing8) {
+                metadataRow
+
+                Spacer(minLength: DefaultSpacing.spacing8)
+
+                scheduleActionButton
+                settingsMenu
+            }
+        }
+    }
+
+    /// 그룹 편집·삭제 메뉴 — HIG 44×44 터치 타겟 보장.
+    ///
+    /// 인접한 expand 토글(`metadataRow`) 영역과 오탭을 피하기 위해 명시 frame을 사용한다.
+    private var settingsMenu: some View {
+        Menu {
+            Button("그룹 편집", systemImage: "pencil") {
+                onEdit?()
+            }
+
+            Divider()
+
+            Button("그룹 삭제", systemImage: "trash", role: .destructive) {
+                deleteAlertPrompt = AlertPrompt(
+                    title: "그룹 삭제",
+                    message: "'\(detail.name)' 그룹을 삭제하시겠습니까?",
+                    positiveBtnTitle: "삭제",
+                    positiveBtnAction: {
+                        onDelete?()
+                    },
+                    negativeBtnTitle: "취소",
+                    isPositiveBtnDestructive: true
+                )
+            }
+        } label: {
+            Image(systemName: "gearshape")
+                .font(.app(.title3))
+                .frame(
+                    width: Constants.minTouchTarget,
+                    height: Constants.minTouchTarget
+                )
+                .contentShape(Rectangle())
+                .glassEffect(.regular.interactive())
+        }
+        .accessibilityLabel("그룹 설정")
+    }
+
+    /// 일정 등록 — collapsed에서는 quiet 아이콘 chip, expanded에서 tinted prominent capsule.
+    ///
+    /// soyeon-ui-review CRITICAL: 카드 N개에 prominent CTA가 반복 배치되면 화면 전체에서
+    /// "primary CTA가 N개" 패턴이 되어 그룹명의 primary attention을 침범한다. collapsed는
+    /// 정보 스캔 우선 → 액션 강조 약화, expanded는 운영 작업 우선 → 강조 회복.
+    ///
+    /// **잔상 방지를 위한 단일 persistent view 패턴**: 이전엔 collapsed(원형)와 expanded(캡슐)를
+    /// 서로 다른 뷰로 두고 `glassEffectID`로 morphing했는데, 전환 중 두 상태가 cross-fade되며
+    /// 캘린더 아이콘이 두 개로 겹쳐 보이는 잔상이 생겼다(영상 검증). 아이콘 하나가 항상 존재하는
+    /// 단일 HStack으로 만들고, 배경은 항상 `.capsule`(44×44면 원으로 보임)로 두어 **너비·틴트·
+    /// 글자만 연속 변화**시킨다. 뷰 identity가 유지되므로 아이콘이 중복 렌더되지 않는다.
+    ///
+    /// 높이는 인접한 `settingsMenu`(고정 44×44)와 baseline 정렬을 위해 `minHeight: 44`.
+    private var scheduleActionButton: some View {
+        Button {
+            onSchedule?()
+        } label: {
+            HStack(spacing: isExpanded ? DefaultSpacing.spacing4 : 0) {
+                Image(systemName: "calendar.badge.plus")
+                    .font(.app(.title3))
+                    .foregroundStyle(isExpanded ? Color.white : Color.indigo600)
+
+                if isExpanded {
+                    Text("일정 등록")
+                        .appFont(.footnote, weight: .semibold, color: .white)
+                        .lineLimit(1)
+                        .fixedSize()
+                }
+            }
+            .padding(.horizontal, isExpanded ? DefaultSpacing.spacing12 : 0)
+            .frame(
+                minWidth: Constants.minTouchTarget,
+                minHeight: Constants.minTouchTarget
+            )
+            .contentShape(.capsule)
+            // 배경을 항상 `.capsule`로 두면 collapsed(44×44)는 원, expanded는 알약으로 같은
+            // shape 프리미티브 안에서 너비만 변해 shape swap 잔상이 없다. tint opacity는
+            // collapsed에서 0(plain glass) → expanded에서 1(indigo)로 연속 전환된다.
+            .glassEffect(
+                .regular
+                    .tint(.indigo600.opacity(isExpanded ? 1 : 0))
+                    .interactive(),
+                in: .capsule
+            )
+        }
+        .accessibilityLabel("일정 등록")
+    }
+
+    /// "오늘 미팅" active 상태 뱃지 (UI hook)
+    /// 산정 로직은 별도 이슈에서 추가하고, 여기서는 `isMeetingToday` false 고정으로 hidden 상태.
+    private var todayMeetingBadge: some View {
+        InfoBadge(
+            "오늘 미팅",
+            textColor: detail.part.color,
+            tintColor: detail.part.color,
+            glassVariant: .regular
+        )
+        .tint(detail.part.color)
+    }
+
+    /// 오늘 미팅 여부 — 산정 로직은 후속 이슈에서 도입. 현 시점에서는 hidden.
+    private var isMeetingToday: Bool { false }
+
+    /// 메타 + 펼침 토글 — collapsed 시각 단서를 강화한 secondary 액션.
+    ///
+    /// 멘토/멤버 수만 표시해 좁은 디바이스에서도 절대 잘리지 않도록 한다.
+    /// 생성일은 부가정보로 prominence가 낮아 collapsed에서는 생략, 필요 시 expanded 내부
+    /// 메타 카드에서 노출 가능하다(향후 도입). 배경에 thinMaterial을 깔아 탭 가능 영역을
+    /// 시각화하고, 우측 chevron 회전으로 상태를 표현한다. `minHeight: 44`로 HIG 터치 타겟 보장.
+    private var metadataRow: some View {
+        Button {
+            toggleExpansion()
+        } label: {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Text("멘토 \(detail.mentors.count)명 · 멤버 \(detail.members.count)명")
+                    .appFont(.caption1, weight: .semibold, color: .grey600)
+                    .lineLimit(1)
+
+                Image(systemName: "chevron.down")
+                    .font(.app(.caption1))
+                    .foregroundStyle(Color.grey500)
+                    .rotationEffect(.degrees(isExpanded ? 180 : 0))
+            }
+            .padding(.horizontal, DefaultSpacing.spacing8)
+            .frame(minHeight: Constants.minTouchTarget)
+            .background(
+                .thinMaterial,
+                in: .rect(cornerRadius: Constants.metadataRowCornerRadius)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isExpanded ? "스터디 그룹 상세 접기" : "스터디 그룹 상세 펼치기")
+        .accessibilityHint("멘토와 스터디원 목록 보기")
+    }
+
+    @ViewBuilder
+    private var mentorSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            HStack {
+                SectionHeaderView(title: "담당 파트장")
+                Spacer()
+                addMentorButton
+            }
+
+            ForEach(detail.mentors) { mentor in
+                StudyGroupLeaderRow(
+                    leader: mentor,
+                    partTintColor: detail.part.color
+                )
+                .equatable()
+                .contextMenu {
+                    Button(role: .destructive) {
+                        onRemoveMentor?(mentor)
+                    } label: {
+                        Label("멘토 삭제", systemImage: "trash")
+                    }
+                }
+            }
+        }
+        .padding(Constants.subSectionPadding)
+        .background(
+            .regularMaterial,
+            in: .rect(cornerRadius: Constants.subSectionCornerRadius)
+        )
+    }
+
+    @ViewBuilder
+    private var membersSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            HStack {
+                SectionHeaderView(title: "스터디원")
+                Spacer()
+                addMemberButton
+            }
+
+            FlowLayout(spacing: DefaultSpacing.spacing8) {
+                ForEach(detail.members) { member in
+                    StudyGroupMemberChip(
+                        member: member,
+                        showsBestWorkbookBadge: topBestWorkbookMemberServerIDs
+                            .contains(member.serverID)
+                    )
+                    .equatable()
+                    .contextMenu {
+                        Button(role: .destructive) {
+                            onRemoveMember?(member)
+                        } label: {
+                            Label("멤버 삭제", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+        }
+        .padding(Constants.subSectionPadding)
+        .background(
+            .regularMaterial,
+            in: .rect(cornerRadius: Constants.subSectionCornerRadius)
+        )
+    }
+
+    private var topBestWorkbookMemberServerIDs: Set<String> {
+        guard let topScore = detail.members
+            .map(\.bestWorkbookPoint)
+            .max(),
+              topScore > 0 else {
+            return []
+        }
+
+        return Set(
+            detail.members
+                .filter { $0.bestWorkbookPoint == topScore }
+                .map(\.serverID)
+        )
+    }
+
+    private var addMemberButton: some View {
+        Button {
+            onAddMember?()
+        } label: {
+            Image(systemName: "plus")
+                .padding(DefaultConstant.defaultBtnPadding)
+        }
+        .glassEffect(.regular.interactive())
+        .accessibilityLabel("스터디원 추가")
+    }
+
+    private var addMentorButton: some View {
+        Button {
+            onAddMentor?()
+        } label: {
+            Image(systemName: "plus")
+                .padding(DefaultConstant.defaultBtnPadding)
+        }
+        .glassEffect(.regular.interactive())
+        .accessibilityLabel("멘토 추가")
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupLeaderRow.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupLeaderRow.swift
@@ -1,0 +1,164 @@
+//
+//  StudyGroupLeaderRow.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+
+// MARK: - StudyGroupLeaderRow
+
+/// 스터디 그룹 파트장 행
+///
+/// 프로필 이미지, 이름, 대학교, 역할 뱃지를 표시합니다.
+struct StudyGroupLeaderRow: View, Equatable {
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let avatarSize: CGFloat = 48
+        static let rowPadding: CGFloat = 12
+        static let surfaceShadowRadius: CGFloat = 10
+        static let surfaceHighlightRadius: CGFloat = 4
+        static let surfaceShadowYOffset: CGFloat = 6
+        /// 표면 라운드 — Nested Material/Glass 환경에서 ConcentricRectangle inheritance가
+        /// 끊기는 문제가 있어 명시 cornerRadius로 곡률을 직접 보장한다.
+        static let surfaceCornerRadius: CGFloat = 16
+    }
+
+    // MARK: - Property
+
+    /// 파트장 정보
+    let leader: StudyGroupMember
+    /// 스터디 파트 메인 색
+    let partTintColor: Color
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - leader: 표시할 파트장 정보
+    ///   - partTintColor: 파트 메인 색상
+    init(
+        leader: StudyGroupMember,
+        partTintColor: Color
+    ) {
+        self.leader = leader
+        self.partTintColor = partTintColor
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.leader == rhs.leader
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            avatarView
+
+            // displayName = "{nickname}/{name}" 또는 "{name}". "운영이/김운영" 같은 단일 식별자가
+            // 좁은 폭에서 임의로 줄바꿈되지 않도록 lineLimit(1) + minimumScaleFactor로 한 줄을
+            // 강제하고, 그래도 부족하면 자동 축소 후 마지막에 ellipsis로 잘린다.
+            Text(leader.displayName)
+                .appFont(.callout, weight: .semibold, color: .black)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .truncationMode(.tail)
+                .layoutPriority(1)
+
+            InfoBadge(leader.university)
+                .layoutPriority(-1)
+
+            InfoBadge(leader.role.rawValue)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Constants.rowPadding)
+        .background(surfaceBackground)
+    }
+
+    // MARK: - View Components
+
+    private var avatarView: some View {
+        RemoteImage(
+            urlString: leader.profileImageURL ?? "",
+            size: CGSize(
+                width: Constants.avatarSize,
+                height: Constants.avatarSize
+            ),
+            cornerRadius: 0,
+            placeholderImage: "person.fill"
+        )
+        .clipShape(Circle())
+    }
+
+    /// 표면 배경 — 파트 컬러 그라데이션 + 미묘한 highlight/shadow.
+    ///
+    /// 카드 외부가 이미 `.glassEffect(.regular)`이고 상위 `mentorSection`은 `.regularMaterial`이다.
+    /// 추가 Glass를 중첩하면 Glass-on-Glass-on-Material 삼중 블러가 발생해 가독성·성능 모두 손해다.
+    /// 따라서 Glass 없이 LinearGradient + shadow만 사용한다.
+    ///
+    /// 곡률은 `RoundedRectangle(cornerRadius:)`로 직접 보장한다. `ConcentricRectangle`은 nested
+    /// Material 컨테이너에서 corner inheritance가 끊겨 곡률이 무너지는 문제가 있다.
+    private var surfaceBackground: some View {
+        RoundedRectangle(cornerRadius: Constants.surfaceCornerRadius)
+            .fill(
+                LinearGradient(
+                    colors: [
+                        .white.opacity(0.85),
+                        partTintColor.opacity(0.20),
+                        partTintColor.opacity(0.08)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .shadow(
+                color: .black.opacity(0.08),
+                radius: Constants.surfaceShadowRadius,
+                x: 0,
+                y: Constants.surfaceShadowYOffset
+            )
+            .shadow(
+                color: .white.opacity(0.7),
+                radius: Constants.surfaceHighlightRadius,
+                x: -2,
+                y: -2
+            )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: DefaultSpacing.spacing16) {
+        StudyGroupLeaderRow(
+            leader: StudyGroupMember(
+                serverID: "1",
+                name: "김운영",
+                nickname: "운영이",
+                university: "홍익대학교",
+                profileImageURL: nil,
+                role: .leader
+            ),
+            partTintColor: .indigo500
+        )
+
+        StudyGroupLeaderRow(
+            leader: StudyGroupMember(
+                serverID: "2",
+                name: "이리더",
+                university: "서울대학교",
+                profileImageURL: nil,
+                role: .leader
+            ),
+            partTintColor: .orange
+        )
+    }
+    .padding()
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupMemberChip.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupMemberChip.swift
@@ -1,0 +1,196 @@
+//
+//  StudyGroupMemberChip.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+
+/// 스터디 그룹 멤버 칩
+///
+/// 프로필 아바타와 이름을 표시하는 컴팩트 뷰입니다.
+struct StudyGroupMemberChip: View, Equatable {
+    // MARK: - Constants
+    fileprivate enum Constants {
+        static let avatarSize: CGFloat = 22
+        static let avatarCornerRadius: CGFloat = 0
+        static let avatarPlaceholderImageName: String = "person.fill"
+        static let bestBorderWidth: CGFloat = 1
+        static let bestPointThreshold: Int = 0
+        /// 칩 corner radius — Nested Material/Glass 환경에서 ConcentricRectangle inheritance가
+        /// 끊기는 문제가 있어 명시 cornerRadius로 곡률을 직접 보장한다.
+        static let chipCornerRadius: CGFloat = 16
+        static let chipHeight: CGFloat = 68
+        static let chipHorizontalPadding: CGFloat = 6
+        static let chipVerticalPadding: CGFloat = 6
+        static let nameLineLimit: Int = 1
+        static let nameMinimumScaleFactor: CGFloat = 0.8
+        static let bestIconSize: CGFloat = 12
+        static let bestIconContainerSize: CGFloat = 22
+        static let bestIconOverlapOffset: CGFloat = 7
+        static let bestIconSystemName: String = "trophy.fill"
+        static let bestBorderOpacity: CGFloat = 0.32
+        static let defaultBorderOpacity: CGFloat = 0.06
+        static let bestIconBackgroundOpacity: CGFloat = 0.12
+        static let chipWidth: CGFloat = 68
+        /// 표면 그라데이션(Glass 대체) — highlight → mid → low 3-stop + 그림자.
+        static let surfaceHighlightOpacity: CGFloat = 0.85
+        static let surfaceMidOpacity: CGFloat = 0.15
+        static let surfaceLowOpacity: CGFloat = 0.06
+        static let surfaceShadowOpacity: CGFloat = 0.06
+        static let surfaceShadowRadius: CGFloat = 6
+        static let surfaceShadowYOffset: CGFloat = 3
+    }
+
+    // MARK: - Property
+    /// 표시할 멤버 정보
+    let member: StudyGroupMember
+    /// 베스트 워크북 배지 노출 여부
+    let showsBestWorkbookBadge: Bool
+
+    // MARK: - Initializer
+    /// - Parameters:
+    ///   - member: 표시할 멤버 정보
+    ///   - showsBestWorkbookBadge: 베스트 워크북 배지 노출 여부
+    init(
+        member: StudyGroupMember,
+        showsBestWorkbookBadge: Bool = false
+    ) {
+        self.member = member
+        self.showsBestWorkbookBadge = showsBestWorkbookBadge
+    }
+
+    // MARK: - Equatable
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.member == rhs.member &&
+            lhs.showsBestWorkbookBadge == rhs.showsBestWorkbookBadge
+    }
+
+    private var hasBestWorkbookPoint: Bool {
+        showsBestWorkbookBadge && member.bestWorkbookPoint > Constants.bestPointThreshold
+    }
+
+    // MARK: - Body
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing4) {
+            avatarView
+            // 칩에는 닉네임만 노출(없으면 본명). LeaderRow의 "닉네임/이름" 풀 표기와 다르게,
+            // 좁은 폭의 칩에서는 한 글자라도 더 보여야 가독성이 높다는 디자인 결정.
+            Text(member.nickname ?? member.name)
+                .appFont(.caption1)
+                .lineLimit(Constants.nameLineLimit)
+                .minimumScaleFactor(Constants.nameMinimumScaleFactor)
+        }
+        .padding(.horizontal, Constants.chipHorizontalPadding)
+        .padding(.vertical, Constants.chipVerticalPadding)
+        .frame(width: Constants.chipWidth, height: Constants.chipHeight)
+        .background(surfaceBackground)
+        .overlay {
+            RoundedRectangle(cornerRadius: Constants.chipCornerRadius)
+                .stroke(
+                    hasBestWorkbookPoint
+                        ? .orange.opacity(Constants.bestBorderOpacity)
+                        : .black.opacity(Constants.defaultBorderOpacity),
+                    lineWidth: Constants.bestBorderWidth
+                )
+        }
+        .overlay(alignment: .topTrailing) {
+            if hasBestWorkbookPoint {
+                bestWorkbookIcon
+                    .offset(
+                        x: Constants.bestIconOverlapOffset,
+                        y: -Constants.bestIconOverlapOffset
+                    )
+            }
+        }
+    }
+
+    // MARK: - View Components
+    @ViewBuilder
+    private var avatarView: some View {
+        RemoteImage(
+            urlString: member.profileImageURL ?? "",
+            size: CGSize(
+                width: Constants.avatarSize,
+                height: Constants.avatarSize
+            ),
+            cornerRadius: Constants.avatarCornerRadius,
+            placeholderImage: Constants.avatarPlaceholderImageName
+        )
+        .clipShape(Circle())
+    }
+
+    /// 칩 표면 — 중립 그라데이션 + 미묘한 그림자 (Glass 미사용).
+    ///
+    /// 칩은 카드의 `.glassEffect(.regular)`와 상위 `.regularMaterial` 위에 놓인다. 여기에
+    /// Glass를 또 얹으면 삼중 블러(Glass-on-Glass-on-Material)로 가독성·성능이 나빠진다.
+    /// `StudyGroupLeaderRow`처럼 `LinearGradient` + shadow만 쓴다.
+    ///
+    /// 곡률은 `RoundedRectangle(cornerRadius:)`로 직접 보장한다. `ConcentricRectangle`은
+    /// nested Material에서 corner inheritance가 끊겨 곡률이 무너진다.
+    private var surfaceBackground: some View {
+        RoundedRectangle(cornerRadius: Constants.chipCornerRadius)
+            .fill(
+                LinearGradient(
+                    colors: [
+                        .white.opacity(Constants.surfaceHighlightOpacity),
+                        .gray.opacity(Constants.surfaceMidOpacity),
+                        .gray.opacity(Constants.surfaceLowOpacity)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .shadow(
+                color: .black.opacity(Constants.surfaceShadowOpacity),
+                radius: Constants.surfaceShadowRadius,
+                x: 0,
+                y: Constants.surfaceShadowYOffset
+            )
+    }
+
+    private var bestWorkbookIcon: some View {
+        Image(systemName: Constants.bestIconSystemName)
+            .font(.system(size: Constants.bestIconSize, weight: .semibold))
+            .foregroundStyle(.orange)
+            .frame(
+                width: Constants.bestIconContainerSize,
+                height: Constants.bestIconContainerSize
+            )
+            .background(.orange.opacity(Constants.bestIconBackgroundOpacity), in: Circle())
+    }
+}
+
+// MARK: - Preview
+
+#Preview("StudyGroupMemberChip") {
+    HStack(spacing: DefaultSpacing.spacing8) {
+        StudyGroupMemberChip(
+            member: StudyGroupMember(
+                serverID: "1",
+                name: "김철수",
+                nickname: "철수",
+                university: "서울대",
+                profileImageURL: nil,
+                role: .leader
+            )
+        )
+        StudyGroupMemberChip(
+            member: StudyGroupMember(
+                serverID: "2",
+                name: "이영희",
+                nickname: "영희",
+                university: "연세대",
+                profileImageURL: nil,
+                role: .member,
+                bestWorkbookPoint: 30
+            ),
+            showsBestWorkbookBadge: true
+        )
+    }
+    .padding()
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/OperatorStudyPreviewSupport.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/OperatorStudyPreviewSupport.swift
@@ -1,0 +1,222 @@
+//
+//  OperatorStudyPreviewSupport.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/20/26.
+//
+
+#if DEBUG
+import ActivityDomain
+import CoreDomain
+import Foundation
+import UMCFoundation
+
+// MARK: - Preview UseCase
+
+/// 프리뷰 전용 스텁 UseCase — 주입된 결과로 조회를 흉내내고, 변경 액션은 no-op.
+final class PreviewOperatorStudyManagementUseCase: OperatorStudyManagementUseCaseProtocol {
+
+    /// 조회 시나리오 — 성공(지정 페이지) 또는 실패(지정 에러).
+    enum Outcome {
+        case page(StudyGroupDetailsPage)
+        case failure(Error)
+    }
+
+    private let outcome: Outcome
+
+    init(outcome: Outcome = .page(OperatorStudyPreviewData.loadedPage)) {
+        self.outcome = outcome
+    }
+
+    func fetchStudyGroupDetailsPage(
+        cursor: String?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage {
+        switch outcome {
+        case .page(let page):
+            return page
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: String?
+    ) async throws -> String? { nil }
+
+    func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws {}
+
+    func updateStudyGroup(groupId: String, name: String) async throws {}
+    func deleteStudyGroup(groupId: String) async throws {}
+    func addStudyGroupMember(groupId: String, memberId: String) async throws {}
+    func removeStudyGroupMember(groupId: String, memberId: String) async throws {}
+    func addStudyGroupMentor(groupId: String, mentorId: String) async throws {}
+    func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {}
+}
+
+/// 프리뷰에서 조회 실패 상태(에러 뷰)를 재현하기 위한 샘플 에러.
+enum PreviewSampleError: Error {
+    case failed
+}
+
+// MARK: - Preview Data
+
+/// 프리뷰 공용 샘플 데이터.
+enum OperatorStudyPreviewData {
+
+    static let mentor = StudyGroupMember(
+        serverID: "M-1",
+        memberID: "M-1",
+        name: "김멘토",
+        nickname: "멘토킴",
+        university: "한성대학교",
+        role: .leader
+    )
+
+    static let members: [StudyGroupMember] = [
+        // nickname nil → 카드/리더 행의 이름 폴백(displayName) 렌더 경로 확인용.
+        StudyGroupMember(
+            serverID: "M-2",
+            memberID: "M-2",
+            name: "박철수",
+            nickname: nil,
+            university: "한성대학교"
+        ),
+        StudyGroupMember(
+            serverID: "M-3",
+            memberID: "M-3",
+            name: "이영희",
+            nickname: "영희",
+            university: "연세대학교",
+            role: .member,
+            bestWorkbookPoint: 30
+        )
+    ]
+
+    static let groups: [StudyGroupInfo] = [
+        StudyGroupInfo(
+            serverID: "G-1",
+            name: "iOS 스터디 A팀",
+            part: .front(type: .ios),
+            createdDate: Date(timeIntervalSince1970: 1_700_000_000),
+            mentors: [mentor],
+            members: members
+        ),
+        StudyGroupInfo(
+            serverID: "G-2",
+            name: "iOS 스터디 B팀",
+            part: .front(type: .ios),
+            createdDate: Date(timeIntervalSince1970: 1_700_100_000),
+            mentors: [mentor],
+            members: Array(members.prefix(1))
+        )
+    ]
+
+    /// 조회 성공(그룹 존재) 페이지.
+    static let loadedPage = StudyGroupDetailsPage(
+        content: groups,
+        hasNext: false,
+        nextCursor: nil
+    )
+
+    /// 조회 성공이지만 그룹이 없는 페이지(빈 상태·권한 안내 재현용).
+    static let emptyPage = StudyGroupDetailsPage(
+        content: [],
+        hasNext: false,
+        nextCursor: nil
+    )
+
+    static let challengers: [ChallengerInfo] = [
+        ChallengerInfo(
+            memberId: "M-2",
+            challengerId: "C-2",
+            gen: "11",
+            name: "박철수",
+            nickname: "철수",
+            schoolName: "한성대학교",
+            profileImage: nil,
+            part: .front(type: .ios)
+        ),
+        ChallengerInfo(
+            memberId: "M-3",
+            challengerId: "C-3",
+            gen: "11",
+            name: "이영희",
+            nickname: "영희",
+            schoolName: "연세대학교",
+            profileImage: nil,
+            part: .front(type: .ios)
+        )
+    ]
+}
+
+// MARK: - Preview Factories
+
+@MainActor
+private func makePreviewViewModel(
+    useCase: PreviewOperatorStudyManagementUseCase,
+    gisuId: String?
+) -> OperatorStudyManagementViewModel {
+    OperatorStudyManagementViewModel(
+        errorHandler: ErrorHandler(),
+        useCase: useCase,
+        gisuIdProvider: { gisuId }
+    )
+}
+
+/// 조회 결과가 샘플 그룹으로 채워지는 프리뷰용 ViewModel.
+@MainActor
+func previewOperatorStudyManagementViewModel(
+    gisuId: String? = "11"
+) -> OperatorStudyManagementViewModel {
+    makePreviewViewModel(
+        useCase: PreviewOperatorStudyManagementUseCase(),
+        gisuId: gisuId
+    )
+}
+
+/// 지정한 조회 결과(빈 목록·조회 실패)로 상태를 재현하는 프리뷰용 ViewModel.
+@MainActor
+func previewOperatorStudyManagementViewModel(
+    outcome: PreviewOperatorStudyManagementUseCase.Outcome,
+    gisuId: String? = "11"
+) -> OperatorStudyManagementViewModel {
+    makePreviewViewModel(
+        useCase: PreviewOperatorStudyManagementUseCase(outcome: outcome),
+        gisuId: gisuId
+    )
+}
+
+/// 편집 시트 프리뷰용 — `editingGroup`·`editingName`을 미리 채운 ViewModel.
+@MainActor
+func previewEditingViewModel() -> OperatorStudyManagementViewModel {
+    let viewModel = previewOperatorStudyManagementViewModel()
+    let group = OperatorStudyPreviewData.groups.first
+    viewModel.editingGroup = group
+    viewModel.editingName = group?.name ?? ""
+    return viewModel
+}
+
+/// 스터디 그룹 생성 권한(교내 회장)을 가진 프리뷰용 세션.
+@MainActor
+func previewCreateCapableSession() -> UserSessionManager {
+    let session = UserSessionManager()
+    session.updateRole(.schoolPresident, allRoles: [.schoolPresident])
+    return session
+}
+
+/// 스터디 그룹 생성 권한이 없는(챌린저) 프리뷰용 세션.
+@MainActor
+func previewChallengerSession() -> UserSessionManager {
+    let session = UserSessionManager()
+    session.updateRole(.challenger, allRoles: [.challenger])
+    return session
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
@@ -94,6 +94,11 @@ final class OperatorStudyManagementViewModel {
         self.gisuIdProvider = gisuIdProvider
     }
 
+    // MARK: - Computed Property
+
+    /// 현재 사용자 기수 ID (서버 응답 `String`). 그룹 생성 화면의 표시·검증용.
+    var currentGisuId: String? { gisuIdProvider() }
+
     // MARK: - Function (조회 / 페이지네이션)
 
     /// 스터디 그룹 관리 탭 진입 시 그룹 목록 및 상세 조회

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyGroupCreateView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyGroupCreateView.swift
@@ -329,3 +329,13 @@ struct OperatorStudyGroupCreateView: View {
         name = String(text.prefix(Constants.groupNameMaxLength))
     }
 }
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("OperatorStudyGroupCreateView") {
+    NavigationStack {
+        OperatorStudyGroupCreateView(viewModel: previewOperatorStudyManagementViewModel())
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyGroupCreateView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyGroupCreateView.swift
@@ -1,0 +1,331 @@
+//
+//  OperatorStudyGroupCreateView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import CoreDesignSystem
+import CoreDomain
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 스터디 그룹 생성 화면
+///
+/// 운영진이 새로운 스터디 그룹을 생성하는 폼 화면입니다.
+/// `navigationDestination`으로 푸시되므로 자체 `NavigationStack` 없음.
+///
+/// - Note: 이식은 완료됐으나 멘토·스터디원 선택이 미이식 상태인 챌린저 검색에 의존해
+///   저장을 완료할 수 없다. 그래서 현재 `OperatorStudyManagementView`의 + 버튼은 이 화면으로
+///   진입하지 않고 "준비 중" 안내만 표시한다(진입점 게이팅). 검색 서브시스템 이식 후
+///   `navigationDestination` 재연결로 활성화한다.
+///   // TODO: 챌린저 검색 이식 후 생성 진입점 재연결 - [26.07.20] 이재원
+struct OperatorStudyGroupCreateView: View {
+
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String = ""
+    @FocusState private var isNameFocused: Bool
+    @State private var selectedPart: UMCPartType?
+    @State private var selectedMentors: [ChallengerInfo] = []
+    @State private var selectedMembers: [ChallengerInfo] = []
+
+    @State private var showMentorSheet = false
+    @State private var showMemberSheet = false
+    @State private var isSaving = false
+
+    private let viewModel: OperatorStudyManagementViewModel
+
+    private var alertPromptBinding: Binding<AlertPrompt?> {
+        Binding(
+            get: { viewModel.alertPrompt },
+            set: { viewModel.alertPrompt = $0 }
+        )
+    }
+
+    init(viewModel: OperatorStudyManagementViewModel) {
+        self.viewModel = viewModel
+    }
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let allParts: [UMCPartType] = UMCPartType.allCases
+        static let participantText: String = "초대받은 스터디원"
+        static let mentorText: String = "담당 파트장(멘토)"
+        static let chevronImage: String = "chevron.right"
+        static let mentorPlaceholderText: String = "담당 파트장(멘토)을 선택하세요 (1명 이상)"
+        static let groupNamePlaceholder: String = "그룹 이름 지정"
+        static let groupNameGuideText: String = "예: React 실습 A팀"
+        static let groupNameMaxLength: Int = 20
+        static let partHeaderText: String = "해당 파트"
+        static let partText: String = "파트"
+        static let partPlaceholderText: String = "파트를 선택하세요"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Form {
+            generationSection
+            nameSection
+            partAndMentorSection
+            memberSection
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .navigationTitle("스터디 그룹 생성")
+        .navigationBarTitleDisplayMode(.inline)
+        .alertPrompt(item: alertPromptBinding)
+        .toolbar {
+            ToolBarCollection.AddBtn(
+                action: { save() },
+                disable: !isValid,
+                isLoading: isSaving,
+                dismissOnTap: false
+            )
+        }
+        .sheet(isPresented: $showMentorSheet) {
+            SelectedChallengerView(challenger: $selectedMentors)
+                .interactiveDismissDisabled()
+        }
+        .sheet(isPresented: $showMemberSheet) {
+            SelectedChallengerView(challenger: $selectedMembers)
+                .interactiveDismissDisabled()
+        }
+    }
+
+    // MARK: - Sections
+
+    private var generationSection: some View {
+        Section {
+            HStack {
+                Text("기수")
+                    .appFont(.subheadline, color: .grey700)
+                Spacer()
+                Text(generationDisplayText)
+                    .appFont(.subheadline, color: .grey900)
+            }
+        }
+    }
+
+    private var nameSection: some View {
+        Section {
+            nameInputSection
+        }
+    }
+
+    private var partAndMentorSection: some View {
+        Section {
+            partSection
+            mentorRow
+        }
+    }
+
+    private var partSection: some View {
+        Picker(selection: $selectedPart) {
+            Text(Constants.partPlaceholderText)
+                .tag(nil as UMCPartType?)
+
+            ForEach(Constants.allParts, id: \.self) { part in
+                Label(part.name, systemImage: part.icon)
+                    .tint(part.color)
+                    .tag(Optional(part))
+            }
+        } label: {
+            Text(Constants.partText)
+                .appFont(.subheadline, color: .grey900)
+        }
+        .pickerStyle(.menu)
+    }
+
+    private var memberSection: some View {
+        Section {
+            memberRow
+        }
+    }
+
+    // MARK: - Rows
+
+    private var mentorRow: some View {
+        selectionButton(
+            title: selectedMentorsText,
+            titleColor: .grey900,
+            countText: selectedMentorsCountText,
+            isPlaceholder: selectedMentors.isEmpty
+        ) {
+            showMentorSheet = true
+        }
+        .accessibilityLabel(Constants.mentorText)
+    }
+
+    private var memberRow: some View {
+        selectionButton(
+            title: Constants.participantText,
+            titleColor: .grey900,
+            countText: selectedMembersCountText
+        ) {
+            showMemberSheet = true
+        }
+    }
+
+    // MARK: - Function
+
+    private var generationDisplayText: String {
+        guard let gisuId = viewModel.currentGisuId,
+              let gisuNumber = Int(gisuId),
+              gisuNumber > 0
+        else { return "정보 없음" }
+        return "\(gisuNumber)기"
+    }
+
+    private var selectedMentorsText: String {
+        if selectedMentors.isEmpty {
+            return Constants.mentorPlaceholderText
+        }
+        if selectedMentors.count == 1, let only = selectedMentors.first {
+            return "\(only.nickname)/\(only.name)"
+        }
+        return Constants.mentorText
+    }
+
+    private var selectedMentorsCountText: String? {
+        selectedMentors.isEmpty ? nil : "\(selectedMentors.count)명"
+    }
+
+    private var selectedMembersCountText: String? {
+        selectedMembers.isEmpty ? nil : "\(selectedMembers.count)명"
+    }
+
+    private var isValid: Bool {
+        !trimmedName.isEmpty
+            && selectedPart != nil
+            && !selectedMentors.isEmpty
+            && !selectedMembers.isEmpty
+            && isGisuValid
+    }
+
+    private var isGisuValid: Bool {
+        guard let gisuId = viewModel.currentGisuId,
+              let gisuNumber = Int(gisuId)
+        else { return false }
+        return gisuNumber > 0
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespaces)
+    }
+
+    private var nameLengthText: String {
+        "\(name.count)/\(Constants.groupNameMaxLength)자"
+    }
+
+    private func save() {
+        guard !isSaving else { return }
+        guard let selectedPart,
+              !selectedMentors.isEmpty,
+              !selectedMembers.isEmpty
+        else { return }
+
+        let nameToSave = trimmedName
+        let partToSave = selectedPart
+        let mentorsToSave = selectedMentors
+        let membersToSave = selectedMembers
+
+        Task { @MainActor in
+            isSaving = true
+            let didSave = await viewModel.createGroup(
+                name: nameToSave,
+                part: partToSave,
+                mentors: mentorsToSave,
+                members: membersToSave
+            )
+            isSaving = false
+
+            if didSave {
+                dismiss()
+            }
+        }
+    }
+
+    private func selectionButton(
+        title: String,
+        titleColor: Color,
+        countText: String? = nil,
+        isPlaceholder: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                    .appFont(
+                        .subheadline,
+                        color: isPlaceholder ? .grey400 : titleColor
+                    )
+                Spacer()
+
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    if let countText {
+                        Text(countText)
+                            .appFont(.callout, color: .grey500)
+                    }
+
+                    Image(systemName: Constants.chevronImage)
+                        .foregroundStyle(Color.grey500)
+                }
+            }
+        }
+    }
+
+    private var nameInputSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            HStack(spacing: DefaultSpacing.spacing8) {
+                nameInputField
+                clearNameButton
+                nameLengthLabel
+            }
+
+            Text(Constants.groupNameGuideText)
+                .appFont(.footnote, color: .grey500)
+        }
+    }
+
+    private var nameInputField: some View {
+        TextField(
+            Constants.groupNamePlaceholder,
+            text: $name
+        )
+        .focused($isNameFocused)
+        .onChange(of: name) { _, newValue in
+            enforceNameMaxLength(newValue)
+        }
+        .submitLabel(.next)
+        .appFont(.subheadline)
+    }
+
+    private var clearNameButton: some View {
+        Group {
+            if !name.isEmpty {
+                Button {
+                    name = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(Color.grey400)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var nameLengthLabel: some View {
+        Text(nameLengthText)
+            .appFont(.footnote, color: .grey500)
+    }
+
+    private func enforceNameMaxLength(_ text: String) {
+        guard text.count > Constants.groupNameMaxLength else { return }
+        name = String(text.prefix(Constants.groupNameMaxLength))
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyManagementView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyManagementView.swift
@@ -342,3 +342,49 @@ struct OperatorStudyManagementView: View {
         }
     }
 }
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("스터디 관리 · 목록") {
+    NavigationStack {
+        OperatorStudyManagementView(
+            viewModel: previewOperatorStudyManagementViewModel(),
+            userSession: previewCreateCapableSession()
+        )
+    }
+}
+
+#Preview("스터디 관리 · 빈 목록") {
+    NavigationStack {
+        OperatorStudyManagementView(
+            viewModel: previewOperatorStudyManagementViewModel(
+                outcome: .page(OperatorStudyPreviewData.emptyPage)
+            ),
+            userSession: previewCreateCapableSession()
+        )
+    }
+}
+
+#Preview("스터디 관리 · 권한 없음") {
+    NavigationStack {
+        OperatorStudyManagementView(
+            viewModel: previewOperatorStudyManagementViewModel(
+                outcome: .page(OperatorStudyPreviewData.emptyPage)
+            ),
+            userSession: previewChallengerSession()
+        )
+    }
+}
+
+#Preview("스터디 관리 · 에러") {
+    NavigationStack {
+        OperatorStudyManagementView(
+            viewModel: previewOperatorStudyManagementViewModel(
+                outcome: .failure(PreviewSampleError.failed)
+            ),
+            userSession: previewCreateCapableSession()
+        )
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyManagementView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyManagementView.swift
@@ -1,0 +1,344 @@
+//
+//  OperatorStudyManagementView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/15/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreDomain
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// Admin 모드의 스터디 관리 섹션
+///
+/// 운영진이 스터디와 활동을 관리하는 화면입니다.
+/// ViewModel 과 세션은 상위(라우터/루트 화면)에서 주입받습니다.
+struct OperatorStudyManagementView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: OperatorStudyManagementViewModel
+
+    private let userSession: UserSessionManager
+
+    /// 스터디 그룹 생성 미결선 안내 표시 여부
+    ///
+    /// 생성 폼(`OperatorStudyGroupCreateView`)은 이식 완료됐으나, 멘토·스터디원 선택이
+    /// 미이식 상태인 챌린저 검색에 의존해 저장을 완료할 수 없다. 검색 서브시스템 이식 전까지
+    /// 진입점(+ 버튼)을 게이팅하고 안내만 표시한다. 이식 후 생성 폼 네비게이션을 복원한다.
+    @State private var showCreateUnavailable = false
+
+    /// 일정 등록 미결선 안내 표시 여부
+    ///
+    /// 레거시는 전역 라우트(`pathStore.activityPath`)로 일정 등록 화면을 push 했으나,
+    /// Activity 라우트 허브와 일정 등록 View 가 아직 미이식이라 네비게이션을 보류한다.
+    @State private var showScheduleUnavailable = false
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - viewModel: 운영진 스터디 관리 ViewModel
+    ///   - userSession: 앱 전역 세션(스터디 그룹 생성 권한 확인용)
+    init(
+        viewModel: OperatorStudyManagementViewModel,
+        userSession: UserSessionManager
+    ) {
+        _viewModel = State(wrappedValue: viewModel)
+        self.userSession = userSession
+    }
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let permissionTitle: String = "스터디 그룹 관리"
+        static let permissionDescription: String = "등록된 스터디 그룹이 없습니다\n스터디 그룹 생성에는 별도 권한이 필요해요"
+        static let permissionGuideTitle: String = "스터디 관리가 가능한 역할"
+        static let roleChapterLeader: String = "지부장"
+        static let rolePresident: String = "회장 / 부회장"
+        static let roleOperator: String = "운영진"
+        static let roleChapterLeaderDescription: String = "지부 내 전체 학교의 스터디를 관리할 수 있어요"
+        static let rolePresidentDescription: String = "소속 학교의 스터디 그룹을 생성·관리할 수 있어요"
+        static let roleOperatorDescription: String = "담당 파트의 스터디를 조회할 수 있어요"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        groupManagementContentView
+            .task {
+                await viewModel.fetchGroupManagementData()
+            }
+            .toolbar {
+                if canCreateStudyGroup {
+                    ToolBarCollection.AddBtn(action: {
+                        showCreateUnavailable = true
+                    })
+                }
+            }
+            .sheet(
+                item: $viewModel.addMemberGroup,
+                onDismiss: {
+                    Task {
+                        await viewModel.applySelectedChallengers()
+                    }
+                }
+            ) { _ in
+                SelectedChallengerView(
+                    challenger: $viewModel.selectedChallengers
+                )
+            }
+            .sheet(item: $viewModel.editingGroup) { _ in
+                OperatorStudyGroupEditSheet(viewModel: viewModel)
+            }
+            .sheet(
+                item: $viewModel.addMentorGroup,
+                onDismiss: {
+                    Task {
+                        await viewModel.applySelectedMentors()
+                    }
+                }
+            ) { _ in
+                SelectedChallengerView(
+                    challenger: $viewModel.selectedMentors
+                )
+            }
+            .alertPrompt(item: $viewModel.alertPrompt)
+            .alert("준비 중", isPresented: $showCreateUnavailable) {
+                Button("확인", role: .cancel) {}
+            } message: {
+                Text("스터디 그룹 생성은 챌린저 검색 이식 후 연결됩니다.")
+            }
+            .alert("준비 중", isPresented: $showScheduleUnavailable) {
+                Button("확인", role: .cancel) {}
+            } message: {
+                Text("일정 등록 화면은 Activity 라우터 이식 후 연결됩니다.")
+            }
+    }
+
+    // MARK: - Function
+
+    /// 스터디 그룹 생성 권한 확인 (보유 역할 중 회장/부회장 포함 여부)
+    private var canCreateStudyGroup: Bool {
+        userSession.hasAnyRole(where: { $0.canCreateStudyGroup })
+    }
+
+    // MARK: - Group Management View
+
+    @ViewBuilder
+    private var groupManagementContentView: some View {
+        switch viewModel.studyGroupDetailsState {
+        case .idle, .loading:
+            loadingView(message: "스터디 그룹 관리 불러오는 중...")
+
+        case .loaded:
+            if viewModel.studyGroupDetails.isEmpty {
+                groupManagementEmptyView
+            } else {
+                groupManagementListView(groups: viewModel.studyGroupDetails)
+            }
+
+        case .failed(let error):
+            errorView(error: error) {
+                await viewModel.fetchGroupManagementData()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var groupManagementEmptyView: some View {
+        if canCreateStudyGroup {
+            ContentUnavailableView {
+                Label("등록된 스터디 그룹이 없어요", systemImage: "person.3")
+            } description: {
+                Text("스터디 그룹 생성 기능을 준비하고 있어요.\n곧 이곳에서 스터디원과 멘토를 배정할 수 있어요.")
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        } else {
+            permissionDeniedView
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        }
+    }
+
+    private func groupManagementListView(groups: [StudyGroupInfo]) -> some View {
+        ScrollView {
+            // Apple iOS 26 가이드: 같은 화면에 Liquid Glass가 여러 개 있을 때
+            // GlassEffectContainer 로 묶어 카드 사이 morphing/blending + 렌더링 성능 ↑
+            GlassEffectContainer(spacing: DefaultSpacing.spacing16) {
+                LazyVStack(spacing: DefaultSpacing.spacing16) {
+                    ForEach(groups) { group in
+                        StudyGroupCard(
+                            detail: group,
+                            onEdit: {
+                                viewModel.showEditSheet(for: group)
+                            },
+                            onDelete: {
+                                Task { await viewModel.deleteGroup(group) }
+                            },
+                            onAddMember: {
+                                viewModel.showAddMemberSheet(for: group)
+                            },
+                            onAddMentor: {
+                                viewModel.showAddMentorSheet(for: group)
+                            },
+                            onSchedule: {
+                                // 일정 등록 화면·라우트 미이식 → 진입은 보류하고 안내만 표시한다.
+                                showScheduleUnavailable = true
+                            },
+                            onRemoveMember: { member in
+                                Task {
+                                    await viewModel.removeMember(member, from: group)
+                                }
+                            },
+                            onRemoveMentor: { mentor in
+                                Task {
+                                    await viewModel.removeMentor(mentor, from: group)
+                                }
+                            }
+                        )
+                        .equatable()
+                        .task {
+                            await viewModel.loadMoreGroupManagementDataIfNeeded(
+                                currentGroupID: group.id
+                            )
+                        }
+                    }
+
+                    if viewModel.isLoadingMoreStudyGroupDetails {
+                        ProgressView()
+                            .tint(Color.grey500)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, DefaultSpacing.spacing8)
+                    }
+                }
+            }
+            .safeAreaPadding(
+                .horizontal,
+                DefaultConstant.defaultSafeBtnPadding
+            )
+        }
+        .contentMargins(
+            .bottom,
+            DefaultConstant.defaultContentBottomMargins,
+            for: .scrollContent
+        )
+    }
+
+    // MARK: - Loading View
+
+    private func loadingView(message: String) -> some View {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            ProgressView()
+                .controlSize(.large)
+                .tint(Color.grey500)
+
+            Text(message)
+                .appFont(.subheadline, color: .grey500)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    // MARK: - Permission Denied View
+
+    private var permissionDeniedView: some View {
+        ScrollView {
+            VStack(spacing: DefaultSpacing.spacing32) {
+                ContentUnavailableView {
+                    Label(Constants.permissionTitle, systemImage: "person.3")
+                } description: {
+                    Text(Constants.permissionDescription)
+                        .multilineTextAlignment(.center)
+                }
+
+                VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+                    Text(Constants.permissionGuideTitle)
+                        .appFont(.callout, weight: .semibold)
+
+                    permissionRoleRow(
+                        icon: "building.columns.fill",
+                        role: Constants.roleChapterLeader,
+                        description: Constants.roleChapterLeaderDescription
+                    )
+
+                    permissionRoleRow(
+                        icon: "star.fill",
+                        role: Constants.rolePresident,
+                        description: Constants.rolePresidentDescription
+                    )
+
+                    permissionRoleRow(
+                        icon: "person.badge.key.fill",
+                        role: Constants.roleOperator,
+                        description: Constants.roleOperatorDescription
+                    )
+                }
+                .padding(DefaultSpacing.spacing16)
+                .background(
+                    .regularMaterial,
+                    in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius)
+                )
+            }
+            .padding(.top, DefaultSpacing.spacing32)
+        }
+    }
+
+    private func permissionRoleRow(
+        icon: String,
+        role: String,
+        description: String
+    ) -> some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            Image(systemName: icon)
+                .font(.app(.title3))
+                .foregroundStyle(Color.grey600)
+                .frame(width: 32, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(role)
+                    .appFont(.subheadline)
+                Text(description)
+                    .appFont(.footnote)
+                    .foregroundStyle(Color.grey500)
+            }
+        }
+    }
+
+    // MARK: - Error View
+
+    /// 로딩 실패 처리.
+    ///
+    /// 레거시는 `AppError.isPermissionDenied`(403)로 권한 안내 분기를 판단했으나 이식된
+    /// `AppError` 에는 해당 프로퍼티가 없다. 권한 안내의 의도(생성 권한 없는 사용자에게 역할
+    /// 가이드 노출)를 세션 권한(`canCreateStudyGroup`)으로 대신 판단한다.
+    @ViewBuilder
+    private func errorView(
+        error: AppError,
+        retryAction: @escaping () async -> Void
+    ) -> some View {
+        if !canCreateStudyGroup {
+            permissionDeniedView
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        } else {
+            RetryContentUnavailableView(
+                title: "불러오지 못했어요",
+                systemImage: "exclamationmark.triangle",
+                description: error.userMessage,
+                isRetrying: false,
+                topPadding: DefaultSpacing.spacing32
+            ) {
+                await retryAction()
+            }
+            .safeAreaPadding(
+                .horizontal,
+                DefaultConstant.defaultSafeHorizon
+            )
+        }
+    }
+}


### PR DESCRIPTION
resolves #894

## ✨ PR 유형

♻️ [Refactor] — 레거시 `AppProduct/` → `UMCApp/`(Tuist) 이식

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="980" alt="스크린샷 2026-07-25 오후 5 05 37" src="https://github.com/user-attachments/assets/5da25007-8fdd-4878-baf2-d99712a0633c" />
<img width="1512" height="980" alt="스크린샷 2026-07-25 오후 5 06 00" src="https://github.com/user-attachments/assets/d7426bae-64d6-4a28-9b16-d85408591661" />




## 🛠️ 작업내용

운영진 스터디 관리 화면과 스터디 그룹 카드/시트 컴포넌트를 Tuist 모듈로 이식했습니다. (Liquid Glass)

- **Core/UIComponents**: `InfoBadge` · `FlowLayout` 추가
- **Study 컴포넌트**: `StudyGroupCard` · `StudyGroupMemberChip` · `StudyGroupLeaderRow` · `OperatorStudyGroupEditSheet`
- **Operator View**: `OperatorStudyManagementView` · `OperatorStudyGroupCreateView`
- **Challenger**: `SelectedChallengerView`
- `OperatorStudyManagementViewModel`에 `currentGisuId` 조회 프로퍼티 추가

## 📋 추후 진행 상황

- 챌린저 검색 이식 → 그룹 생성 진입점(현재 "준비 중" 게이팅) 재연결
- 일정 등록 화면·Activity 라우트 허브 이식 → 일정 등록 진입 연결
- `NoticePresentation` 로컬 `FlowLayout`을 이번 canonical로 통합

## 📌 리뷰 포인트

- **미이식 의존 게이팅** — 생성 폼은 이식됐지만 멘토·스터디원 선택이 미이식 챌린저 검색에 의존. 저장 불가한 dead-end 대신 + 버튼을 "준비 중" 안내로 게이팅(일정 등록도 동일).
- **Glass-on-Glass 회피** — `StudyGroupMemberChip`은 카드 glass + `.regularMaterial` 위라, glass 대신 `StudyGroupLeaderRow`와 동일한 `LinearGradient` + shadow 표면 사용.
- **`FlowLayout` 임시 중복** — canonical을 `Core/UIComponents`에 추가, `NoticePresentation` 로컬본은 범위 밖이라 유지(통합 TODO).
- `Features/Activity/Presentation/{Views,ViewModels}/` — UI·상태 관리, `Core/UIComponents/` — 공통 컴포넌트 영향도.

`make build SCHEME=ActivityPresentation` 성공, ActivityPresentation 테스트 118 케이스 통과.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
