### PR TITLE
♻️ [Refactor] 운영진 멤버 관리 화면 이식 — 상세 시트 + 상벌점 부여 폼

### DIFF
--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Member/PointGrantFormSheet.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Member/PointGrantFormSheet.swift
@@ -1,0 +1,221 @@
+//
+//  PointGrantFormSheet.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/25/26.
+//
+
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 상벌점 부여 폼 시트
+///
+/// 포인트 타입 선택 → 배점 입력(CUSTOM 타입만) → 사유 입력 순서로 진행합니다.
+/// `viewModel.grantPoint`를 통해 부여 결과를 `OperatorMemberDetailSheetViewModel`과 공유합니다.
+struct PointGrantFormSheet: View {
+
+    // MARK: - Property
+
+    let availablePointTypes: [ChallengerPointType]
+    let isSubmittingPoint: Bool
+
+    /// 상벌점 부여 결과를 공유하는 ViewModel
+    ///
+    /// 상세 시트가 소유한 인스턴스를 그대로 참조합니다(폼이 소유하지 않음).
+    let viewModel: OperatorMemberDetailSheetViewModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedPointType: ChallengerPointType?
+    @State private var customPointValueText: String = ""
+    @State private var pointValue: Int = 0
+    @State private var pointReason: String = ""
+    @State private var showReasonAlert: Bool = false
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let customValueFieldWidth: CGFloat = 100
+        static let selectionAnimationDuration: TimeInterval = 0.2
+    }
+
+    // MARK: - Computed Property
+
+    private var rewardTypes: [ChallengerPointType] {
+        availablePointTypes.filter { $0.isReward }
+    }
+
+    private var penaltyTypes: [ChallengerPointType] {
+        availablePointTypes.filter { !$0.isReward }
+    }
+
+    /// CUSTOM 타입일 때 입력된 배점 유효성 검증. 0점 부여는 허용하지 않습니다.
+    private var isCustomPointValueValid: Bool {
+        guard selectedPointType?.isCustom == true else { return true }
+        return Int(customPointValueText).map { $0 != 0 } ?? false
+    }
+
+    /// 확인 버튼 활성화 조건
+    private var isConfirmEnabled: Bool {
+        selectedPointType != nil && isCustomPointValueValid && !isSubmittingPoint
+    }
+
+    private var isReasonBlank: Bool {
+        pointReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                if !rewardTypes.isEmpty {
+                    Section("상점") {
+                        ForEach(rewardTypes) { pointTypeRow(type: $0, tint: .green) }
+                    }
+                }
+
+                Section("벌점") {
+                    ForEach(penaltyTypes) { pointTypeRow(type: $0, tint: .red) }
+                }
+
+                if selectedPointType?.isCustom == true {
+                    customPointValueSection
+                }
+            }
+            .navigationTitle("상벌점 부여")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolBarCollection.CancelBtn { dismiss() }
+                ToolBarCollection.ConfirmBtn(
+                    action: { showReasonAlert = true },
+                    disable: !isConfirmEnabled,
+                    isLoading: isSubmittingPoint,
+                    dismissOnTap: false
+                )
+            }
+            .alert("사유 입력", isPresented: $showReasonAlert) {
+                TextField("사유를 입력하세요", text: $pointReason)
+                Button("취소", role: .cancel) { pointReason = "" }
+                Button("확인") { Task { await submitPoint() } }
+            } message: {
+                if let selected = selectedPointType {
+                    Text(reasonAlertMessage(for: selected))
+                }
+            }
+        }
+        // 레거시 .fullScreenCover 는 스와이프 dismiss 경로가 구조적으로 없었다. .sheet 로 바꾸면서
+        // 그 보증이 사라지므로 부모 상세 시트와 동일하게 막는다(취소 버튼으로만 종료).
+        // 동작하지 않는 제스처를 광고하지 않도록 드래그 인디케이터도 노출하지 않는다.
+        .presentationDetents([.medium, .large])
+        .interactiveDismissDisabled()
+    }
+
+    // MARK: - SubView
+
+    /// Custom 타입 선택 시 나타나는 배점 직접 입력 섹션
+    private var customPointValueSection: some View {
+        Section("배점") {
+            HStack {
+                Text("점수 입력")
+                    .appFont(.subheadline)
+
+                Spacer()
+
+                TextField("예: 3 또는 -2", text: $customPointValueText)
+                    .keyboardType(.numbersAndPunctuation)
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: Constants.customValueFieldWidth)
+                    .onChange(of: customPointValueText) { _, newValue in
+                        if let parsed = Int(newValue) { pointValue = parsed }
+                    }
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    /// 포인트 부여를 요청하고, 성공 시 시트를 닫고 입력값을 초기화합니다.
+    ///
+    /// alert 의 확인 버튼은 `disabled` 를 적용해도 시스템이 무시하므로, 빈 사유 방어는
+    /// 이 가드가 담당합니다.
+    @MainActor
+    private func submitPoint() async {
+        guard let type = selectedPointType, !isReasonBlank else { return }
+
+        let success = await viewModel.grantPoint(
+            type: type,
+            value: pointValue,
+            reason: pointReason
+        )
+        guard success else { return }
+
+        dismiss()
+        selectedPointType = nil
+        customPointValueText = ""
+        pointReason = ""
+    }
+
+    private func reasonAlertMessage(for type: ChallengerPointType) -> String {
+        let sign = pointValue > 0 ? "+" : ""
+        return "\(type.displayName) (\(sign)\(pointValue)점) 사유를 입력해주세요."
+    }
+
+    /// 포인트 타입 선택 행. 선택 시 체크마크 표시 및 배점 자동 설정.
+    private func pointTypeRow(type: ChallengerPointType, tint: Color) -> some View {
+        let isSelected = selectedPointType == type
+
+        return Button {
+            // 이미 선택된 행 재탭은 무시한다. 재탭을 그대로 처리하면 CUSTOM 행에서
+            // 입력해 둔 배점(customPointValueText)이 경고 없이 초기화된다.
+            guard selectedPointType != type else { return }
+
+            withAnimation(.easeInOut(duration: Constants.selectionAnimationDuration)) {
+                selectedPointType = type
+                pointValue = type.isCustom ? 0 : type.defaultPointValue
+                if type.isCustom { customPointValueText = "" }
+            }
+        } label: {
+            HStack {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? tint : .grey400)
+                    .contentTransition(.symbolEffect(.replace))
+
+                Text(type.displayName)
+                    .appFont(.subheadline, color: .primary)
+
+                Spacer()
+
+                if !type.isCustom {
+                    Text("\(type.defaultPointValue > 0 ? "+" : "")\(type.defaultPointValue)")
+                        .appFont(
+                            .subheadline,
+                            weight: .semibold,
+                            color: isSelected ? tint : .grey500
+                        )
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview {
+    Text("Preview")
+        .sheet(isPresented: .constant(true)) {
+            PointGrantFormSheet(
+                availablePointTypes: ChallengerPointType.availableTypes(for: 30),
+                isSubmittingPoint: false,
+                viewModel: OperatorMemberDetailSheetViewModel(
+                    onGrantPoint: { _, _, _ in true },
+                    onDeletePoint: { _ in nil }
+                )
+            )
+        }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorMemberDetailSheetView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorMemberDetailSheetView.swift
@@ -1,0 +1,449 @@
+//
+//  OperatorMemberDetailSheetView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/25/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+// MARK: - OperatorMemberDetailSheetView
+
+/// 운영진 멤버 상세 정보 및 상벌점 관리 시트 뷰
+///
+/// 상태·액션은 `OperatorMemberDetailSheetViewModel`이 담당합니다.
+/// 상벌점 부여 폼은 `PointGrantFormSheet`으로 분리되어 있으며, ViewModel을 공유합니다.
+struct OperatorMemberDetailSheetView: View {
+
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+
+    let member: MemberManagementItem
+    let availablePointTypes: [ChallengerPointType]
+    let isSubmittingPoint: Bool
+    let isDeletingPoint: Bool
+
+    @State private var viewModel: OperatorMemberDetailSheetViewModel
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let contentHorizontalPadding: CGFloat = 16
+        static let contentSpacing: CGFloat = 24
+        static let baseHeight: CGFloat = 340
+        static let maxVisibleHistory: Int = 7
+        static let minVisibleHistoryHeight: CGFloat = 180
+        static let minSheetHeight: CGFloat = 420
+        static let maxSheetHeight: CGFloat = 820
+    }
+
+    // MARK: - Init
+
+    init(
+        member: MemberManagementItem,
+        availablePointTypes: [ChallengerPointType],
+        isSubmittingPoint: Bool,
+        isDeletingPoint: Bool,
+        onGrantPoint: @escaping @Sendable (ChallengerPointType, Int, String) async -> Bool,
+        onDeletePoint: @escaping @Sendable (OperatorMemberPenaltyHistory) async -> String?
+    ) {
+        self.member = member
+        self.availablePointTypes = availablePointTypes
+        self.isSubmittingPoint = isSubmittingPoint
+        self.isDeletingPoint = isDeletingPoint
+        _viewModel = State(
+            initialValue: OperatorMemberDetailSheetViewModel(
+                onGrantPoint: onGrantPoint,
+                onDeletePoint: onDeletePoint
+            )
+        )
+    }
+
+    // MARK: - Computed Property
+
+    private var dynamicSheetHeight: CGFloat {
+        let height = Constants.baseHeight
+            + historyAreaHeight(for: viewModel.penaltyHistory.count)
+        return max(Constants.minSheetHeight, min(height, Constants.maxSheetHeight))
+    }
+
+    /// 하단 안내 문구. 일시적 에러 메시지가 있을 경우 우선 표시.
+    private var historyDescription: String {
+        if let message = viewModel.transientHistoryMessage { return message }
+        return member.canViewPenaltyHistory
+            ? "히스토리 항목을 왼쪽으로 밀어서 삭제할 수 있습니다."
+            : "본인이 아닌 경우 포인트 히스토리를 확인할 수 없습니다."
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: Constants.contentSpacing) {
+                MemberInfoSectionPresenter(member: member)
+                historySection
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .toolbar { toolbarItems }
+            .padding(.horizontal, Constants.contentHorizontalPadding)
+            .scrollContentBackground(.hidden)
+            .presentationDetents([.height(dynamicSheetHeight)])
+            .interactiveDismissDisabled()
+            .animation(
+                OperatorMemberDetailSheetViewModel.animation,
+                value: viewModel.penaltyHistory.count
+            )
+            .sheet(isPresented: $viewModel.showPointForm) {
+                PointGrantFormSheet(
+                    availablePointTypes: availablePointTypes,
+                    isSubmittingPoint: isSubmittingPoint,
+                    viewModel: viewModel
+                )
+            }
+        }
+        .onChange(of: member) { _, newValue in viewModel.syncState(from: newValue) }
+        .task { viewModel.syncState(from: member) }
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarItems: some ToolbarContent {
+        ToolBarCollection.CancelBtn { dismiss() }
+        ToolBarCollection.AddBtn(
+            imageSystemName: "plus.circle.fill",
+            action: { viewModel.showPointForm = true },
+            isLoading: isSubmittingPoint
+        )
+    }
+
+    // MARK: - SubView
+
+    /// 히스토리 헤더·안내문·목록을 묶은 섹션
+    private var historySection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            HistoryHeaderPresenter(
+                totalReward: viewModel.totalReward,
+                totalPenalty: viewModel.totalPenalty
+            )
+
+            Text(historyDescription)
+                .appFont(
+                    .footnote,
+                    color: viewModel.transientHistoryMessage == nil ? .grey500 : .red
+                )
+
+            if viewModel.penaltyHistory.isEmpty {
+                EmptyHistoryPresenter(canViewHistory: member.canViewPenaltyHistory)
+            } else {
+                historyListView
+            }
+        }
+    }
+
+    /// 히스토리 목록 (스와이프 삭제 지원)
+    private var historyListView: some View {
+        List {
+            ForEach(viewModel.penaltyHistory) { history in
+                PenaltyHistoryRowPresenter(history: history)
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            Task {
+                                await viewModel.deletePenalty(
+                                    history,
+                                    canView: member.canViewPenaltyHistory
+                                )
+                            }
+                        } label: {
+                            Label("삭제", systemImage: "trash")
+                        }
+                    }
+                    .disabled(isDeletingPoint || !member.canViewPenaltyHistory)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(.init())
+            }
+        }
+        .listStyle(.plain)
+        .listRowSpacing(DefaultSpacing.spacing8)
+        .scrollContentBackground(.hidden)
+        .scrollIndicators(.hidden)
+    }
+
+    // MARK: - Function
+
+    /// 히스토리 표시 영역 높이. 0건이면 최소 높이, 1건 이상이면 행 높이 합산에 최소 높이를 하한으로 건다.
+    ///
+    /// 행 높이는 실제로 행을 그리는 ``PenaltyHistoryRowPresenter`` 의 상수를 그대로 읽는다.
+    /// 값을 따로 들고 있으면 행 높이만 바뀌었을 때 시트 높이 계산이 조용히 어긋난다.
+    private func historyAreaHeight(for count: Int) -> CGFloat {
+        guard count > 0 else { return Constants.minVisibleHistoryHeight }
+        let visible = min(count, Constants.maxVisibleHistory)
+        let rowsHeight = CGFloat(visible) * PenaltyHistoryRowPresenter.Constants.rowHeight
+            + CGFloat(visible - 1) * DefaultSpacing.spacing8
+        return max(rowsHeight, Constants.minVisibleHistoryHeight)
+    }
+}
+
+// MARK: - MemberInfoSectionPresenter
+
+/// 멤버 프로필 이미지, 이름/닉네임, 파트·학교·운영진 칩을 표시하는 섹션
+private struct MemberInfoSectionPresenter: View, Equatable {
+
+    // MARK: - Property
+
+    let member: MemberManagementItem
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let tagPadding: EdgeInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
+        static let profileSize: CGSize = .init(width: 60, height: 60)
+        static let partTagOpacity: Double = 0.14
+        static let partStrokeOpacity: Double = 0.4
+        static let partStrokeWidth: CGFloat = 1
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            RemoteImage(urlString: member.profile ?? "", size: Constants.profileSize)
+
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+                Text("\(member.nickname)/\(member.name)")
+                    .appFont(.body, weight: .semibold)
+
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    accentChip(title: member.part.name, tint: member.part.color)
+                    schoolChip(title: member.school)
+
+                    if member.managementTeam != .challenger {
+                        ManagementTeamBadgePresenter(managementTeam: member.managementTeam)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    private func accentChip(title: String, tint: Color) -> some View {
+        Text(title)
+            .appFont(.callout, color: tint)
+            .padding(Constants.tagPadding)
+            .background(tint.opacity(Constants.partTagOpacity), in: Capsule())
+            .overlay {
+                Capsule()
+                    .stroke(
+                        tint.opacity(Constants.partStrokeOpacity),
+                        lineWidth: Constants.partStrokeWidth
+                    )
+            }
+    }
+
+    private func schoolChip(title: String) -> some View {
+        Text(title)
+            .appFont(.callout, color: .grey700)
+            .padding(Constants.tagPadding)
+            .background(.regularMaterial, in: Capsule())
+    }
+}
+
+// MARK: - HistoryHeaderPresenter
+
+/// 히스토리 섹션 헤더: 제목 레이블 + 상점/벌점 배지
+///
+/// 합계가 0인 경우 해당 배지를 표시하지 않습니다.
+private struct HistoryHeaderPresenter: View, Equatable {
+
+    // MARK: - Property
+
+    let totalReward: Double
+    let totalPenalty: Double
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let badgePadding: EdgeInsets = .init(top: 6, leading: 8, bottom: 6, trailing: 8)
+        static let bgOpacity: Double = 0.2
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Label(
+                "히스토리",
+                systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90"
+            )
+            .appFont(.title3, weight: .semibold)
+
+            if totalReward > 0 {
+                pointBadge(label: "상점 \(formatted(totalReward))", color: .green)
+            }
+
+            if totalPenalty > 0 {
+                pointBadge(label: "벌점 \(formatted(totalPenalty))", color: .red)
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    private func formatted(_ value: Double) -> String {
+        String(format: "%.0f", value)
+    }
+
+    private func pointBadge(label: String, color: Color) -> some View {
+        Text(label)
+            .font(.app(.footnote, weight: .regular))
+            .foregroundStyle(color)
+            .padding(Constants.badgePadding)
+            .background {
+                RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+                    .fill(color.opacity(Constants.bgOpacity))
+            }
+    }
+}
+
+// MARK: - PenaltyHistoryRowPresenter
+
+/// 상벌점 히스토리 개별 행: 날짜 · 사유 · 점수
+private struct PenaltyHistoryRowPresenter: View, Equatable {
+
+    // MARK: - Property
+
+    let history: OperatorMemberPenaltyHistory
+
+    // MARK: - Constants
+
+    /// `rowHeight` 는 시트 높이 계산(``OperatorMemberDetailSheetView/historyAreaHeight(for:)``)도
+    /// 함께 읽으므로 `fileprivate` 로 연다.
+    fileprivate enum Constants {
+        static let horizontalPadding: CGFloat = 16
+        static let rowHeight: CGFloat = 50
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        let isReward = history.pointType.isReward
+
+        HStack(spacing: DefaultSpacing.spacing16) {
+            Text(history.date.toYearMonthDay())
+                .appFont(.subheadline, weight: .semibold)
+
+            Text(history.reason)
+                .appFont(.subheadline)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text("\(isReward ? "+" : "-")\(String(format: "%.0f", history.penaltyScore))")
+                .appFont(.subheadline, color: isReward ? .green : .red)
+        }
+        .padding(.horizontal, Constants.horizontalPadding)
+        .frame(maxWidth: .infinity)
+        .frame(height: Constants.rowHeight)
+        .background(
+            .ultraThinMaterial,
+            in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+        )
+    }
+}
+
+// MARK: - EmptyHistoryPresenter
+
+/// 히스토리가 없거나 열람 불가일 때 표시되는 빈 상태 뷰
+private struct EmptyHistoryPresenter: View, Equatable {
+
+    // MARK: - Property
+
+    /// `true`이면 "기록 없음", `false`이면 "열람 불가" 메시지를 표시
+    let canViewHistory: Bool
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let height: CGFloat = 150
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing8) {
+            Image(systemName: "exclamationmark.bubble.fill")
+                .appFont(.title1, color: .grey500)
+
+            Text(canViewHistory ? "포인트 기록이 없습니다" : "타인의 포인트 히스토리를 확인할 수 없습니다")
+                .appFont(.subheadline, color: .grey500)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: Constants.height)
+        .background(
+            .ultraThinMaterial,
+            in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+        )
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+private extension OperatorMemberDetailSheetView {
+    static let previewMember = MemberManagementItem(
+        profile: nil,
+        name: "김미주",
+        nickname: "마티",
+        generation: "9기",
+        school: "덕성여자대학교",
+        position: "Challenger",
+        part: .front(type: .ios),
+        penalty: 4,
+        rewardPoints: 3,
+        badge: false,
+        managementTeam: .schoolPartLeader,
+        attendanceRecords: [],
+        penaltyHistory: [
+            OperatorMemberPenaltyHistory(
+                date: Date().addingTimeInterval(-14 * 24 * 60 * 60),
+                reason: "스터디 지각",
+                penaltyScore: 2.0,
+                pointType: .studyLate
+            ),
+            OperatorMemberPenaltyHistory(
+                date: Date().addingTimeInterval(-7 * 24 * 60 * 60),
+                reason: "우수 워크북",
+                penaltyScore: 2.0,
+                pointType: .bestWorkbook
+            ),
+            OperatorMemberPenaltyHistory(
+                date: Date().addingTimeInterval(-3 * 24 * 60 * 60),
+                reason: "스터디 결석",
+                penaltyScore: 4.0,
+                pointType: .studyAbsent
+            ),
+        ]
+    )
+}
+
+#Preview {
+    Text("Preview")
+        .sheet(isPresented: .constant(true)) {
+            OperatorMemberDetailSheetView(
+                member: OperatorMemberDetailSheetView.previewMember,
+                availablePointTypes: ChallengerPointType.availableTypes(for: 30),
+                isSubmittingPoint: false,
+                isDeletingPoint: false,
+                onGrantPoint: { _, _, _ in true },
+                onDeletePoint: { _ in nil }
+            )
+        }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorMemberManagementView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorMemberManagementView.swift
@@ -1,0 +1,300 @@
+//
+//  OperatorMemberManagementView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 7/25/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreDI
+import CoreDomain
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 운영진 모드의 멤버 관리 화면
+///
+/// 파트별로 그룹핑된 동아리 멤버를 무한 스크롤로 표시하고, 검색과 상벌점 관리 시트를
+/// 제공합니다. 화면 소유의 `NavigationStack` 없이 콘텐츠만 구성하며, 상위(Activity 루트)의
+/// 네비게이션 컨텍스트 안에서 사용됩니다.
+///
+/// 목록 자체는 챌린저 모드(``ChallengerMemberListView``)와 동일한 `MemberListViewModel` 을
+/// 쓰지만, 상세 시트에서 상벌점 부여·삭제 권한이 열리는 점이 다릅니다.
+struct OperatorMemberManagementView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: MemberListViewModel
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let loadingOverlayRadius: CGFloat = 12
+    }
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - container: UseCase·세션을 resolve 할 DI 컨테이너
+    ///   - errorHandler: 흐름 중단형 전역 에러 처리기
+    ///   - viewModel: 프리뷰/테스트용 주입 지점 (기본값: container 로 생성)
+    init(
+        container: DIContainer,
+        errorHandler: ErrorHandler,
+        viewModel: MemberListViewModel? = nil
+    ) {
+        _viewModel = State(
+            initialValue: viewModel ?? MemberListViewModel(
+                fetchMembersUseCase: container.resolve(FetchMembersUseCaseProtocol.self),
+                errorHandler: errorHandler,
+                userSessionManager: container.resolve(UserSessionManager.self)
+            )
+        )
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            switch viewModel.membersState {
+            case .idle, .loading:
+                loadingView
+            case .loaded:
+                memberListContent
+            case .failed(let error):
+                RetryContentUnavailableView(
+                    title: "불러오지 못했어요",
+                    systemImage: "exclamationmark.triangle",
+                    description: error.userMessage,
+                    isRetrying: false
+                ) {
+                    await viewModel.fetchMembers()
+                }
+            }
+        }
+        .task {
+            await viewModel.fetchMembers()
+        }
+        .searchable(text: $viewModel.searchText)
+        .searchToolbarBehavior(.minimize)
+        .overlay {
+            if viewModel.isLoadingMemberDetail {
+                ProgressView()
+                    .controlSize(.regular)
+                    .padding()
+                    .background(
+                        .ultraThinMaterial,
+                        in: RoundedRectangle(cornerRadius: Constants.loadingOverlayRadius)
+                    )
+            }
+        }
+        .sheet(item: $viewModel.selectedMember) { member in
+            detailSheet(for: member)
+        }
+        .alertPrompt(item: $viewModel.alertPrompt)
+    }
+
+    // MARK: - SubView
+
+    private var loadingView: some View {
+        VStack(spacing: DefaultSpacing.spacing16) {
+            ProgressView()
+
+            Text("멤버 목록 불러오는 중...")
+                .appFont(.subheadline, color: .grey500)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var memberListContent: some View {
+        Group {
+            if viewModel.groupedMembers.isEmpty && viewModel.searchText.isEmpty {
+                emptyMemberView
+            } else if viewModel.isSearchResultEmpty {
+                searchEmptyView
+            } else {
+                memberList
+            }
+        }
+    }
+
+    private var memberList: some View {
+        List {
+            ForEach(viewModel.groupedMembers, id: \.part) { group in
+                Section {
+                    ForEach(group.members) { item in
+                        Button {
+                            Task {
+                                await viewModel.openChallengerMemberDetail(item)
+                            }
+                        } label: {
+                            CoreMemberManagementRow(memberManagementItem: item)
+                        }
+                        .onAppear {
+                            if item.id == group.members.last?.id,
+                               group.part == viewModel.groupedMembers.last?.part {
+                                Task { await viewModel.fetchNextPage() }
+                            }
+                        }
+                    }
+                } header: {
+                    Text(group.part.name)
+                        .appFont(.title3, weight: .semibold, color: .black)
+                }
+            }
+
+            if viewModel.isLoadingNextPage {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .listRowSeparator(.hidden)
+            }
+        }
+    }
+
+    private var searchEmptyView: some View {
+        ContentUnavailableView {
+            Label("검색 결과가 없습니다.", systemImage: "magnifyingglass")
+        } description: {
+            Text("'\(viewModel.searchText)'에 대한 결과가 없습니다")
+        }
+    }
+
+    private var emptyMemberView: some View {
+        ContentUnavailableView {
+            Label("멤버 관리", systemImage: "person.3")
+        } description: {
+            Text("등록된 멤버가 없습니다")
+        }
+    }
+
+    // MARK: - Function
+
+    /// 상벌점 부여·삭제 액션을 `MemberListViewModel` 로 위임한 상세 시트를 구성합니다.
+    ///
+    /// - Note: 아래 클로저는 리렌더마다 최신 `member` 를 새로 캡처하지만, 실제로 실행되는
+    ///   것은 **시트가 열린 시점의 첫 클로저** 입니다. `OperatorMemberDetailSheetView` 가
+    ///   이를 `State(initialValue:)` 로 ViewModel 에 넣어 보관하므로 이후 클로저는 폐기됩니다.
+    ///   mutation 대상 식별에는 영향이 없습니다 — `submitPoint`/`deletePoint` 가 쓰는
+    ///   `challengerID` 는 재조회를 거쳐도 변하지 않는 서버 식별자이기 때문입니다.
+    private func detailSheet(for member: MemberManagementItem) -> some View {
+        OperatorMemberDetailSheetView(
+            member: member,
+            availablePointTypes: viewModel.availablePointTypes,
+            isSubmittingPoint: viewModel.isSubmittingPoint,
+            isDeletingPoint: viewModel.isDeletingPoint,
+            onGrantPoint: { pointType, pointValue, description in
+                await viewModel.submitPoint(
+                    member: member,
+                    pointType: pointType,
+                    pointValue: pointValue,
+                    description: description
+                )
+            },
+            onDeletePoint: { history in
+                await viewModel.deletePoint(member: member, history: history)
+            }
+        )
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+/// 네트워크 없이 멤버 관리 화면을 확인하기 위한 프리뷰 전용 UseCase (절대규칙 #5)
+private struct PreviewOperatorMembersUseCase: FetchMembersUseCaseProtocol {
+    func execute() async throws -> [MemberManagementItem] {
+        previewMembers
+    }
+
+    func executePage(page: Int) async throws -> MemberPage {
+        MemberPage(members: previewMembers, hasNext: false, currentPage: page)
+    }
+
+    func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws {}
+
+    func deletePoint(challengerPointId: String) async throws {}
+
+    func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory] {
+        []
+    }
+
+    func fetchAllGenerations(memberId: String) async throws -> String {
+        "9기"
+    }
+
+    func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary] {
+        []
+    }
+
+    func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord] {
+        []
+    }
+
+    private var previewMembers: [MemberManagementItem] {
+        [
+            MemberManagementItem(
+                memberID: "1",
+                challengerID: "10",
+                profile: nil,
+                name: "이예지",
+                nickname: "소피",
+                generation: "9기",
+                school: "가천대학교",
+                position: "Part Leader",
+                part: .front(type: .ios),
+                penalty: 0,
+                badge: false,
+                managementTeam: .schoolPartLeader,
+                attendanceRecords: [],
+                penaltyHistory: []
+            ),
+            MemberManagementItem(
+                memberID: "2",
+                challengerID: "11",
+                profile: nil,
+                name: "홍길동",
+                nickname: "라이언",
+                generation: "9기",
+                school: "한성대학교",
+                position: "Challenger",
+                part: .front(type: .web),
+                penalty: 1,
+                badge: false,
+                managementTeam: .challenger,
+                attendanceRecords: [],
+                penaltyHistory: []
+            ),
+        ]
+    }
+}
+
+#Preview {
+    let viewModel = MemberListViewModel(
+        fetchMembersUseCase: PreviewOperatorMembersUseCase(),
+        errorHandler: ErrorHandler(),
+        userSessionManager: UserSessionManager()
+    )
+    return NavigationStack {
+        OperatorMemberManagementView(
+            container: DIContainer(),
+            errorHandler: ErrorHandler(),
+            viewModel: viewModel
+        )
+    }
+}
+#endif


### PR DESCRIPTION
resolves #898

## ✨ PR 유형

♻️ Refactor — 운영진 멤버 관리 화면 3종을 레거시 `AppProduct/` → `UMCApp/`(Tuist) `ActivityPresentation` 모듈로 이식

## 📷 스크린샷 or 영상(UI 변경 시)
<img width="1512" height="982" alt="스크린샷 2026-07-30 오후 10 16 12" src="https://github.com/user-attachments/assets/9ee5a022-a075-41a6-b493-1a8e9163750b" />

<img width="1512" height="982" alt="스크린샷 2026-07-30 오후 10 16 20" src="https://github.com/user-attachments/assets/d603df24-8748-4068-9f11-e0d6d4ffd2fa" />


## 🛠️ 작업내용

ViewModel 2종(`MemberListViewModel`·`OperatorMemberDetailSheetViewModel`)은 #896에서, 공유 컴포넌트·챌린저 화면은 #1004에서 선이식되어 있어 **본 PR은 운영진 View 3개만** 얹습니다. ViewModel·Domain·Data 수정 0건, 기존 파일 수정 0건(신규 3파일만 추가).

| 파일 | 역할 |
|------|------|
| `Views/Operator/OperatorMemberManagementView.swift` | 멤버 목록 — 파트별 그룹핑·검색·무한스크롤·상세 시트 결선 |
| `Views/Operator/OperatorMemberDetailSheetView.swift` | 상세 시트 — 프로필·상벌점 히스토리(스와이프 삭제) |
| `Components/Member/PointGrantFormSheet.swift` | 상벌점 부여 폼 |

`#1004`가 먼저 머지되어 최신 develop 위로 rebase 했고, 목록 행 컴포넌트는 develop의 canonical 이름인 `CoreMemberManagementRow`를 그대로 씁니다(로컬 중복 선언 없음).

**검증** — `make build SCHEME=ActivityPresentation` 성공(경고 0), `ActivityPresentation` 기존 테스트 118개 전부 통과(View 이식이 ViewModel 계약을 깨지 않음을 확인). 본 PR diff에 테스트 코드는 없습니다.

## 📋 추후 진행 상황

- #996 Activity 탭 루트 `ActivityView` 이식 시 본 PR의 3화면을 탭 분기에 배선 (현재는 파일만 존재, 호출부 없음)

## 📌 리뷰 포인트

**1. 상벌점 부여 폼의 표시 방식 전환** — `PointGrantFormSheet.swift`
레거시 `.fullScreenCover` → `.sheet` + `.presentationDetents([.medium, .large])`로 전환했습니다(이슈 완료조건). 다만 `.fullScreenCover`가 **구조적으로 보장하던 "스와이프로 실수로 닫힐 수 없음"** 이 사라지므로, 부모 상세 시트와 동일하게 `.interactiveDismissDisabled()`를 걸고 드래그 인디케이터는 노출하지 않았습니다(동작하지 않는 제스처를 광고하지 않도록). 입력 중 폼이 닫혀 값이 날아가는 경로를 막는 것이 의도입니다.

**2. 디자인 토큰 매핑** — 전 파일
레거시의 `AppFont.*Emphasis` 케이스는 `UMCApp`의 `AppFont`에 존재하지 않아 `weight: .semibold`로 변환했습니다. 이미 머지된 챌린저 화면과 동일한 매핑입니다.

**3. 카드/칩 배경 처리** — `OperatorMemberDetailSheetView.swift`
`.background(.white, in:)` → 카드는 `.ultraThinMaterial`, 칩은 `.regularMaterial`. 불투명 흰 배경이 iOS 26 Glass 환경에서 z-fighting을 일으키던 문제를 이미 정리한 챌린저 상세 시트와 어휘를 통일했습니다. 같은 맥락에서 빈 상태 뷰의 `.glass()`(그림자 모디파이어)도 제거해 히스토리 행과 대칭을 맞췄습니다.

**4. 레거시 dead 요소는 복원하지 않았습니다** — 되살릴 필요가 있는지 봐주세요
| 대상 | 레거시 상태 |
|------|------------|
| `scrollViewHeight` | 유일 사용처 `.frame(height:)`가 주석 처리됨 |
| 빈 히스토리 높이 상수 | `max(150, 180)`이라 150이 결과에 영향 못 줌 |
| 행 높이 상수 | 부모와 행 뷰가 각자 `50`을 들고 있어 조용히 어긋날 수 있었음 → 행 뷰의 값을 단일 출처로 통합 |

**5. 입력값 소실 방어 추가** — `PointGrantFormSheet.pointTypeRow`
이미 선택된 CUSTOM 행을 다시 탭하면 입력한 배점이 경고 없이 초기화되던 동작(레거시 동일)에 `guard selectedPointType != type` 가드를 넣었습니다.

**알려진 한계 (본 PR 범위 밖, 레거시와 동일)**
- 상세 시트의 mutation 클로저가 시트 오픈 시점 `member`에 고정됩니다. `challengerID`가 불변 서버 식별자라 **대상 멤버 오식별은 발생하지 않지만**, 재조회 실패 시 폴백이 이전 히스토리로 되돌아갈 수 있습니다. 고치려면 이미 머지된 ViewModel의 클로저 시그니처를 바꿔야 해 별도 티켓이 맞다고 봤습니다.
- 제출 중 스피너가 중첩 시트 2단을 넘어 갱신되는지는 정적으로 단정할 수 없어, 탭 배선 이후 실기 확인이 필요합니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)