### PR TITLE
✨ [Feature] 홈 - 출석 흐름·알람 히스토리 등 잔여 요소 이식 (Home 슬라이스 4)

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Enums/AppStorageKey.swift
+++ b/UMCApp/Core/Foundation/Sources/Enums/AppStorageKey.swift
@@ -27,6 +27,11 @@ public enum AppStorageKey {
     public static let connectedSocialProviders: String = "connectedSocialProviders"
     /// 자동 로그인 허용 여부 (승인/등록 완료 사용자만 true)
     public static let canAutoLogin: String = "canAutoLogin"
+    /// 마지막 앱스토어 리뷰 요청 시각 (`Date`)
+    ///
+    /// - Note: 키 문자열은 레거시 앱(`AppProduct`)과 동일하게 유지한다. 이미 리뷰 요청을 받은
+    ///   사용자가 앱 업데이트 직후 다시 요청받지 않도록 기존 저장값을 그대로 승계해야 한다.
+    public static let lastReviewRequestDate: String = "lastReviewRequestDate"
 
     // MARK: - Profile (최신 기수 기준)
 

--- a/UMCApp/Core/Foundation/Sources/Review/ReviewRequestPolicy.swift
+++ b/UMCApp/Core/Foundation/Sources/Review/ReviewRequestPolicy.swift
@@ -1,0 +1,59 @@
+//
+//  ReviewRequestPolicy.swift
+//  UMCFoundation
+//
+//  Created by JEONG on 7/30/26.
+//
+
+import Foundation
+
+/// 앱스토어 리뷰 요청 노출 빈도를 제한하는 정책.
+///
+/// `StoreKit`의 `requestReview`는 시스템이 자체적으로 표시 횟수를 제한하지만, 앱 쪽에서도
+/// 최소 간격을 둬야 홈 진입마다 요청이 소모되지 않는다. 마지막 요청 시각을 `UserDefaults`에
+/// 기록해 4주 이내 재요청을 차단한다.
+public struct ReviewRequestPolicy {
+
+    // MARK: - Property
+
+    /// 기본 최소 요청 간격 (4주)
+    public static let defaultMinimumInterval: TimeInterval = 60 * 60 * 24 * 28
+
+    private let userDefaults: UserDefaults
+    private let minimumInterval: TimeInterval
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - userDefaults: 마지막 요청 시각을 보관할 저장소 (테스트에서 격리 suite 주입)
+    ///   - minimumInterval: 재요청을 허용하기까지의 최소 경과 시간
+    public init(
+        userDefaults: UserDefaults = .standard,
+        minimumInterval: TimeInterval = ReviewRequestPolicy.defaultMinimumInterval
+    ) {
+        self.userDefaults = userDefaults
+        self.minimumInterval = minimumInterval
+    }
+
+    // MARK: - Function
+
+    /// 리뷰 요청 가능 시점이면 요청 시각을 기록하고 `true`를 반환합니다.
+    ///
+    /// 판정과 기록을 한 번에 수행하므로, 호출부는 반환값이 `true`일 때만 실제 요청을
+    /// 트리거하면 된다.
+    ///
+    /// - Parameter now: 현재 시각 (테스트 주입용)
+    /// - Returns: 리뷰를 요청해야 하면 `true`
+    public func markRequestedIfDue(now: Date = .now) -> Bool {
+        let lastRequestedAt = userDefaults.object(
+            forKey: AppStorageKey.lastReviewRequestDate
+        ) as? Date
+
+        if let lastRequestedAt, now.timeIntervalSince(lastRequestedAt) < minimumInterval {
+            return false
+        }
+
+        userDefaults.set(now, forKey: AppStorageKey.lastReviewRequestDate)
+        return true
+    }
+}

--- a/UMCApp/Core/Foundation/Tests/ReviewRequestPolicyTests.swift
+++ b/UMCApp/Core/Foundation/Tests/ReviewRequestPolicyTests.swift
@@ -1,0 +1,94 @@
+//
+//  ReviewRequestPolicyTests.swift
+//  UMCFoundationTests
+//
+//  Created by JEONG on 7/30/26.
+//
+
+import Foundation
+import Testing
+@testable import UMCFoundation
+
+// MARK: - Helpers
+
+private func makeIsolatedUserDefaults() -> UserDefaults {
+    let suiteName = "ReviewRequestPolicyTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+}
+
+// MARK: - Tests
+
+@Suite("ReviewRequestPolicy — 4주 간격 리뷰 요청 판정")
+struct ReviewRequestPolicyTests {
+
+    @Test("최초 호출은 요청을 허용하고 시각을 기록한다")
+    func firstCallIsDueAndRecordsDate() {
+        let userDefaults = makeIsolatedUserDefaults()
+        let policy = ReviewRequestPolicy(userDefaults: userDefaults)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+        #expect(policy.markRequestedIfDue(now: now))
+        #expect(
+            userDefaults.object(forKey: AppStorageKey.lastReviewRequestDate) as? Date == now
+        )
+    }
+
+    @Test("4주 경과 직전(1초 부족)에는 요청을 차단한다")
+    func blocksJustBeforeInterval() {
+        let userDefaults = makeIsolatedUserDefaults()
+        let policy = ReviewRequestPolicy(userDefaults: userDefaults)
+        let firstRequestedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        _ = policy.markRequestedIfDue(now: firstRequestedAt)
+
+        let justBefore = firstRequestedAt
+            .addingTimeInterval(ReviewRequestPolicy.defaultMinimumInterval - 1)
+
+        #expect(policy.markRequestedIfDue(now: justBefore) == false)
+        #expect(
+            userDefaults.object(forKey: AppStorageKey.lastReviewRequestDate) as? Date
+                == firstRequestedAt
+        )
+    }
+
+    @Test("4주가 정확히 경과하면 요청을 허용하고 시각을 갱신한다")
+    func allowsExactlyAtInterval() {
+        let userDefaults = makeIsolatedUserDefaults()
+        let policy = ReviewRequestPolicy(userDefaults: userDefaults)
+        let firstRequestedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        _ = policy.markRequestedIfDue(now: firstRequestedAt)
+
+        let fourWeeksLater = firstRequestedAt
+            .addingTimeInterval(ReviewRequestPolicy.defaultMinimumInterval)
+
+        #expect(policy.markRequestedIfDue(now: fourWeeksLater))
+        #expect(
+            userDefaults.object(forKey: AppStorageKey.lastReviewRequestDate) as? Date
+                == fourWeeksLater
+        )
+    }
+
+    @Test("기본 최소 간격은 4주(28일)다")
+    func defaultIntervalIsFourWeeks() {
+        #expect(ReviewRequestPolicy.defaultMinimumInterval == 60 * 60 * 24 * 28)
+    }
+
+    @Test("최소 간격을 주입하면 해당 간격으로 판정한다")
+    func respectsInjectedInterval() {
+        let userDefaults = makeIsolatedUserDefaults()
+        let policy = ReviewRequestPolicy(userDefaults: userDefaults, minimumInterval: 60)
+        let firstRequestedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        _ = policy.markRequestedIfDue(now: firstRequestedAt)
+
+        #expect(policy.markRequestedIfDue(now: firstRequestedAt.addingTimeInterval(59)) == false)
+        #expect(policy.markRequestedIfDue(now: firstRequestedAt.addingTimeInterval(60)))
+    }
+
+    @Test("리뷰 요청 시각 키는 세션 스코프에 포함되지 않는다")
+    func reviewDateKeyIsNotSessionScoped() {
+        #expect(
+            AppStorageKey.sessionScopedKeys.contains(AppStorageKey.lastReviewRequestDate) == false
+        )
+    }
+}

--- a/UMCApp/Core/UIComponents/Sources/ToolBar/ToolBarCollection.swift
+++ b/UMCApp/Core/UIComponents/Sources/ToolBar/ToolBarCollection.swift
@@ -238,13 +238,17 @@ public struct ToolBarCollection {
     }
     
     /// 앱 브랜딩용 로고를 상단 좌측에 배치하는 툴바입니다.
+    ///
+    /// - Note: 로고 애셋은 `CoreUIComponents` 리소스 번들에 있어 다른 모듈에서 `ImageResource`로
+    ///   전달할 수 없다. 따라서 `AuthLogoBlock`과 동일하게 컴포넌트가 애셋을 직접 참조한다.
     public struct Logo: ToolbarContent {
-        public let image: ImageResource
-        @Namespace var namespace
-        
+        @Namespace private var namespace
+
+        public init() {}
+
         public var body: some ToolbarContent {
             ToolbarItem(placement: .topBarLeading) {
-                Image(image)
+                Image("logoLight", bundle: .module)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 80, height: 40)

--- a/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
+++ b/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
@@ -12,8 +12,11 @@ import Moya
 
 /// 일정 V2 API 라우터
 ///
-/// 슬라이스 2(#914)는 홈 일정 캘린더 표시에 필요한 목록 조회만 다룬다. 생성/수정/삭제·출석
-/// 관련 엔드포인트는 등록/출석 기능 이식 시 별도로 추가한다.
+/// 홈 일정 캘린더 표시에 필요한 목록 조회만 다룬다. 출석 관련 엔드포인트
+/// (`/api/v2/schedules/attendance`, `/api/v2/schedules/{id}/attendance`,
+/// `.../attendances/decide`, `.../attendances/excuse`, `.../attendances/request`)는
+/// `ActivityData`의 `AttendanceRouter`에 있다. 일정 생성/수정/삭제는 Schedule 모듈 분리
+/// 이슈(#981)에서 다룬다.
 ///
 /// - Note: `URLEncoding`(Alamofire) 노출을 막기 위해 `internal import Alamofire`를 쓰므로,
 ///   이 라우터와 멤버는 `HomeData` 모듈 내부(`ScheduleRepository`)에서만 사용하는 `internal`로 둔다.

--- a/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleRepositoryProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleRepositoryProtocol.swift
@@ -9,8 +9,8 @@ import Foundation
 
 /// 홈 일정 캘린더 데이터 접근 계층 인터페이스.
 ///
-/// 조회 전용이다. 일정 생성/수정/삭제·출석 관련 액션은 이 슬라이스(#914)의 범위 밖으로,
-/// 등록/출석 기능 이식 시 별도 Repository로 추가한다.
+/// 조회 전용이다. 출석 관련 액션은 `ActivityDomain`의 `ChallengerAttendanceRepositoryProtocol`
+/// 이 담당하고, 일정 생성/수정/삭제는 Schedule 모듈 분리 이슈(#981)에서 다룬다.
 public protocol ScheduleRepositoryProtocol {
 
     /// 기간 내 내 일정을 조회해 KST 자정 기준 날짜별로 그룹핑한다.

--- a/UMCApp/Features/Home/Presentation/Sources/HomeFeatureView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/HomeFeatureView.swift
@@ -16,19 +16,36 @@ public struct HomeFeatureView: View {
 
     @Environment(\.di) private var di
     private let onNoticeSelected: (NoticeDetail) -> Void
+    private let onScheduleSelected: (String) -> Void
+    private let onAlarmHistoryTapped: () -> Void
 
     // MARK: - Init
 
-    /// - Parameter onNoticeSelected: 최근 공지 카드 탭 시 상세 화면 이동을 상위(App)에 위임하는 콜백.
-    ///   Home Feature는 App 타깃의 전역 `NavigationDestination`을 참조할 수 없어(Feature → App 의존
-    ///   방향 금지) 실제 push는 호출부(`RootTabView`)에서 수행한다.
-    public init(onNoticeSelected: @escaping (NoticeDetail) -> Void) {
+    /// Home Feature는 App 타깃의 전역 `NavigationDestination`을 참조할 수 없어(Feature → App 의존
+    /// 방향 금지) 화면 이동을 콜백으로 위임한다. 실제 push는 호출부(`RootTabView`)에서 수행한다.
+    ///
+    /// - Parameters:
+    ///   - onNoticeSelected: 최근 공지 카드 탭 시 공지 상세 이동 콜백
+    ///   - onScheduleSelected: 일정 카드 탭 시 일정 상세 이동 콜백 (일정 ID 전달)
+    ///   - onAlarmHistoryTapped: 툴바 알림 버튼 탭 시 알림 보관함 이동 콜백
+    public init(
+        onNoticeSelected: @escaping (NoticeDetail) -> Void,
+        onScheduleSelected: @escaping (String) -> Void,
+        onAlarmHistoryTapped: @escaping () -> Void
+    ) {
         self.onNoticeSelected = onNoticeSelected
+        self.onScheduleSelected = onScheduleSelected
+        self.onAlarmHistoryTapped = onAlarmHistoryTapped
     }
 
     // MARK: - Body
 
     public var body: some View {
-        HomeView(container: di, onNoticeSelected: onNoticeSelected)
+        HomeView(
+            container: di,
+            onNoticeSelected: onNoticeSelected,
+            onScheduleSelected: onScheduleSelected,
+            onAlarmHistoryTapped: onAlarmHistoryTapped
+        )
     }
 }

--- a/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
@@ -10,6 +10,7 @@ import CoreDI
 import CoreUIComponents
 import HomeDomain
 import NoticeDomain
+import StoreKit
 import SwiftUI
 import UMCFoundation
 
@@ -18,15 +19,21 @@ import UMCFoundation
 /// 슬라이스 1(#913) 범위: 진입 시 프로필을 로드해 시즌 카드와 세대별 상벌점 카드를 표시한다.
 /// 슬라이스 2(#914) 범위: 이번 달 일정 캘린더와 선택 날짜의 일정 리스트를 표시한다.
 /// 슬라이스 3(#915) 범위: 최신 기수의 최근 공지 5건을 표시하고, 탭 시 상세 화면으로 이동한다.
+/// 슬라이스 4(#982) 범위: 툴바(로고/알림 보관함)와 일정 카드 → 일정 상세 진입, 상벌점 변경
+/// 알림 수신 시 프로필 재조회, 4주 간격 앱스토어 리뷰 요청을 복구한다.
 /// `NavigationStack`은 루트 탭 셸이 소유하므로 이 뷰는 콘텐츠만 구성한다.
 struct HomeView: View {
 
     // MARK: - Property
 
+    @Environment(\.requestReview) private var requestReview
     @State private var viewModel: HomeViewModel
     @State private var selectedDate: Date = .now
     @State private var currentMonth: Date = .now
     private let onNoticeSelected: (NoticeDetail) -> Void
+    private let onScheduleSelected: (String) -> Void
+    private let onAlarmHistoryTapped: () -> Void
+    private let reviewRequestPolicy: ReviewRequestPolicy
 
     // MARK: - Constants
 
@@ -42,13 +49,22 @@ struct HomeView: View {
     ///   - container: UseCase를 resolve할 DI 컨테이너
     ///   - viewModel: 프리뷰/테스트용 주입 지점 (기본값: container로 생성)
     ///   - onNoticeSelected: 최근 공지 카드 탭 시 상세 화면 이동을 위임하는 콜백
+    ///   - onScheduleSelected: 일정 카드 탭 시 일정 상세 이동을 위임하는 콜백
+    ///   - onAlarmHistoryTapped: 툴바 알림 버튼 탭 시 알림 보관함 이동을 위임하는 콜백
+    ///   - reviewRequestPolicy: 리뷰 요청 간격 정책 (프리뷰/테스트용 주입 지점)
     init(
         container: DIContainer,
         viewModel: HomeViewModel? = nil,
-        onNoticeSelected: @escaping (NoticeDetail) -> Void = { _ in }
+        onNoticeSelected: @escaping (NoticeDetail) -> Void = { _ in },
+        onScheduleSelected: @escaping (String) -> Void = { _ in },
+        onAlarmHistoryTapped: @escaping () -> Void = {},
+        reviewRequestPolicy: ReviewRequestPolicy = ReviewRequestPolicy()
     ) {
         _viewModel = State(initialValue: viewModel ?? HomeViewModel(container: container))
         self.onNoticeSelected = onNoticeSelected
+        self.onScheduleSelected = onScheduleSelected
+        self.onAlarmHistoryTapped = onAlarmHistoryTapped
+        self.reviewRequestPolicy = reviewRequestPolicy
     }
 
     // MARK: - Body
@@ -68,8 +84,13 @@ struct HomeView: View {
             await viewModel.fetchProfile(forceRefresh: true)
         }
         .umcDefaultBackground()
+        .toolbar {
+            ToolBarCollection.Logo()
+            ToolBarCollection.BellBtn(action: onAlarmHistoryTapped)
+        }
         .task {
             await viewModel.fetchProfileIfNeeded()
+            requestReviewIfDue()
         }
         .task {
             await viewModel.fetchSchedules()
@@ -82,6 +103,10 @@ struct HomeView: View {
                     month: calendar.component(.month, from: newMonth)
                 )
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .memberPenaltyUpdated)) { _ in
+            // 상벌점이 방금 변경됐으므로 세션 프로필 캐시를 우회해 서버 최신값으로 갱신한다.
+            Task { await viewModel.fetchProfile(forceRefresh: true) }
         }
     }
 
@@ -197,11 +222,16 @@ struct HomeView: View {
             )
         } else {
             ForEach(schedules) { schedule in
-                ScheduleListCard(
-                    data: schedule,
-                    category: viewModel.category(for: schedule.scheduleId)
-                )
-                .equatable()
+                Button {
+                    onScheduleSelected(schedule.scheduleId)
+                } label: {
+                    ScheduleListCard(
+                        data: schedule,
+                        category: viewModel.category(for: schedule.scheduleId)
+                    )
+                    .equatable()
+                }
+                .buttonStyle(ScheduleCardPressStyle())
             }
         }
     }
@@ -245,6 +275,29 @@ struct HomeView: View {
             .glassEffect(
                 .regular,
                 in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
+            )
+    }
+
+    // MARK: - Function
+
+    /// 마지막 요청 이후 4주가 지났으면 앱스토어 리뷰를 요청한다.
+    private func requestReviewIfDue() {
+        guard reviewRequestPolicy.markRequestedIfDue() else { return }
+        requestReview()
+    }
+}
+
+// MARK: - Style
+
+/// 일정 카드 탭 시 눌림 효과를 제공하는 ButtonStyle
+private struct ScheduleCardPressStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .opacity(configuration.isPressed ? 0.92 : 1.0)
+            .animation(
+                .spring(response: 0.22, dampingFraction: 0.8),
+                value: configuration.isPressed
             )
     }
 }

--- a/UMCApp/Features/Home/Presentation/Sources/Views/NoticeAlarmView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/NoticeAlarmView.swift
@@ -1,0 +1,52 @@
+//
+//  NoticeAlarmView.swift
+//  HomePresentation
+//
+//  Created by JEONG on 7/30/26.
+//
+
+import CoreUIComponents
+import SwiftUI
+
+/// 알림 보관함 화면.
+///
+/// - Important: 아직 빈 상태만 표시하는 스텁이다. 실제 알림 내역은 SwiftData 모델
+///   `NoticeHistoryData`와 `NoticeAlarmCard`에 의존하는데 둘 다 이식 전이므로, 이 슬라이스는
+///   홈 툴바 → 알림 보관함 라우팅만 복구한다. 두 타입이 이식되면 `@Query`로 최신순 목록과
+///   스와이프/전체 삭제 액션을 채운다.
+public struct NoticeAlarmView: View {
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let emptyTitle: String = "알림 내역이 없습니다."
+        static let emptySystemImage: String = "bell.slash"
+        static let emptyDescription: String = "새로운 소식이 도착하면 이곳에 표시됩니다."
+    }
+
+    // MARK: - Init
+
+    public init() {}
+
+    // MARK: - Body
+
+    public var body: some View {
+        ContentUnavailableView(
+            Constants.emptyTitle,
+            systemImage: Constants.emptySystemImage,
+            description: Text(Constants.emptyDescription)
+        )
+        .umcDefaultBackground()
+        .navigation(naviTitle: NavigationTitle.Notice.alarmArchive, displayMode: .inline)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        NoticeAlarmView()
+    }
+}
+#endif

--- a/UMCApp/Features/Home/Project.swift
+++ b/UMCApp/Features/Home/Project.swift
@@ -16,6 +16,8 @@ let project = featureProject(
         "Data/Sources/MLModels/**",
     ],
     presentationExtraDependencies: [
+        // 홈 진입 시 앱스토어 리뷰 요청(requestReview) 환경 값 사용.
+        .sdk(name: "StoreKit", type: .framework),
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationDestination.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationDestination.swift
@@ -21,7 +21,13 @@ import NoticeDomain
 ///   (b) 여러 Feature가 공유할 신규 Core 모듈을 신설해 이 타입을 옮기는 방안 중 하나를
 ///   메인테이너 승인 하에 선택해야 한다.
 enum NavigationDestination: Hashable {
+    case home(Home)
     case notice(Notice)
+
+    enum Home: Hashable {
+        case alarmHistory
+        case scheduleDetail(scheduleId: String)
+    }
 
     enum Notice: Hashable {
         case detail(detailItem: NoticeDetail)

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
@@ -6,6 +6,7 @@
 //
 
 import CoreDI
+import HomePresentation
 import NoticePresentation
 import SwiftUI
 import UMCFoundation
@@ -32,8 +33,25 @@ struct NavigationRoutingView: View {
 
     var body: some View {
         switch destination {
+        case .home(let route):
+            homeView(route)
         case .notice(let route):
             noticeView(route)
+        }
+    }
+}
+
+// MARK: - Home Routing
+
+private extension NavigationRoutingView {
+    @ViewBuilder
+    func homeView(_ route: NavigationDestination.Home) -> some View {
+        switch route {
+        case .alarmHistory:
+            NoticeAlarmView()
+        case .scheduleDetail:
+            // ScheduleDetailView는 Schedule 모듈 분리 이슈(#981)에서 이식된다.
+            Text("아직 지원하지 않는 화면입니다")
         }
     }
 }

--- a/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
+++ b/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
@@ -73,9 +73,17 @@ struct RootTabView: View {
     private func tabContent(_ tab: TabCase) -> some View {
         switch tab {
         case .home:
-            HomeFeatureView { detailItem in
-                pathStore.homePath.append(.notice(.detail(detailItem: detailItem)))
-            }
+            HomeFeatureView(
+                onNoticeSelected: { detailItem in
+                    pathStore.homePath.append(.notice(.detail(detailItem: detailItem)))
+                },
+                onScheduleSelected: { scheduleId in
+                    pathStore.homePath.append(.home(.scheduleDetail(scheduleId: scheduleId)))
+                },
+                onAlarmHistoryTapped: {
+                    pathStore.homePath.append(.home(.alarmHistory))
+                }
+            )
         case .notice:
             // TODO: NoticePresentation의 실제 NoticeView 연결 (Notice 탭 실연결 후속 이슈)
             NoticeFeatureView()


### PR DESCRIPTION
## ✨ PR 유형

새로운 기능 (`AppProduct` → `UMCApp` 이관 · Home 슬라이스 4)

Resolves #982

## 🛠️ 작업내용

### 1. 출석 Data/Domain 이식 — 이미 완료돼 있어 주석만 현행화

원본의 출석 요소를 UMCApp과 대조한 결과 **이미 `Activity` 모듈로 이관이 끝난 상태**여서, 중복 구현 없이 낡은 주석만 실제 위치를 가리키도록 고쳤습니다.

| 원본(AppProduct) | UMCApp 위치 | 상태 |
|---|---|---|
| `AttendanceListQuery` / `AttendanceDetailQuery` | `ActivityData/DTOs/` | 이관 완료 |
| `V2AttendancePolicyDTO` | `ActivityData/DTOs/ScheduleAttendancePolicyDTO` | 이관 완료 (custom `init(from:)`) |
| 출석 5개 엔드포인트 (`/schedules/attendance`, `/{id}/attendance`, `decide`, `excuse`, `request`) | `ActivityData/Routers/AttendanceRouter` | 이관 완료 (`scheduleId: String`) |

→ `ScheduleV2Router` · `ScheduleRepositoryProtocol` 의 "출석은 나중에 별도 추가" 주석을 실제 이관 위치 안내로 교체했습니다.

### 2. 알람 히스토리 진입점 복원

- `NavigationDestination` 에 `home` 네임스페이스 신설 (`alarmHistory` / `scheduleDetail`)
- 홈 툴바에 로고 + `BellBtn` 복원, 탭 시 알림 보관함으로 이동
- `NoticeAlarmView` 추가 — **의도된 스텁**(빈 상태만 표시)

### 3. 일정 → 출석 연결 (부분)

일정 카드 탭 → `.home(.scheduleDetail)` 라우트까지 연결했습니다. **일정 상세 화면 자체가 미이식**이라 목적지는 현재 스텁입니다.

### 4. 홈 부속 동작 복원

- `ReviewRequestPolicy` 신설 — 4주 간격 앱스토어 리뷰 요청. `UserDefaults`/간격/현재 시각을 주입 가능하게 만들어 단위 테스트 6케이스 작성
- `lastReviewRequestDate` 키 문자열을 레거시와 동일하게 유지해 **기존 사용자의 요청 이력 승계**
- `.memberPenaltyUpdated` 수신 시 프로필 재조회 (캐시 우회 `forceRefresh: true`)

## 📋 추후 진행 상황

이번 슬라이스에서 스텁으로 남긴 부분은 후속 이슈로 분리했습니다.

- #1034 일정 상세 화면 이식 + 출석 체크/현황 진입 흐름 연결 (본 PR의 `scheduleDetail` 스텁 교체)
- #1035 알림 보관함 실내용 이식 — `NoticeHistoryData`(SwiftData) · `NoticeAlarmCard`
- #1036 출석 화면 View 이식 (운영진 목록/상세 · 챌린저) — ViewModel만 있고 View 부재

## 📌 리뷰 포인트

1. **`ToolBarCollection.Logo` 의 public API 변경** — `Logo(image:)` → `Logo()`. 로고 애셋이 `CoreUIComponents` 리소스 번들에 있어 외부 모듈에서 `ImageResource` 로 넘길 수 없어, 기존 `AuthLogoBlock` 과 동일하게 컴포넌트가 애셋을 직접 참조하도록 바꿨습니다. 호출부는 이번에 추가된 곳 하나뿐이라 파급은 없습니다.
2. **일정 카드가 탭 가능해졌지만 목적지는 스텁** — 누르면 "아직 지원하지 않는 화면입니다" 가 뜹니다. #1034 가 올 때까지 라우트만 깔아두는 방향으로 진행했는데, 그때까지 탭을 막아두는 편이 낫다고 보시면 조정하겠습니다.
3. **`ReviewRequestPolicy` 배치** — View에 `UserDefaults` 를 직접 두지 않고 `UMCFoundation` 의 작은 정책 타입으로 분리했습니다. 위치와 책임 범위가 적절한지 봐주세요.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
- [x] `AppProduct/` 무변경 (`v2.2.0` 동결 — 절대 규칙 #9)
- [x] 전체 컴파일 통과 (0 에러)
- [x] `make test SCHEME=UMCFoundation` → **TEST SUCCEEDED** (신규 `ReviewRequestPolicy` 스위트 포함)

> ⚠️ `make test` 전체(UMCApp 스킴)는 로컬에 `Secrets.xcconfig` 가 없어 `KAKAO_KEY not found in Info.plist` fatalError 로 러너가 부팅에 실패합니다. **이번 변경과 무관한 선재 환경 문제**이며, 컴파일은 CodeSign·Validate 단계까지 전부 통과했습니다.