### PR TITLE
♻️ [Refactor] 온보딩 시네마틱(Metal 셰이더) 인트로 애니메이션 AppProduct → UMCApp 이관 (#1009)

### DIFF
--- a/UMCApp/Core/UIComponents/Sources/ChromaticLens/ChromaticLens.swift
+++ b/UMCApp/Core/UIComponents/Sources/ChromaticLens/ChromaticLens.swift
@@ -1,0 +1,265 @@
+//
+//  ChromaticLens.swift
+//  CoreUIComponents
+//
+//  Created by euijjang97 on 7/27/26.
+//
+//  Apple `.glassEffect(.clear.interactive())` 가 노출하지 않는 굴절·색분산 강도를
+//  디자이너가 직접 조정할 수 있게 해주는 재사용 ViewModifier.
+//
+//  내부적으로 `chromaticLens` Metal shader 를 `.layerEffect` 로 합성한다. 원형 lens 안쪽으로
+//  sample 위치를 중심 쪽으로 당겨 굴절 magnification 을 만들고, R/G/B 채널마다 magnification
+//  강도를 조금씩 달리해서 "굴곡질 때 무지개" — chromatic dispersion fringe — 가 자연스럽게
+//  드러난다.
+//
+//  > Important: 셰이더 소스는 **앱 타겟**(`UMCApp/Sources/Shaders/ChromaticLens.metal`)이
+//  > 소유한다. `ShaderLibrary.chromaticLens` 는 메인 번들의 default shader library 에서 함수를
+//  > 찾는데, Core 모듈(staticFramework)에 .metal 을 두면 metallib 이 앱 번들에 실리지 않기
+//  > 때문이다. 같은 이유로 앱 실행 없이 이 모듈 단독 #Preview 에서는 lens 효과가 렌더되지
+//  > 않을 수 있다.
+//
+//  ## Usage
+//
+//  **인터랙티브 lens (권장)** — 손가락 위치에 lens 가 따라오고 떼면 사라진다.
+//  "효과를 내가 만들어낸다" 는 인지를 주기 위해 자동 재생보다 선호된다.
+//
+//  ```swift
+//  Logo()
+//      .chromaticLensInteractive(radius: 120)
+//  ```
+//
+//  **정적 lens** — 고정된 위치에 항상 효과. 데코레이션 용도.
+//
+//  ```swift
+//  Image("logoLight", bundle: .module)
+//      .resizable()
+//      .aspectRatio(contentMode: .fit)
+//      .frame(width: 160)
+//      .chromaticLens(radius: 70)
+//  ```
+//
+//  ## 파라미터 가이드
+//
+//  - `radius`: lens 영역 반경(px). 작을수록 점 위에 작은 보석 박힌 느낌, 클수록 화면 절반을 덮는 거대 굴절.
+//  - `refractionStrength`: 중심 magnification 강도. 클수록 안쪽이 더 크게 부풀어 보임.
+//  - `dispersionStrength`: R/G/B 채널 분리 강도. 클수록 가장자리 무지개 fringe 강해짐.
+//  - `edgeHighlight`: 유리 rim ring 강조. 0 이면 ring 사라짐.
+//
+
+import SwiftUI
+
+/// Lens 중심 좌표를 UnitPoint(0~1) 로 받아 화면 절대 좌표로 변환하고 shader uniform 으로 넘기는
+/// 재사용 ViewModifier. 호출부는 절대 좌표 계산을 신경 쓰지 않아도 된다.
+private struct ChromaticLensModifier: ViewModifier {
+
+    // MARK: - Property
+
+    let center: UnitPoint
+    let radius: CGFloat
+    let refractionStrength: CGFloat
+    let dispersionStrength: CGFloat
+    let edgeHighlight: CGFloat
+    let iridescenceStrength: CGFloat
+    /// 경과 초. 0 이면 셰이더의 흐르는 빛(무지개 흐름/글림/호흡)이 비활성 — 정적 lens 는 0 고정.
+    let time: Double
+
+    @State private var contentSize: CGSize = .zero
+
+    // MARK: - Body
+
+    func body(content: Content) -> some View {
+        content
+            .onGeometryChange(for: CGSize.self) { proxy in
+                proxy.size
+            } action: { newSize in
+                contentSize = newSize
+            }
+            .layerEffect(
+                ShaderLibrary.chromaticLens(
+                    .float2(
+                        Float(contentSize.width * center.x),
+                        Float(contentSize.height * center.y)
+                    ),
+                    .float(Float(radius)),
+                    .float(Float(refractionStrength)),
+                    .float(Float(dispersionStrength)),
+                    .float(Float(edgeHighlight)),
+                    .float(Float(iridescenceStrength)),
+                    .float(Float(time))
+                ),
+                maxSampleOffset: CGSize(width: radius, height: radius),
+                // radius 가 시각적으로 의미 없는 크기(5px 미만) 면 layerEffect 자체를 비활성화한다.
+                // `SpringKeyframe(bounce: 0)` 의 critically damped 시뮬레이션이 정확히 0 으로
+                // 수렴하지 못하고 작은 잔여 radius (예: 0.5~3.0px) 에서 멈추는 numerical residue
+                // 때문에, layerEffect 가 켜져있는 한 정중앙 몇 픽셀에 lens (작은 굴절 + iridescence)
+                // 가 영구히 보이는 artifact 가 발생한다. isEnabled=false 면 layer 가 통째로
+                // bypass 되어 view 가 원본 그대로 통과 — raster cache 도 안 만들어진다.
+                isEnabled: radius >= 5.0
+            )
+    }
+}
+
+// MARK: - Interactive Modifier
+
+/// 손가락 위치를 따라 lens 가 이동하고, 떼면 부드럽게 사라지는 인터랙티브 ViewModifier.
+///
+/// 사용자가 "효과를 직접 만들어낸다" 는 인지를 주기 위한 변종. 자동 재생 대비 학습 비용이 들지만,
+/// 한 번 발견하면 인터랙션 자체가 재미 요소가 된다.
+///
+/// 내부 동작
+/// - `contentShape(.rect)` 으로 투명 영역 포함 전체 bounds 가 hit-test 대상.
+/// - `DragGesture(minimumDistance: 0)` — 탭만 해도 즉시 trigger.
+/// - 터치 시작: `displayRadius` 0 → `maxRadius` 로 ease-out 애니메이션 (lens 가 피어나는 느낌).
+/// - 터치 종료: `displayRadius` → 0 으로 ease-out (lens 가 잦아드는 느낌).
+/// - `displayRadius = 0` 이면 shader 가 모든 픽셀에 대해 `dist > radius` 분기를 타 그대로 통과.
+private struct ChromaticLensInteractiveModifier: ViewModifier {
+
+    // MARK: - Property
+
+    let maxRadius: CGFloat
+    let refractionStrength: CGFloat
+    let dispersionStrength: CGFloat
+    let edgeHighlight: CGFloat
+    let iridescenceStrength: CGFloat
+
+    /// 현재 손가락 위치(view-local). 시작값은 화면 밖이라 lens 가 보이지 않음.
+    @State private var touchLocation: CGPoint = .init(x: -10_000, y: -10_000)
+    /// shader 로 넘기는 현재 반경. 0 → maxRadius 사이를 애니메이션.
+    @State private var displayRadius: CGFloat = 0
+
+    // MARK: - Body
+
+    func body(content: Content) -> some View {
+        content
+            .contentShape(.rect)
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        touchLocation = value.location
+                        if displayRadius != maxRadius {
+                            withAnimation(.easeOut(duration: 0.22)) {
+                                displayRadius = maxRadius
+                            }
+                        }
+                    }
+                    .onEnded { _ in
+                        withAnimation(.easeOut(duration: 0.32)) {
+                            displayRadius = 0
+                        }
+                    }
+            )
+            .layerEffect(
+                ShaderLibrary.chromaticLens(
+                    .float2(Float(touchLocation.x), Float(touchLocation.y)),
+                    .float(Float(displayRadius)),
+                    .float(Float(refractionStrength)),
+                    .float(Float(dispersionStrength)),
+                    .float(Float(edgeHighlight)),
+                    .float(Float(iridescenceStrength)),
+                    .float(0)  // time=0 — 인터랙티브 lens 는 흐르는 빛 모션 미사용
+                ),
+                maxSampleOffset: CGSize(width: maxRadius, height: maxRadius)
+            )
+    }
+}
+
+// MARK: - View Extension
+
+extension View {
+
+    /// View 에 chromatic dispersion lens 효과를 입힌다 (정적 위치).
+    ///
+    /// 원형 lens 안쪽에서 sample 위치가 중심 쪽으로 당겨져 굴절 magnification 이 발생하고,
+    /// R/G/B 채널이 분리되며 가장자리에 무지개 fringe 가 나타난다.
+    ///
+    /// - Parameters:
+    ///   - center: Lens 중심의 상대 좌표(0~1). 기본 `.center`.
+    ///   - radius: Lens 영역 반경(px).
+    ///   - refractionStrength: 중심 magnification 강도. 기본 52.
+    ///   - dispersionStrength: R/G/B 색분산 강도. 기본 60 — 굴곡질 때 무지개가 또렷이 보이는 값.
+    ///   - edgeHighlight: 유리 rim ring 강조. 기본 0.35.
+    ///   - iridescenceStrength: lens 안쪽 무지개 광택 강도(0~1). 기본 0.55.
+    ///     배경이 단조로워(흰색 등) chromatic dispersion 만으로는 무지개가 잘 안 드러날 때
+    ///     이 값을 키워 비누거품·진주 같은 holographic 광택을 추가한다.
+    ///   - time: 경과 초. 0(기본)이면 흐르는 빛(무지개 흐름/이동 글림/미세 호흡)이 비활성.
+    ///     `RefractiveCinematic` 이 시간 클럭을 주입해 시네마틱에서 빛을 살아 움직이게 한다.
+    public func chromaticLens(
+        center: UnitPoint = .center,
+        radius: CGFloat,
+        refractionStrength: CGFloat = 52,
+        dispersionStrength: CGFloat = 60,
+        edgeHighlight: CGFloat = 0.35,
+        iridescenceStrength: CGFloat = 0.55,
+        time: Double = 0
+    ) -> some View {
+        modifier(
+            ChromaticLensModifier(
+                center: center,
+                radius: radius,
+                refractionStrength: refractionStrength,
+                dispersionStrength: dispersionStrength,
+                edgeHighlight: edgeHighlight,
+                iridescenceStrength: iridescenceStrength,
+                time: time
+            )
+        )
+    }
+
+    /// View 에 손가락을 따라가는 인터랙티브 chromaticLens 효과를 입힌다.
+    ///
+    /// 사용자가 탭/드래그하면 그 위치에 lens 가 피어나고, 손을 떼면 부드럽게 사라진다.
+    /// 자동 재생 대신 인터랙션으로 발견하게 만들어 효과에 대한 인지·재미를 강화하는 용도.
+    ///
+    /// > Note: 내부에서 `DragGesture(minimumDistance: 0)` 를 사용하므로 호출 대상 view 안쪽에
+    /// > 다른 tap 인터랙션(Button 등) 이 있으면 충돌할 수 있다. **버튼이 포함되지 않은 영역**
+    /// > (로고, 일러스트 등) 에만 적용하는 것을 권장.
+    ///
+    /// - Parameters:
+    ///   - radius: 활성 시 lens 의 최대 반경(px). 작을수록 정밀한 보석 느낌, 클수록 광활한 굴절.
+    ///   - refractionStrength: 중심 magnification 강도. 기본 52.
+    ///   - dispersionStrength: R/G/B 색분산 강도. 기본 60.
+    ///   - edgeHighlight: 유리 rim ring 강조. 기본 0.35.
+    ///   - iridescenceStrength: lens 안쪽 무지개 광택 강도(0~1). 기본 0.55.
+    public func chromaticLensInteractive(
+        radius: CGFloat,
+        refractionStrength: CGFloat = 52,
+        dispersionStrength: CGFloat = 60,
+        edgeHighlight: CGFloat = 0.35,
+        iridescenceStrength: CGFloat = 0.55
+    ) -> some View {
+        modifier(
+            ChromaticLensInteractiveModifier(
+                maxRadius: radius,
+                refractionStrength: refractionStrength,
+                dispersionStrength: dispersionStrength,
+                edgeHighlight: edgeHighlight,
+                iridescenceStrength: iridescenceStrength
+            )
+        )
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+// 셰이더가 앱 번들 metallib 에 있으므로, 모듈 단독 프리뷰에서는 lens 효과가 보이지 않을 수 있다.
+#Preview("인터랙티브 lens — 드래그하여 탐색") {
+    VStack(spacing: 24) {
+        Image(systemName: "sparkles")
+            .font(.system(size: 96))
+            .foregroundStyle(.indigo)
+        Text("화면을 드래그해 보세요")
+            .font(.headline)
+            .foregroundStyle(.indigo)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .chromaticLensInteractive(radius: 140)
+}
+
+#Preview("정적 lens") {
+    Image(systemName: "drop.fill")
+        .font(.system(size: 120))
+        .foregroundStyle(.indigo)
+        .chromaticLens(radius: 70)
+}
+#endif

--- a/UMCApp/Core/UIComponents/Sources/ChromaticLens/RefractiveCinematic.swift
+++ b/UMCApp/Core/UIComponents/Sources/ChromaticLens/RefractiveCinematic.swift
@@ -1,0 +1,272 @@
+//
+//  RefractiveCinematic.swift
+//  CoreUIComponents
+//
+//  Created by euijjang97 on 7/27/26.
+//
+//  부트스트랩 진입 시 한 번 자동 재생되는 chromaticLens 시네마틱.
+//
+//  사용자가 먼저 로고를 인지한 뒤 (preDelay) 화면 중앙에서 lens 가 자동으로 피어났다 (bloom)
+//  → 즉시 다시 중앙으로 잦아드는 (collapse) 3-phase 시퀀스. dwell(정지) 단계 없이 한 연속
+//  keyframe timeline 으로 처리해 "정점에서 멈춘 듯한" 느낌을 제거한다. 굴곡(refraction) 과
+//  무지개(dispersion + iridescence) 강도를 기본 `chromaticLens()` 보다 강하게 잡아 시네마틱
+//  느낌을 강조한다.
+//
+//  여기에 더해 `TimelineView(.animation)` 으로 경과 시간을 셰이더에 주입해 무지개 흐름 +
+//  이동 specular glint + 광택 미세 호흡(="살아있는 빛")을 더한다. 시간 클럭은 radius keyframe
+//  과 독립적이며, 시네마틱이 끝나면 정지(`paused`)해 로그인 화면에서 GPU 비용을 0 으로
+//  되돌린다. Reduce Motion 이 켜지면 흐르는 빛은 비활성화되고 굴절 bloom/collapse 만 재생된다.
+//
+//  ## Usage
+//
+//  ```swift
+//  AuthLogoBlock()
+//      .refractiveCinematic(maxRadius: 280)
+//  ```
+//
+//  ## Timeline (총 2.3초)
+//
+//  - **preDelay** (0.0s → 0.4s): 정적 로고. 사용자가 UMC 로고를 인지할 시간.
+//  - **bloom**    (0.4s → 1.4s): radius 0 → maxRadius. 로고 위에서 lens 가 굴절하며 피어남.
+//  - **collapse** (1.4s → 2.3s): radius maxRadius → 0. bloom 의 종료 속도(0이 아님)에서 자연
+//    스럽게 이어받아 가운데로 모임. dwell(정지) 단계 없음.
+//
+//  > 워터마크 reveal (preDelay 동안 흐릿한 로고 → bloom 동안 선명) 컨셉은 `revealStartOpacity`
+//  > 파라미터로 옵트인 가능하다 (기본값 1.0 = 비활성화). 기본 동작은 로고가 처음부터 선명하게
+//  > 보이고 lens 만 굴절·반환된다.
+//
+//  `radius == 0` 상태에선 shader 가 모든 픽셀을 그대로 통과시켜 GPU 비용 0. preDelay 구간은
+//  정적 로고가 그대로 보인다. 한 `keyframeAnimator` timeline 으로 처리하므로 bloom→collapse
+//  사이에 별도 정지 구간이 생기지 않는다 (분리된 `withAnimation` 호출은 사이에 속도 0 인
+//  순간이 생겨 사용자에게 "멈춤" 으로 인지됨).
+//
+
+import SwiftUI
+
+/// 시네마틱 한 프레임의 애니메이션 상태.
+///
+/// `radius`(렌즈 반경)와 `logoOpacity`(reveal 투명도)를 하나의 `keyframeAnimator` 의 두
+/// `KeyframeTrack` 으로 함께 보간한다. 렌즈가 커지는 동안 로고가 흐릿한 워터마크에서 선명하게
+/// 차올라, 렌즈가 전환을 가린 채 reveal 되는 연출을 만든다.
+private struct CinematicState {
+    var radius: CGFloat
+    var logoOpacity: Double
+}
+
+/// 자동 재생 chromaticLens 시네마틱 ViewModifier.
+///
+/// 정적 로고(preDelay) → bloom → collapse 3-phase 시퀀스를 한 번 재생한다.
+/// preDelay 구간은 lens 가 비활성(radius=0) 이므로 호출 대상 view 의 원본 모습이 그대로
+/// 보인다 — LoginView 등 동일한 layout 의 화면으로 매끄럽게 연결되는 buffer 역할.
+private struct RefractiveCinematicModifier: ViewModifier {
+
+    // MARK: - Property
+
+    let center: UnitPoint
+    let maxRadius: CGFloat
+    let refractionStrength: CGFloat
+    let dispersionStrength: CGFloat
+    let edgeHighlight: CGFloat
+    let iridescenceStrength: CGFloat
+    let preDelay: TimeInterval
+    let bloomDuration: TimeInterval
+    let collapseDuration: TimeInterval
+    /// 시네마틱 시작 시 로고 투명도(0~1). 기본 1.0 = 처음부터 선명 (워터마크 reveal 비활성).
+    /// 0.18 등 낮은 값을 주면 흐릿한 워터마크 → bloom 동안 1.0 으로 차오르는 reveal 컨셉이
+    /// 되살아난다. preDelay → bloom → collapse 트랙으로 보간되며 collapse 후 1.0 유지.
+    let revealStartOpacity: Double
+
+    /// keyframeAnimator 트리거. mount 직후 한 번만 토글되어 시퀀스를 1회 재생한다.
+    ///
+    /// `.task` 가 view body re-evaluation(예: 인증 검사 완료로 인한 ViewModel 상태 변화)
+    /// 마다 다시 호출되더라도, `hasStarted` 가드로 trigger 가 추가로 토글되는 것을 막아
+    /// keyframe 이 재시작되며 lens 가 두 번 bloom 하는 현상을 방지한다.
+    @State private var trigger: Bool = false
+    @State private var hasStarted: Bool = false
+    /// 흐르는 빛 시간 클럭의 기준점. 시네마틱 시작 시 갱신한다.
+    @State private var startDate: Date = .now
+    /// 흐르는 빛 시간 클럭 on/off. 시네마틱 동안만 true → 종료 후 TimelineView 정지(perf 0).
+    @State private var isLightActive: Bool = false
+
+    /// 접근성 — Reduce Motion 시 흐르는 빛을 비활성(굴절 bloom/collapse 는 유지)한다.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    // MARK: - Body
+
+    func body(content: Content) -> some View {
+        // TimelineView 가 매 프레임 경과 시간을 셰이더에 공급해 흐르는 빛을 구동한다.
+        // radius 는 keyframeAnimator 가, time 은 이 시간 클럭이 — 서로 독립적으로 흐른다.
+        // `paused: !isLightActive` 로 시네마틱 종료 후 tick 을 멈춰 GPU 비용을 0 으로 되돌린다.
+        TimelineView(.animation(paused: !isLightActive)) { timeline in
+            cinematicLens(content, now: timeline.date)
+        }
+        .task {
+            // .task 는 view re-evaluation 마다 재호출될 수 있으므로 한 번만 발동.
+            guard !hasStarted else { return }
+            hasStarted = true
+            startDate = .now
+
+            // Reduce Motion 이면 시간 클럭을 켜지 않아 흐르는 빛이 비활성(굴절 bloom 만 재생).
+            guard !reduceMotion else {
+                trigger.toggle()
+                return
+            }
+
+            isLightActive = true
+            trigger.toggle()
+
+            // 시네마틱 총 길이 후 시간 클럭 정지 → morph 된 로그인 화면에서 GPU 비용 0.
+            let total = preDelay + bloomDuration + collapseDuration
+            try? await Task.sleep(for: .seconds(total))
+            isLightActive = false
+        }
+    }
+
+    // MARK: - Function
+
+    /// 경과 시간(`now − startDate`)을 셰이더의 `time` 으로 주입한 chromaticLens 시네마틱 본체.
+    ///
+    /// `body` 의 `TimelineView` 클로저를 **단일 표현식**으로 유지하기 위해 분리한다 —
+    /// keyframeAnimator + ternary + `MainActor.assumeIsolated` 가 한 클로저에 모이면
+    /// 타입체커가 `TimelineView` 의 `Content` 제네릭을 추론하지 못한다.
+    private func cinematicLens(_ content: Content, now: Date) -> some View {
+        // 시간 클럭이 꺼져 있으면 0 → 셰이더의 흐르는 빛 정지 (정적 호출부와 동일 경로).
+        let elapsed: Double = isLightActive ? now.timeIntervalSince(startDate) : 0
+
+        return content
+            .keyframeAnimator(
+                initialValue: CinematicState(radius: 0, logoOpacity: revealStartOpacity),
+                trigger: trigger,
+                content: { view, state in
+                    // SpringKeyframe(bounce: 0) 의 collapse 종료 시 발생하는 numerical residue
+                    // (정확히 0 으로 수렴 못 하고 작은 잔여값 — 측정상 0.5~3.0px — 이 남는 현상)
+                    // 가 정중앙 몇 픽셀에 작은 lens 를 영구히 남기는 artifact 를 만든다.
+                    // 5px 미만은 0 으로 clamp 해 lens 가 완전히 사라지도록 보장한다.
+                    // ChromaticLens 의 `.layerEffect(isEnabled: radius >= 5.0)` 가드와 같은
+                    // 임계값으로 묶어, layer 자체가 bypass 되어 raster cache 도 안 만들어진다.
+                    let clampedRadius: CGFloat = state.radius < 5.0 ? 0 : state.radius
+
+                    // keyframeAnimator 의 content closure 는 `@Sendable` (non-isolated) 시그니처라
+                    // `@MainActor` 격리된 `chromaticLens(...)` 을 직접 호출하면 Swift 6 isolation
+                    // 경고가 난다. SwiftUI body 평가는 런타임상 항상 MainActor 에서 일어나므로
+                    // `MainActor.assumeIsolated` 로 안전하게 격리 경계를 표명하고 호출한다.
+                    MainActor.assumeIsolated {
+                        view
+                            // 워터마크 reveal 옵트인 컨셉 — 기본값(1.0) 이면 opacity 변화 없이
+                            // 통과되어 로고가 처음부터 선명. 낮은 startOpacity 를 주면 흐릿한
+                            // 워터마크 → 선명한 reveal 로 차오른다.
+                            .opacity(state.logoOpacity)
+                            .chromaticLens(
+                                center: center,
+                                radius: clampedRadius,
+                                refractionStrength: refractionStrength,
+                                dispersionStrength: dispersionStrength,
+                                edgeHighlight: edgeHighlight,
+                                iridescenceStrength: iridescenceStrength,
+                                time: elapsed
+                            )
+                    }
+                },
+                keyframes: { _ in
+                    // radius 트랙 — 렌즈 반경. preDelay 0 유지 → bloom → collapse.
+                    KeyframeTrack(\.radius) {
+                        // [0] PreDelay — radius 0 유지 (워터마크 로고 인지 구간)
+                        LinearKeyframe(0, duration: preDelay)
+                        // [1] Bloom — 0 → maxRadius. SpringKeyframe(bounce: 0) 로 critically
+                        //   damped spring 을 만들어 정점 overshoot 없이 자연스럽게 가속/감속한다.
+                        SpringKeyframe(
+                            maxRadius,
+                            duration: bloomDuration,
+                            spring: .init(duration: bloomDuration, bounce: 0)
+                        )
+                        // [2] Collapse — maxRadius → 0 (overshoot 없는 spring 으로 즉시 감속)
+                        SpringKeyframe(
+                            0,
+                            duration: collapseDuration,
+                            spring: .init(duration: collapseDuration, bounce: 0)
+                        )
+                    }
+                    // logoOpacity 트랙 — reveal. preDelay 동안 흐릿하게 유지 → bloom 동안 1.0 으로
+                    // 차올라 렌즈가 덮는 사이 선명해지고 → collapse 후 선명 유지.
+                    KeyframeTrack(\.logoOpacity) {
+                        LinearKeyframe(revealStartOpacity, duration: preDelay)
+                        LinearKeyframe(1.0, duration: bloomDuration)
+                        LinearKeyframe(1.0, duration: collapseDuration)
+                    }
+                }
+            )
+    }
+}
+
+// MARK: - View Extension
+
+extension View {
+
+    /// View 에 자동 재생 chromaticLens 시네마틱을 입힌다.
+    ///
+    /// 정적 로고 (preDelay) → 중앙 bloom → collapse 3-phase 시퀀스를 mount 직후 한 번 재생한다.
+    /// 단일 `keyframeAnimator` timeline 이라 bloom 과 collapse 사이에 정지 구간이 없다. 기본
+    /// 굴곡/무지개 파라미터가 `chromaticLens()` 보다 강하게 잡혀 있어, 짧은 시간 안에 lens
+    /// 효과를 또렷이 인지시키는 시네마틱 용도.
+    ///
+    /// - Parameters:
+    ///   - center: Lens 중심의 상대 좌표(0~1). 기본 `.center` — 가운데에서 피어났다 모인다.
+    ///   - maxRadius: bloom 정점에서의 lens 반경(px). 기본 280 — 화면 절반 이상을 덮는 시네마틱 크기.
+    ///   - refractionStrength: 중심 magnification 강도. 기본 80 — 일반 `chromaticLens()` 의 52 보다 강함.
+    ///   - dispersionStrength: R/G/B 색분산 강도. 기본 90 — 가장자리 무지개 fringe 가 또렷이 보이는 값.
+    ///   - edgeHighlight: 유리 rim ring 강조. 기본 0.50.
+    ///   - iridescenceStrength: lens 안쪽 무지개 광택 강도(0~1). 기본 1.0 — 시네마틱에서 무지개가
+    ///     뚜렷이 드러나도록 holographic 광택을 최대로.
+    ///   - preDelay: 시네마틱 시작 전 정적 로고를 보여주는 시간. 기본 0.4s — 사용자가 로고 인지.
+    ///   - bloomDuration: 0 → maxRadius 까지 부풀어 오르는 시간. 기본 1.0s.
+    ///   - collapseDuration: maxRadius → 0 으로 모이는 시간. 기본 0.9s.
+    ///   - revealStartOpacity: 시네마틱 시작 시 로고 투명도(0~1). **기본 1.0 = 처음부터 선명**.
+    ///     0.18 같은 낮은 값을 주면 흐릿한 워터마크 → bloom 동안 선명해지는 reveal 컨셉으로
+    ///     전환된다 (옵트인). 1.0 이면 logoOpacity 트랙이 전구간 1.0 으로 보간되어 사실상
+    ///     opacity 변화 없음.
+    public func refractiveCinematic(
+        center: UnitPoint = .center,
+        maxRadius: CGFloat = 280,
+        refractionStrength: CGFloat = 80,
+        dispersionStrength: CGFloat = 90,
+        edgeHighlight: CGFloat = 0.50,
+        iridescenceStrength: CGFloat = 1.0,
+        preDelay: TimeInterval = 0.4,
+        bloomDuration: TimeInterval = 1.0,
+        collapseDuration: TimeInterval = 0.9,
+        revealStartOpacity: Double = 1.0
+    ) -> some View {
+        modifier(
+            RefractiveCinematicModifier(
+                center: center,
+                maxRadius: maxRadius,
+                refractionStrength: refractionStrength,
+                dispersionStrength: dispersionStrength,
+                edgeHighlight: edgeHighlight,
+                iridescenceStrength: iridescenceStrength,
+                preDelay: preDelay,
+                bloomDuration: bloomDuration,
+                collapseDuration: collapseDuration,
+                revealStartOpacity: revealStartOpacity
+            )
+        )
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+// 셰이더가 앱 번들 metallib 에 있으므로, 모듈 단독 프리뷰에서는 lens 효과가 보이지 않을 수 있다.
+#Preview("자동 시네마틱 — 살아있는 빛(흐름+글림+호흡)") {
+    VStack(spacing: 24) {
+        Image(systemName: "sparkles")
+            .font(.system(size: 96))
+            .foregroundStyle(.indigo)
+        Text("자동 재생")
+            .font(.headline)
+            .foregroundStyle(.indigo)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .refractiveCinematic()
+}
+#endif

--- a/UMCApp/Core/UIComponents/Sources/Logo/AuthLogoBlock.swift
+++ b/UMCApp/Core/UIComponents/Sources/Logo/AuthLogoBlock.swift
@@ -8,13 +8,23 @@
 import CoreDesignSystem
 import SwiftUI
 
-/// 인증 진입 화면(LoginView 등)에서 공통으로 사용하는 로고 + 슬로건 블록.
+/// 인증 진입 화면(BootstrapView/LoginView)에서 공통으로 사용하는 로고 + 슬로건 블록.
 ///
-/// 부트스트랩 화면(`BootstrapView`)은 `ProgressView` 기반의 최소 구현이라 이 블록과
-/// 픽셀 단위로 맞출 시네마틱 연출은 계획되어 있지 않다 — 정적으로 렌더링되는 로고다.
+/// `BootstrapView` 의 굴절 시네마틱이 끝나는 순간과 `LoginView` 의 평소 상태가 **픽셀 단위로
+/// 일치**해야 시네마틱이 단절 없이 로그인 화면으로 연결된다. 따라서 두 화면의 로고+슬로건은
+/// 동일한 View 컴포넌트로 추출해 layout 차이를 원천 봉쇄한다.
+///
+/// `sloganOpacity` 는 `BootstrapView` 의 시네마틱 reveal 연출을 위한 옵트인 파라미터.
+/// 이미지 로고는 항상 선명하게 보이고 슬로건 텍스트만 lens 가 비춰지는 동안 0 → 1 로
+/// 차오르도록 호출부에서 컨트롤한다. LoginView 처럼 시네마틱 없는 호출부는 기본값(1.0)
+/// 로 두면 정적 layout 그대로.
 public struct AuthLogoBlock: View, Equatable {
 
     // MARK: - Property
+
+    /// 슬로건(부제 + statement) 영역의 투명도(0~1). 기본 1.0 = 정적(LoginView 등).
+    /// `BootstrapView` 가 시네마틱 bloom 동안 0 → 1 로 reveal 시킨다.
+    private let sloganOpacity: Double
 
     fileprivate enum Constants {
         static let logoImageWidth: CGFloat = 160
@@ -24,7 +34,9 @@ public struct AuthLogoBlock: View, Equatable {
 
     // MARK: - Init
 
-    public init() {}
+    public init(sloganOpacity: Double = 1.0) {
+        self.sloganOpacity = sloganOpacity
+    }
 
     // MARK: - Body
 
@@ -43,6 +55,7 @@ public struct AuthLogoBlock: View, Equatable {
                 Text(Constants.appStatement)
                     .appFont(.subheadline, color: .grey500)
             }
+            .opacity(sloganOpacity)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/BootstrapView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/BootstrapView.swift
@@ -4,41 +4,154 @@
 //
 //  Created by euijjang97 on 7/8/26.
 //
+//  앱 진입 시 자동 chromaticLens 시네마틱을 한 번 재생하면서 인증 부트스트랩을 병렬 수행하고,
+//  로그인 단계로 진입해야 할 경우 **같은 화면 안에서** 로고를 위로 슬라이드하며 로그인 버튼들을
+//  등장시키는 단일 진입 화면.
+//
+//  ## 동작
+//
+//  - mount 직후 `refractiveCinematic` modifier 가 3-phase (정적 로고 → bloom → collapse) 시퀀스를
+//    2.3s 동안 재생한다. dwell(정점 정지) 단계 없이 한 keyframe timeline 으로 흘러 멈춤 느낌 없음.
+//  - 동시에 `bootstrapViewModel.resolveAuthStatus()` 가 background 에서 토큰/프로필 검사를
+//    수행한다.
+//  - 시네마틱 최소 시간(2.3s) + 인증 완료 둘 다 만족하면 결과에 따라 분기한다.
+//    - `.approved` / `.pendingApproval` → AppFlow 로 외부 화면 라우팅
+//    - `.notLoggedIn` → **`stage` 를 `.loginReady` 로 전환** → 같은 화면 안에서 layout 이
+//      `withAnimation` 으로 morph (로고가 위로 슬라이드, LoginActionStack 이 아래에서 등장)
+//  - 사용자가 로그인 버튼을 누르면 내부 `LoginViewModel` 이 인증을 진행하고, 결과 상태 변경 시
+//    AppFlow 로 외부 화면 라우팅.
+//
+//  ## 왜 한 화면인가
+//
+//  BootstrapView 와 LoginView 를 AppFlow 상태 전환(cross-fade)으로만 연결하면 "lens 가 다
+//  사라지고 화면이 잠시 멈추는" dead-time 이 생긴다. 한 View 안에서 `stage` enum 으로 layout 을
+//  변경하면 SwiftUI 가 동일 view tree 의 spacer/component 위치를 보간해, 로고 morph + 버튼
+//  등장이 한 동작으로 흘러간다. `.loginReady` layout 은 `LoginView` 와 동일한 구조라 시각적
+//  일관성이 유지된다 (별도 `LoginView` 는 로그아웃 복귀 경로에서 계속 사용).
+//
 
 import AuthDomain
+import CoreDesignSystem
 import CoreDI
-import Foundation
+import CoreDomain
+import CoreUIComponents
 import SwiftUI
 import UMCFoundation
 
-/// 부트스트랩 화면 — 앱 진입 시 토큰/프로필을 확인해 로그인·메인 여부를 판단하는 동안 표시된다.
-///
-/// 시네마틱(Metal 셰이더) 연출은 포함하지 않는 최소 화면이다.
 public struct BootstrapView: View {
+
+    // MARK: - Stage
+
+    /// 진입 화면 단계
+    private enum Stage: Equatable {
+        /// 시네마틱 재생 중. 로고가 화면 정중앙.
+        case cinematic
+        /// 시네마틱 종료 + 자동 로그인 실패. 로고가 위쪽으로 morph, 하단에 LoginActionStack 등장.
+        case loginReady
+    }
 
     // MARK: - Property
 
-    @State private var viewModel: BootstrapViewModel
+    @State private var bootstrapViewModel: BootstrapViewModel
+    @State private var loginViewModel: LoginViewModel
+    @State private var stage: Stage = .cinematic
+    /// 슬로건 reveal 투명도(0~1). preDelay 동안 0 (이미지 로고만 보임) → bloom 동안 0 → 1
+    /// (lens 가 비춰지면서 슬로건이 차오름) → collapse 동안 1 유지. `revealSlogan()` 가 컨트롤.
+    @State private var sloganOpacity: Double = 0
+
     @Environment(\.appFlow) private var appFlow
+
+    private enum Constants {
+        /// 시네마틱 종료 시점. `RefractiveCinematic` 시퀀스 총 길이(preDelay 0.4 + bloom 1.0 +
+        /// collapse 0.9 = 2.3s)와 일치한다. 인증이 더 빨리 끝나도 이 시간만큼은 시네마틱을
+        /// 유지하고, 그 후 morph 트리거. **이 값과 refractiveCinematic 의 duration 합은 항상
+        /// 동기화해야 한다** — 어긋나면 라우팅이 collapse 도중 끊고 들어온다.
+        static let cinematicTotalDuration: TimeInterval = 2.3
+        /// 인증 최대 대기 시간. 초과 시 `.notLoggedIn` 가정 후 loginReady morph.
+        static let authTimeout: TimeInterval = 3.0
+        /// stage 전환 애니메이션 시간 — 로고 위로 슬라이드 + actionStack 등장 morph.
+        static let morphDuration: TimeInterval = 0.55
+        /// 슬로건 reveal 시작 지연. RefractiveCinematic 의 preDelay 와 동기화 — preDelay 동안
+        /// 이미지 로고만 보이고 슬로건은 숨김.
+        static let sloganRevealDelay: TimeInterval = 0.4
+        /// 슬로건 reveal 애니메이션 시간. RefractiveCinematic 의 bloomDuration 과 동기화 —
+        /// lens 가 펴지는 동안 슬로건이 0 → 1 로 차올라 "lens 안에서 슬로건이 보이며 등장" 효과.
+        static let sloganRevealDuration: TimeInterval = 1.0
+    }
 
     // MARK: - Init
 
-    public init(container: DIContainer) {
-        _viewModel = State(initialValue: BootstrapViewModel(container: container))
+    public init(container: DIContainer, errorHandler: ErrorHandler) {
+        _bootstrapViewModel = State(initialValue: BootstrapViewModel(container: container))
+        _loginViewModel = State(
+            initialValue: LoginViewModel(container: container, errorHandler: errorHandler)
+        )
     }
 
     // MARK: - Body
 
     public var body: some View {
-        ProgressView()
-            .task {
-                await checkAuthStatus()
+        contentLayout
+            .refractiveCinematic()
+            .task { await runBootstrap() }
+            .task { await revealSlogan() }
+            .onChange(of: loginViewModel.loginState) { _, newState in
+                handle(newState: newState)
+            }
+            .onChange(of: loginViewModel.signUpDestination) { _, newDestination in
+                handle(signUpDestination: newDestination)
             }
     }
 
-    // MARK: - Function
+    // MARK: - Layout
 
-    private func checkAuthStatus() async {
+    /// `.loginReady` 상태의 layout 은 `LoginView` 의 body 와 동일한 구조를 유지해야 한다 —
+    /// 로그아웃 복귀(`LoginView`) 화면과 시각적으로 일치시키기 위함.
+    private var contentLayout: some View {
+        VStack(spacing: .zero) {
+            Spacer()
+
+            AuthLogoBlock(sloganOpacity: sloganOpacity)
+                .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+
+            Spacer()
+
+            if stage == .loginReady {
+                LoginActionStack(
+                    isLoading: loginViewModel.loginState.isLoading,
+                    onKakaoTap: { Task { await loginViewModel.loginWithKakao() } },
+                    onAppleTap: { loginViewModel.loginWithApple() },
+                    onGoogleTap: { Task { await loginViewModel.loginWithGoogle() } }
+                )
+                .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+                .padding(.bottom, DefaultConstant.defaultSafeBottom)
+                .transition(
+                    .opacity.combined(with: .move(edge: .bottom))
+                )
+            }
+        }
+        .animation(.easeInOut(duration: Constants.morphDuration), value: stage)
+    }
+
+    // MARK: - Bootstrap
+
+    /// 슬로건 reveal — preDelay 동안 숨겨두고 (sloganOpacity = 0), bloom 시작 시점에 0 → 1 로
+    /// ease-in-out 차오르게 한다. RefractiveCinematic 의 lens 가 펴지는 동안 슬로건이 lens
+    /// 안에서 동시에 reveal 되어 "lens 가 비춰지면서 슬로건이 보이는" 시네마틱 연출이 완성된다.
+    ///
+    /// 별도 `.task` 로 띄워 `runBootstrap` 의 인증 결과와 무관하게 timeline 을 따라가게 한다 —
+    /// 인증이 빨라서 일찍 morph 가 트리거돼도 슬로건은 이미 reveal 된 상태로 인계.
+    @MainActor
+    private func revealSlogan() async {
+        try? await Task.sleep(for: .seconds(Constants.sloganRevealDelay))
+        withAnimation(.easeInOut(duration: Constants.sloganRevealDuration)) {
+            sloganOpacity = 1.0
+        }
+    }
+
+    /// 시네마틱 최소 시간과 인증 검사를 병렬로 진행하고, 둘 다 완료되면 라우팅 or morph.
+    @MainActor
+    private func runBootstrap() async {
         #if DEBUG
         if Self.isMockAuthBypassEnabled {
             appFlow.showMain()
@@ -46,20 +159,74 @@ public struct BootstrapView: View {
         }
         #endif
 
-        switch await viewModel.resolveAuthStatus() {
+        async let minimumWait: Void = sleepSeconds(Constants.cinematicTotalDuration)
+        async let authStatus = resolveAuthStatusWithTimeout()
+
+        let (_, resolvedStatus) = await (minimumWait, authStatus)
+        route(for: resolvedStatus)
+    }
+
+    /// 인증 검사를 타임아웃 안에서 실행한다. 타임아웃이 먼저 끝나면 `.notLoggedIn` 으로 간주해
+    /// 시네마틱이 무한정 인증을 기다리며 화면이 멈추는 상황을 방지한다.
+    @MainActor
+    private func resolveAuthStatusWithTimeout() async -> AuthBootstrapStatus {
+        await withTaskGroup(of: AuthBootstrapStatus?.self) { group in
+            group.addTask { @MainActor in
+                await bootstrapViewModel.resolveAuthStatus()
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(Constants.authTimeout))
+                return nil
+            }
+            let firstResult = await group.next() ?? nil
+            group.cancelAll()
+            return firstResult ?? .notLoggedIn
+        }
+    }
+
+    private func sleepSeconds(_ seconds: TimeInterval) async {
+        guard seconds > 0 else { return }
+        try? await Task.sleep(for: .seconds(seconds))
+    }
+
+    /// 인증 결과에 따라 외부 화면으로 라우팅하거나, 같은 화면 안에서 loginReady stage 로 morph.
+    private func route(for status: AuthBootstrapStatus) {
+        switch status {
         case .approved:
             appFlow.showMain()
         case .pendingApproval:
             appFlow.showPendingApproval()
         case .notLoggedIn:
-            appFlow.showLogin()
+            stage = .loginReady
         }
+    }
+
+    // MARK: - Login Handling
+
+    /// 내장 `LoginViewModel` 의 로그인 결과를 AppFlow 라우팅으로 변환 (`LoginView` 와 동일 규칙).
+    private func handle(newState: Loadable<Profile>) {
+        if case .loaded = newState {
+            appFlow.showMain()
+        }
+        if newState == .failed(.auth(.pendingApproval)) {
+            appFlow.showPendingApproval()
+        }
+    }
+
+    private func handle(signUpDestination: SignUpDestination?) {
+        guard let signUpDestination else { return }
+        appFlow.showSignUp(
+            signUpDestination.verificationToken,
+            signUpDestination.email,
+            signUpDestination.fullName,
+            signUpDestination.postRegisterLoginContext
+        )
     }
 
     #if DEBUG
     /// `MOCK_AUTH_BYPASS=1` 환경변수(스킴의 Arguments > Environment Variables)를 설정하면
-    /// 실제 토큰/서버 상태와 무관하게 즉시 메인으로 진입한다. 로그인 화면이 구현되기 전
-    /// Home을 단독으로 테스트하기 위한 개발 전용 우회 경로다 (절대규칙 #5).
+    /// 실제 토큰/서버 상태와 무관하게 즉시 메인으로 진입한다. 시네마틱을 기다리지 않고 Home을
+    /// 단독으로 테스트하기 위한 개발 전용 우회 경로다 (절대규칙 #5).
     private static var isMockAuthBypassEnabled: Bool {
         ProcessInfo.processInfo.environment["MOCK_AUTH_BYPASS"] == "1"
     }

--- a/UMCApp/UMCApp/Sources/AppRootView.swift
+++ b/UMCApp/UMCApp/Sources/AppRootView.swift
@@ -39,7 +39,7 @@ struct AppRootView: View {
         ZStack {
             switch viewModel.state {
             case .bootstrap:
-                BootstrapView(container: di)
+                BootstrapView(container: di, errorHandler: errorHandler)
 
             case .login:
                 LoginView(container: di, errorHandler: errorHandler)

--- a/UMCApp/UMCApp/Sources/Shaders/ChromaticLens.metal
+++ b/UMCApp/UMCApp/Sources/Shaders/ChromaticLens.metal
@@ -1,0 +1,151 @@
+//
+//  ChromaticLens.metal
+//  UMCApp
+//
+//  Created by euijjang97 on 7/27/26.
+//
+//  커스텀 chromatic dispersion + 굴절 셰이더 (Apple `.clear.interactive()` 의 한계를 우회하기 위한 PoC).
+//  SwiftUI 의 .layerEffect 로 적용되며, lens 의 중심·반경·굴절 강도·색분산 강도·edge highlight 를
+//  uniform 으로 받아 pixel 단위로 분광 lensing 을 직접 계산한다.
+//
+//  ## 왜 앱 타겟에 있나
+//
+//  호출부(`CoreUIComponents`의 ChromaticLens.swift)는 `ShaderLibrary.chromaticLens` — 즉
+//  **메인 번들의 default shader library** 에서 함수를 찾는다. Core 모듈은 전부 staticFramework
+//  라 .metal 을 모듈 소스에 두면 컴파일된 metallib 이 앱 번들에 실리지 않아 런타임에 함수를
+//  찾지 못한다. 따라서 .metal 소스는 앱 타겟이 소유한다 (metallib → 앱 번들 default.metallib).
+//
+//  동작 원리
+//  1. 각 destination pixel 의 lens 중심까지 거리(dist)와 정규화 위치(0~1) 를 구한다.
+//  2. lens 바깥(dist > radius) 은 layer 를 그대로 통과 — 영향 0.
+//  3. lens 안쪽은 spherical 굴절 곡선(curve = normalized^2)을 따라 sampling point 를 중심 쪽으로 당긴다.
+//     → 중심은 그대로, 가장자리로 갈수록 더 많이 휘어 magnification 효과 발생.
+//  4. R / G / B 채널마다 굴절 강도를 살짝 다르게 줘서 sample 위치를 달리한다(=색분산).
+//     실제 유리 dispersion 처럼 blue 가 더 많이, red 가 더 적게 휜다.
+//  5. 가장자리에는 smoothstep 으로 얇은 highlight ring 을 더해 유리 rim 느낌을 추가.
+//  6. lens 안쪽에 각도+반경 기반 HSV pastel 을 합성해 진주·비누거품 같은 무지개 광택을 더한다.
+//  7. time uniform(경과 초) 으로 무지개 흐름 + 이동 specular glint + 광택 미세 호흡을 구동해
+//     "살아있는 빛" 을 더한다. time=0 이면 이 모션은 비활성 — 정적 호출부와 픽셀 단위로 동일.
+//
+
+#include <metal_stdlib>
+#include <SwiftUI/SwiftUI_Metal.h>
+using namespace metal;
+
+[[ stitchable ]]
+half4 chromaticLens(
+    float2 position,
+    SwiftUI::Layer layer,
+    float2 center,
+    float radius,
+    float refractionStrength,
+    float dispersionStrength,
+    float edgeHighlight,
+    float iridescenceStrength,
+    float time
+) {
+    float2 toCenter = position - center;
+    float dist = length(toCenter);
+
+    // Outside the lens — or lens too small to render — pass through unchanged.
+    // `radius < 5.0` 가드는 `SpringKeyframe(bounce: 0)` 의 collapse 종료 시 발생하는 numerical
+    // residue (정확히 0 으로 수렴 못 하고 0.5~3.0px 의 작은 lens 잔여가 영구히 남는 현상) 가
+    // 정중앙 몇 픽셀에 작은 굴절+iridescence 를 남기는 artifact 를 방어한다. Swift 측
+    // RefractiveCinematic 의 radius clamp 와 ChromaticLens `.layerEffect(isEnabled:)` 가드
+    // 와 같은 임계값으로 묶어 삼중 안전망 — 5px 미만 lens 는 시각적으로 의미 없으므로 통과.
+    if (radius < 5.0 || dist > radius) {
+        return layer.sample(position);
+    }
+
+    float normalized = dist / radius;
+
+    // Spherical lens 굴절 곡선 — 중심 0, 가장자리 1 (가장자리로 갈수록 강하게 휘어짐).
+    float refractCurve = pow(normalized, 2.0);
+    // Dispersion 곡선 — 중간 영역에서 무지개 fringe 가 드러나고,
+    // **가장자리(normalized > 0.85)에서는 smoothstep 으로 0 으로 fade** 한다.
+    // 이렇게 하지 않으면 lens 가 view 가장자리에 가까울 때 dispersion sample 좌표가
+    // 텍스처 밖으로 나가 R/G/B 중 한 채널이 0 으로 떨어지고, 나머지 두 채널이 합쳐져
+    // cyan/magenta fringe 가 화면 가장자리에 박혀 보이는 artifact 가 생긴다.
+    float dispCurve = pow(normalized, 1.2)
+                    * (1.0 - smoothstep(0.85, 1.0, normalized));
+
+    // 채널별 magnification factor.
+    //  - baseK 가 작을수록 sample 이 중심 쪽으로 더 당겨짐 = 더 강한 magnification.
+    //  - red 는 덜 휘고(kR 큼), blue 는 더 휨(kB 작음) — 실제 유리 dispersion 방향.
+    //  - dispersion 진폭은 baseK 기준 양쪽 여유분(min(baseK, 1-baseK)) 으로 자동 clamp 해
+    //    kB 가 음수(=반대편 sample) 가 되지 않도록 안전 보장.
+    float baseK = 1.0 - refractionStrength * 0.01 * refractCurve;
+    float dispRange = min(baseK, 1.0 - baseK);
+    float safeDisp = min(dispersionStrength * 0.01 * dispCurve, dispRange);
+    float kR = baseK + safeDisp;
+    float kG = baseK;
+    float kB = baseK - safeDisp;
+
+    half r = layer.sample(center + toCenter * kR).r;
+    half g = layer.sample(center + toCenter * kG).g;
+    half b = layer.sample(center + toCenter * kB).b;
+    half a = layer.sample(center + toCenter * kG).a;
+
+    // Edge highlight ring — 얇은 유리 rim 강조.
+    float rim = smoothstep(0.92, 0.96, normalized)
+              * (1.0 - smoothstep(0.96, 1.0, normalized));
+    half3 highlight = half3(1.0) * rim * edgeHighlight;
+
+    // ── Iridescence (무지개 광택) ─────────────────────────────────────────
+    // lens 안쪽에 각도+반경 기반 HSV spectrum 을 합성한다.
+    // 배경(흰색 + indigo 텍스트 등)을 그대로 굴절시키면 lens 안쪽이 회녹색 톤으로
+    // 단조롭게 보이는데, iridescent overlay 가 비누거품·진주 같은 무지개 광택을
+    // 더해 "유리 너머의 빛이 분광되어 보인다" 는 인지를 만든다.
+    //
+    // 합성 위치 — 중심부터 가장자리까지 전구간에 ring mask 로 fade in/out:
+    //   normalized ∈ [0.05, 0.30]  fade in (이전 0.10~0.40 보다 더 넓게 시작)
+    //   normalized ∈ [0.75, 0.92]  fade out (이전 0.70~0.90 보다 살짝 외곽까지)
+    // → 무지개가 덮이는 lens 내부 영역이 넓어져 "lens 가 통과했다" 인지가 강화된다.
+    // 가장자리(0.92+) 는 rim highlight 영역이라 iridescence 와 겹치지 않게 분리.
+    float angle = atan2(toCenter.y, toCenter.x);
+    float angleNorm = (angle + 3.14159265) / 6.28318530;  // 0~1
+    // 무지개 흐름 — time 항이 hue 를 회전시켜 색띠가 유동한다 (time=0 이면 기존과 동일).
+    const float hueFlowSpeed = 0.12;  // cycle/s
+    float hue = fract(angleNorm + normalized * 0.6 + time * hueFlowSpeed);
+    float h6 = hue * 6.0;
+    half3 iridescent = half3(
+        clamp(abs(h6 - 3.0) - 1.0, 0.0, 1.0),
+        clamp(2.0 - abs(h6 - 2.0), 0.0, 1.0),
+        clamp(2.0 - abs(h6 - 4.0), 0.0, 1.0)
+    );
+    float irisMask = smoothstep(0.05, 0.30, normalized)
+                   * (1.0 - smoothstep(0.75, 0.92, normalized))
+                   * iridescenceStrength;
+    // 미세 호흡 — 광택 강도가 부드럽게 맥동. time>0 일 때만 적용해 정적 호출부 회귀를 막는다.
+    if (time > 0.0) {
+        const float breathSpeed = 2.2;  // rad/s
+        irisMask *= (0.85 + 0.15 * sin(time * breathSpeed));
+    }
+    half3 baseRGB = half3(r, g, b);
+
+    // 채도 조정 — 진주·비누거품 톤을 위해 iridescent 자체를 흰색에 살짝 mix.
+    // **0.35 = 흰빛 65% + 원색 35%** (이전 0.55 보다 vivid). 사용자가 "lens 안쪽이
+    // 무지개로 물들었다" 를 또렷이 인지하도록 원색 비중을 올림. 그래도 흰빛 65% 비중이
+    // 남아 있어 글자가 완전히 뭉개지진 않고 *유리에 비친 무지개* 톤으로 읽힌다.
+    half3 pastelIridescent = mix(half3(1.0), iridescent, half(0.35));
+    half3 finalRGB = mix(baseRGB, pastelIridescent, half(irisMask));
+
+    // ── 이동 specular glint ───────────────────────────────────────────────
+    // 대각 축을 따라 움직이는 가우시안 밝은 띠 — 유리 표면을 빛줄기가 주기적으로
+    // 가로지르는 반짝임. time>0 일 때만 (정적/인터랙티브 호출부는 glint 없이 회귀 보존).
+    // exp(-d*d) 로 띠를 만든다. pow(음수, 2.0) 이 일부 GPU 에서 NaN 을 내므로 d*d 직접 사용.
+    half3 glintHighlight = half3(0.0);
+    if (time > 0.0) {
+        const float glintSpeed = 0.45;      // sweep/s
+        const float glintWidth = 0.18;
+        const float glintIntensity = 0.6;
+        float s = dot(toCenter, normalize(float2(1.0, 1.0))) / radius;  // 대각 좌표 ≈ [-1,1]
+        float sweepPos = -1.3 + fract(time * glintSpeed) * 2.6;         // 한쪽→반대쪽 주기 이동
+        float d = (s - sweepPos) / glintWidth;
+        float glint = exp(-d * d);                                      // 밝은 띠
+        glint *= (1.0 - smoothstep(0.70, 1.0, normalized));            // rim 영역과 분리
+        glintHighlight = half3(1.0) * half(glint * glintIntensity);
+    }
+
+    return half4(finalRGB + highlight + glintHighlight, a);
+}

--- a/docs/claude/tuist-file-mapping.md
+++ b/docs/claude/tuist-file-mapping.md
@@ -819,6 +819,7 @@
 | `Mock/AttendancePreviewData.swift` | ActivityDomain/Sources/Mock |
 | `Mock/AttendanceTestWrapper.swift` | ActivityPresentation/Sources/Mock |
 | `Mock/CurriculumPreviewData.swift` | ActivityDomain/Sources/Mock |
+| `Mock/DesignPreview/ChromaticLens.metal` | App (UMCApp/UMCApp/Sources/Shaders) — staticFramework 는 metallib 이 앱 번들에 실리지 않으므로 앱 타겟 소유 |
 | `Mock/DesignPreview/ChromaticLensPreview.swift` | CoreDesignSystem/Sources/Mock |
 | `Mock/DesignPreview/LiquidIntroPreview.swift` | CoreDesignSystem/Sources/Mock |
 | `Mock/DesignPreview/LoginPreview.swift` | AuthPresentation/Sources/Mock (Home부는 HomePresentation) |


### PR DESCRIPTION
## ✨ PR 유형

리팩토링 — AppProduct 온보딩 시네마틱(Metal 셰이더) 인트로의 UMCApp(Tuist) 이관

Resolves #1009

## 📷 스크린샷 or 영상(UI 변경 시)

시뮬레이터(iPhone 17 Pro, iOS 26.5) 구동 검증 완료 — 로고 인지(preDelay) → lens bloom(굴절+무지개 광택+슬로건 reveal) → collapse → `.notLoggedIn` 판정 시 같은 화면 안에서 loginReady morph(로고 슬라이드 + LoginActionStack 등장)까지 정상 재생. 녹화 영상은 코멘트로 첨부 예정.

## 🛠️ 작업내용

- **`ChromaticLens.metal` → 앱 타겟**(`UMCApp/Sources/Shaders/`) 이관
  - Core 모듈은 전부 staticFramework라 .metal을 모듈 소스에 두면 컴파일된 metallib이 앱 번들에 실리지 않음. `ShaderLibrary.chromaticLens`는 메인 번들의 default shader library에서 함수를 찾으므로 앱 타겟이 셰이더를 소유 (파일 헤더에 사유 주석)
- **`ChromaticLens.swift` / `RefractiveCinematic.swift` → `CoreUIComponents/Sources/ChromaticLens/`** 이관 (tuist-file-mapping.md 매핑 준수). View extension(`chromaticLens` / `chromaticLensInteractive` / `refractiveCinematic`)만 `public` 개방
- **`AuthLogoBlock`** — 슬로건 reveal용 `sloganOpacity` 파라미터 복원. 기본값 1.0이라 기존 `LoginView` 호출부 무영향
- **`BootstrapView`** — `ProgressView()` 스텁 → 시네마틱 stage 머신 복원
  - 2.3s 시네마틱(최소 유지 시간)과 인증 검사(`resolveAuthStatus`, 3s 타임아웃)를 `async let` 병렬 진행, 둘 다 완료 후 분기
  - `.approved`/`.pendingApproval` → AppFlow 라우팅, `.notLoggedIn` → 같은 화면 안에서 `.loginReady`로 morph (로고 위로 슬라이드 + `LoginActionStack` 하단 등장)
  - `.loginReady` 레이아웃은 `LoginView` body와 동일 구조 — 시각적 일관성 유지 (`LoginView`는 로그아웃 복귀 경로용으로 존치)
  - `LoginViewModel` 내장으로 로그인 결과(`loginState`)/회원가입 목적지(`signUpDestination`) 처리 — `LoginView`와 동일 규칙
  - `MOCK_AUTH_BYPASS` 디버그 우회 경로 유지
- **접근성**: Reduce Motion 시 흐르는 빛(무지개 흐름/글림/호흡) 비활성, 굴절 bloom/collapse만 재생 (`RefractiveCinematic` 내장 처리). 시네마틱 종료 후 `TimelineView` 정지로 GPU 비용 0 복귀
- **`AppRootView`** — `BootstrapView(container:errorHandler:)` 호출부 갱신
- **`docs/claude/tuist-file-mapping.md`** — `ChromaticLens.metal` 매핑 행 추가

## 📋 추후 진행 상황

- `ChromaticLensPreview.swift` / `LiquidIntroPreview.swift`(디자인 프리뷰 데모)는 이번 범위에서 제외 — `ChromaticLensPreview`는 매핑 문서상 CoreDesignSystem/Mock이지만 `chromaticLens` modifier(CoreUIComponents) 의존이라 역방향 의존이 생겨 위치 재검토 필요
- 카카오 문의 채널 버튼(`onSupportTap`)은 UMCApp `LoginActionStack` 스코프 밖(기존 결정 유지)

## 📌 리뷰 포인트

- `Constants.cinematicTotalDuration(2.3s)`과 `refractiveCinematic`의 preDelay+bloom+collapse 합은 항상 동기화 필요 (주석 명시) — 어긋나면 라우팅이 collapse 도중 끊고 들어옴
- 인증 타임아웃(3s) 초과 시 `.notLoggedIn` 간주 후 morph — 타임아웃 직후 인증이 늦게 성공하는 경우도 로그인 화면 유지가 의도된 동작인지
- Metal 셰이더의 앱 타겟 배치(staticFramework metallib 제약) 접근이 적절한지

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?