### PR TITLE
♻️ [Refactor] LocationManager · GeofenceEvent CoreFoundation 이관

### DIFF
--- a/UMCApp/Core/Foundation/Project.swift
+++ b/UMCApp/Core/Foundation/Project.swift
@@ -6,6 +6,11 @@ let project = coreProject(
     bundleIdSuffix: "foundation",
     destinations: [.iPhone, .appleWatch],
     deploymentTargets: .multiplatform(iOS: "26.4", watchOS: "26.4"),
+    dependencies: [
+        // LocationManager: 위치 갱신/역지오코딩(MKReverseGeocodingRequest)/지오펜스 모니터링.
+        .sdk(name: "CoreLocation", type: .framework),
+        .sdk(name: "MapKit", type: .framework),
+    ],
     includesTests: true
 )
 

--- a/UMCApp/Core/Foundation/Sources/Location/GeocodedAddress.swift
+++ b/UMCApp/Core/Foundation/Sources/Location/GeocodedAddress.swift
@@ -1,0 +1,31 @@
+//
+//  GeocodedAddress.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/6/26.
+//
+
+import Foundation
+
+/// 역지오코딩 결과를 손실 없이 담는 Core 값 타입
+///
+/// Core는 Feature 모듈(`ActivityDomain`)의 `Address`에 의존할 수 없으므로, MapKit이 제공하는
+/// 구조화된 주소 필드를 그대로 보존해 반환합니다. Feature 어댑터(#992 Phase B)가 이 값을
+/// `Address`로 변환합니다.
+///
+/// - Note: `city`/`district`는 MapKit(iOS 26) `MKAddressRepresentations`의 `regionName`/
+///   `cityName`에서 옵니다. 미국식 지역 체계(도시/주) 기준이라 한국 주소의 시/구와 정확히
+///   1:1 대응하지 않을 수 있어, 실제 화면 표기에 맞는 매핑은 어댑터에서 검증이 필요합니다.
+public struct GeocodedAddress: Equatable, Sendable {
+    public let fullAddress: String
+    public let shortAddress: String?
+    public let city: String?
+    public let district: String?
+
+    public init(fullAddress: String, shortAddress: String?, city: String?, district: String?) {
+        self.fullAddress = fullAddress
+        self.shortAddress = shortAddress
+        self.city = city
+        self.district = district
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Location/GeofenceCalculator.swift
+++ b/UMCApp/Core/Foundation/Sources/Location/GeofenceCalculator.swift
@@ -7,6 +7,15 @@
 
 import CoreLocation
 
+/// 모니터링 중인 지오펜스의 중심/반경
+///
+/// `LocationManager`와 `GeofenceCalculator` 양쪽에서 식별자 기반 판정에 쓰는 값 타입이라
+/// 모듈 내부(`GeofenceCalculator.swift`)에 둡니다. Core 밖으로 노출할 필요가 없어 internal.
+struct MonitoredGeofence {
+    let center: CLLocationCoordinate2D
+    let radius: CLLocationDistance
+}
+
 /// 지오펜스 판정에 쓰이는 순수 거리 계산 로직
 ///
 /// `CLLocationManager`/`CLMonitor` 상태에 의존하지 않는 값 계산만 모아 두어
@@ -32,5 +41,18 @@ enum GeofenceCalculator {
         radius: CLLocationDistance
     ) -> Bool {
         distance(from: current, to: center) <= radius
+    }
+
+    /// 식별자로 등록된 지오펜스 기준 판정
+    ///
+    /// 등록되지 않은 식별자거나 현재 위치를 모르면 `false`. 여러 지오펜스가 동시에
+    /// 모니터링 중이어도 요청한 식별자의 조건만으로 판정한다(다른 식별자 상태는 영향 없음).
+    static func isInside(
+        geofenceId: String,
+        current: CLLocationCoordinate2D?,
+        geofences: [String: MonitoredGeofence]
+    ) -> Bool {
+        guard let current, let geofence = geofences[geofenceId] else { return false }
+        return isInside(current: current, center: geofence.center, radius: geofence.radius)
     }
 }

--- a/UMCApp/Core/Foundation/Sources/Location/GeofenceCalculator.swift
+++ b/UMCApp/Core/Foundation/Sources/Location/GeofenceCalculator.swift
@@ -1,0 +1,36 @@
+//
+//  GeofenceCalculator.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/6/26.
+//
+
+import CoreLocation
+
+/// 지오펜스 판정에 쓰이는 순수 거리 계산 로직
+///
+/// `CLLocationManager`/`CLMonitor` 상태에 의존하지 않는 값 계산만 모아 두어
+/// 델리게이트 없이도 단위 테스트가 가능하도록 `LocationManager`에서 분리했습니다.
+enum GeofenceCalculator {
+
+    // MARK: - Function
+
+    /// 두 좌표 사이의 거리(미터)
+    static func distance(
+        from: CLLocationCoordinate2D,
+        to: CLLocationCoordinate2D
+    ) -> CLLocationDistance {
+        let fromLocation = CLLocation(latitude: from.latitude, longitude: from.longitude)
+        let toLocation = CLLocation(latitude: to.latitude, longitude: to.longitude)
+        return fromLocation.distance(from: toLocation)
+    }
+
+    /// 현재 위치가 지정된 중심/반경의 지오펜스 안에 있는지 판정
+    static func isInside(
+        current: CLLocationCoordinate2D,
+        center: CLLocationCoordinate2D,
+        radius: CLLocationDistance
+    ) -> Bool {
+        distance(from: current, to: center) <= radius
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Location/GeofenceEvent.swift
+++ b/UMCApp/Core/Foundation/Sources/Location/GeofenceEvent.swift
@@ -1,0 +1,18 @@
+//
+//  GeofenceEvent.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/6/26.
+//
+
+import Foundation
+
+/// 지오펜스 진입/이탈/실패 이벤트
+///
+/// `LocationManager`가 지오펜스 모니터링 중 관측한 상태 변화를 나타냅니다.
+/// 연관값은 지오펜스 식별자(진입/이탈) 또는 실패 사유(실패)입니다.
+public enum GeofenceEvent: Equatable, Sendable {
+    case entered(String)
+    case exited(String)
+    case failed(String)
+}

--- a/UMCApp/Core/Foundation/Sources/Location/LocationManager.swift
+++ b/UMCApp/Core/Foundation/Sources/Location/LocationManager.swift
@@ -1,0 +1,326 @@
+//
+//  LocationManager.swift
+//  UMCFoundation
+//
+//  Created by jaewon Lee on 1/6/26.
+//
+
+import CoreLocation
+import Foundation
+import MapKit
+import Observation
+
+/// 위치 갱신·역지오코딩·지오펜스 모니터링을 담당하는 Core 매니저
+///
+/// `CLLocationManager`/`CLMonitor` 래퍼로, GPS 기반 스마트 출석 등 위치가 필요한 기능이
+/// 공유하는 단일 canonical 구현체입니다. 아직 `LocationProviding`(ActivityDomain)에는
+/// conform 하지 않으며, 이는 후속 어댑터(#992 Phase B)에서 처리합니다.
+///
+/// Core 모듈은 Feature 모듈(Coordinate/Address 등)에 의존할 수 없으므로, 이 타입은
+/// `CLLocationCoordinate2D`/`String` 같은 CoreLocation 원시 타입만 노출합니다.
+/// 어댑터가 이를 도메인 타입으로 변환합니다.
+///
+/// - Important: `CLMonitor`는 watchOS에서 지원되지 않습니다(`API_UNAVAILABLE(watchos)`).
+///   `UMCFoundation`은 iOS/watchOS 멀티플랫폼 모듈이므로 지오펜스 모니터링 관련 API는
+///   `#if !os(watchOS)`로 감쌌습니다. 위치 조회/권한/역지오코딩은 두 플랫폼 모두 사용 가능합니다.
+@MainActor
+@Observable
+public final class LocationManager: NSObject {
+
+    // MARK: - Property
+
+    public static let shared: LocationManager = .init()
+
+    public private(set) var currentLocation: CLLocationCoordinate2D?
+    public private(set) var authorizationStatus: CLAuthorizationStatus = .notDetermined
+    public private(set) var isAuthorized: Bool = false
+    public private(set) var locationError: Error?
+
+    public private(set) var activeGeofenceId: String?
+    public private(set) var isInsideGeofence: Bool = false
+    public private(set) var geofenceEvent: GeofenceEvent?
+
+    private let manager = CLLocationManager()
+    private var locationContinuation: CheckedContinuation<CLLocationCoordinate2D, Error>?
+
+    #if !os(watchOS)
+    private var monitor: CLMonitor?
+    private var monitorTask: Task<Void, Never>?
+    private let monitorName = "LocationGeofenceMonitor"
+    #endif
+
+    // MARK: - Lifecycle
+
+    private override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+        updateAuthorizationStatus(manager.authorizationStatus)
+    }
+
+    // `shared` 싱글톤은 앱 생명주기 동안 해제되지 않으므로 `deinit` 정리 로직은 두지 않습니다.
+
+    // MARK: - Location
+
+    public func requestAuthorization() {
+        manager.requestWhenInUseAuthorization()
+    }
+
+    public func startLocationUpdating() {
+        guard isAuthorized else {
+            requestAuthorization()
+            return
+        }
+
+        manager.startUpdatingLocation()
+    }
+
+    public func stopLocationUpdating() {
+        manager.stopUpdatingLocation()
+    }
+
+    public func getCurrentLocation() async throws -> CLLocationCoordinate2D {
+        guard isAuthorized else {
+            requestAuthorization()
+            throw LocationError.notAuthorized
+        }
+
+        if let currentLocation {
+            return currentLocation
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            locationContinuation = continuation
+            manager.requestLocation()
+        }
+    }
+
+    // MARK: - Reverse Geocoding
+
+    /// 좌표를 주소 문자열로 변환
+    /// - Parameter coordinate: 변환할 좌표
+    /// - Returns: 주소 문자열 (예: "서울특별시 강남구 테헤란로 123")
+    /// - Throws: `LocationError.geocodingFailed`
+    public func reverseGeocode(coordinate: CLLocationCoordinate2D) async throws -> String {
+        let location = CLLocation(
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude
+        )
+
+        guard let request = MKReverseGeocodingRequest(location: location) else {
+            throw LocationError.geocodingFailed("요청을 생성할 수 없습니다.")
+        }
+
+        do {
+            let mapItems = try await request.mapItems
+            guard let address = mapItems.first?.address?.shortAddress else {
+                throw LocationError.geocodingFailed("주소 정보가 없습니다.")
+            }
+
+            return address
+        } catch let error as LocationError {
+            throw error
+        } catch {
+            throw LocationError.geocodingFailed(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Geofence
+
+    #if !os(watchOS)
+    public func startGeofenceMonitoring(
+        at coordinate: CLLocationCoordinate2D,
+        identifier: String,
+        radius: CLLocationDistance
+    ) async {
+        if activeGeofenceId == identifier {
+            checkCurrentLocationInGeofence(center: coordinate, radius: radius)
+        }
+
+        if let currentId = activeGeofenceId {
+            await monitor?.remove(currentId)
+        }
+
+        if monitor == nil {
+            monitor = await CLMonitor(monitorName)
+            startMonitoringEvents()
+        }
+
+        let condition = CLMonitor.CircularGeographicCondition(center: coordinate, radius: radius)
+        await monitor?.add(condition, identifier: identifier, assuming: .unsatisfied)
+        activeGeofenceId = identifier
+
+        checkCurrentLocationInGeofence(center: coordinate, radius: radius)
+    }
+
+    public func stopGeofenceMonitoring(identifier: String) async {
+        await monitor?.remove(identifier)
+
+        if activeGeofenceId == identifier {
+            activeGeofenceId = nil
+            isInsideGeofence = false
+        }
+    }
+
+    public func stopAllGeofenceMonitoring() async {
+        monitorTask?.cancel()
+        monitorTask = nil
+
+        if let monitor {
+            for identifier in await monitor.identifiers {
+                await monitor.remove(identifier)
+            }
+        }
+
+        activeGeofenceId = nil
+        isInsideGeofence = false
+        geofenceEvent = nil
+    }
+    #endif
+
+    // MARK: - Private
+
+    private func checkCurrentLocationInGeofence(
+        center: CLLocationCoordinate2D,
+        radius: CLLocationDistance
+    ) {
+        guard let currentLocation else { return }
+        isInsideGeofence = GeofenceCalculator.isInside(
+            current: currentLocation,
+            center: center,
+            radius: radius
+        )
+    }
+
+    private func updateAuthorizationStatus(_ status: CLAuthorizationStatus) {
+        authorizationStatus = status
+        isAuthorized = (status == .authorizedWhenInUse || status == .authorizedAlways)
+    }
+
+    #if !os(watchOS)
+    private func startMonitoringEvents() {
+        monitorTask?.cancel()
+
+        monitorTask = Task { [weak self] in
+            guard let self, let monitor = self.monitor else { return }
+
+            do {
+                for try await event in await monitor.events {
+                    self.handleMonitorEvent(event)
+                }
+            } catch {
+                print("모니터링 에러: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func handleMonitorEvent(_ event: CLMonitor.Event) {
+        switch event.state {
+        case .satisfied:
+            isInsideGeofence = true
+            geofenceEvent = .entered(event.identifier)
+
+        case .unsatisfied:
+            isInsideGeofence = false
+            geofenceEvent = .exited(event.identifier)
+
+        case .unknown:
+            break
+
+        case .unmonitored:
+            if activeGeofenceId == event.identifier {
+                isInsideGeofence = false
+                activeGeofenceId = nil
+                geofenceEvent = nil
+            }
+
+        @unknown default:
+            break
+        }
+    }
+
+    private func updateGeofenceStatus() {
+        guard let currentLocation, activeGeofenceId != nil else { return }
+
+        Task {
+            guard let monitor else { return }
+
+            for identifier in await monitor.identifiers {
+                guard let record = await monitor.record(for: identifier) else { continue }
+
+                if let condition = record.condition as? CLMonitor.CircularGeographicCondition {
+                    isInsideGeofence = GeofenceCalculator.isInside(
+                        current: currentLocation,
+                        center: condition.center,
+                        radius: condition.radius
+                    )
+                }
+            }
+        }
+    }
+    #endif
+
+    // MARK: - Delegate Handling
+
+    private func handleLocationUpdate(_ coordinate: CLLocationCoordinate2D) {
+        currentLocation = coordinate
+
+        if let continuation = locationContinuation {
+            locationContinuation = nil
+            continuation.resume(returning: coordinate)
+        }
+
+        #if !os(watchOS)
+        updateGeofenceStatus()
+        #endif
+    }
+
+    private func handleLocationFailure(_ error: Error) {
+        locationError = error
+
+        if let continuation = locationContinuation {
+            locationContinuation = nil
+            continuation.resume(throwing: LocationError.locationFailed(error.localizedDescription))
+        }
+    }
+
+    private func handleAuthorizationChange(_ status: CLAuthorizationStatus) {
+        updateAuthorizationStatus(status)
+
+        if isAuthorized {
+            manager.startUpdatingLocation()
+        }
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension LocationManager: CLLocationManagerDelegate {
+    /// - Note: `CLLocationManagerDelegate` 요구사항은 `nonisolated`이므로, 상태 변경은
+    ///   `Task { @MainActor in }`로 액터를 넘겨 처리합니다.
+    nonisolated public func locationManager(
+        _ manager: CLLocationManager,
+        didUpdateLocations locations: [CLLocation]
+    ) {
+        guard let coordinate = locations.last?.coordinate else { return }
+        Task { @MainActor in
+            self.handleLocationUpdate(coordinate)
+        }
+    }
+
+    nonisolated public func locationManager(
+        _ manager: CLLocationManager,
+        didFailWithError error: any Error
+    ) {
+        Task { @MainActor in
+            self.handleLocationFailure(error)
+        }
+    }
+
+    nonisolated public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in
+            self.handleAuthorizationChange(status)
+        }
+    }
+}

--- a/UMCApp/Core/Foundation/Sources/Location/LocationManager.swift
+++ b/UMCApp/Core/Foundation/Sources/Location/LocationManager.swift
@@ -17,7 +17,7 @@ import Observation
 /// conform 하지 않으며, 이는 후속 어댑터(#992 Phase B)에서 처리합니다.
 ///
 /// Core 모듈은 Feature 모듈(Coordinate/Address 등)에 의존할 수 없으므로, 이 타입은
-/// `CLLocationCoordinate2D`/`String` 같은 CoreLocation 원시 타입만 노출합니다.
+/// `CLLocationCoordinate2D`/`GeocodedAddress` 같은 Feature-독립 타입만 노출합니다.
 /// 어댑터가 이를 도메인 타입으로 변환합니다.
 ///
 /// - Important: `CLMonitor`는 watchOS에서 지원되지 않습니다(`API_UNAVAILABLE(watchos)`).
@@ -47,6 +47,10 @@ public final class LocationManager: NSObject {
     private var monitor: CLMonitor?
     private var monitorTask: Task<Void, Never>?
     private let monitorName = "LocationGeofenceMonitor"
+    /// 식별자별로 모니터링 중인 지오펜스의 중심/반경 캐시.
+    /// `CLMonitor`는 식별자 단위 조회 API가 async라 `isInside(geofenceId:)`를 동기로
+    /// 노출하기 위해 등록 시점 값을 별도로 들고 있다.
+    private var monitoredGeofences: [String: MonitoredGeofence] = [:]
     #endif
 
     // MARK: - Lifecycle
@@ -97,11 +101,11 @@ public final class LocationManager: NSObject {
 
     // MARK: - Reverse Geocoding
 
-    /// 좌표를 주소 문자열로 변환
+    /// 좌표를 구조화된 주소로 변환
     /// - Parameter coordinate: 변환할 좌표
-    /// - Returns: 주소 문자열 (예: "서울특별시 강남구 테헤란로 123")
+    /// - Returns: `GeocodedAddress`(전체/짧은 주소 + 시/구 후보 필드, 정보 손실 없이 보존)
     /// - Throws: `LocationError.geocodingFailed`
-    public func reverseGeocode(coordinate: CLLocationCoordinate2D) async throws -> String {
+    public func reverseGeocode(coordinate: CLLocationCoordinate2D) async throws -> GeocodedAddress {
         let location = CLLocation(
             latitude: coordinate.latitude,
             longitude: coordinate.longitude
@@ -113,11 +117,16 @@ public final class LocationManager: NSObject {
 
         do {
             let mapItems = try await request.mapItems
-            guard let address = mapItems.first?.address?.shortAddress else {
+            guard let mapItem = mapItems.first, let address = mapItem.address else {
                 throw LocationError.geocodingFailed("주소 정보가 없습니다.")
             }
 
-            return address
+            return GeocodedAddress(
+                fullAddress: address.fullAddress,
+                shortAddress: address.shortAddress,
+                city: mapItem.addressRepresentations?.regionName,
+                district: mapItem.addressRepresentations?.cityName
+            )
         } catch let error as LocationError {
             throw error
         } catch {
@@ -128,21 +137,19 @@ public final class LocationManager: NSObject {
     // MARK: - Geofence
 
     #if !os(watchOS)
+    /// 여러 지오펜스를 동시에 등록할 수 있다(활동별 스케줄 ID 등). 기존에 등록된 다른
+    /// 식별자는 유지되며, 같은 식별자로 다시 호출하면 조건(중심/반경)만 갱신된다.
     public func startGeofenceMonitoring(
         at coordinate: CLLocationCoordinate2D,
         identifier: String,
         radius: CLLocationDistance
     ) async {
-        if activeGeofenceId == identifier {
-            checkCurrentLocationInGeofence(center: coordinate, radius: radius)
-        }
-
-        if let currentId = activeGeofenceId {
-            await monitor?.remove(currentId)
-        }
+        monitoredGeofences[identifier] = MonitoredGeofence(center: coordinate, radius: radius)
 
         if monitor == nil {
             monitor = await CLMonitor(monitorName)
+        }
+        if monitorTask == nil {
             startMonitoringEvents()
         }
 
@@ -155,6 +162,7 @@ public final class LocationManager: NSObject {
 
     public func stopGeofenceMonitoring(identifier: String) async {
         await monitor?.remove(identifier)
+        monitoredGeofences.removeValue(forKey: identifier)
 
         if activeGeofenceId == identifier {
             activeGeofenceId = nil
@@ -172,9 +180,22 @@ public final class LocationManager: NSObject {
             }
         }
 
+        monitoredGeofences.removeAll()
         activeGeofenceId = nil
         isInsideGeofence = false
         geofenceEvent = nil
+    }
+
+    /// 특정 지오펜스 식별자 안에 현재 위치가 있는지 판정
+    ///
+    /// 여러 지오펜스가 동시에 모니터링 중이어도 요청한 식별자만 정확히 조회한다.
+    /// 등록되지 않은 식별자거나 현재 위치를 모르면 `false`.
+    public func isInside(geofenceId: String) -> Bool {
+        GeofenceCalculator.isInside(
+            geofenceId: geofenceId,
+            current: currentLocation,
+            geofences: monitoredGeofences
+        )
     }
     #endif
 
@@ -239,24 +260,17 @@ public final class LocationManager: NSObject {
         }
     }
 
+    /// 현재 `activeGeofenceId` 하나만 갱신한다. 다른 모니터링 대상 지오펜스는
+    /// `isInside(geofenceId:)`로 별도 조회하므로 이 상태와 무관하다.
     private func updateGeofenceStatus() {
-        guard let currentLocation, activeGeofenceId != nil else { return }
+        guard let currentLocation, let activeGeofenceId,
+              let geofence = monitoredGeofences[activeGeofenceId] else { return }
 
-        Task {
-            guard let monitor else { return }
-
-            for identifier in await monitor.identifiers {
-                guard let record = await monitor.record(for: identifier) else { continue }
-
-                if let condition = record.condition as? CLMonitor.CircularGeographicCondition {
-                    isInsideGeofence = GeofenceCalculator.isInside(
-                        current: currentLocation,
-                        center: condition.center,
-                        radius: condition.radius
-                    )
-                }
-            }
-        }
+        isInsideGeofence = GeofenceCalculator.isInside(
+            current: currentLocation,
+            center: geofence.center,
+            radius: geofence.radius
+        )
     }
     #endif
 

--- a/UMCApp/Core/Foundation/Tests/GeofenceCalculatorTests.swift
+++ b/UMCApp/Core/Foundation/Tests/GeofenceCalculatorTests.swift
@@ -1,0 +1,75 @@
+//
+//  GeofenceCalculatorTests.swift
+//  UMCFoundationTests
+//
+//  Created by jaewon Lee on 1/6/26.
+//
+
+import CoreLocation
+import Testing
+@testable import UMCFoundation
+
+@Suite("GeofenceCalculator — 지오펜스 거리·판정 순수 로직")
+struct GeofenceCalculatorTests {
+
+    /// 서울시청 좌표 (기준점)
+    private let seoulCityHall = CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780)
+
+    @Test("동일 좌표의 거리는 0에 가깝다")
+    func distanceToSelfIsZero() {
+        let distance = GeofenceCalculator.distance(from: seoulCityHall, to: seoulCityHall)
+        #expect(distance == 0)
+    }
+
+    @Test("위도 1도 차이는 약 111km(허용 오차 내)")
+    func distanceOneDegreeLatitude() {
+        let oneDegreeNorth = CLLocationCoordinate2D(
+            latitude: seoulCityHall.latitude + 1,
+            longitude: seoulCityHall.longitude
+        )
+        let distance = GeofenceCalculator.distance(from: seoulCityHall, to: oneDegreeNorth)
+        #expect((110_000...112_000).contains(distance))
+    }
+
+    @Test("반경 이내 좌표는 isInside == true")
+    func isInsideTrueWhenWithinRadius() {
+        let nearbyPoint = CLLocationCoordinate2D(
+            latitude: seoulCityHall.latitude + 0.0001,
+            longitude: seoulCityHall.longitude
+        )
+        let isInside = GeofenceCalculator.isInside(
+            current: nearbyPoint,
+            center: seoulCityHall,
+            radius: 100
+        )
+        #expect(isInside == true)
+    }
+
+    @Test("반경 밖 좌표는 isInside == false")
+    func isInsideFalseWhenOutsideRadius() {
+        let farPoint = CLLocationCoordinate2D(
+            latitude: seoulCityHall.latitude + 1,
+            longitude: seoulCityHall.longitude
+        )
+        let isInside = GeofenceCalculator.isInside(
+            current: farPoint,
+            center: seoulCityHall,
+            radius: 100
+        )
+        #expect(isInside == false)
+    }
+
+    @Test("경계값(정확히 반경)은 isInside == true (이하 포함)")
+    func isInsideBoundaryIsInclusive() {
+        let center = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let boundaryPoint = CLLocationCoordinate2D(latitude: 0.001, longitude: 0)
+        let radius = GeofenceCalculator.distance(from: boundaryPoint, to: center)
+
+        let isInside = GeofenceCalculator.isInside(
+            current: boundaryPoint,
+            center: center,
+            radius: radius
+        )
+        #expect(isInside == true)
+    }
+}

--- a/UMCApp/Core/Foundation/Tests/GeofenceCalculatorTests.swift
+++ b/UMCApp/Core/Foundation/Tests/GeofenceCalculatorTests.swift
@@ -72,4 +72,54 @@ struct GeofenceCalculatorTests {
         )
         #expect(isInside == true)
     }
+
+    // MARK: - isInside(geofenceId:current:geofences:)
+
+    @Test("등록된 식별자의 반경 안이면 true")
+    func isInsideGeofenceIdTrueWhenWithinRadius() {
+        let nearbyPoint = CLLocationCoordinate2D(
+            latitude: seoulCityHall.latitude + 0.0001,
+            longitude: seoulCityHall.longitude
+        )
+        let isInside = GeofenceCalculator.isInside(
+            geofenceId: "schedule-100",
+            current: nearbyPoint,
+            geofences: ["schedule-100": MonitoredGeofence(center: seoulCityHall, radius: 100)]
+        )
+        #expect(isInside == true)
+    }
+
+    @Test("등록된 식별자의 반경 밖이면 false")
+    func isInsideGeofenceIdFalseWhenOutsideRadius() {
+        let farPoint = CLLocationCoordinate2D(
+            latitude: seoulCityHall.latitude + 1,
+            longitude: seoulCityHall.longitude
+        )
+        let isInside = GeofenceCalculator.isInside(
+            geofenceId: "schedule-100",
+            current: farPoint,
+            geofences: ["schedule-100": MonitoredGeofence(center: seoulCityHall, radius: 100)]
+        )
+        #expect(isInside == false)
+    }
+
+    @Test("다른 식별자가 반경 안이어도 요청한 식별자가 미등록이면 false")
+    func isInsideGeofenceIdFalseWhenIdentifierNotRegistered() {
+        let isInside = GeofenceCalculator.isInside(
+            geofenceId: "schedule-999",
+            current: seoulCityHall,
+            geofences: ["schedule-100": MonitoredGeofence(center: seoulCityHall, radius: 100)]
+        )
+        #expect(isInside == false)
+    }
+
+    @Test("현재 위치를 모르면 등록된 식별자여도 false")
+    func isInsideGeofenceIdFalseWhenCurrentLocationMissing() {
+        let isInside = GeofenceCalculator.isInside(
+            geofenceId: "schedule-100",
+            current: nil,
+            geofences: ["schedule-100": MonitoredGeofence(center: seoulCityHall, radius: 100)]
+        )
+        #expect(isInside == false)
+    }
 }

--- a/UMCApp/Project.swift
+++ b/UMCApp/Project.swift
@@ -22,6 +22,7 @@ let project = Project(
                     "NSBluetoothPeripheralUsageDescription": "주변 명함을 교환하기 위해 블루투스를 사용합니다.",
                     "NFCReaderUsageDescription": "NFC로 명함 정보를 주고받습니다.",
                     "NSNearbyInteractionUsageDescription": "근거리에서 정확한 명함 교환을 위해 위치를 사용합니다.",
+                    "NSLocationWhenInUseUsageDescription": "GPS 기반 스마트 출석 체크를 위해 위치 정보를 사용합니다.",
                     // Secrets/Shared.xcconfig(+ Secrets.xcconfig)에서 주입되는 값.
                     // UMCFoundation의 Config가 이 키들을 읽는다.
                     // (BASE_URL / KAKAO_KEY / TMAP_SECRET_KEY / GOOGLE_CLIENT_ID / GOOGLE_REVERSED_CLIENT_ID)


### PR DESCRIPTION
resolves #1017

## ✨ PR 유형

♻️ 리팩토링 — 레거시 `LocationManager` · `GeofenceEvent`를 `UMCFoundation`(Core/Foundation)으로 이관, `LocationProviding` 실구현체 부재 해소

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 — 테스트 실행 결과로 갈음합니다.

```
make test SCHEME=UMCFoundation
Test run with 93 tests in 19 suites passed after 0.172 seconds.

GeofenceCalculatorTests (9 케이스)
✔ Suite "GeofenceCalculator — 지오펜스 거리·판정 순수 로직" passed
✔ Test run with 9 tests in 1 suite passed after 0.004 seconds.

make build SCHEME=UMCFoundation → ** BUILD SUCCEEDED **
make build SCHEME=UMCApp → ** BUILD SUCCEEDED **
```

## 🛠️ 작업내용

- `Core/Foundation/Sources/Location/` 신설 — `LocationManager` / `GeofenceEvent` / `GeofenceCalculator` / `GeocodedAddress` 배치
- Core는 Feature(ActivityDomain) 타입에 의존할 수 없어 `CLLocationCoordinate2D` · `GeocodedAddress` 기반 API로 재설계 — 도메인 타입(`Coordinate`/`Address`) 변환은 #992 Phase B 어댑터가 담당
- Swift 6 격리: `@MainActor` + `@Observable`, `CLLocationManagerDelegate`는 `nonisolated` 후 액터 홉 (`KakaoPlusManager` 선례와 동일 패턴)
- `CLMonitor`가 watchOS 미지원이라 지오펜스 모니터링 코드를 `#if !os(watchOS)` 가드 (UMCFoundation은 iPhone+Watch 멀티플랫폼 모듈)
- 멀티 지오펜스 추적(`monitoredGeofences`) 및 `isInside(geofenceId:)` 노출 — `LocationProviding` 계약의 per-ID 판정 시맨틱 충족
- `stopAllGeofenceMonitoring()` 후에도 이벤트 스트림이 재개되도록 `CLMonitor` 생성과 이벤트 소비 태스크 재시작 조건 분리
- `reverseGeocode(coordinate:)`가 `GeocodedAddress`(fullAddress/shortAddress/city/district)를 반환 — 어댑터가 `Address`를 무손실 복원 가능
- `UMCFoundation` `Project.swift`에 CoreLocation/MapKit SDK 의존성 추가, 앱 타깃 Info.plist에 `NSLocationWhenInUseUsageDescription` 추가
- `GeofenceCalculator` 순수 로직 Swift Testing 단위 테스트 9케이스

## 📋 추후 진행 상황

- #992 Phase B: `LocationProviding` conform 어댑터 + DI 교체 — `isInsideAnyGeofence`는 `isInsideGeofence` 재사용 대신 `monitoredGeofences` OR-reduction으로 도출 권장
- `GeocodedAddress`의 city/district ↔ `MKAddressRepresentations.regionName`/`cityName` 매핑 실기기(한국 주소) 검증
- 커버리지 리포트 수집 (Tuist 스킴 `-enableCodeCoverage` 활성화)

## 📌 리뷰 포인트

- `UMCApp/Core/Foundation/Sources/Location/LocationManager.swift` - `@MainActor` 격리 + `nonisolated` 델리게이트 홉, 멀티 지오펜스 추적/재시작 조건
- `UMCApp/Core/Foundation/Sources/Location/GeofenceCalculator.swift` - 거리·판정 순수 로직 (단위 테스트 대상)
- `UMCApp/Core/Foundation/Sources/Location/GeocodedAddress.swift` - 한국 주소 체계 매핑 주석 (실기기 검증 필요 항목)
- `UMCApp/Project.swift` - 위치 권한 키 추가

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)