### PR TITLE
✨ [Feature] 일정 상세 필드 확장 (장소/참여자/출석 정책) — 출석·등록 슬라이스 연계

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Extensions/Date+KST.swift
+++ b/UMCApp/Core/Foundation/Sources/Extensions/Date+KST.swift
@@ -11,6 +11,17 @@
 
 import Foundation
 
+// MARK: - Constants
+
+/// KST 하루 경계 계산에 쓰는 밀리초 기준값.
+fileprivate enum Constants {
+    /// KST 자정에서 그 날의 마지막 순간(23:59:59.999)까지 경과한 밀리초.
+    static let endOfDayMilliseconds: Int = 86_399_999
+
+    /// ``endOfDayMilliseconds`` 를 초 단위 오프셋으로 환산한 값.
+    static let endOfDayOffset: TimeInterval = Double(endOfDayMilliseconds) / 1000
+}
+
 // MARK: - TimeZone / Calendar
 
 public extension TimeZone {
@@ -31,16 +42,18 @@ public extension Calendar {
 
 public extension Date {
 
-    /// KST 기준 그 날의 시작(00:00:00) 시각.
+    /// KST 기준 그 날의 시작(00:00:00.000) 시각.
     var kstStartOfDay: Date {
         Calendar.kstGregorian.startOfDay(for: self)
     }
 
-    /// KST 기준 그 날의 끝(다음 날 00:00:00 직전) 시각.
+    /// KST 기준 그 날의 끝(23:59:59.**999**) 시각.
+    ///
+    /// 같은 날 자정에서 정확히 86_399_999ms 후의 시각을 반환합니다.
+    /// 서버가 종일 일정의 종료 시각을 밀리초까지 채운 `23:59:59.999` 로 내려주므로,
+    /// 초 단위(`23:59:59.000`)가 아닌 밀리초 단위를 경계값으로 삼습니다.
     var kstEndOfDay: Date {
-        let calendar = Calendar.kstGregorian
-        let start = calendar.startOfDay(for: self)
-        return calendar.date(byAdding: DateComponents(day: 1, second: -1), to: start) ?? self
+        kstStartOfDay.addingTimeInterval(Constants.endOfDayOffset)
     }
 
     /// KST 기준 그 날의 시작 시각을 UTC ISO8601 문자열로 반환합니다.
@@ -50,7 +63,9 @@ public extension Date {
         ServerDateTimeConverter.toUTCDateTimeString(kstStartOfDay)
     }
 
-    /// KST 기준 그 날의 끝 시각을 UTC ISO8601 문자열로 반환합니다.
+    /// KST 기준 그 날의 끝(23:59:59.999) 시각을 UTC ISO8601 문자열로 반환합니다.
+    ///
+    /// 예: 2026/02/15 KST 임의 시각 → `"2026-02-15T14:59:59.999Z"`
     var kstEndOfDayUTCISO8601: String {
         ServerDateTimeConverter.toUTCDateTimeString(kstEndOfDay)
     }
@@ -60,10 +75,33 @@ public extension Date {
 
 public extension ClosedRange where Bound == Date {
 
-    /// KST 기준으로 이 구간이 하루 전체(00:00 ~ 23:59:59)를 덮는지 여부.
+    /// KST 기준으로 이 구간이 하루 전체(00:00:00.000 ~ 23:59:59.999)를 덮는지 여부.
     ///
-    /// 종일 일정(all-day) 판정에 사용합니다.
+    /// 서버가 종일 여부 플래그를 내려주지 않으므로, 응답의 시작/종료 시각만으로 판정합니다.
+    /// 부동소수 등호 비교는 오차에 취약하므로 KST 자정으로부터 경과한 **밀리초**를
+    /// 정수로 환산해 비교하며, 아래 세 조건을 모두 만족할 때 `true` 입니다.
+    /// - 시작과 끝이 KST 기준 같은 날
+    /// - 시작이 자정으로부터 0ms
+    /// - 끝이 자정으로부터 86_399_999ms
+    ///
+    /// - Note: `ClosedRange` 는 `lowerBound > upperBound` 로 생성 시 트랩하므로
+    ///   역전 구간 가드는 두지 않습니다.
     var isAllDayInKST: Bool {
-        lowerBound == lowerBound.kstStartOfDay && upperBound == lowerBound.kstEndOfDay
+        guard Calendar.kstGregorian.isDate(lowerBound, inSameDayAs: upperBound) else {
+            return false
+        }
+        guard lowerBound.millisecondsSinceKSTStartOfDay == 0 else { return false }
+
+        return upperBound.millisecondsSinceKSTStartOfDay == Constants.endOfDayMilliseconds
+    }
+}
+
+// MARK: - Date + 밀리초 환산
+
+fileprivate extension Date {
+
+    /// KST 자정으로부터 경과한 밀리초. 부동소수 오차를 제거하기 위해 반올림해 정수로 환산합니다.
+    var millisecondsSinceKSTStartOfDay: Int {
+        Int((timeIntervalSince(kstStartOfDay) * 1000).rounded())
     }
 }

--- a/UMCApp/Core/Foundation/Tests/DateKSTTests.swift
+++ b/UMCApp/Core/Foundation/Tests/DateKSTTests.swift
@@ -25,6 +25,11 @@ struct DateKSTTests {
         return Calendar.kstGregorian.date(from: components)!
     }
 
+    /// 두 시각 사이의 경과 밀리초. 부동소수 오차를 배제하기 위해 반올림해 비교합니다.
+    private func milliseconds(from start: Date, to end: Date) -> Int {
+        Int((end.timeIntervalSince(start) * 1000).rounded())
+    }
+
     @Test("kstStartOfDay 는 그 날 00:00(KST)")
     func startOfDay() {
         let start = kstDate().kstStartOfDay
@@ -32,11 +37,23 @@ struct DateKSTTests {
         #expect(ServerDateTimeConverter.toKSTDateString(start) == "2026-02-15")
     }
 
-    @Test("kstEndOfDay 는 그 날 23:59(KST)")
+    @Test("kstEndOfDay 는 그 날 23:59:59.999(KST) — 자정 + 86_399_999ms")
     func endOfDay() {
-        let end = kstDate().kstEndOfDay
+        let day = kstDate()
+        let end = day.kstEndOfDay
         #expect(ServerDateTimeConverter.toKSTTimeString(end) == "23:59")
         #expect(ServerDateTimeConverter.toKSTDateString(end) == "2026-02-15")
+        #expect(milliseconds(from: day.kstStartOfDay, to: end) == 86_399_999)
+    }
+
+    @Test("kstEndOfDay 는 다음 날 자정보다 1ms 앞선다")
+    func endOfDayIsBeforeNextMidnight() {
+        let day = kstDate()
+        let nextMidnight = Calendar.kstGregorian.date(
+            byAdding: .day, value: 1, to: day.kstStartOfDay
+        )!
+        #expect(day.kstEndOfDay < nextMidnight)
+        #expect(milliseconds(from: day.kstEndOfDay, to: nextMidnight) == 1)
     }
 
     @Test("start ≤ 원본 ≤ end 순서가 성립한다")
@@ -54,11 +71,55 @@ struct DateKSTTests {
         #expect(parsed == date.kstStartOfDay)
     }
 
-    @Test("isAllDayInKST — 00:00~23:59 구간은 true")
+    @Test("kstEndOfDayUTCISO8601 는 밀리초까지 채운 .999 로 직렬화된다")
+    func endOfDayUTCISO8601HasMilliseconds() {
+        #expect(kstDate().kstEndOfDayUTCISO8601 == "2026-02-15T14:59:59.999Z")
+    }
+
+    @Test("isAllDayInKST — 00:00:00.000~23:59:59.999 구간은 true")
     func isAllDayTrue() {
         let day = kstDate()
         let range = day.kstStartOfDay...day.kstEndOfDay
         #expect(range.isAllDayInKST == true)
+    }
+
+    @Test("isAllDayInKST — 종료가 23:59:59.999 면 true (서버 종일 일정 응답 형태)")
+    func isAllDayTrueForMillisecondPreciseEnd() {
+        let start = kstDate().kstStartOfDay
+        let end = start.addingTimeInterval(86_399.999)
+        #expect((start...end).isAllDayInKST == true)
+    }
+
+    @Test("isAllDayInKST — 서버 UTC ISO8601 문자열을 파싱한 구간도 true")
+    func isAllDayTrueForParsedServerResponse() throws {
+        let start = try #require(
+            ServerDateTimeConverter.parseUTCDateTime("2026-02-14T15:00:00.000Z")
+        )
+        let end = try #require(
+            ServerDateTimeConverter.parseUTCDateTime("2026-02-15T14:59:59.999Z")
+        )
+        #expect((start...end).isAllDayInKST == true)
+    }
+
+    @Test("isAllDayInKST — 종료가 23:59:59.000 이면 false")
+    func isAllDayFalseForSecondPreciseEnd() {
+        let start = kstDate().kstStartOfDay
+        let end = start.addingTimeInterval(86_399)
+        #expect((start...end).isAllDayInKST == false)
+    }
+
+    @Test("isAllDayInKST — 시작이 자정이 아니면 false")
+    func isAllDayFalseWhenStartIsNotMidnight() {
+        let day = kstDate()
+        let start = day.kstStartOfDay.addingTimeInterval(1)
+        #expect((start...day.kstEndOfDay).isAllDayInKST == false)
+    }
+
+    @Test("isAllDayInKST — 시작과 종료가 KST 기준 다른 날이면 false")
+    func isAllDayFalseAcrossDifferentDays() {
+        let start = kstDate().kstStartOfDay
+        let end = kstDate(day: 16).kstEndOfDay
+        #expect((start...end).isAllDayInKST == false)
     }
 
     @Test("isAllDayInKST — 부분 구간은 false")

--- a/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleAttendancePolicyDTO.swift
+++ b/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleAttendancePolicyDTO.swift
@@ -1,0 +1,78 @@
+//
+//  ScheduleAttendancePolicyDTO.swift
+//  HomeData
+//
+//  Created by euijjang97 on 8/1/26.
+//
+
+import Foundation
+import HomeDomain
+import UMCFoundation
+
+/// V2 일정 응답의 `attendancePolicy` 객체 DTO
+///
+/// 응답이 `null` 이면 출석 비필수 일정을 의미하므로 상위 DTO 가 옵셔널로 보유한다.
+///
+/// - SeeAlso: ``HomeDomain/ScheduleAttendancePolicy``
+public struct ScheduleAttendancePolicyDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    /// 출석 체크인 시작 시각 (UTC ISO8601 문자열)
+    public let checkInStartAt: String
+
+    /// 정시 출석 종료 시각 (UTC ISO8601 문자열)
+    public let onTimeEndAt: String
+
+    /// 지각 종료 시각 (UTC ISO8601 문자열)
+    public let lateEndAt: String
+
+    private enum CodingKeys: String, CodingKey {
+        case checkInStartAt
+        case onTimeEndAt
+        case lateEndAt
+    }
+
+    // MARK: - Init
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        checkInStartAt = try container.decodeIfPresent(String.self, forKey: .checkInStartAt) ?? ""
+        onTimeEndAt = try container.decodeIfPresent(String.self, forKey: .onTimeEndAt) ?? ""
+        lateEndAt = try container.decodeIfPresent(String.self, forKey: .lateEndAt) ?? ""
+    }
+
+    // MARK: - Function
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(checkInStartAt, forKey: .checkInStartAt)
+        try container.encode(onTimeEndAt, forKey: .onTimeEndAt)
+        try container.encode(lateEndAt, forKey: .lateEndAt)
+    }
+}
+
+// MARK: - Domain 변환
+
+extension ScheduleAttendancePolicyDTO {
+
+    /// DTO → 도메인 변환
+    ///
+    /// 세 시각 중 하나라도 UTC ISO8601 파싱에 실패하면 정책 자체가 무의미하므로 `nil` 이다.
+    /// 상위 DTO 는 이 `nil` 을 "정책 미부착(출석 비필수)" 과 동일하게 취급한다.
+    func toDomain() -> ScheduleAttendancePolicy? {
+        guard
+            let checkIn = ServerDateTimeConverter.parseUTCDateTime(checkInStartAt),
+            let onTime = ServerDateTimeConverter.parseUTCDateTime(onTimeEndAt),
+            let late = ServerDateTimeConverter.parseUTCDateTime(lateEndAt)
+        else {
+            return nil
+        }
+
+        return ScheduleAttendancePolicy(
+            checkInStartAt: checkIn,
+            onTimeEndAt: onTime,
+            lateEndAt: late
+        )
+    }
+}

--- a/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleDetailDTO.swift
+++ b/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleDetailDTO.swift
@@ -12,11 +12,11 @@ import UMCFoundation
 /// 일정 목록/상세 응답 DTO (V2)
 ///
 /// `GET /api/v2/schedules/me` 목록과 `GET /api/v2/schedules/{id}` 상세 응답이 동일한
-/// 형태로 내려오므로 단일 DTO로 처리한다. 슬라이스 2(#914)는 캘린더 표시에 필요한
-/// 필드만 다루며, 장소/참여자/출석 정책 등은 이후 슬라이스에서 확장한다.
+/// 형태로 내려오므로 단일 DTO로 처리한다. 슬라이스 2(#914)에서 캘린더 표시에 필요한 필드로
+/// 시작해, #980에서 장소/참여자/출석 정책까지 확장을 마쳤다.
 ///
 /// - SeeAlso: ``ScheduleDetailData``
-public struct ScheduleDetailDTO: Codable {
+public struct ScheduleDetailDTO: Codable, Sendable, Equatable {
 
     // MARK: - Property
 
@@ -31,6 +31,18 @@ public struct ScheduleDetailDTO: Codable {
     public let endsAt: String
     /// 현재 사용자의 참여 여부
     public let isParticipant: Bool
+    /// 장소 객체 (`nil` = 비대면)
+    public let location: ScheduleLocationDTO?
+    public let participants: [ScheduleParticipantDTO]
+    /// 작성자 멤버 식별자. 서버 정수를 절대 규칙 #2에 따라 `String`으로 보존한다.
+    public let authorMemberId: String
+    /// 출석 정책 객체 (`nil` = 출석 비필수)
+    public let attendancePolicy: ScheduleAttendancePolicyDTO?
+    /// 현재 사용자의 출석 상태 (서버 raw 문자열). 도메인 변환 시 enum 으로 매핑한다.
+    public let attendanceStatus: String?
+    public let isAttendanceChecked: Bool
+    /// 비대면 일정 여부
+    public let isOnline: Bool
 
     private enum CodingKeys: String, CodingKey {
         case scheduleId
@@ -40,6 +52,13 @@ public struct ScheduleDetailDTO: Codable {
         case startsAt
         case endsAt
         case isParticipant
+        case location
+        case participants
+        case authorMemberId
+        case attendancePolicy
+        case attendanceStatus
+        case isAttendanceChecked
+        case isOnline
     }
 
     // MARK: - Init
@@ -53,6 +72,19 @@ public struct ScheduleDetailDTO: Codable {
         startsAt = try container.decodeIfPresent(String.self, forKey: .startsAt) ?? ""
         endsAt = try container.decodeIfPresent(String.self, forKey: .endsAt) ?? ""
         isParticipant = try container.decodeBoolFlexibleIfPresent(forKey: .isParticipant) ?? false
+        location = try container.decodeIfPresent(ScheduleLocationDTO.self, forKey: .location)
+        participants = try container.decodeIfPresent(
+            [ScheduleParticipantDTO].self, forKey: .participants
+        ) ?? []
+        authorMemberId = container.decodeFlexibleStringOrEmpty(forKey: .authorMemberId)
+        attendancePolicy = try container.decodeIfPresent(
+            ScheduleAttendancePolicyDTO.self, forKey: .attendancePolicy
+        )
+        attendanceStatus = try container.decodeIfPresent(String.self, forKey: .attendanceStatus)
+        isAttendanceChecked = try container.decodeBoolFlexibleIfPresent(
+            forKey: .isAttendanceChecked
+        ) ?? false
+        isOnline = try container.decodeBoolFlexibleIfPresent(forKey: .isOnline) ?? false
     }
 
     // MARK: - Function
@@ -66,6 +98,13 @@ public struct ScheduleDetailDTO: Codable {
         try container.encode(startsAt, forKey: .startsAt)
         try container.encode(endsAt, forKey: .endsAt)
         try container.encode(isParticipant, forKey: .isParticipant)
+        try container.encodeIfPresent(location, forKey: .location)
+        try container.encode(participants, forKey: .participants)
+        try container.encode(authorMemberId, forKey: .authorMemberId)
+        try container.encodeIfPresent(attendancePolicy, forKey: .attendancePolicy)
+        try container.encodeIfPresent(attendanceStatus, forKey: .attendanceStatus)
+        try container.encode(isAttendanceChecked, forKey: .isAttendanceChecked)
+        try container.encode(isOnline, forKey: .isOnline)
     }
 }
 
@@ -82,7 +121,14 @@ extension ScheduleDetailDTO {
             tags: tags,
             startsAt: ServerDateTimeConverter.parseUTCDateTime(startsAt) ?? .now,
             endsAt: ServerDateTimeConverter.parseUTCDateTime(endsAt) ?? .now,
-            isParticipant: isParticipant
+            isParticipant: isParticipant,
+            location: location?.toDomain(),
+            participants: participants.map { $0.toDomain() },
+            authorMemberId: authorMemberId,
+            attendancePolicy: attendancePolicy?.toDomain(),
+            attendanceStatus: attendanceStatus.map(ScheduleAttendanceStatus.init(serverStatus:)),
+            isAttendanceChecked: isAttendanceChecked,
+            isOnline: isOnline
         )
     }
 }

--- a/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleLocationDTO.swift
+++ b/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleLocationDTO.swift
@@ -1,0 +1,67 @@
+//
+//  ScheduleLocationDTO.swift
+//  HomeData
+//
+//  Created by euijjang97 on 8/1/26.
+//
+
+import Foundation
+import HomeDomain
+import UMCFoundation
+
+/// V2 일정 응답의 `location` 객체 DTO
+///
+/// 응답에서 `null` 이면 비대면 일정을 의미하므로 상위 DTO 가 옵셔널로 보유한다.
+///
+/// - SeeAlso: ``HomeDomain/ScheduleLocation``
+public struct ScheduleLocationDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    /// 위도
+    public let latitude: Double
+
+    /// 경도
+    public let longitude: Double
+
+    /// 장소명
+    public let locationName: String
+
+    private enum CodingKeys: String, CodingKey {
+        case latitude
+        case longitude
+        case locationName
+    }
+
+    // MARK: - Init
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        latitude = try container.decodeDoubleFlexibleIfPresent(forKey: .latitude) ?? 0
+        longitude = try container.decodeDoubleFlexibleIfPresent(forKey: .longitude) ?? 0
+        locationName = try container.decodeIfPresent(String.self, forKey: .locationName) ?? ""
+    }
+
+    // MARK: - Function
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(latitude, forKey: .latitude)
+        try container.encode(longitude, forKey: .longitude)
+        try container.encode(locationName, forKey: .locationName)
+    }
+}
+
+// MARK: - Domain 변환
+
+extension ScheduleLocationDTO {
+
+    /// DTO → 도메인 변환
+    func toDomain() -> ScheduleLocation {
+        ScheduleLocation(
+            latitude: latitude,
+            longitude: longitude,
+            locationName: locationName
+        )
+    }
+}

--- a/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleParticipantDTO.swift
+++ b/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleParticipantDTO.swift
@@ -1,0 +1,78 @@
+//
+//  ScheduleParticipantDTO.swift
+//  HomeData
+//
+//  Created by euijjang97 on 8/1/26.
+//
+
+import Foundation
+import HomeDomain
+import UMCFoundation
+
+/// V2 일정 응답의 `participants[]` 항목 DTO
+///
+/// - SeeAlso: ``HomeDomain/ScheduleParticipant``
+public struct ScheduleParticipantDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    /// 멤버 식별자. 서버 정수를 절대 규칙 #2에 따라 `String`으로 보존한다.
+    public let memberId: String
+    public let name: String
+    public let nickname: String
+    /// 프로필 이미지 URL (서버가 `null` 로 내려줄 수 있음)
+    public let profileImageUrl: String?
+    /// 학교 식별자. 서버 정수를 절대 규칙 #2에 따라 `String`으로 보존한다.
+    public let schoolId: String
+    public let schoolName: String
+
+    private enum CodingKeys: String, CodingKey {
+        case memberId
+        case name
+        case nickname
+        case profileImageUrl
+        case schoolId
+        case schoolName
+    }
+
+    // MARK: - Init
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        memberId = container.decodeFlexibleStringOrEmpty(forKey: .memberId)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
+        profileImageUrl = try container.decodeIfPresent(String.self, forKey: .profileImageUrl)
+        schoolId = container.decodeFlexibleStringOrEmpty(forKey: .schoolId)
+        schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
+    }
+
+    // MARK: - Function
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(memberId, forKey: .memberId)
+        try container.encode(name, forKey: .name)
+        try container.encode(nickname, forKey: .nickname)
+        try container.encodeIfPresent(profileImageUrl, forKey: .profileImageUrl)
+        try container.encode(schoolId, forKey: .schoolId)
+        try container.encode(schoolName, forKey: .schoolName)
+    }
+}
+
+// MARK: - Domain 변환
+
+extension ScheduleParticipantDTO {
+
+    /// DTO → 도메인 변환. 프로필 이미지가 없으면 빈 문자열로 정규화한다.
+    func toDomain() -> ScheduleParticipant {
+        ScheduleParticipant(
+            memberId: memberId,
+            name: name,
+            nickname: nickname,
+            profileImageUrl: profileImageUrl ?? "",
+            schoolId: schoolId,
+            schoolName: schoolName
+        )
+    }
+}

--- a/UMCApp/Features/Home/Data/Tests/ScheduleDetailDTOTests.swift
+++ b/UMCApp/Features/Home/Data/Tests/ScheduleDetailDTOTests.swift
@@ -1,0 +1,287 @@
+//
+//  ScheduleDetailDTOTests.swift
+//  HomeDataTests
+//
+//  Created by euijjang97 on 8/1/26.
+//
+//  서버가 정수를 String/Number 어느 쪽으로 내려주든 동일한 도메인 값이 나오는지(절대 규칙 #2),
+//  옵셔널 객체(`location`/`attendancePolicy`)와 누락 키가 크래시 없이 흡수되는지,
+//  출석 상태 raw 문자열이 ``ScheduleAttendanceStatus`` 로 올바르게 매핑되는지 검증한다.
+//
+
+import Foundation
+import Testing
+import HomeDomain
+import UMCFoundation
+@testable import HomeData
+
+@Suite("ScheduleDetailDTO — 디코딩 & 도메인 매핑")
+struct ScheduleDetailDTOTests {
+
+    // MARK: - 서버 정수 직렬화 유연성
+
+    @Test("서버가 정수를 String으로 내려줘도 도메인에서 String으로 보존된다")
+    func decodesStringSerializedIdentifiers() throws {
+        let dto = try decodeScheduleDetail(makeFullJSON(numericIdentifiers: false))
+        let domain = dto.toDomain()
+
+        #expect(domain.scheduleId == "12")
+        #expect(domain.authorMemberId == "7")
+        #expect(domain.participants.first?.memberId == "7")
+        #expect(domain.participants.first?.schoolId == "3")
+        #expect(domain.participants.first?.id == "7")
+    }
+
+    @Test("서버가 정수를 숫자로 내려줘도 String 직렬화와 동일한 도메인 값을 만든다")
+    func decodesNumberSerializedIdentifiersIdentically() throws {
+        let stringSerialized = try decodeScheduleDetail(
+            makeFullJSON(numericIdentifiers: false)
+        ).toDomain()
+        let numberSerialized = try decodeScheduleDetail(
+            makeFullJSON(numericIdentifiers: true)
+        ).toDomain()
+
+        #expect(numberSerialized.scheduleId == "12")
+        #expect(numberSerialized.authorMemberId == "7")
+        #expect(numberSerialized.participants.first?.memberId == "7")
+        #expect(numberSerialized.participants.first?.schoolId == "3")
+        #expect(numberSerialized == stringSerialized)
+    }
+
+    // MARK: - 옵셔널 객체 & 누락 키
+
+    @Test("location/attendancePolicy가 명시적 null이면 도메인에서 nil이다")
+    func nullOptionalObjectsBecomeNil() throws {
+        let json = """
+        {
+            "scheduleId": "12",
+            "name": "비대면 세미나",
+            "description": "",
+            "tags": [],
+            "startsAt": "2026-08-01T01:00:00Z",
+            "endsAt": "2026-08-01T03:00:00Z",
+            "isParticipant": true,
+            "location": null,
+            "participants": [],
+            "authorMemberId": "7",
+            "attendancePolicy": null,
+            "attendanceStatus": null,
+            "isAttendanceChecked": false,
+            "isOnline": true
+        }
+        """
+
+        let domain = try decodeScheduleDetail(json).toDomain()
+
+        #expect(domain.location == nil)
+        #expect(domain.attendancePolicy == nil)
+        #expect(domain.attendanceStatus == nil)
+        #expect(domain.requiresAttendanceApproval == false)
+    }
+
+    @Test("location/attendancePolicy/participants 키 자체가 없어도 안전하게 기본값으로 흡수된다")
+    func missingKeysFallBackToDefaults() throws {
+        let json = """
+        {
+            "scheduleId": "12",
+            "name": "정기 회의",
+            "description": "메모",
+            "tags": ["회의"],
+            "startsAt": "2026-08-01T01:00:00Z",
+            "endsAt": "2026-08-01T03:00:00Z",
+            "isParticipant": false
+        }
+        """
+
+        let domain = try decodeScheduleDetail(json).toDomain()
+
+        #expect(domain.location == nil)
+        #expect(domain.attendancePolicy == nil)
+        #expect(domain.attendanceStatus == nil)
+        #expect(domain.participants.isEmpty)
+        #expect(domain.participantMemberIds.isEmpty)
+        #expect(domain.authorMemberId == "")
+        #expect(domain.isAttendanceChecked == false)
+        #expect(domain.isOnline == false)
+    }
+
+    @Test("location이 있으면 좌표/장소명이 그대로 도메인에 전달된다")
+    func decodesLocation() throws {
+        let domain = try decodeScheduleDetail(makeFullJSON(numericIdentifiers: false)).toDomain()
+
+        #expect(domain.location?.latitude == 37.5665)
+        #expect(domain.location?.longitude == 126.9780)
+        #expect(domain.location?.locationName == "서울시청")
+    }
+
+    @Test("participants의 profileImageUrl이 null이면 도메인에서 빈 문자열로 정규화된다")
+    func nullProfileImageUrlBecomesEmptyString() throws {
+        let domain = try decodeScheduleDetail(makeFullJSON(numericIdentifiers: false)).toDomain()
+
+        #expect(domain.participants.first?.profileImageUrl == "")
+        #expect(domain.participants.first?.name == "홍길동")
+        #expect(domain.participants.first?.schoolName == "UMC대학교")
+    }
+
+    // MARK: - 출석 상태 매핑
+
+    @Test(
+        "attendanceStatus raw 문자열이 도메인 enum으로 매핑된다",
+        arguments: [
+            ("PRESENT", ScheduleAttendanceStatus.present),
+            ("EXCUSED", .present),
+            ("LATE", .late),
+            ("ABSENT", .absent),
+            ("PENDING", .beforeAttendance),
+            ("LATE_PENDING", .pendingApproval),
+            ("FUTURE_NEW_TYPE_PENDING", .pendingApproval),
+            ("TOTALLY_UNKNOWN", .beforeAttendance)
+        ]
+    )
+    func mapsAttendanceStatus(rawValue: String, expected: ScheduleAttendanceStatus) throws {
+        let json = makeMinimalJSON(extraFields: "\"attendanceStatus\": \"\(rawValue)\"")
+
+        let domain = try decodeScheduleDetail(json).toDomain()
+
+        #expect(domain.attendanceStatus == expected)
+    }
+
+    // MARK: - 출석 정책
+
+    @Test("attendancePolicy 세 시각이 모두 유효하면 도메인 정책으로 변환된다")
+    func decodesAttendancePolicy() throws {
+        let domain = try decodeScheduleDetail(makeFullJSON(numericIdentifiers: false)).toDomain()
+        let expectedLateEnd = ServerDateTimeConverter.parseUTCDateTime("2026-08-01T01:30:00Z")
+
+        #expect(domain.requiresAttendanceApproval)
+        #expect(domain.attendancePolicy?.lateEndAt == expectedLateEnd)
+        #expect(domain.attendanceWindowEndsAt == domain.endsAt)
+    }
+
+    @Test("attendancePolicy의 시각 하나라도 파싱 불가하면 정책 전체가 nil이 된다")
+    func invalidPolicyTimestampDropsPolicy() throws {
+        let policy = """
+        "attendancePolicy": {
+            "checkInStartAt": "2026-08-01T00:30:00Z",
+            "onTimeEndAt": "not-a-date",
+            "lateEndAt": "2026-08-01T01:30:00Z"
+        }
+        """
+        let json = makeMinimalJSON(extraFields: policy)
+
+        let domain = try decodeScheduleDetail(json).toDomain()
+
+        #expect(domain.attendancePolicy == nil)
+        #expect(domain.requiresAttendanceApproval == false)
+        #expect(domain.attendanceWindowEndsAt == domain.endsAt)
+    }
+
+    // MARK: - Bool 유연 디코딩
+
+    @Test(
+        "isOnline/isAttendanceChecked는 Bool/String/Int 어느 표현으로 와도 true로 해석된다",
+        arguments: ["true", "\"true\"", "1"]
+    )
+    func decodesFlexibleBooleans(rawValue: String) throws {
+        let json = makeMinimalJSON(
+            extraFields: "\"isOnline\": \(rawValue), \"isAttendanceChecked\": \(rawValue)"
+        )
+
+        let domain = try decodeScheduleDetail(json).toDomain()
+
+        #expect(domain.isOnline)
+        #expect(domain.isAttendanceChecked)
+    }
+
+    // MARK: - 라운드트립
+
+    @Test("encode(to:) 후 다시 디코딩하면 동일한 DTO가 복원된다")
+    func encodeDecodeRoundTripPreservesValues() throws {
+        let original = try decodeScheduleDetail(makeFullJSON(numericIdentifiers: true))
+
+        let encoded = try JSONEncoder().encode(original)
+        let restored = try JSONDecoder().decode(ScheduleDetailDTO.self, from: encoded)
+
+        #expect(restored == original)
+        #expect(restored.toDomain() == original.toDomain())
+    }
+
+    @Test("옵셔널 필드가 비어 있어도 라운드트립이 유지된다")
+    func encodeDecodeRoundTripWithoutOptionalFields() throws {
+        let original = try decodeScheduleDetail(makeMinimalJSON(extraFields: nil))
+
+        let encoded = try JSONEncoder().encode(original)
+        let restored = try JSONDecoder().decode(ScheduleDetailDTO.self, from: encoded)
+
+        #expect(restored == original)
+        #expect(restored.location == nil)
+        #expect(restored.attendancePolicy == nil)
+        #expect(restored.attendanceStatus == nil)
+    }
+}
+
+// MARK: - Helpers
+
+private func decodeScheduleDetail(_ json: String) throws -> ScheduleDetailDTO {
+    try JSONDecoder().decode(ScheduleDetailDTO.self, from: Data(json.utf8))
+}
+
+/// 모든 확장 필드를 채운 응답 본문. `numericIdentifiers` 로 서버의 정수 직렬화 방식을 전환한다.
+private func makeFullJSON(numericIdentifiers: Bool) -> String {
+    let scheduleId = numericIdentifiers ? "12" : "\"12\""
+    let memberId = numericIdentifiers ? "7" : "\"7\""
+    let schoolId = numericIdentifiers ? "3" : "\"3\""
+
+    return """
+    {
+        "scheduleId": \(scheduleId),
+        "name": "정기 세미나",
+        "description": "1층 대강당",
+        "tags": ["세미나", "필수"],
+        "startsAt": "2026-08-01T01:00:00Z",
+        "endsAt": "2026-08-01T03:00:00Z",
+        "isParticipant": true,
+        "location": {
+            "latitude": 37.5665,
+            "longitude": 126.9780,
+            "locationName": "서울시청"
+        },
+        "participants": [
+            {
+                "memberId": \(memberId),
+                "name": "홍길동",
+                "nickname": "길동",
+                "profileImageUrl": null,
+                "schoolId": \(schoolId),
+                "schoolName": "UMC대학교"
+            }
+        ],
+        "authorMemberId": \(memberId),
+        "attendancePolicy": {
+            "checkInStartAt": "2026-08-01T00:30:00Z",
+            "onTimeEndAt": "2026-08-01T01:10:00Z",
+            "lateEndAt": "2026-08-01T01:30:00Z"
+        },
+        "attendanceStatus": "PRESENT",
+        "isAttendanceChecked": true,
+        "isOnline": false
+    }
+    """
+}
+
+/// 필수 필드만 담은 응답 본문. `extraFields` 는 JSON 최상위에 그대로 병합된다.
+private func makeMinimalJSON(extraFields: String?) -> String {
+    let trailing = extraFields.map { ",\n    \($0)" } ?? ""
+
+    return """
+    {
+        "scheduleId": "12",
+        "name": "정기 세미나",
+        "description": "",
+        "tags": [],
+        "startsAt": "2026-08-01T01:00:00Z",
+        "endsAt": "2026-08-01T03:00:00Z",
+        "isParticipant": true\(trailing)
+    }
+    """
+}

--- a/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleAttendancePolicy.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleAttendancePolicy.swift
@@ -1,0 +1,37 @@
+//
+//  ScheduleAttendancePolicy.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/1/26.
+//
+
+import Foundation
+
+/// 일정에 부착된 출석 시각 임계값
+///
+/// 서버 V2 일정 응답에 임베드되어 내려오는 동적 정책이다.
+/// 컨테이너에서 `nil` 은 출석 비필수 일정을 의미한다.
+///
+/// > Note: 지오펜스 반경 같은 앱 전역 상수(`AttendancePolicy`)와 이름이 겹치지 않도록
+///   `Schedule` 접두사를 부여했다.
+public struct ScheduleAttendancePolicy: Equatable, Sendable {
+
+    // MARK: - Property
+
+    /// 출석 체크인 시작 시각 (이전엔 출석 불가)
+    public let checkInStartAt: Date
+
+    /// 정시 출석 종료 시각 (이후엔 지각)
+    public let onTimeEndAt: Date
+
+    /// 지각 종료 시각 (이후엔 결석)
+    public let lateEndAt: Date
+
+    // MARK: - Init
+
+    public init(checkInStartAt: Date, onTimeEndAt: Date, lateEndAt: Date) {
+        self.checkInStartAt = checkInStartAt
+        self.onTimeEndAt = onTimeEndAt
+        self.lateEndAt = lateEndAt
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleAttendanceStatus.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleAttendanceStatus.swift
@@ -1,0 +1,60 @@
+//
+//  ScheduleAttendanceStatus.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/1/26.
+//
+
+import Foundation
+
+/// 일정에 대한 현재 사용자의 출석 상태
+///
+/// 표시용 텍스트/색상 매핑은 Presentation 레이어의 책임이므로 도메인에는 두지 않는다.
+///
+/// > Note: Home → Activity 모듈 의존을 만들지 않기 위해 `ActivityDomain/AttendanceStatus` 를
+///   재사용하지 않고 HomeDomain 에 자체 정의한다. rawValue 는 영속/서버 호환을 위해 동일하다.
+public enum ScheduleAttendanceStatus: String, CaseIterable, Equatable, Sendable {
+
+    /// 출석 전
+    case beforeAttendance = "pending"
+
+    /// 승인 대기
+    case pendingApproval
+
+    /// 출석
+    case present
+
+    /// 지각
+    case late
+
+    /// 결석
+    case absent
+}
+
+// MARK: - Server Status Mapping
+
+public extension ScheduleAttendanceStatus {
+
+    /// 서버 API 상태 문자열 → 도메인 enum 변환
+    ///
+    /// - Parameter serverStatus: 서버 응답 status 필드
+    ///   (e.g., `"PRESENT"`, `"LATE"`, `"ABSENT"`, `"PENDING"`,
+    ///    `"PRESENT_PENDING"`, `"LATE_PENDING"`, `"EXCUSED"`, `"EXCUSED_PENDING"`)
+    init(serverStatus: String) {
+        switch serverStatus {
+        case "PRESENT", "EXCUSED":
+            self = .present
+        case "LATE":
+            self = .late
+        case "ABSENT":
+            self = .absent
+        case "PENDING":
+            self = .beforeAttendance
+        case "PRESENT_PENDING", "LATE_PENDING", "EXCUSED_PENDING":
+            self = .pendingApproval
+        default:
+            // 서버에 새 PENDING 변형이 추가돼도 승인 대기로 안전하게 흡수한다.
+            self = serverStatus.hasSuffix("_PENDING") ? .pendingApproval : .beforeAttendance
+        }
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleLocation.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleLocation.swift
@@ -1,0 +1,34 @@
+//
+//  ScheduleLocation.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/1/26.
+//
+
+import Foundation
+
+/// 일정 장소 도메인 모델
+///
+/// 서버 V2 일정 응답의 `location` 객체를 도메인으로 변환한 값이다.
+/// 컨테이너에서 `nil` 은 비대면 일정을 의미한다.
+public struct ScheduleLocation: Equatable, Sendable {
+
+    // MARK: - Property
+
+    /// 위도
+    public let latitude: Double
+
+    /// 경도
+    public let longitude: Double
+
+    /// 장소명
+    public let locationName: String
+
+    // MARK: - Init
+
+    public init(latitude: Double, longitude: Double, locationName: String) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.locationName = locationName
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleParticipant.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleParticipant.swift
@@ -1,0 +1,55 @@
+//
+//  ScheduleParticipant.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/1/26.
+//
+
+import Foundation
+
+/// 일정 참여자 도메인 모델
+///
+/// 서버 V2 일정 응답의 `participants` 배열 항목을 도메인으로 변환한 값이다.
+/// 화면에서 즉시 이름/프로필을 표시할 수 있도록 식별자뿐 아니라 멤버 정보를 함께 보유한다.
+public struct ScheduleParticipant: Equatable, Sendable, Identifiable {
+
+    // MARK: - Property
+
+    public var id: String { memberId }
+
+    /// 멤버 식별자. 서버 정수를 절대 규칙 #2에 따라 `String`으로 보존한다.
+    public let memberId: String
+
+    /// 본명
+    public let name: String
+
+    /// 닉네임
+    public let nickname: String
+
+    /// 프로필 이미지 URL (없으면 빈 문자열)
+    public let profileImageUrl: String
+
+    /// 학교 식별자. 서버 정수를 절대 규칙 #2에 따라 `String`으로 보존한다.
+    public let schoolId: String
+
+    /// 학교명
+    public let schoolName: String
+
+    // MARK: - Init
+
+    public init(
+        memberId: String,
+        name: String,
+        nickname: String,
+        profileImageUrl: String,
+        schoolId: String,
+        schoolName: String
+    ) {
+        self.memberId = memberId
+        self.name = name
+        self.nickname = nickname
+        self.profileImageUrl = profileImageUrl
+        self.schoolId = schoolId
+        self.schoolName = schoolName
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/Models/ScheduleDetailData.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/ScheduleDetailData.swift
@@ -11,8 +11,8 @@ import UMCFoundation
 /// 홈 일정 캘린더가 표시하는 일정 상세 모델.
 ///
 /// 서버 V2 스키마는 목록/상세 응답이 동일한 형태이므로 단일 모델로 양쪽을 지원한다.
-/// 슬라이스 2(#914) 범위는 캘린더 표시에 필요한 필드만 다루며, 장소/참여자/출석 정책 등은
-/// 출석·등록 기능 이식 시 별도로 확장한다.
+/// 슬라이스 2(#914)에서 캘린더 표시에 필요한 필드로 시작해, #980에서 장소/참여자/출석 정책까지
+/// 확장을 마쳤다.
 public struct ScheduleDetailData: Equatable, Identifiable, Sendable {
 
     // MARK: - Property
@@ -26,6 +26,17 @@ public struct ScheduleDetailData: Equatable, Identifiable, Sendable {
     public let startsAt: Date
     public let endsAt: Date
     public let isParticipant: Bool
+    /// 일정 장소 (`nil` = 비대면)
+    public let location: ScheduleLocation?
+    public let participants: [ScheduleParticipant]
+    /// 작성자 멤버 식별자. 서버 정수를 절대 규칙 #2에 따라 `String`으로 보존한다.
+    public let authorMemberId: String
+    /// 출석 정책 (`nil` = 출석 비필수)
+    public let attendancePolicy: ScheduleAttendancePolicy?
+    /// 현재 사용자의 출석 상태 (서버가 내려주지 않으면 `nil`)
+    public let attendanceStatus: ScheduleAttendanceStatus?
+    public let isAttendanceChecked: Bool
+    public let isOnline: Bool
 
     // MARK: - Init
 
@@ -36,7 +47,14 @@ public struct ScheduleDetailData: Equatable, Identifiable, Sendable {
         tags: [String],
         startsAt: Date,
         endsAt: Date,
-        isParticipant: Bool
+        isParticipant: Bool,
+        location: ScheduleLocation? = nil,
+        participants: [ScheduleParticipant] = [],
+        authorMemberId: String = "",
+        attendancePolicy: ScheduleAttendancePolicy? = nil,
+        attendanceStatus: ScheduleAttendanceStatus? = nil,
+        isAttendanceChecked: Bool = false,
+        isOnline: Bool = false
     ) {
         self.scheduleId = scheduleId
         self.name = name
@@ -45,9 +63,41 @@ public struct ScheduleDetailData: Equatable, Identifiable, Sendable {
         self.startsAt = startsAt
         self.endsAt = endsAt
         self.isParticipant = isParticipant
+        self.location = location
+        self.participants = participants
+        self.authorMemberId = authorMemberId
+        self.attendancePolicy = attendancePolicy
+        self.attendanceStatus = attendanceStatus
+        self.isAttendanceChecked = isAttendanceChecked
+        self.isOnline = isOnline
     }
 
     // MARK: - Computed
+
+    /// 종일 일정 여부 — `(start...end)` 가 KST 기준 단일 일자 전체를 덮는지 판정한다.
+    public var isAllDay: Bool {
+        guard startsAt <= endsAt else { return false }
+        return (startsAt...endsAt).isAllDayInKST
+    }
+
+    /// 출석 정책이 부착된 일정인지 여부.
+    public var requiresAttendanceApproval: Bool {
+        attendancePolicy != nil
+    }
+
+    /// 출석 표시가 의미를 갖는 마지막 시각.
+    ///
+    /// 정책이 있으면 지각 인정 마감(`lateEndAt`)과 일정 종료 중 늦은 쪽, 없으면 일정 종료 시각이다.
+    /// 이 시각이 지나면 출석 가능 목록에서 제외한다.
+    public var attendanceWindowEndsAt: Date {
+        guard let attendancePolicy else { return endsAt }
+        return max(attendancePolicy.lateEndAt, endsAt)
+    }
+
+    /// 참여자 멤버 식별자 목록.
+    public var participantMemberIds: [String] {
+        participants.map(\.memberId)
+    }
 
     /// KST 기준 오늘 자정과 일정 시작 자정의 일수 차. 양수는 미래, 음수는 과거, 0은 오늘.
     public var dDay: Int {


### PR DESCRIPTION
## ✨ PR 유형

Feature — 일정 상세(`ScheduleDetailData`) 도메인 모델과 `ScheduleDetailDTO` 에 **장소 / 참여자 / 출석 정책** 필드를 확장했습니다. 부수적으로 확장 필드가 의존하는 KST 종일(all-day) 판정 버그를 Core 레이어에서 정정했습니다.

Resolves #980 (슬라이스 2 #914 에서 최소 필드로 출발한 일정 상세의 후속 확장)

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 — Domain / Data 레이어 모델·DTO 확장과 Core 날짜 유틸 정정 작업입니다. 기존 캘린더 화면은 동작·표시 모두 그대로입니다.

## 🛠️ 작업내용

### HomeDomain — 모델 확장

- `ScheduleDetailData` 에 확장 필드 7종 추가 (전부 `public let`)
  - `location` / `participants` / `authorMemberId` / `attendancePolicy` / `attendanceStatus` / `isAttendanceChecked` / `isOnline`
  - 서버 정수(`memberId`, `schoolId`, `authorMemberId`)는 **전 레이어 `String` 통일** (절대 규칙 #2)
- 신규 값 타입 4종을 `Domain/Sources/Models/Schedule/` 에 추가
  - `ScheduleLocation` (위경도 + 장소명)
  - `ScheduleParticipant` (`Identifiable`, `id == memberId`)
  - `ScheduleAttendancePolicy` (체크인 시작 / 정시 마감 / 지각 마감)
  - `ScheduleAttendanceStatus` (서버 raw 문자열 → 도메인 enum 매핑, `_PENDING` 접미사 fallback 포함)
- 파생 계산 프로퍼티 추가 — `isAllDay`, `requiresAttendanceApproval`, `attendanceWindowEndsAt`, `participantMemberIds`
- 신규 이니셜라이저 파라미터에 **전부 기본값을 부여**해 기존 호출부 4곳이 수정 없이 컴파일되도록 무회귀 보장

### HomeData — DTO 확장

- `ScheduleDetailDTO` 에 대응 필드 7종 추가, `Codable, Sendable, Equatable` 로 확장
- Response DTO 3종 신규 추가 — `ScheduleLocationDTO` / `ScheduleParticipantDTO` / `ScheduleAttendancePolicyDTO`
- 전부 **synthesized Codable 금지 → custom `init(from:)` + `encode(to:)`** (절대 규칙 #3)
  - 정수: `decodeFlexibleStringOrEmpty` — 서버가 `"7"` 로 주든 `7` 로 주든 동일한 도메인 값
  - 실수: `decodeDoubleFlexibleIfPresent`
  - 불리언: `decodeBoolFlexibleIfPresent` — `true` / `"true"` / `1` 모두 흡수
- `ScheduleAttendancePolicyDTO.toDomain()` 은 세 시각 중 **하나라도 파싱 실패하면 정책 전체를 `nil`** 로 떨궈, 반쪽짜리 출석 정책이 도메인에 흘러들지 않도록 처리
- `participants[].profileImageUrl` 이 `null` 이면 도메인에서 빈 문자열로 정규화

### Core(UMCFoundation) — KST 종일 판정 정정 🐛

- `Date.kstEndOfDay` 가 23:59:59.**000** 을 반환하고 있어, 서버가 `...T14:59:59.999Z` 로 내려주는 종일 일정이 `isAllDayInKST == false` 로 오판되던 문제를 수정
  - `kstEndOfDay` → 23:59:59.**999** (다음 자정 1ms 전)
  - `isAllDayInKST` 를 부동소수 비교 대신 **밀리초 정수 비교**로 변경해 오차 제거
  - 매직넘버는 `fileprivate enum Constants` 로 분리
- 다른 소비처는 `HomeViewModel.fetchSchedules()` 의 월말 경계(`endOfMonth.kstEndOfDay`) 한 곳뿐이며, 경계가 999ms 넓어지는 방향이라 조회 결과 회귀 없음

### 테스트

- `ScheduleDetailDTOTests` **신규 12건** — 정수 String/Number 직렬화 동치, null·키 누락 흡수, location 매핑, profileImageUrl 정규화, attendanceStatus 8-케이스 파라미터라이즈드 매핑, 정책 유효/무효, Bool 3표현, encode/decode 라운드트립 2건
- `DateKSTTests` 보강 — `.999` 종일 true / `.000` true 아님 / 시작이 자정 아님 / 서로 다른 KST 일자 / `kstEndOfDay` 경계 / UTC ISO8601 직렬화 / 서버 응답 파싱 range

**테스트 결과 — 모듈 스킴 4종 총 149건 전부 통과**

| Scheme | 결과 |
|---|---|
| `UMCFoundation` | 106 tests / 20 suites ✅ |
| `HomeDomain` | 9 tests / 2 suites ✅ |
| `HomeData` | 23 tests / 3 suites ✅ (신규 12건 포함) |
| `HomePresentation` | 11 tests / 1 suite ✅ |

> `make test`(앱 호스팅 `UMCAppTests`)는 로컬에서 `KAKAO_KEY not found in Info.plist` 로 부트 실패합니다. `Secrets/Secrets.xcconfig` 가 gitignore 대상인 **로컬 시크릿 환경 이슈**이며 이번 변경과 무관합니다(컴파일·링크·코드사이닝은 모두 성공). 그래서 호스트 앱이 필요 없는 모듈 스킴으로 검증했습니다.

## 📋 추후 진행 상황

- **#980 체크리스트 4번(출석/등록 화면에서 확장 필드 사용 검증)은 이번 PR 범위 밖**입니다. 해당 소비처 화면이 아직 `UMCApp/` 으로 이식되지 않아, #1034 / #994 슬라이스에서 화면과 함께 검증합니다.
- #981 에서 Schedule 전용 모듈을 분리할 때, 이번에 `HomeDomain/Models/Schedule/` 로 묶어둔 4개 타입이 디렉터리째 이동 가능하도록 배치해 두었습니다.
- `ActivityDomain` 의 기존 TODO(`ChallengerAttendanceRepositoryProtocol.swift:47-52`, `ChallengerAttendanceUseCaseProtocol.swift:97-99`)는 Schedule 모듈 분리 이후 `ScheduleDetailData` 를 참조하도록 연결 예정입니다.

## 📌 리뷰 포인트

- `UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleAttendanceStatus.swift` — **`ActivityDomain.AttendanceStatus` 를 재사용하지 않고 HomeDomain 에 자체 정의한 결정**이 핵심입니다. `ActivityDomain` 은 `[.iPhone, .appleWatch]` 멀티플랫폼이고 `HomeDomain` 은 iOS 전용이라 `ActivityDomain → HomeDomain` 의존이 watchOS 빌드를 깨뜨리며, 반대 방향(Home → Activity) 의존도 #981 모듈 분리 시 순환을 만듭니다. 그래서 `Home/Project.swift` 는 손대지 않았습니다.
- `UMCApp/Core/Foundation/Sources/Extensions/Date+KST.swift` — `kstEndOfDay` 의미 변경(23:59:59.000 → .999)이 가장 파급 범위가 넓은 변경입니다. 소비처는 `HomeViewModel.swift:119` 한 곳뿐이며 경계가 넓어지는 방향임을 확인해 주세요.
- `UMCApp/Features/Home/Domain/Sources/Models/ScheduleDetailData.swift` — 신규 파라미터 기본값 설계(무회귀 보장 목적)와 `attendanceWindowEndsAt` 이 `max(lateEndAt, endsAt)` 인 이유를 봐주세요.
- `UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleAttendancePolicyDTO.swift` — 시각 파싱 실패 시 정책 전체를 `nil` 로 떨구는 all-or-nothing 정책이 적절한지.
- `UMCApp/Features/Home/Data/Tests/ScheduleDetailDTOTests.swift` — 서버 계약 가정(필드명/`attendanceStatus` raw 값)이 실제 API 명세와 일치하는지 확인 부탁드립니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
