### PR TITLE
♻️ [Refactor] CoreUIComponents 잔여 이관 — AttendanceStatusBadge · LoadingView 이식, SectionErrorCard 대체 판정

### DIFF
--- a/UMCApp/Core/UIComponents/Project.swift
+++ b/UMCApp/Core/UIComponents/Project.swift
@@ -16,5 +16,6 @@ let project = coreProject(
         // CoreDesignSystem과 동일한 규칙 — 자동 생성 심볼 대신 문자열 이름으로 접근한다.
         "ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS": "NO",
         "ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS": "NO",
-    ]
+    ],
+    includesTests: true
 )

--- a/UMCApp/Core/UIComponents/Sources/Badge/AttendanceBadgeStatus.swift
+++ b/UMCApp/Core/UIComponents/Sources/Badge/AttendanceBadgeStatus.swift
@@ -1,0 +1,94 @@
+//
+//  AttendanceBadgeStatus.swift
+//  CoreUIComponents
+//
+//  Created by euijjang97 on 5/6/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+
+// MARK: - AttendanceBadgeStatus
+
+/// ``AttendanceStatusBadge`` 가 표현하는 출석 상태의 Core-safe 추상화입니다.
+///
+/// CoreUIComponents는 Feature Domain 모듈(예: ActivityDomain의 `ParticipantAttendanceStatus`)에
+/// 의존할 수 없으므로, 실제 출석 도메인 enum과 동일한 케이스 집합을 자체적으로 보유합니다.
+/// 각 Feature는 자신의 도메인 enum을 Presentation 레이어에서 이 타입으로 매핑해 사용합니다.
+public enum AttendanceBadgeStatus: String, CaseIterable, Equatable, Hashable, Sendable {
+
+    /// 출석 승인 대기 (체크인 완료, 운영진 승인 전)
+    case presentPending
+    /// 지각 승인 대기
+    case latePending
+    /// 사유 결석 승인 대기
+    case excusedPending
+    /// 출석 (정시)
+    case present
+    /// 지각
+    case late
+    /// 결석
+    case absent
+    /// 사유 결석 (출석으로 인정)
+    case excused
+    /// 출석 전 (정책 시작 전)
+    case pending
+    /// 알 수 없는 상태 (도메인 enum이 forward-compatible 폴백으로 매핑)
+    case unknown
+
+    // MARK: - Display
+
+    /// 뱃지 컴포넌트에 렌더링할 짧은 텍스트
+    public var badgeText: String {
+        switch self {
+        case .presentPending: return "출석 승인 대기"
+        case .latePending: return "지각 승인 대기"
+        case .excusedPending: return "사유 승인 대기"
+        case .present: return "출석"
+        case .late: return "지각"
+        case .absent: return "결석"
+        case .excused: return "사유 결석"
+        case .pending: return "출석 전"
+        case .unknown: return "알 수 없음"
+        }
+    }
+
+    /// VoiceOver 등 접근성 라벨에 사용할 전체 문구
+    public var accessibilityText: String {
+        self == .unknown ? "상태 미지정" : badgeText
+    }
+
+    // MARK: - Color
+
+    /// 배지 배경(tint)에 사용할 색상
+    public var tintColor: Color {
+        switch self {
+        case .present, .excused:
+            return .green500
+        case .late:
+            return .orange500
+        case .absent:
+            return .red500
+        case .presentPending, .latePending, .excusedPending:
+            return .yellow500
+        case .pending, .unknown:
+            return .grey500
+        }
+    }
+
+    /// 배지 텍스트/아이콘에 사용할 색상
+    public var foregroundColor: Color {
+        switch self {
+        case .present, .excused:
+            return .green500
+        case .late:
+            return .orange500
+        case .absent:
+            return .red500
+        case .presentPending, .latePending, .excusedPending:
+            return .orange500
+        case .pending, .unknown:
+            return .grey600
+        }
+    }
+}

--- a/UMCApp/Core/UIComponents/Sources/Badge/AttendanceStatusBadge.swift
+++ b/UMCApp/Core/UIComponents/Sources/Badge/AttendanceStatusBadge.swift
@@ -1,0 +1,75 @@
+//
+//  AttendanceStatusBadge.swift
+//  CoreUIComponents
+//
+//  Created by euijjang97 on 5/6/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+
+// MARK: - AttendanceStatusBadge
+
+/// 출석 상태를 색상으로 구분해 표시하는 뱃지 컴포넌트
+///
+/// ``AttendanceBadgeStatus`` 의 9개 케이스(`unknown` 포함)를 색상으로 구분합니다.
+/// 운영진 출석 현황 목록/상세 등 여러 Feature가 공유하는 컴포넌트입니다.
+/// 색상/문구 매핑은 ``AttendanceBadgeStatus`` 가 소유하며, 본 뷰는 렌더링만 담당합니다.
+public struct AttendanceStatusBadge: View, Equatable {
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let backgroundOpacity: Double = 0.18
+        static let unknownIconSize: CGFloat = 11
+    }
+
+    // MARK: - Property
+
+    private let status: AttendanceBadgeStatus
+
+    // MARK: - Initializer
+
+    public init(status: AttendanceBadgeStatus) {
+        self.status = status
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        HStack(spacing: DefaultSpacing.spacing4) {
+            if status == .unknown {
+                Image(systemName: "questionmark.circle")
+                    .font(.system(size: Constants.unknownIconSize, weight: .semibold))
+            }
+            Text(status.badgeText)
+                .lineLimit(1)
+        }
+        .appFont(.caption1, color: status.foregroundColor)
+        .padding(.horizontal, DefaultSpacing.spacing8)
+        .padding(.vertical, DefaultSpacing.spacing4)
+        .glassEffect(
+            .clear.tint(status.tintColor.opacity(Constants.backgroundOpacity)),
+            in: Capsule()
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(status.accessibilityText)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview {
+    VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+        ForEach(AttendanceBadgeStatus.allCases, id: \.self) { status in
+            HStack {
+                AttendanceStatusBadge(status: status)
+                Text(status.rawValue)
+                    .appFont(.footnote, color: .grey500)
+            }
+        }
+    }
+    .padding()
+}
+#endif

--- a/UMCApp/Core/UIComponents/Sources/Loading/LoadingView.swift
+++ b/UMCApp/Core/UIComponents/Sources/Loading/LoadingView.swift
@@ -1,0 +1,116 @@
+//
+//  LoadingView.swift
+//  CoreUIComponents
+//
+//  Created by euijjang97 on 1/21/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+
+// MARK: - LoadingView
+
+/// 데이터 로딩 중 표시되는 공용 로딩 뷰입니다.
+///
+/// 각 Feature별로 컨텍스트에 맞는 로딩 메시지를 표시하며,
+/// Liquid Glass 효과가 적용된 디자인 시스템을 따릅니다.
+///
+/// - Important: `Loadable<T>` 의 `.loading` 상태에서 사용합니다.
+///
+/// - Usage:
+/// ```swift
+/// switch viewModel.seasonState {
+/// case .idle: Color.clear
+/// case .loading: LoadingView(.home(.seasonLoading))
+/// case .loaded(let data): ContentView(data)
+/// case .failed(let error): ErrorView(error)
+/// }
+/// ```
+public struct LoadingView: View {
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        /// `DefaultSpacing` 에 16/24는 있으나 20에 정확히 대응하는 토큰이 없어 레거시 값을 유지합니다.
+        static let contentPadding: CGFloat = 20
+    }
+
+    // MARK: - Property
+
+    /// 로딩 타입 (Feature별 메시지 구분)
+    private let type: LoadingType
+
+    // MARK: - Nested Types
+
+    /// Feature별 로딩 타입을 정의하는 열거형입니다.
+    ///
+    /// 새로운 Feature의 로딩 메시지를 추가할 때는 여기에 case를 추가합니다.
+    public enum LoadingType {
+        /// 홈 화면 로딩 타입
+        ///
+        /// - Parameter home: 홈 화면 내 세부 로딩 타입
+        case home(Home)
+
+        /// 홈 화면의 세부 로딩 타입을 정의합니다.
+        public enum Home: String {
+            /// 기수 정보 로딩 중
+            case seasonLoading = "기수 정보를 가져오는 중입니다."
+
+            /// 패널티 정보 로딩 중
+            case penaltyLoading = "패널티 정보를 가져오는 중입니다."
+
+            /// 최근 공지 로딩 중
+            case recentNoticeLoading = "최근 공지를 가져오는 중입니다."
+        }
+
+        /// 로딩 메시지 텍스트를 반환합니다.
+        ///
+        /// - Returns: 로딩 타입에 맞는 사용자 친화적 메시지
+        public var text: String {
+            switch self {
+            case .home(let homeType):
+                return homeType.rawValue
+            }
+        }
+    }
+
+    // MARK: - Initializer
+
+    /// LoadingView 초기화
+    ///
+    /// - Parameter type: 로딩 타입 (Feature별 메시지 구분)
+    public init(_ type: LoadingType) {
+        self.type = type
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        ProgressView(label: {
+            Text(type.text)
+                .appFont(.footnote, color: .grey400)
+                .frame(maxWidth: .infinity)
+        })
+        .padding(Constants.contentPadding)
+        .glassEffect(
+            .regular,
+            in: .rect(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview {
+    VStack(spacing: DefaultSpacing.spacing24) {
+        LoadingView(.home(.seasonLoading))
+        LoadingView(.home(.penaltyLoading))
+        LoadingView(.home(.recentNoticeLoading))
+    }
+    .padding()
+}
+#endif

--- a/UMCApp/Core/UIComponents/Tests/Badge/AttendanceBadgeStatusTests.swift
+++ b/UMCApp/Core/UIComponents/Tests/Badge/AttendanceBadgeStatusTests.swift
@@ -1,0 +1,116 @@
+//
+//  AttendanceBadgeStatusTests.swift
+//  CoreUIComponentsTests
+//
+//  Created by euijjang97 on 5/6/26.
+//
+
+import SwiftUI
+import Testing
+@testable import CoreUIComponents
+
+@Suite("AttendanceBadgeStatus — 출석 상태 → 색상/문구 매핑")
+struct AttendanceBadgeStatusTests {
+
+    // MARK: - badgeText
+
+    @Test(
+        "상태별 짧은 배지 텍스트가 정확히 매핑된다",
+        arguments: [
+            (AttendanceBadgeStatus.presentPending, "출석 승인 대기"),
+            (.latePending, "지각 승인 대기"),
+            (.excusedPending, "사유 승인 대기"),
+            (.present, "출석"),
+            (.late, "지각"),
+            (.absent, "결석"),
+            (.excused, "사유 결석"),
+            (.pending, "출석 전"),
+            (.unknown, "알 수 없음")
+        ]
+    )
+    func badgeTextMapping(status: AttendanceBadgeStatus, expected: String) {
+        #expect(status.badgeText == expected)
+    }
+
+    // MARK: - accessibilityText
+
+    @Test("unknown 상태의 접근성 문구는 '상태 미지정' 이다")
+    func unknownAccessibilityTextIsUnspecified() {
+        #expect(AttendanceBadgeStatus.unknown.accessibilityText == "상태 미지정")
+    }
+
+    @Test(
+        "unknown 이 아닌 상태의 접근성 문구는 badgeText 와 동일하다",
+        arguments: AttendanceBadgeStatus.allCases.filter { $0 != .unknown }
+    )
+    func nonUnknownAccessibilityTextEqualsBadgeText(status: AttendanceBadgeStatus) {
+        #expect(status.accessibilityText == status.badgeText)
+    }
+
+    // MARK: - tintColor
+
+    @Test(
+        "출석/사유 결석은 초록 tint 를 사용한다",
+        arguments: [AttendanceBadgeStatus.present, .excused]
+    )
+    func presentAndExcusedUseGreenTint(status: AttendanceBadgeStatus) {
+        #expect(status.tintColor == .green500)
+    }
+
+    @Test("지각은 주황 tint 를 사용한다")
+    func lateUsesOrangeTint() {
+        #expect(AttendanceBadgeStatus.late.tintColor == .orange500)
+    }
+
+    @Test("결석은 빨강 tint 를 사용한다")
+    func absentUsesRedTint() {
+        #expect(AttendanceBadgeStatus.absent.tintColor == .red500)
+    }
+
+    @Test(
+        "승인 대기 상태는 노랑 tint 를 사용한다",
+        arguments: [AttendanceBadgeStatus.presentPending, .latePending, .excusedPending]
+    )
+    func pendingStatusesUseYellowTint(status: AttendanceBadgeStatus) {
+        #expect(status.tintColor == .yellow500)
+    }
+
+    @Test(
+        "출석 전/unknown 은 회색 tint 를 사용한다",
+        arguments: [AttendanceBadgeStatus.pending, .unknown]
+    )
+    func pendingAndUnknownUseGreyTint(status: AttendanceBadgeStatus) {
+        #expect(status.tintColor == .grey500)
+    }
+
+    // MARK: - foregroundColor
+
+    @Test(
+        "출석/사유 결석은 초록 전경색을 사용한다",
+        arguments: [AttendanceBadgeStatus.present, .excused]
+    )
+    func presentAndExcusedUseGreenForeground(status: AttendanceBadgeStatus) {
+        #expect(status.foregroundColor == .green500)
+    }
+
+    @Test("결석은 빨강 전경색을 사용한다")
+    func absentUsesRedForeground() {
+        #expect(AttendanceBadgeStatus.absent.foregroundColor == .red500)
+    }
+
+    @Test(
+        "지각과 승인 대기 상태는 주황 전경색을 사용한다",
+        arguments: [AttendanceBadgeStatus.late, .presentPending, .latePending, .excusedPending]
+    )
+    func lateAndPendingStatusesUseOrangeForeground(status: AttendanceBadgeStatus) {
+        #expect(status.foregroundColor == .orange500)
+    }
+
+    @Test(
+        "출석 전/unknown 은 회색 전경색을 사용한다",
+        arguments: [AttendanceBadgeStatus.pending, .unknown]
+    )
+    func pendingAndUnknownUseGreyForeground(status: AttendanceBadgeStatus) {
+        #expect(status.foregroundColor == .grey600)
+    }
+}


### PR DESCRIPTION
resolves #1019

## ✨ PR 유형

♻️ 리팩토링 — 레거시 공용 UI 컴포넌트 잔여 3종 처리: `AttendanceStatusBadge` · `LoadingView` 이관 + `SectionErrorCard` 대체 판정(이관 제외)

## 📷 스크린샷 or 영상(UI 변경 시)

신규 공용 컴포넌트 이관으로 아직 소비 화면 배선 없음 — 테스트 실행 결과로 갈음합니다.

```
make test SCHEME=CoreUIComponents
✔ Suite "AttendanceBadgeStatus — 출석 상태 → 색상/문구 매핑" passed
✔ Test run with 12 tests in 1 suite passed after 0.067 seconds.

make build SCHEME=CoreUIComponents → ** BUILD SUCCEEDED **
make build SCHEME=HomePresentation → ** BUILD SUCCEEDED **
```

## 🛠️ 작업내용

- `AttendanceStatusBadge` 이관 — 레거시가 Feature Domain 타입(`AttendanceStatusV2`)을 직접 받던 구조를 Core 소유 `AttendanceBadgeStatus`(public enum, 9 case) 기반으로 재설계해 CoreUIComponents의 Feature 비의존 제약 충족. 색상/문구 매핑을 enum computed property로 이동해 View 없이 단위 테스트 가능
- `LoadingView` 이관 — 레거시 구조(`LoadingType`/`Home` nested enum) 보존, `public` 노출, `CoreDesignSystem` 토큰(`AppFont`/`DefaultConstant`/`DefaultSpacing`) 적용
- `SectionErrorCard` 이관 제외 확정 — 기존 `RetryContentUnavailableView`가 동일 역할(섹션 인라인 에러 + 재시도)을 이미 수행 중이며 실제 호출부(HomeView 기수 정보, Notice 상세/읽음 상태/대상 시트)에서 사용 중임을 확인. 동일 역할 경쟁 컴포넌트 신설 방지
- `CoreUIComponents` `Project.swift`에 `includesTests: true` 추가(모듈 최초 테스트 타깃) + `AttendanceBadgeStatus` 분기 로직 Swift Testing 12케이스

## 📋 추후 진행 상황

- Fast-follow: `ParticipantAttendanceStatus → AttendanceBadgeStatus` 매핑 확장(ActivityPresentation)으로 실제 소비 배선 — 배선 전까지 뱃지는 미참조 상태
- `LoadingView` 콘텐츠 패딩 20pt는 대응 `DefaultSpacing` 토큰 부재로 레거시 값 유지(주석 기록) — 디자인 토큰 갭 확인 필요 시 후속 이슈
- 커버리지 리포트 수집 (Tuist 스킴 `-enableCodeCoverage` 활성화)

## 📌 리뷰 포인트

- `UMCApp/Core/UIComponents/Sources/Badge/AttendanceBadgeStatus.swift` - Core-safe 표현 enum 설계, 케이스 집합이 `ParticipantAttendanceStatus`와 1:1 (rawValue는 서버 계약과 비호환 — 디코딩 용도 아님)
- `UMCApp/Core/UIComponents/Sources/Badge/AttendanceStatusBadge.swift` - 렌더링 전용 View 분리, Glass Capsule 패턴
- `UMCApp/Core/UIComponents/Sources/Loading/LoadingView.swift` - 레거시 파리티 + 토큰 치환
- `SectionErrorCard` 제외 판정 근거 — 본문 작업내용 참고

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)