### PR TITLE
🐛 [Fix] 베스트 워크북 포인트 서버 미제공 필드 의존 정리 및 스터디 그룹 DTO 계약 정렬

### DIFF
--- a/UMCApp/Features/Activity/Data/Sources/DTOs/MemberProfileDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/MemberProfileDTO.swift
@@ -9,22 +9,28 @@ import Foundation
 import UMCFoundation
 // MARK: - MemberProfileDTO
 
-/// 멤버 프로필 응답 DTO (챌린저 ID 해석 전용)
+/// 멤버 프로필 응답 DTO (챌린저 ID·닉네임 해석 전용)
 ///
 /// `GET /api/v1/member/profile/{memberId}`
 ///
-/// ``StudyRepository/resolveChallengerId(memberId:preferredGeneration:)`` 가
-/// `challengerRecords` 만 사용하므로 본 DTO 는 해당 필드만 디코딩한다(나머지 응답 필드는
-/// `Codable` 이 무시). 서버 식별자는 전 레이어 `String` 통일 규칙에 따라 `String` 으로 디코딩한다.
+/// 스터디 그룹 응답이 주지 않는 `challengerId`·`nickname` 을 이 응답에서 해석한다. 필요한
+/// 필드만 디코딩하며 나머지 응답 필드는 `Codable` 이 무시한다. 서버 식별자는 전 레이어 `String`
+/// 통일 규칙에 따라 `String` 으로 디코딩한다.
+///
+/// - Note: 타인 프로필 조회는 서버에서 민감 정보가 필터링되지만, `nickname` 과
+///   `challengerRecords[].challengerId` 는 보존된다. 상벌점(`challengerPoints`)만 빈 배열로
+///   내려오므로 이 경로로는 포인트를 얻을 수 없다.
 struct MemberProfileDTO: Codable, Sendable, Equatable {
 
     // MARK: - Property
 
+    let nickname: String?
     let challengerRecords: [MemberChallengerRecordDTO]
 
     // MARK: - CodingKeys
 
     private enum CodingKeys: String, CodingKey {
+        case nickname
         case challengerRecords
     }
 
@@ -32,6 +38,7 @@ struct MemberProfileDTO: Codable, Sendable, Equatable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        nickname = try container.decodeIfPresent(String.self, forKey: .nickname)
         challengerRecords = try container.decodeIfPresent(
             [MemberChallengerRecordDTO].self,
             forKey: .challengerRecords
@@ -42,6 +49,7 @@ struct MemberProfileDTO: Codable, Sendable, Equatable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(nickname, forKey: .nickname)
         try container.encode(challengerRecords, forKey: .challengerRecords)
     }
 }

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/MyStudyGroupsPageDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/MyStudyGroupsPageDTO.swift
@@ -82,12 +82,26 @@ struct MyStudyGroupsPageDTO: Codable, Sendable, Equatable {
         try container.encode(hasNext, forKey: .hasNext)
     }
 
+    // MARK: - Computed Property
+
+    /// 페이지 전체 그룹의 멤버 `memberId` 목록 — 그룹 간 중복이 남아 있으므로 조회 전 중복 제거한다.
+    var allMemberIDs: [String] {
+        studyGroups.flatMap(\.allMemberIDs)
+    }
+
     // MARK: - toDomain
 
     /// DTO 를 도메인 모델 ``StudyGroupDetailsPage`` 로 변환한다.
-    func toDomain() -> StudyGroupDetailsPage {
+    ///
+    /// - Parameter supplementsByMemberID: `memberId` → 멤버 프로필에서 해석한 보강 정보
+    ///   (서버 응답에 없는 `challengerId`·`nickname`). 페이지 전체가 하나의 매핑을 공유한다.
+    func toDomain(
+        supplementsByMemberID: [String: StudyGroupMemberSupplement] = [:]
+    ) -> StudyGroupDetailsPage {
         StudyGroupDetailsPage(
-            content: studyGroups.map { $0.toDomain() },
+            content: studyGroups.map {
+                $0.toDomain(supplementsByMemberID: supplementsByMemberID)
+            },
             hasNext: hasNext,
             nextCursor: nextCursor
         )

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupDetailDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupDetailDTO.swift
@@ -13,36 +13,42 @@ import UMCFoundation
 
 /// 스터디 그룹 상세 응답 DTO
 ///
-/// `GET /api/v1/study-groups/{groupId}`
+/// `GET /api/v1/study-groups/{studyGroupId}` · `GET /api/v1/study-groups/managed`
 ///
-/// 서버 식별자(`groupId`, `schoolId`, `challengerId`, `memberId`)는 전 레이어 `String` 통일
-/// 규칙에 따라 `String` 으로 디코딩한다.
+/// 서버 `StudyGroupResponse` 계약에 맞춘 키만 디코딩한다. 서버 식별자(`studyGroupId`,
+/// `memberId`)는 정수로 내려오지만 전 레이어 `String` 통일 규칙에 따라 `String` 으로 받는다.
+///
+/// - Note: 서버가 함께 내려주는 `gisuId` 는 도메인에서 쓰지 않아 디코딩하지 않는다.
 struct StudyGroupDetailDTO: Codable, Sendable, Equatable {
 
     // MARK: - Property
 
-    let groupId: String
+    let studyGroupId: String
     let name: String
-    let part: String
-    let partDisplayName: String?
-    let schools: [StudyGroupSchoolDTO]
+    let studyPart: String
     let createdAt: String
-    let memberCount: Int
     let mentors: [StudyGroupChallengerDTO]
     let members: [StudyGroupChallengerDTO]
+
+    // MARK: - Computed Property
+
+    /// 그룹에 속한 모든 멤버(파트장 + 스터디원)의 `memberId` — 빈 값은 제외한다.
+    ///
+    /// 서버가 주지 않는 `challengerId`·`nickname` 을 멤버 프로필로 보강할 때 조회 대상 목록으로 쓴다.
+    var allMemberIDs: [String] {
+        (mentors + members)
+            .map(\.memberId)
+            .filter { !$0.isEmpty }
+    }
 
     // MARK: - CodingKeys
 
     private enum CodingKeys: String, CodingKey {
-        case groupId
+        case studyGroupId
         case name
-        case part
-        case partDisplayName
-        case schools
+        case studyPart
         case createdAt
-        case memberCount
         case mentors
-        case leader
         case members
     }
 
@@ -50,27 +56,14 @@ struct StudyGroupDetailDTO: Codable, Sendable, Equatable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        groupId = container.decodeFlexibleStringOrNil(forKey: .groupId) ?? ""
+        studyGroupId = container.decodeFlexibleStringOrNil(forKey: .studyGroupId) ?? ""
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
-        part = try container.decodeIfPresent(String.self, forKey: .part) ?? ""
-        partDisplayName = try container.decodeIfPresent(String.self, forKey: .partDisplayName)
-        schools = try container.decodeIfPresent([StudyGroupSchoolDTO].self, forKey: .schools) ?? []
+        studyPart = try container.decodeIfPresent(String.self, forKey: .studyPart) ?? ""
         createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt) ?? ""
-        memberCount = try container.decodeIntFlexibleIfPresent(forKey: .memberCount) ?? 0
-
-        if let decodedMentors = try container.decodeIfPresent(
+        mentors = try container.decodeIfPresent(
             [StudyGroupChallengerDTO].self,
             forKey: .mentors
-        ) {
-            mentors = decodedMentors
-        } else if let legacyLeader = try container.decodeIfPresent(
-            StudyGroupChallengerDTO.self,
-            forKey: .leader
-        ) {
-            mentors = [legacyLeader]
-        } else {
-            mentors = []
-        }
+        ) ?? []
         members = try container.decodeIfPresent(
             [StudyGroupChallengerDTO].self,
             forKey: .members
@@ -81,90 +74,43 @@ struct StudyGroupDetailDTO: Codable, Sendable, Equatable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(groupId, forKey: .groupId)
+        try container.encode(studyGroupId, forKey: .studyGroupId)
         try container.encode(name, forKey: .name)
-        try container.encode(part, forKey: .part)
-        try container.encodeIfPresent(partDisplayName, forKey: .partDisplayName)
-        try container.encode(schools, forKey: .schools)
+        try container.encode(studyPart, forKey: .studyPart)
         try container.encode(createdAt, forKey: .createdAt)
-        try container.encode(memberCount, forKey: .memberCount)
         try container.encode(mentors, forKey: .mentors)
         try container.encode(members, forKey: .members)
     }
 }
 
-// MARK: - StudyGroupSchoolDTO
-
-/// 스터디 그룹 소속 학교 정보 DTO
-struct StudyGroupSchoolDTO: Codable, Sendable, Equatable {
-
-    // MARK: - Property
-
-    let schoolId: String
-    let schoolName: String
-    let logoImageId: String?
-    let totalStudyGroupCount: Int
-    let totalMemberCount: Int
-
-    // MARK: - CodingKeys
-
-    private enum CodingKeys: String, CodingKey {
-        case schoolId
-        case schoolName
-        case logoImageId
-        case totalStudyGroupCount
-        case totalMemberCount
-    }
-
-    // MARK: - Decodable
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        schoolId = container.decodeFlexibleStringOrNil(forKey: .schoolId) ?? ""
-        schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
-        logoImageId = container.decodeFlexibleStringOrNil(forKey: .logoImageId)
-        totalStudyGroupCount =
-            try container.decodeIntFlexibleIfPresent(forKey: .totalStudyGroupCount) ?? 0
-        totalMemberCount =
-            try container.decodeIntFlexibleIfPresent(forKey: .totalMemberCount) ?? 0
-    }
-
-    // MARK: - Encodable
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(schoolId, forKey: .schoolId)
-        try container.encode(schoolName, forKey: .schoolName)
-        try container.encodeIfPresent(logoImageId, forKey: .logoImageId)
-        try container.encode(totalStudyGroupCount, forKey: .totalStudyGroupCount)
-        try container.encode(totalMemberCount, forKey: .totalMemberCount)
-    }
-}
-
 // MARK: - StudyGroupChallengerDTO
 
-/// 스터디 그룹 소속 챌린저(멤버/리더) 정보 DTO
+/// 스터디 그룹 소속 챌린저(파트장/스터디원) 정보 DTO
+///
+/// 서버 `StudyGroupMemberResponse` 계약에 맞춘 키만 디코딩한다. 응답에 함께 오는 `schoolId` 는
+/// 도메인에서 쓰지 않아 생략한다.
 struct StudyGroupChallengerDTO: Codable, Sendable, Equatable {
 
     // MARK: - Property
 
-    let challengerId: String
     let memberId: String
-    let name: String
+    let memberName: String
+    let schoolName: String
     let profileImageURL: String?
     /// 베스트 워크북 표시 점수.
     ///
     /// - Note: 서버가 **아직 내려주지 않는 필드**라 실제 응답에서는 항상 `nil` 이며,
-    ///   ``StudyGroupDetailDTO/toDomain(defaultGroupName:)`` 이 `0` 으로 폴백한다.
-    ///   서버가 멤버별 값을 응답에 포함하면 코드 변경 없이 그대로 반영되도록 자리를 유지한다.
+    ///   ``StudyGroupDetailDTO/toDomain(defaultGroupName:supplementsByMemberID:)`` 이 `0` 으로
+    ///   폴백한다. 서버가 멤버별 값을 응답에 포함하면 코드 변경 없이 그대로 반영되도록 자리를
+    ///   유지한다.
     let bestWorkbookPoint: Int?
 
     // MARK: - CodingKeys
 
     private enum CodingKeys: String, CodingKey {
-        case challengerId
         case memberId
-        case name
+        case memberName
+        case schoolName
         case profileImageURL = "profileImageUrl"
         case bestWorkbookPoint
     }
@@ -173,9 +119,9 @@ struct StudyGroupChallengerDTO: Codable, Sendable, Equatable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        challengerId = container.decodeFlexibleStringOrNil(forKey: .challengerId) ?? ""
         memberId = container.decodeFlexibleStringOrNil(forKey: .memberId) ?? ""
-        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        memberName = try container.decodeIfPresent(String.self, forKey: .memberName) ?? ""
+        schoolName = try container.decodeIfPresent(String.self, forKey: .schoolName) ?? ""
         profileImageURL = try container.decodeIfPresent(String.self, forKey: .profileImageURL)
         bestWorkbookPoint = try container.decodeIntFlexibleIfPresent(forKey: .bestWorkbookPoint)
     }
@@ -184,11 +130,33 @@ struct StudyGroupChallengerDTO: Codable, Sendable, Equatable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(challengerId, forKey: .challengerId)
         try container.encode(memberId, forKey: .memberId)
-        try container.encode(name, forKey: .name)
+        try container.encode(memberName, forKey: .memberName)
+        try container.encode(schoolName, forKey: .schoolName)
         try container.encodeIfPresent(profileImageURL, forKey: .profileImageURL)
         try container.encodeIfPresent(bestWorkbookPoint, forKey: .bestWorkbookPoint)
+    }
+}
+
+// MARK: - StudyGroupMemberSupplement
+
+/// 스터디 그룹 응답에 없는 멤버 정보를 멤버 프로필에서 보강한 값.
+///
+/// 서버 `StudyGroupMemberResponse` 는 `challengerId` 와 `nickname` 을 주지 않으므로
+/// ``StudyRepository`` 가 `GET /api/v1/member/profile/{memberId}` 로 해석해 채운다.
+/// 해석에 실패한 멤버는 매핑에서 빠지고, 두 값 모두 `nil` 로 남는다.
+struct StudyGroupMemberSupplement: Sendable, Equatable {
+
+    // MARK: - Property
+
+    let challengerID: String?
+    let nickname: String?
+
+    // MARK: - Init
+
+    init(challengerID: String?, nickname: String?) {
+        self.challengerID = challengerID
+        self.nickname = nickname
     }
 }
 
@@ -198,31 +166,40 @@ extension StudyGroupDetailDTO {
 
     /// DTO 를 도메인 모델 ``StudyGroupInfo`` 로 변환한다.
     ///
-    /// - Note: `bestWorkbookPoint` 는 **서버가 아직 내려주지 않는 필드**라 현재 전 멤버가 `0`
-    ///   으로 폴백된다(스터디 그룹 응답에 해당 필드가 없음). 값 복원은 서버가 멤버별
-    ///   `bestWorkbookPoint` 를 응답에 포함해야 가능하다 — 클라이언트 집계는 불가능한데,
-    ///   포인트 원천인 `GET /api/v1/member/profile/{memberId}` 가 타인 조회 시 상벌점을
-    ///   비공개 처리해 `challengerPoints` 를 빈 배열로 내려주기 때문이다. 서버가 채울 때의
-    ///   집계 규칙은 `BEST_WORKBOOK`·`BEST_WORKBOOK_V2` 선정 횟수 합 × 5 로 확정되었다
-    ///   (두 타입은 배점 관례만 다른 동일 사건이므로 동일 가중치).
+    /// - Note: `challengerID`·`nickname` 은 스터디 그룹 응답에 없어
+    ///   `supplementsByMemberID` 로만 채워진다. 보강 값이 없으면 두 필드는 `nil` 로 남는다.
+    ///   특히 `challengerID` 는 `memberId` 로 대체하지 않는다 — 챌린저와 멤버는 서로 다른
+    ///   식별자라 대체하면 잘못된 대상으로 서버를 호출하게 된다.
     ///
-    /// - Parameter defaultGroupName: 그룹명이 비어 있을 때 대체할 이름
+    /// - Parameters:
+    ///   - defaultGroupName: 그룹명이 비어 있을 때 대체할 이름
+    ///   - supplementsByMemberID: `memberId` → 멤버 프로필에서 해석한 보강 정보
     /// - Returns: 변환된 ``StudyGroupInfo`` 도메인 모델
-    func toDomain(defaultGroupName: String? = nil) -> StudyGroupInfo {
-        let partType = UMCPartType(apiValue: part) ?? .front(type: .ios)
-        let university = schools.first?.schoolName ?? ""
+    func toDomain(
+        defaultGroupName: String? = nil,
+        supplementsByMemberID: [String: StudyGroupMemberSupplement] = [:]
+    ) -> StudyGroupInfo {
+        let partType = UMCPartType(apiValue: studyPart) ?? .front(type: .ios)
         let parsedDate = StudyGroupDateParser.parse(createdAt) ?? Date()
 
         let mentorItems = mentors.map { mentor in
-            makeMember(from: mentor, university: university, role: .leader)
+            makeMember(
+                from: mentor,
+                role: .leader,
+                supplement: supplementsByMemberID[mentor.memberId]
+            )
         }
 
         let memberItems = members.map { member in
-            makeMember(from: member, university: university, role: .member)
+            makeMember(
+                from: member,
+                role: .member,
+                supplement: supplementsByMemberID[member.memberId]
+            )
         }
 
         return StudyGroupInfo(
-            serverID: groupId,
+            serverID: studyGroupId,
             name: name.isEmpty ? (defaultGroupName ?? "") : name,
             part: partType,
             createdDate: parsedDate,
@@ -233,15 +210,16 @@ extension StudyGroupDetailDTO {
 
     private func makeMember(
         from challenger: StudyGroupChallengerDTO,
-        university: String,
-        role: StudyGroupMember.MemberRole
+        role: StudyGroupMember.MemberRole,
+        supplement: StudyGroupMemberSupplement?
     ) -> StudyGroupMember {
         StudyGroupMember(
             serverID: challenger.memberId,
-            challengerID: challenger.challengerId.isEmpty ? nil : challenger.challengerId,
+            challengerID: supplement?.challengerID,
             memberID: challenger.memberId.isEmpty ? nil : challenger.memberId,
-            name: challenger.name,
-            university: university,
+            name: challenger.memberName,
+            nickname: supplement?.nickname,
+            university: challenger.schoolName,
             profileImageURL: normalizedURL(challenger.profileImageURL),
             role: role,
             bestWorkbookPoint: challenger.bestWorkbookPoint ?? 0

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupDetailDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/StudyGroupDetailDTO.swift
@@ -152,6 +152,11 @@ struct StudyGroupChallengerDTO: Codable, Sendable, Equatable {
     let memberId: String
     let name: String
     let profileImageURL: String?
+    /// 베스트 워크북 표시 점수.
+    ///
+    /// - Note: 서버가 **아직 내려주지 않는 필드**라 실제 응답에서는 항상 `nil` 이며,
+    ///   ``StudyGroupDetailDTO/toDomain(defaultGroupName:)`` 이 `0` 으로 폴백한다.
+    ///   서버가 멤버별 값을 응답에 포함하면 코드 변경 없이 그대로 반영되도록 자리를 유지한다.
     let bestWorkbookPoint: Int?
 
     // MARK: - CodingKeys
@@ -193,34 +198,27 @@ extension StudyGroupDetailDTO {
 
     /// DTO 를 도메인 모델 ``StudyGroupInfo`` 로 변환한다.
     ///
-    /// - Parameters:
-    ///   - defaultGroupName: 그룹명이 비어 있을 때 대체할 이름
-    ///   - bestWorkbookPointByMemberID: memberId → 베스트 워크북 점수 매핑 (없으면 DTO 내 점수 사용)
+    /// - Note: `bestWorkbookPoint` 는 **서버가 아직 내려주지 않는 필드**라 현재 전 멤버가 `0`
+    ///   으로 폴백된다(스터디 그룹 응답에 해당 필드가 없음). 값 복원은 서버가 멤버별
+    ///   `bestWorkbookPoint` 를 응답에 포함해야 가능하다 — 클라이언트 집계는 불가능한데,
+    ///   포인트 원천인 `GET /api/v1/member/profile/{memberId}` 가 타인 조회 시 상벌점을
+    ///   비공개 처리해 `challengerPoints` 를 빈 배열로 내려주기 때문이다. 서버가 채울 때의
+    ///   집계 규칙은 `BEST_WORKBOOK`·`BEST_WORKBOOK_V2` 선정 횟수 합 × 5 로 확정되었다
+    ///   (두 타입은 배점 관례만 다른 동일 사건이므로 동일 가중치).
+    ///
+    /// - Parameter defaultGroupName: 그룹명이 비어 있을 때 대체할 이름
     /// - Returns: 변환된 ``StudyGroupInfo`` 도메인 모델
-    func toDomain(
-        defaultGroupName: String? = nil,
-        bestWorkbookPointByMemberID: [String: Int] = [:]
-    ) -> StudyGroupInfo {
+    func toDomain(defaultGroupName: String? = nil) -> StudyGroupInfo {
         let partType = UMCPartType(apiValue: part) ?? .front(type: .ios)
         let university = schools.first?.schoolName ?? ""
         let parsedDate = StudyGroupDateParser.parse(createdAt) ?? Date()
 
         let mentorItems = mentors.map { mentor in
-            makeMember(
-                from: mentor,
-                university: university,
-                role: .leader,
-                bestWorkbookPointByMemberID: bestWorkbookPointByMemberID
-            )
+            makeMember(from: mentor, university: university, role: .leader)
         }
 
         let memberItems = members.map { member in
-            makeMember(
-                from: member,
-                university: university,
-                role: .member,
-                bestWorkbookPointByMemberID: bestWorkbookPointByMemberID
-            )
+            makeMember(from: member, university: university, role: .member)
         }
 
         return StudyGroupInfo(
@@ -236,8 +234,7 @@ extension StudyGroupDetailDTO {
     private func makeMember(
         from challenger: StudyGroupChallengerDTO,
         university: String,
-        role: StudyGroupMember.MemberRole,
-        bestWorkbookPointByMemberID: [String: Int]
+        role: StudyGroupMember.MemberRole
     ) -> StudyGroupMember {
         StudyGroupMember(
             serverID: challenger.memberId,
@@ -247,9 +244,7 @@ extension StudyGroupDetailDTO {
             university: university,
             profileImageURL: normalizedURL(challenger.profileImageURL),
             role: role,
-            bestWorkbookPoint: bestWorkbookPointByMemberID[challenger.memberId]
-                ?? challenger.bestWorkbookPoint
-                ?? 0
+            bestWorkbookPoint: challenger.bestWorkbookPoint ?? 0
         )
     }
 

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
@@ -22,6 +22,11 @@ import Moya
 /// - Note: 서버 식별자는 전 레이어 `String` 으로 통일된다. 커리큘럼 조회에 필요한 현재
 ///   기수·담당 파트는 ``StudyContextProviding`` 에서 읽는다(신규 모듈에는 레거시
 ///   `AppStorageKey` 세션 저장소가 아직 없어 컨텍스트 제공자를 주입한다).
+/// - Note: 스터디 그룹 조회는 응답에 없는 `challengerId`·`nickname` 을 멤버 프로필
+///   (`GET /api/v1/member/profile/{memberId}`)로 보강하므로 **멤버 수만큼 추가 요청**이 따른다.
+///   중복 제거는 **한 번의 조회 안에서만** 적용되므로(페이지 단위), 전체 페이지를 순회하는
+///   ``fetchStudyGroupDetails()`` 는 페이지에 걸쳐 같은 멤버를 다시 부를 수 있다. 서버가 두
+///   필드를 그룹 응답에 포함해 주면 이 보강 단계는 통째로 사라진다.
 public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable {
 
     // MARK: - Property
@@ -35,6 +40,11 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
     private enum Constants {
         /// 운영진 스터디 그룹 전체 조회 시 페이지당 항목 수.
         static let studyGroupsPageSize = 100
+        /// 멤버 프로필 보강 시 동시에 띄울 최대 요청 수.
+        ///
+        /// 한 페이지에 그룹이 100개면 멤버가 수백 명이 될 수 있어, 무제한으로 띄우면 서버와
+        /// 연결 풀에 과부하가 걸린다. 창(window)을 두고 완료되는 만큼만 새로 채운다.
+        static let memberSupplementConcurrencyLimit = 8
     }
 
     // MARK: - Init
@@ -136,7 +146,9 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
             APIResponse<MyStudyGroupsPageDTO>.self,
             from: response.data
         )
-        return try apiResponse.unwrap().toDomain()
+        let page = try apiResponse.unwrap()
+        let supplements = await fetchMemberSupplements(memberIDs: page.allMemberIDs)
+        return page.toDomain(supplementsByMemberID: supplements)
     }
 
     public func fetchStudyGroupDetail(groupId: String) async throws -> StudyGroupInfo {
@@ -147,38 +159,21 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
             APIResponse<StudyGroupDetailDTO>.self,
             from: response.data
         )
-        return try apiResponse.unwrap().toDomain()
+        let detail = try apiResponse.unwrap()
+        let supplements = await fetchMemberSupplements(memberIDs: detail.allMemberIDs)
+        return detail.toDomain(supplementsByMemberID: supplements)
     }
 
     public func resolveChallengerId(
         memberId: String,
         preferredGeneration: String?
     ) async throws -> String? {
-        let response = try await networkRequesting.request(
-            StudyRouter.getMemberProfile(memberId: memberId)
+        let profile = try await fetchMemberProfile(memberId: memberId)
+        return selectChallengerID(
+            from: profile,
+            memberID: memberId,
+            preferredGeneration: preferredGeneration
         )
-        let apiResponse = try decoder.decode(
-            APIResponse<MemberProfileDTO>.self,
-            from: response.data
-        )
-        let profile = try apiResponse.unwrap()
-
-        let records = profile.challengerRecords.filter {
-            $0.memberId == memberId && !$0.challengerId.isEmpty
-        }
-
-        // 기수는 String 으로 전달받아 숫자 비교 연산 시점에만 Int 로 변환한다.
-        if let preferredGisu = preferredGeneration.flatMap(Int.init), preferredGisu > 0,
-           let matched = records.first(where: { $0.gisu == preferredGisu }) {
-            return matched.challengerId
-        }
-
-        if let preferredGisuId = context.gisuId,
-           let matched = records.first(where: { $0.gisuId == preferredGisuId }) {
-            return matched.challengerId
-        }
-
-        return records.first?.challengerId
     }
 
     // MARK: - 운영진 스터디 그룹 CRUD / 일정 연결
@@ -284,6 +279,123 @@ private extension StudyRepository {
         )
         return (try apiResponse.unwrap(), part)
     }
+
+    // MARK: - 멤버 프로필 보강
+
+    /// 스터디 그룹 응답에 없는 멤버 정보(`challengerId`·`nickname`)를 멤버 프로필로 해석한다.
+    ///
+    /// 서버 `StudyGroupMemberResponse` 는 두 값을 주지 않으므로 `memberId` 마다
+    /// `GET /api/v1/member/profile/{memberId}` 를 조회한다. 중복 `memberId` 는 한 번만 부르고,
+    /// 동시 요청은 ``Constants/memberSupplementConcurrencyLimit`` 개로 제한한다.
+    ///
+    /// 보강은 부가 정보이므로 실패해도 그룹 목록 자체는 반환한다. 취소된 뒤 호출되면 요청을
+    /// 아예 시작하지 않고, 진행 중 취소되면 남은 멤버 없이 그때까지의 결과만 돌려준다
+    /// (이 경로의 결과는 취소된 호출자가 어차피 버린다).
+    ///
+    /// - Parameter memberIDs: 보강할 멤버 식별자 목록 (중복 허용)
+    /// - Returns: `memberId` → 보강 정보. 조회에 실패한 멤버는 매핑에 담기지 않는다.
+    func fetchMemberSupplements(
+        memberIDs: [String]
+    ) async -> [String: StudyGroupMemberSupplement] {
+        let uniqueIDs = Array(Set(memberIDs))
+        // 이 파일은 Moya 를 import 하므로 `Task` 는 `Moya.Task` 로 해석된다. 동시성 타입을 쓰려면
+        // `_Concurrency` 로 한정해야 한다.
+        guard !uniqueIDs.isEmpty, !_Concurrency.Task.isCancelled else { return [:] }
+
+        var result: [String: StudyGroupMemberSupplement] = [:]
+        var nextIndex = 0
+
+        await withTaskGroup(of: (String, StudyGroupMemberSupplement)?.self) { group in
+            let initialCount = min(Constants.memberSupplementConcurrencyLimit, uniqueIDs.count)
+            while nextIndex < initialCount {
+                let memberID = uniqueIDs[nextIndex]
+                group.addTask { await self.makeSupplementEntry(memberID: memberID) }
+                nextIndex += 1
+            }
+
+            // 하나가 끝날 때마다 다음 하나를 채워 in-flight 개수를 창 크기로 유지한다.
+            while let entry = await group.next() {
+                if let entry {
+                    result[entry.0] = entry.1
+                }
+                guard nextIndex < uniqueIDs.count else { continue }
+                let memberID = uniqueIDs[nextIndex]
+                group.addTask { await self.makeSupplementEntry(memberID: memberID) }
+                nextIndex += 1
+            }
+        }
+
+        return result
+    }
+
+    /// 단일 멤버의 보강 정보를 조회한다.
+    ///
+    /// 개별 멤버 조회 실패가 그룹 목록 전체를 막지 않도록 에러를 삼키고 `nil` 을 반환한다.
+    /// 이 경우 해당 멤버는 `challengerID`·`nickname` 이 `nil` 로 남는다.
+    func makeSupplementEntry(
+        memberID: String
+    ) async -> (String, StudyGroupMemberSupplement)? {
+        do {
+            let profile = try await fetchMemberProfile(memberId: memberID)
+            let supplement = StudyGroupMemberSupplement(
+                challengerID: selectChallengerID(
+                    from: profile,
+                    memberID: memberID,
+                    preferredGeneration: nil
+                ),
+                nickname: profile.nickname
+            )
+            return (memberID, supplement)
+        } catch {
+            return nil
+        }
+    }
+
+    /// 멤버 프로필을 조회해 ``MemberProfileDTO`` 로 디코딩한다.
+    func fetchMemberProfile(memberId: String) async throws -> MemberProfileDTO {
+        let response = try await networkRequesting.request(
+            StudyRouter.getMemberProfile(memberId: memberId)
+        )
+        let apiResponse = try decoder.decode(
+            APIResponse<MemberProfileDTO>.self,
+            from: response.data
+        )
+        return try apiResponse.unwrap()
+    }
+
+    /// 멤버 프로필의 기수별 챌린저 레코드 중 현재 맥락에 맞는 `challengerId` 를 고른다.
+    ///
+    /// 우선순위는 요청 기수 → 컨텍스트 기수(`gisuId`) → 첫 유효 레코드 순이다.
+    ///
+    /// - Parameters:
+    ///   - profile: 조회한 멤버 프로필
+    ///   - memberID: 대상 멤버 식별자 (레코드가 다른 멤버 것을 섞어 주는 경우를 걸러낸다)
+    ///   - preferredGeneration: 우선 매칭할 기수 번호. `nil` 이면 컨텍스트 기수부터 본다.
+    /// - Returns: 선택된 `challengerId`. 유효 레코드가 없으면 `nil`.
+    func selectChallengerID(
+        from profile: MemberProfileDTO,
+        memberID: String,
+        preferredGeneration: String?
+    ) -> String? {
+        let records = profile.challengerRecords.filter {
+            $0.memberId == memberID && !$0.challengerId.isEmpty
+        }
+
+        // 기수는 String 으로 전달받아 숫자 비교 연산 시점에만 Int 로 변환한다.
+        if let preferredGisu = preferredGeneration.flatMap(Int.init), preferredGisu > 0,
+           let matched = records.first(where: { $0.gisu == preferredGisu }) {
+            return matched.challengerId
+        }
+
+        if let preferredGisuId = context.gisuId,
+           let matched = records.first(where: { $0.gisuId == preferredGisuId }) {
+            return matched.challengerId
+        }
+
+        return records.first?.challengerId
+    }
+
+    // MARK: - 공통 요청
 
     /// 결과 본문이 없는 변경(CRUD/연결) 요청의 공통 호출·검증.
     ///

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/MyStudyGroupsPageDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/MyStudyGroupsPageDTOTests.swift
@@ -16,17 +16,22 @@ private func decodePage(_ json: String) throws -> MyStudyGroupsPageDTO {
     try JSONDecoder().decode(MyStudyGroupsPageDTO.self, from: Data(json.utf8))
 }
 
-/// 단일 스터디 그룹 상세 JSON (페이지 항목용). part/createdAt 고정.
-private func makeGroupJSON(groupId: String = "\"10\"", name: String = "\"iOS 1팀\"") -> String {
+/// 단일 스터디 그룹 상세 JSON (페이지 항목용). 서버 `StudyGroupResponse` 실제 키를 쓴다.
+private func makeGroupJSON(
+    studyGroupId: String = "\"10\"",
+    name: String = "\"iOS 1팀\"",
+    memberId: String = "\"2001\""
+) -> String {
     """
     {
-        "groupId": \(groupId),
+        "studyGroupId": \(studyGroupId),
         "name": \(name),
-        "part": "IOS",
+        "gisuId": 7,
+        "studyPart": "IOS",
         "createdAt": "2026-05-11T09:30:00Z",
-        "memberCount": 1,
-        "schools": [],
-        "mentors": [ { "challengerId": "1", "memberId": "1", "name": "재원" } ],
+        "mentors": [
+            { "memberId": \(memberId), "memberName": "재원", "schoolName": "한성대학교" }
+        ],
         "members": []
     }
     """
@@ -51,7 +56,7 @@ struct MyStudyGroupsPageDTOTests {
         let dto = try decodePage(json)
 
         #expect(dto.studyGroups.count == 1)
-        #expect(dto.studyGroups.first?.groupId == "10")
+        #expect(dto.studyGroups.first?.studyGroupId == "10")
         #expect(dto.nextCursor == "cursor-2")
         #expect(dto.hasNext == true)
     }
@@ -73,7 +78,10 @@ struct MyStudyGroupsPageDTOTests {
     func decodesFlatContentFormat() throws {
         let json = """
         {
-            "content": [\(makeGroupJSON()), \(makeGroupJSON(groupId: "\"11\"", name: "\"iOS 2팀\""))],
+            "content": [
+                \(makeGroupJSON()),
+                \(makeGroupJSON(studyGroupId: "\"11\"", name: "\"iOS 2팀\""))
+            ],
             "nextCursor": "next-1",
             "hasNext": true
         }
@@ -177,5 +185,60 @@ struct MyStudyGroupsPageDTOTests {
         #expect(page.content.isEmpty)
         #expect(page.hasNext == false)
         #expect(page.nextCursor == nil)
+    }
+
+    // MARK: - allMemberIDs / 멤버 프로필 보강
+
+    @Test("allMemberIDs — 페이지 내 모든 그룹의 memberId 를 모은다")
+    func allMemberIDsSpansEveryGroup() throws {
+        let json = """
+        {
+            "studyGroups": [
+                \(makeGroupJSON(memberId: "\"2001\"")),
+                \(makeGroupJSON(studyGroupId: "\"11\"", memberId: "\"2002\""))
+            ],
+            "hasNext": false
+        }
+        """
+        #expect(try Set(decodePage(json).allMemberIDs) == ["2001", "2002"])
+    }
+
+    /// 같은 멤버가 여러 그룹에 속하면 `allMemberIDs` 에 중복이 남는다. 중복 제거는 조회 직전
+    /// ``StudyRepository`` 가 담당하므로, 여기서는 원본을 그대로 노출하는 것이 계약이다.
+    @Test("allMemberIDs — 그룹 간 중복 memberId 는 제거하지 않고 그대로 넘긴다")
+    func allMemberIDsKeepsDuplicatesAcrossGroups() throws {
+        let json = """
+        {
+            "studyGroups": [
+                \(makeGroupJSON(memberId: "\"2001\"")),
+                \(makeGroupJSON(studyGroupId: "\"11\"", memberId: "\"2001\""))
+            ],
+            "hasNext": false
+        }
+        """
+        #expect(try decodePage(json).allMemberIDs == ["2001", "2001"])
+    }
+
+    @Test("toDomain — 보강 매핑이 페이지 내 모든 그룹에 적용된다")
+    func toDomainAppliesSupplementAcrossGroups() throws {
+        let json = """
+        {
+            "studyGroups": [
+                \(makeGroupJSON(memberId: "\"2001\"")),
+                \(makeGroupJSON(studyGroupId: "\"11\"", memberId: "\"2002\""))
+            ],
+            "hasNext": false
+        }
+        """
+        let page = try decodePage(json).toDomain(
+            supplementsByMemberID: [
+                "2001": StudyGroupMemberSupplement(challengerID: "C1", nickname: "닉1"),
+                "2002": StudyGroupMemberSupplement(challengerID: "C2", nickname: "닉2")
+            ]
+        )
+
+        #expect(page.content[0].mentors.first?.challengerID == "C1")
+        #expect(page.content[1].mentors.first?.challengerID == "C2")
+        #expect(page.content[1].mentors.first?.nickname == "닉2")
     }
 }

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/StudyGroupDetailDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/StudyGroupDetailDTOTests.swift
@@ -68,6 +68,22 @@ private func makeFullDetailJSON(
     """
 }
 
+/// 멘토 1명만 담은 최소 JSON. `bestWorkbookPointField` 에는 `"bestWorkbookPoint": 90` 같은
+/// 완성된 키-값 조각을 넣으며, 빈 문자열을 주면 키 자체가 빠진 응답(= 서버 현행)이 된다.
+private func makeSingleMentorJSON(bestWorkbookPointField: String) -> String {
+    let pointEntry = bestWorkbookPointField.isEmpty ? "" : ", \(bestWorkbookPointField)"
+    return """
+    {
+        "groupId": "1", "name": "g", "part": "IOS",
+        "createdAt": "2026-05-11T09:30:00Z", "memberCount": 1,
+        "mentors": [
+            { "challengerId": "1", "memberId": "2001", "name": "m"\(pointEntry) }
+        ],
+        "members": []
+    }
+    """
+}
+
 @Suite("StudyGroupDetailDTO — 디코딩/매핑")
 struct StudyGroupDetailDTOTests {
 
@@ -188,17 +204,19 @@ struct StudyGroupDetailDTOTests {
 
     // MARK: - StudyGroupChallengerDTO bestWorkbookPoint
 
-    @Test("bestWorkbookPoint 가 숫자 String 으로 와도 Int 로 디코딩한다")
-    func decodesBestWorkbookPointAsString() throws {
-        let json = """
-        { "groupId": "1", "name": "g", "part": "IOS",
-          "createdAt": "2026-05-11T09:30:00Z", "memberCount": 1,
-          "mentors": [ { "challengerId": "1", "memberId": "1", "name": "m",
-                         "bestWorkbookPoint": "70" } ],
-          "members": [] }
-        """
-        let dto = try decodeDetail(json)
-        #expect(dto.mentors.first?.bestWorkbookPoint == 70)
+    @Test(
+        "bestWorkbookPoint 는 숫자·숫자 String 을 Int 로 받고, null·키 부재는 nil 로 둔다",
+        arguments: [
+            ("\"bestWorkbookPoint\": 70", 70),
+            ("\"bestWorkbookPoint\": \"70\"", 70),
+            ("\"bestWorkbookPoint\": 0", 0),
+            ("\"bestWorkbookPoint\": null", nil),
+            ("", nil)
+        ] as [(String, Int?)]
+    )
+    func decodesBestWorkbookPoint(field: String, expected: Int?) throws {
+        let dto = try decodeDetail(makeSingleMentorJSON(bestWorkbookPointField: field))
+        #expect(dto.mentors.first?.bestWorkbookPoint == expected)
     }
 
     // MARK: - Encodable round-trip (custom encode)
@@ -273,18 +291,42 @@ struct StudyGroupDetailDTOTests {
         #expect(info.members[1].profileImageURL == nil)
     }
 
-    @Test("toDomain — bestWorkbookPoint 가 없으면 0 으로 폴백한다")
-    func toDomainFallsBackBestWorkbookPointToZero() throws {
-        let info = try decodeDetail(makeFullDetailJSON()).toDomain()
-        // members[1].bestWorkbookPoint == null → 0
-        #expect(info.members[1].bestWorkbookPoint == 0)
+    @Test(
+        "toDomain — bestWorkbookPoint 는 값이 있으면 그대로, null·키 부재면 0 으로 폴백한다",
+        arguments: [
+            ("\"bestWorkbookPoint\": 70", 70),
+            ("\"bestWorkbookPoint\": \"70\"", 70),
+            ("\"bestWorkbookPoint\": 0", 0),
+            ("\"bestWorkbookPoint\": null", 0),
+            ("", 0)
+        ]
+    )
+    func toDomainResolvesBestWorkbookPoint(field: String, expected: Int) throws {
+        let info = try decodeDetail(makeSingleMentorJSON(bestWorkbookPointField: field))
+            .toDomain()
+        #expect(info.mentors.first?.bestWorkbookPoint == expected)
     }
 
-    @Test("toDomain — bestWorkbookPointByMemberID 오버라이드가 DTO 값보다 우선한다")
-    func toDomainOverridesBestWorkbookPointByMemberID() throws {
-        let info = try decodeDetail(makeFullDetailJSON())
-            .toDomain(bestWorkbookPointByMemberID: ["2001": 100])
-        #expect(info.mentors.first?.bestWorkbookPoint == 100)
+    /// 서버 계약 박제 — 스터디 그룹 응답(`StudyGroupMemberResponse`)에는 `bestWorkbookPoint`
+    /// 필드가 없어 현행 응답에서는 전 멤버가 `0` 이 된다. 서버가 필드를 추가하면 이 테스트가
+    /// 깨지는 게 아니라 위 파라미터화 테스트가 값 반영을 보장한다.
+    @Test("toDomain — 서버 현행 응답처럼 필드가 전혀 없으면 모든 멤버가 0 이다")
+    func toDomainYieldsZeroForEveryMemberWhenServerOmitsField() throws {
+        let json = """
+        {
+            "groupId": "1", "name": "g", "part": "IOS",
+            "createdAt": "2026-05-11T09:30:00Z", "memberCount": 3,
+            "mentors": [ { "challengerId": "1", "memberId": "2001", "name": "멘토" } ],
+            "members": [
+                { "challengerId": "2", "memberId": "2002", "name": "챌린저1" },
+                { "challengerId": "3", "memberId": "2003", "name": "챌린저2" }
+            ]
+        }
+        """
+        let info = try decodeDetail(json).toDomain()
+
+        #expect(info.mentors.allSatisfy { $0.bestWorkbookPoint == 0 })
+        #expect(info.members.allSatisfy { $0.bestWorkbookPoint == 0 })
     }
 
     @Test("toDomain — name 이 비어 있으면 defaultGroupName 으로 대체한다")

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/StudyGroupDetailDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/StudyGroupDetailDTOTests.swift
@@ -17,51 +17,45 @@ private func decodeDetail(_ json: String) throws -> StudyGroupDetailDTO {
     try JSONDecoder().decode(StudyGroupDetailDTO.self, from: Data(json.utf8))
 }
 
+/// 서버 `StudyGroupResponse` 실제 키로 구성한 전체 응답 픽스처.
+///
+/// 키 이름(`studyGroupId`/`studyPart`/`memberName`/`schoolName`)은 실행 중인 서버의 OpenAPI
+/// 스키마와 일치해야 한다. iOS 가 기대하는 이름으로 바꿔 쓰면 계약 어긋남을 테스트가 가려버린다.
 private func makeFullDetailJSON(
-    groupId: String = "\"10\"",
-    part: String = "\"IOS\"",
+    studyGroupId: String = "\"10\"",
+    studyPart: String = "\"IOS\"",
     createdAt: String = "2026-05-11T09:30:00Z"
 ) -> String {
     """
     {
-        "groupId": \(groupId),
+        "studyGroupId": \(studyGroupId),
         "name": "iOS 1팀",
-        "part": \(part),
-        "partDisplayName": "iOS",
-        "schools": [
-            {
-                "schoolId": "100",
-                "schoolName": "한성대학교",
-                "logoImageId": "200",
-                "totalStudyGroupCount": 3,
-                "totalMemberCount": 24
-            }
-        ],
+        "gisuId": 7,
+        "studyPart": \(studyPart),
         "createdAt": "\(createdAt)",
-        "memberCount": 5,
         "mentors": [
             {
-                "challengerId": "1001",
                 "memberId": "2001",
-                "name": "재원",
-                "profileImageUrl": "https://cdn.umc.it/p/1001.png",
-                "bestWorkbookPoint": 90
+                "memberName": "재원",
+                "schoolId": 100,
+                "schoolName": "한성대학교",
+                "profileImageUrl": "https://cdn.umc.it/p/1001.png"
             }
         ],
         "members": [
             {
-                "challengerId": "1002",
                 "memberId": "2002",
-                "name": "의재",
-                "profileImageUrl": null,
-                "bestWorkbookPoint": 80
+                "memberName": "의재",
+                "schoolId": 100,
+                "schoolName": "한성대학교",
+                "profileImageUrl": null
             },
             {
-                "challengerId": "1003",
                 "memberId": "2003",
-                "name": "민수",
-                "profileImageUrl": "",
-                "bestWorkbookPoint": null
+                "memberName": "민수",
+                "schoolId": 200,
+                "schoolName": "중앙대학교",
+                "profileImageUrl": ""
             }
         ]
     }
@@ -74,132 +68,91 @@ private func makeSingleMentorJSON(bestWorkbookPointField: String) -> String {
     let pointEntry = bestWorkbookPointField.isEmpty ? "" : ", \(bestWorkbookPointField)"
     return """
     {
-        "groupId": "1", "name": "g", "part": "IOS",
-        "createdAt": "2026-05-11T09:30:00Z", "memberCount": 1,
+        "studyGroupId": "1", "name": "g", "studyPart": "IOS",
+        "createdAt": "2026-05-11T09:30:00Z",
         "mentors": [
-            { "challengerId": "1", "memberId": "2001", "name": "m"\(pointEntry) }
+            { "memberId": "2001", "memberName": "m", "schoolName": "한성대"\(pointEntry) }
         ],
         "members": []
     }
     """
 }
 
-@Suite("StudyGroupDetailDTO — 디코딩/매핑")
+@Suite("StudyGroupDetailDTO — 디코딩 매핑 (서버 contract)")
 struct StudyGroupDetailDTOTests {
 
     // MARK: - Decoding (happy path)
 
-    @Test("전체 JSON 의 모든 필드를 정확히 디코딩한다")
+    @Test("서버 실제 키로 구성한 전체 JSON 의 모든 필드를 디코딩한다")
     func decodesFullJSON() throws {
         let dto = try decodeDetail(makeFullDetailJSON())
 
-        #expect(dto.groupId == "10")
+        #expect(dto.studyGroupId == "10")
         #expect(dto.name == "iOS 1팀")
-        #expect(dto.part == "IOS")
-        #expect(dto.partDisplayName == "iOS")
+        #expect(dto.studyPart == "IOS")
         #expect(dto.createdAt == "2026-05-11T09:30:00Z")
-        #expect(dto.memberCount == 5)
-        #expect(dto.schools.count == 1)
         #expect(dto.mentors.count == 1)
         #expect(dto.members.count == 2)
     }
 
     // MARK: - Decoding (server contract: number vs string IDs)
 
-    @Test("groupId 가 JSON 숫자로 와도 String 으로 디코딩한다")
-    func decodesGroupIdAsNumber() throws {
-        let dto = try decodeDetail(makeFullDetailJSON(groupId: "10"))
-        #expect(dto.groupId == "10")
+    @Test(
+        "studyGroupId 는 JSON 숫자로 와도 문자열로 와도 같은 String 이 된다",
+        arguments: ["10", "\"10\""]
+    )
+    func decodesStudyGroupIdRegardlessOfJSONType(studyGroupIdJSON: String) throws {
+        let dto = try decodeDetail(makeFullDetailJSON(studyGroupId: studyGroupIdJSON))
+        #expect(dto.studyGroupId == "10")
     }
 
-    @Test("groupId 가 JSON 문자열로 와도 동일한 String 으로 디코딩한다")
-    func decodesGroupIdAsString() throws {
-        let dto = try decodeDetail(makeFullDetailJSON(groupId: "\"10\""))
-        #expect(dto.groupId == "10")
-    }
-
-    @Test("schoolId/logoImageId/challengerId/memberId 가 숫자로 와도 String 으로 디코딩한다")
-    func decodesNestedIdsAsNumbers() throws {
+    @Test("memberId 가 숫자로 와도 String 으로 디코딩한다")
+    func decodesMemberIdAsNumber() throws {
         let json = """
         {
-            "groupId": 10,
-            "name": "g",
-            "part": "IOS",
-            "schools": [
-                { "schoolId": 100, "schoolName": "s", "logoImageId": 200,
-                  "totalStudyGroupCount": 1, "totalMemberCount": 2 }
-            ],
+            "studyGroupId": 10, "name": "g", "studyPart": "IOS",
             "createdAt": "2026-05-11T09:30:00Z",
-            "memberCount": 1,
-            "mentors": [
-                { "challengerId": 1001, "memberId": 2001, "name": "m" }
-            ],
+            "mentors": [ { "memberId": 2001, "memberName": "m", "schoolName": "한성대" } ],
             "members": []
         }
         """
         let dto = try decodeDetail(json)
-
-        #expect(dto.schools.first?.schoolId == "100")
-        #expect(dto.schools.first?.logoImageId == "200")
-        #expect(dto.mentors.first?.challengerId == "1001")
         #expect(dto.mentors.first?.memberId == "2001")
     }
 
     // MARK: - Decoding (defaults / missing / null)
 
-    @Test("거의 모든 필드가 없어도 기본값으로 안전하게 디코딩한다")
+    @Test("모든 필드가 없어도 기본값으로 안전하게 디코딩한다")
     func decodesWithDefaultsWhenFieldsMissing() throws {
         let dto = try decodeDetail("{}")
 
-        #expect(dto.groupId == "")
+        #expect(dto.studyGroupId == "")
         #expect(dto.name == "")
-        #expect(dto.part == "")
-        #expect(dto.partDisplayName == nil)
-        #expect(dto.schools.isEmpty)
+        #expect(dto.studyPart == "")
         #expect(dto.createdAt == "")
-        #expect(dto.memberCount == 0)
         #expect(dto.mentors.isEmpty)
         #expect(dto.members.isEmpty)
     }
 
-    @Test("partDisplayName 이 null 이면 nil 로 디코딩한다")
-    func decodesNullPartDisplayNameAsNil() throws {
-        let json = """
-        { "groupId": "1", "name": "g", "part": "IOS", "partDisplayName": null,
-          "createdAt": "2026-05-11T09:30:00Z", "memberCount": 0,
-          "mentors": [], "members": [] }
-        """
-        let dto = try decodeDetail(json)
-        #expect(dto.partDisplayName == nil)
+    // MARK: - allMemberIDs
+
+    @Test("allMemberIDs — 멘토와 스터디원의 memberId 를 모두 모은다")
+    func allMemberIDsCollectsMentorsAndMembers() throws {
+        let ids = try decodeDetail(makeFullDetailJSON()).allMemberIDs
+        #expect(Set(ids) == ["2001", "2002", "2003"])
     }
 
-    @Test("mentors 키가 없고 legacy leader 단일 객체만 오면 mentors 배열로 흡수한다")
-    func decodesLegacyLeaderIntoMentors() throws {
+    @Test("allMemberIDs — 빈 memberId 는 조회 대상에서 제외한다")
+    func allMemberIDsExcludesEmpty() throws {
         let json = """
         {
-            "groupId": "1",
-            "name": "g",
-            "part": "IOS",
+            "studyGroupId": "1", "name": "g", "studyPart": "IOS",
             "createdAt": "2026-05-11T09:30:00Z",
-            "memberCount": 1,
-            "leader": { "challengerId": "1001", "memberId": "2001", "name": "리더" },
-            "members": []
+            "mentors": [ { "memberId": "", "memberName": "빈값" } ],
+            "members": [ { "memberId": "2002", "memberName": "정상" } ]
         }
         """
-        let dto = try decodeDetail(json)
-
-        #expect(dto.mentors.count == 1)
-        #expect(dto.mentors.first?.name == "리더")
-    }
-
-    @Test("mentors 와 leader 모두 없으면 mentors 는 빈 배열이다")
-    func decodesEmptyMentorsWhenNoMentorKeys() throws {
-        let json = """
-        { "groupId": "1", "name": "g", "part": "IOS",
-          "createdAt": "2026-05-11T09:30:00Z", "memberCount": 0, "members": [] }
-        """
-        let dto = try decodeDetail(json)
-        #expect(dto.mentors.isEmpty)
+        #expect(try decodeDetail(json).allMemberIDs == ["2002"])
     }
 
     // MARK: - StudyGroupChallengerDTO bestWorkbookPoint
@@ -232,10 +185,9 @@ struct StudyGroupDetailDTOTests {
 
     // MARK: - toDomain (mapping)
 
-    @Test("toDomain — serverID/name/createdDate 와 mentor/member 역할이 올바르게 매핑된다")
+    @Test("toDomain — serverID/name 과 mentor/member 역할이 올바르게 매핑된다")
     func toDomainMapsCoreFields() throws {
-        let dto = try decodeDetail(makeFullDetailJSON())
-        let info = dto.toDomain()
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain()
 
         #expect(info.serverID == "10")
         #expect(info.name == "iOS 1팀")
@@ -246,8 +198,38 @@ struct StudyGroupDetailDTOTests {
         #expect(info.members.allSatisfy { $0.role == .member })
     }
 
+    /// 서버 계약 회귀 방어 — `studyGroupId` 를 `groupId` 로 잘못 읽으면 `serverID` 가 빈 문자열이
+    /// 되고, 그러면 운영진 화면이 모든 그룹을 "서버 미저장"으로 판정해 수정·삭제·멤버 변경이
+    /// 통째로 막힌다. 키 이름이 다시 어긋나면 이 테스트가 먼저 깨진다.
+    @Test("toDomain — serverID 가 비어 있지 않다 (CRUD 차단 회귀 방어)")
+    func toDomainYieldsNonEmptyServerID() throws {
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain()
+
+        #expect(!info.serverID.isEmpty)
+        #expect(info.serverID == "10")
+    }
+
+    @Test("toDomain — 멤버 이름은 서버 memberName 에서 채운다")
+    func toDomainMapsMemberName() throws {
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain()
+
+        #expect(info.mentors.first?.name == "재원")
+        #expect(info.members.map(\.name) == ["의재", "민수"])
+    }
+
+    /// 그룹 단위 대표 학교가 아니라 **멤버별** `schoolName` 을 쓴다 — 한 그룹에 여러 학교
+    /// 멤버가 섞일 수 있어 그룹 대표값으로 뭉개면 틀린 학교가 표시된다.
+    @Test("toDomain — university 는 멤버별 schoolName 에서 채운다")
+    func toDomainMapsPerMemberSchoolName() throws {
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain()
+
+        #expect(info.mentors.first?.university == "한성대학교")
+        #expect(info.members[0].university == "한성대학교")
+        #expect(info.members[1].university == "중앙대학교")
+    }
+
     @Test(
-        "toDomain — 알려진 part 문자열을 UMCPartType 으로 매핑한다",
+        "toDomain — 알려진 studyPart 문자열을 UMCPartType 으로 매핑한다",
         arguments: [
             ("\"IOS\"", UMCPartType.front(type: .ios)),
             ("\"ANDROID\"", UMCPartType.front(type: .android)),
@@ -258,26 +240,22 @@ struct StudyGroupDetailDTOTests {
         ]
     )
     func toDomainMapsKnownPart(partJSON: String, expected: UMCPartType) throws {
-        let dto = try decodeDetail(makeFullDetailJSON(part: partJSON))
+        let dto = try decodeDetail(makeFullDetailJSON(studyPart: partJSON))
         #expect(dto.toDomain().part == expected)
     }
 
-    @Test("toDomain — 알 수 없는 part 문자열은 .front(.ios) 로 폴백한다")
+    @Test("toDomain — 알 수 없는 studyPart 문자열은 .front(.ios) 로 폴백한다")
     func toDomainFallsBackToIOSOnUnknownPart() throws {
-        let dto = try decodeDetail(makeFullDetailJSON(part: "\"QUANTUM\""))
+        let dto = try decodeDetail(makeFullDetailJSON(studyPart: "\"QUANTUM\""))
         #expect(dto.toDomain().part == .front(type: .ios))
     }
 
-    @Test("toDomain — challengerID/memberID 가 String 으로 매핑되고 university 가 학교명으로 채워진다")
-    func toDomainMapsIdsAndUniversity() throws {
-        let dto = try decodeDetail(makeFullDetailJSON())
-        let mentor = try #require(dto.toDomain().mentors.first)
+    @Test("toDomain — memberID 가 String 으로 매핑된다")
+    func toDomainMapsMemberID() throws {
+        let mentor = try #require(decodeDetail(makeFullDetailJSON()).toDomain().mentors.first)
 
         #expect(mentor.serverID == "2001")
-        #expect(mentor.challengerID == "1001")
         #expect(mentor.memberID == "2001")
-        #expect(mentor.university == "한성대학교")
-        #expect(mentor.bestWorkbookPoint == 90)
     }
 
     @Test("toDomain — 빈 profileImageURL 은 nil 로, 유효한 URL 은 그대로 매핑한다")
@@ -307,23 +285,11 @@ struct StudyGroupDetailDTOTests {
         #expect(info.mentors.first?.bestWorkbookPoint == expected)
     }
 
-    /// 서버 계약 박제 — 스터디 그룹 응답(`StudyGroupMemberResponse`)에는 `bestWorkbookPoint`
-    /// 필드가 없어 현행 응답에서는 전 멤버가 `0` 이 된다. 서버가 필드를 추가하면 이 테스트가
-    /// 깨지는 게 아니라 위 파라미터화 테스트가 값 반영을 보장한다.
+    /// 서버 계약 박제 — 스터디 그룹 응답에는 `bestWorkbookPoint` 필드가 없어 현행 응답에서는
+    /// 전 멤버가 `0` 이 된다. 서버가 필드를 추가하면 위 파라미터화 테스트가 값 반영을 보장한다.
     @Test("toDomain — 서버 현행 응답처럼 필드가 전혀 없으면 모든 멤버가 0 이다")
     func toDomainYieldsZeroForEveryMemberWhenServerOmitsField() throws {
-        let json = """
-        {
-            "groupId": "1", "name": "g", "part": "IOS",
-            "createdAt": "2026-05-11T09:30:00Z", "memberCount": 3,
-            "mentors": [ { "challengerId": "1", "memberId": "2001", "name": "멘토" } ],
-            "members": [
-                { "challengerId": "2", "memberId": "2002", "name": "챌린저1" },
-                { "challengerId": "3", "memberId": "2003", "name": "챌린저2" }
-            ]
-        }
-        """
-        let info = try decodeDetail(json).toDomain()
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain()
 
         #expect(info.mentors.allSatisfy { $0.bestWorkbookPoint == 0 })
         #expect(info.members.allSatisfy { $0.bestWorkbookPoint == 0 })
@@ -332,27 +298,84 @@ struct StudyGroupDetailDTOTests {
     @Test("toDomain — name 이 비어 있으면 defaultGroupName 으로 대체한다")
     func toDomainUsesDefaultGroupNameWhenNameEmpty() throws {
         let json = """
-        { "groupId": "1", "name": "", "part": "IOS",
-          "createdAt": "2026-05-11T09:30:00Z", "memberCount": 0,
-          "mentors": [], "members": [] }
+        {
+            "studyGroupId": "1", "name": "", "studyPart": "IOS",
+            "createdAt": "2026-05-11T09:30:00Z", "mentors": [], "members": []
+        }
         """
         let info = try decodeDetail(json).toDomain(defaultGroupName: "기본 그룹명")
         #expect(info.name == "기본 그룹명")
     }
 
-    // MARK: - toDomain (date parsing)
+    // MARK: - toDomain (멤버 프로필 보강)
 
-    @Test("toDomain — fractional seconds 가 없는 ISO8601 createdAt 을 파싱한다")
-    func toDomainParsesISO8601WithoutFractionalSeconds() throws {
-        let dto = try decodeDetail(makeFullDetailJSON(createdAt: "2026-05-11T09:30:00Z"))
-        let expected = Date(timeIntervalSince1970: 1_778_491_800) // 2026-05-11T09:30:00Z
-        #expect(dto.toDomain().createdDate == expected)
+    @Test("toDomain — 보강 정보가 있으면 challengerID/nickname 을 채운다")
+    func toDomainAppliesSupplement() throws {
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain(
+            supplementsByMemberID: [
+                "2001": StudyGroupMemberSupplement(challengerID: "C1", nickname: "재원닉")
+            ]
+        )
+        let mentor = try #require(info.mentors.first)
+
+        #expect(mentor.challengerID == "C1")
+        #expect(mentor.nickname == "재원닉")
     }
 
-    @Test("toDomain — fractional seconds 가 있는 ISO8601 createdAt 을 파싱한다")
-    func toDomainParsesISO8601WithFractionalSeconds() throws {
-        let dto = try decodeDetail(makeFullDetailJSON(createdAt: "2026-05-11T09:30:00.000Z"))
-        let expected = Date(timeIntervalSince1970: 1_778_491_800)
+    /// 보강은 멤버 단위로 독립적이다 — 일부만 해석돼도 나머지가 오염되면 안 된다.
+    @Test("toDomain — 보강되지 않은 멤버는 challengerID/nickname 이 nil 로 남는다")
+    func toDomainLeavesUnsupplementedMembersNil() throws {
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain(
+            supplementsByMemberID: [
+                "2002": StudyGroupMemberSupplement(challengerID: "C2", nickname: "의재닉")
+            ]
+        )
+
+        #expect(info.members[0].challengerID == "C2")
+        #expect(info.members[1].challengerID == nil)
+        #expect(info.members[1].nickname == nil)
+        #expect(info.mentors.first?.challengerID == nil)
+    }
+
+    /// `challengerId` 는 `memberId` 로 대체하지 않는다 — 서로 다른 식별자라 대체하면 잘못된
+    /// 대상으로 서버를 호출하게 된다. 보강 실패 시에는 `nil` 이어야 한다.
+    @Test("toDomain — 보강이 전혀 없으면 challengerID 는 memberId 로 대체되지 않는다")
+    func toDomainDoesNotSubstituteMemberIDForChallengerID() throws {
+        let info = try decodeDetail(makeFullDetailJSON()).toDomain()
+
+        #expect(info.mentors.allSatisfy { $0.challengerID == nil })
+        #expect(info.members.allSatisfy { $0.challengerID == nil })
+    }
+
+    @Test(
+        "toDomain — 보강 값이 부분적으로만 있어도 있는 쪽만 채운다",
+        arguments: [
+            (StudyGroupMemberSupplement(challengerID: "C1", nickname: nil), "C1", nil),
+            (StudyGroupMemberSupplement(challengerID: nil, nickname: "닉"), nil, "닉")
+        ] as [(StudyGroupMemberSupplement, String?, String?)]
+    )
+    func toDomainAppliesPartialSupplement(
+        supplement: StudyGroupMemberSupplement,
+        expectedChallengerID: String?,
+        expectedNickname: String?
+    ) throws {
+        let info = try decodeDetail(makeFullDetailJSON())
+            .toDomain(supplementsByMemberID: ["2001": supplement])
+        let mentor = try #require(info.mentors.first)
+
+        #expect(mentor.challengerID == expectedChallengerID)
+        #expect(mentor.nickname == expectedNickname)
+    }
+
+    // MARK: - toDomain (date parsing)
+
+    @Test(
+        "toDomain — fractional seconds 유무와 무관하게 ISO8601 createdAt 을 파싱한다",
+        arguments: ["2026-05-11T09:30:00Z", "2026-05-11T09:30:00.000Z"]
+    )
+    func toDomainParsesISO8601(createdAt: String) throws {
+        let dto = try decodeDetail(makeFullDetailJSON(createdAt: createdAt))
+        let expected = Date(timeIntervalSince1970: 1_778_491_800) // 2026-05-11T09:30:00Z
         #expect(dto.toDomain().createdDate == expected)
     }
 }

--- a/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
@@ -16,10 +16,14 @@ import UMCFoundation
 
 // MARK: - Test Double
 
-/// ``NetworkRequesting`` 가짜 구현 (FIFO outcome 큐).
+/// ``NetworkRequesting`` 가짜 구현 (FIFO outcome 큐 + 멤버 프로필 경로 분리).
 ///
 /// 페이지네이션처럼 호출이 여러 번 일어나는 흐름을 위해 미리 설정한 결과를 순서대로
 /// 반환하고, 호출된 라우터의 경로·메서드를 기록해 엔드포인트 계약을 검증합니다.
+///
+/// 스터디 그룹 조회는 멤버마다 프로필 보강 요청을 **병렬로** 보내므로 완료 순서가
+/// 비결정적입니다. 그래서 (1) 기록을 락으로 보호하고, (2) 멤버 프로필 요청은
+/// ``memberProfileResponder`` 로 경로 분리해 주 엔드포인트의 FIFO 계약이 흔들리지 않게 합니다.
 private final class StubNetworkRequesting: NetworkRequesting, @unchecked Sendable {
 
     enum Outcome {
@@ -34,33 +38,94 @@ private final class StubNetworkRequesting: NetworkRequesting, @unchecked Sendabl
         case noOutcomeQueued
     }
 
-    private var outcomes: [Outcome]
-    private(set) var requestedPaths: [String] = []
-    private(set) var requestedMethods: [Moya.Method] = []
-    /// 각 요청의 `cursor` 쿼리 파라미터 (없으면 `nil`). 페이지네이션 echo 검증용.
-    private(set) var requestedCursors: [String?] = []
+    /// 한 번의 요청 기록.
+    struct Record {
+        let path: String
+        let method: Moya.Method
+        /// `cursor` 쿼리 파라미터 (없으면 `nil`). 페이지네이션 echo 검증용.
+        let cursor: String?
+    }
 
-    var requestCount: Int { requestedPaths.count }
-    var lastPath: String? { requestedPaths.last }
-    var lastMethod: Moya.Method? { requestedMethods.last }
+    /// 멤버 프로필 보강 요청 경로 접두사.
+    static let memberProfilePathPrefix = "/api/v1/member/profile/"
+
+    private let lock = NSLock()
+    private var outcomes: [Outcome]
+    private var records: [Record] = []
+
+    /// 멤버 프로필 요청에 `memberId` 별 응답을 돌려주는 클로저.
+    ///
+    /// 지정하면 FIFO 큐를 소비하지 않고 이 클로저 결과를 반환합니다. `nil` 로 두면 기존처럼
+    /// FIFO 큐를 사용합니다(단일 호출인 챌린저 ID 해석 테스트).
+    var memberProfileResponder: (@Sendable (String) -> Outcome)?
 
     init(_ outcomes: [Outcome]) {
         self.outcomes = outcomes
     }
 
+    // MARK: - 기록 조회
+
+    /// 멤버 프로필 보강을 포함한 전체 요청 기록.
+    var allRecords: [Record] {
+        lock.lock()
+        defer { lock.unlock() }
+        return records
+    }
+
+    var requestedPaths: [String] { allRecords.map(\.path) }
+    var requestCount: Int { allRecords.count }
+    var lastPath: String? { allRecords.last?.path }
+    var lastMethod: Moya.Method? { allRecords.last?.method }
+
+    /// 멤버 프로필 보강을 **제외한** 요청 기록 — 주 엔드포인트 계약 검증용.
+    private var primaryRecords: [Record] {
+        allRecords.filter { !$0.path.hasPrefix(Self.memberProfilePathPrefix) }
+    }
+
+    var primaryPaths: [String] { primaryRecords.map(\.path) }
+    var primaryRequestCount: Int { primaryRecords.count }
+    var lastPrimaryPath: String? { primaryRecords.last?.path }
+    var lastPrimaryMethod: Moya.Method? { primaryRecords.last?.method }
+    var primaryCursors: [String?] { primaryRecords.map(\.cursor) }
+
+    /// 멤버 프로필 보강 요청만 추린 경로 (병렬이라 순서는 비결정적 — 집합/개수로만 검증할 것).
+    var memberProfilePaths: [String] {
+        allRecords.map(\.path).filter { $0.hasPrefix(Self.memberProfilePathPrefix) }
+    }
+
+    // MARK: - NetworkRequesting
+
     func request<T: TargetType>(_ target: T) async throws -> Response {
-        requestedPaths.append(target.path)
-        requestedMethods.append(target.method)
-        requestedCursors.append(Self.cursor(from: target.task))
-        guard !outcomes.isEmpty else {
-            throw StubError.noOutcomeQueued
-        }
-        switch outcomes.removeFirst() {
+        switch try nextOutcome(for: target) {
         case .success(let data):
             return Response(statusCode: 200, data: data)
         case .failure(let error):
             throw error
         }
+    }
+
+    private func nextOutcome<T: TargetType>(for target: T) throws -> Outcome {
+        lock.lock()
+        defer { lock.unlock() }
+
+        records.append(
+            Record(
+                path: target.path,
+                method: target.method,
+                cursor: Self.cursor(from: target.task)
+            )
+        )
+
+        if target.path.hasPrefix(Self.memberProfilePathPrefix),
+           let responder = memberProfileResponder {
+            let memberID = String(target.path.dropFirst(Self.memberProfilePathPrefix.count))
+            return responder(memberID)
+        }
+
+        guard !outcomes.isEmpty else {
+            throw StubError.noOutcomeQueued
+        }
+        return outcomes.removeFirst()
     }
 
     private static func cursor(from task: Moya.Task) -> String? {
@@ -106,31 +171,45 @@ private enum Fixture {
     }
     """
 
-    /// 단일 스터디 그룹 상세 (멘토 1 + 스터디원 1)
+    /// 단일 스터디 그룹 상세 (멘토 1 + 스터디원 1). 서버 `StudyGroupResponse` 실제 키 사용.
     static let studyGroupDetailObject = """
     {
-      "groupId": "42", "name": "iOS 스터디", "part": "IOS", "partDisplayName": "iOS",
-      "schools": [
-        {
-          "schoolId": "5", "schoolName": "한성대", "logoImageId": null,
-          "totalStudyGroupCount": 1, "totalMemberCount": 10
-        }
-      ],
-      "createdAt": "2026-06-01T09:00:00.000Z", "memberCount": 2,
+      "studyGroupId": "42", "name": "iOS 스터디", "gisuId": 7, "studyPart": "IOS",
+      "createdAt": "2026-06-01T09:00:00.000Z",
       "mentors": [
         {
-          "challengerId": "1", "memberId": "10", "name": "멘토",
-          "profileImageUrl": null, "bestWorkbookPoint": 0
+          "memberId": "10", "memberName": "멘토", "schoolId": 5,
+          "schoolName": "한성대", "profileImageUrl": null
         }
       ],
       "members": [
         {
-          "challengerId": "2", "memberId": "20", "name": "챌린저",
-          "profileImageUrl": null, "bestWorkbookPoint": 5
+          "memberId": "20", "memberName": "챌린저", "schoolId": 5,
+          "schoolName": "한성대", "profileImageUrl": null
         }
       ]
     }
     """
+
+    /// 보강용 멤버 프로필 — 주어진 `memberID` 에 대응하는 챌린저 레코드 1건과 닉네임을 담는다.
+    static func memberProfile(
+        memberID: String,
+        challengerID: String,
+        nickname: String?
+    ) -> String {
+        let nicknameField = nickname.map { "\"\($0)\"" } ?? "null"
+        return """
+        {
+          "nickname": \(nicknameField),
+          "challengerRecords": [
+            {
+              "challengerId": "\(challengerID)", "memberId": "\(memberID)",
+              "gisu": 7, "gisuId": "70"
+            }
+          ]
+        }
+        """
+    }
 
     /// 필터(memberId 일치 & challengerId 비어있지 않음) 검증을 포함한 멤버 프로필
     static let memberProfileObject = """
@@ -185,20 +264,52 @@ private enum Fixture {
 
 private typealias RepositoryPair = (StudyRepository, StubNetworkRequesting)
 
+/// 스터디 그룹 조회 테스트의 기본 보강 응답 — `memberId` 마다 `C{memberId}` / `닉{memberId}`.
+///
+/// 그룹 조회는 멤버마다 프로필을 부르므로, 기본값이 없으면 그 요청들이 FIFO 큐에서 다음 페이지
+/// 응답을 먹어버린다. 챌린저 ID 해석 테스트처럼 FIFO 동작 자체를 검증할 때만 `nil` 을 넘긴다.
+private let stubMemberProfileResponder:
+    @Sendable (String) -> StubNetworkRequesting.Outcome = { memberID in
+        .success(
+            Fixture.success(
+                Fixture.memberProfile(
+                    memberID: memberID,
+                    challengerID: "C\(memberID)",
+                    nickname: "닉\(memberID)"
+                )
+            )
+        )
+    }
+
+/// 프로필 보강이 항상 실패하는 responder — 보강 실패 폴백 경로 검증용.
+private let failingMemberProfileResponder:
+    @Sendable (String) -> StubNetworkRequesting.Outcome = { _ in
+        .failure(StubNetworkRequesting.StubError.noOutcomeQueued)
+    }
+
 private func makeRepository(
     _ outcomes: [StubNetworkRequesting.Outcome],
-    context: StudyContextProviding = StubStudyContext()
+    context: StudyContextProviding = StubStudyContext(),
+    memberProfileResponder: (@Sendable (String) -> StubNetworkRequesting.Outcome)?
+        = stubMemberProfileResponder
 ) -> RepositoryPair {
     let stub = StubNetworkRequesting(outcomes)
+    stub.memberProfileResponder = memberProfileResponder
     let repository = StudyRepository(networkRequesting: stub, context: context)
     return (repository, stub)
 }
 
 private func makeRepository(
     _ outcome: StubNetworkRequesting.Outcome,
-    context: StudyContextProviding = StubStudyContext()
+    context: StudyContextProviding = StubStudyContext(),
+    memberProfileResponder: (@Sendable (String) -> StubNetworkRequesting.Outcome)?
+        = stubMemberProfileResponder
 ) -> RepositoryPair {
-    makeRepository([outcome], context: context)
+    makeRepository(
+        [outcome],
+        context: context,
+        memberProfileResponder: memberProfileResponder
+    )
 }
 
 // MARK: - Suite: 커리큘럼 조회 계약
@@ -293,8 +404,8 @@ struct StudyRepositoryGroupTests {
         #expect(page.content.first?.serverID == "42")
         #expect(page.hasNext)
         #expect(page.nextCursor == "5")
-        #expect(stub.lastPath == "/api/v1/study-groups/managed")
-        #expect(stub.lastMethod == .get)
+        #expect(stub.lastPrimaryPath == "/api/v1/study-groups/managed")
+        #expect(stub.lastPrimaryMethod == .get)
     }
 
     @Test("fetchStudyGroupDetails — 다음 페이지가 없을 때까지 누적한다")
@@ -313,7 +424,7 @@ struct StudyRepositoryGroupTests {
         let details = try await sut.fetchStudyGroupDetails()
 
         #expect(details.count == 2)
-        #expect(stub.requestCount == 2)
+        #expect(stub.primaryRequestCount == 2)
     }
 
     @Test("fetchStudyGroupDetails — hasNext 인데 커서가 없으면 무한 루프를 막고 중단한다")
@@ -326,7 +437,7 @@ struct StudyRepositoryGroupTests {
         let details = try await sut.fetchStudyGroupDetails()
 
         #expect(details.count == 1)
-        #expect(stub.requestCount == 1)        // 두 번째 페이지를 요청하지 않음
+        #expect(stub.primaryRequestCount == 1)  // 두 번째 페이지를 요청하지 않음
     }
 
     @Test("fetchStudyGroupDetails — 불투명 nextCursor 를 다음 페이지 요청 커서로 그대로 echo 한다")
@@ -345,7 +456,7 @@ struct StudyRepositoryGroupTests {
         _ = try await sut.fetchStudyGroupDetails()
 
         // 1페이지는 커서 없음, 2페이지는 불투명 토큰을 숫자 변환 없이 그대로 전달.
-        #expect(stub.requestedCursors == [nil, "cursor-2"])
+        #expect(stub.primaryCursors == [nil, "cursor-2"])
     }
 
     @Test("fetchStudyGroupDetail — 단일 상세를 매핑하고 groupId 를 path 에 보간한다")
@@ -359,7 +470,129 @@ struct StudyRepositoryGroupTests {
         #expect(info.serverID == "42")
         #expect(info.mentors.count == 1)
         #expect(info.members.count == 1)
-        #expect(stub.lastPath == "/api/v1/study-groups/42")
+        #expect(stub.lastPrimaryPath == "/api/v1/study-groups/42")
+    }
+
+    /// 서버 계약 회귀 방어 — `studyGroupId` 키를 놓치면 `serverID` 가 비고, 운영진 화면이 모든
+    /// 그룹을 "서버 미저장"으로 판정해 CRUD 가 통째로 막힌다.
+    @Test("fetchStudyGroupDetail — serverID 가 비어 있지 않다 (CRUD 차단 회귀 방어)")
+    func fetchStudyGroupDetailYieldsNonEmptyServerID() async throws {
+        let (sut, _) = makeRepository(
+            .success(Fixture.success(Fixture.studyGroupDetailObject))
+        )
+
+        let info = try await sut.fetchStudyGroupDetail(groupId: "42")
+
+        #expect(!info.serverID.isEmpty)
+    }
+
+    @Test("fetchStudyGroupDetail — 멤버 이름·학교는 서버 memberName/schoolName 에서 채운다")
+    func fetchStudyGroupDetailMapsMemberNameAndSchool() async throws {
+        let (sut, _) = makeRepository(
+            .success(Fixture.success(Fixture.studyGroupDetailObject))
+        )
+
+        let info = try await sut.fetchStudyGroupDetail(groupId: "42")
+
+        #expect(info.mentors.first?.name == "멘토")
+        #expect(info.members.first?.name == "챌린저")
+        #expect(info.mentors.first?.university == "한성대")
+    }
+
+    // MARK: - 멤버 프로필 보강
+
+    @Test("fetchStudyGroupDetail — 멤버마다 프로필을 조회해 challengerID/nickname 을 채운다")
+    func fetchStudyGroupDetailSupplementsMembers() async throws {
+        let (sut, stub) = makeRepository(
+            .success(Fixture.success(Fixture.studyGroupDetailObject))
+        )
+
+        let info = try await sut.fetchStudyGroupDetail(groupId: "42")
+
+        #expect(info.mentors.first?.challengerID == "C10")
+        #expect(info.mentors.first?.nickname == "닉10")
+        #expect(info.members.first?.challengerID == "C20")
+        #expect(info.members.first?.nickname == "닉20")
+        #expect(
+            Set(stub.memberProfilePaths) == [
+                "/api/v1/member/profile/10",
+                "/api/v1/member/profile/20"
+            ]
+        )
+    }
+
+    /// 같은 멤버가 여러 그룹·페이지에 등장해도 프로필은 한 번만 부른다.
+    @Test("fetchStudyGroupDetailsPage — 중복 memberId 는 프로필을 한 번만 조회한다")
+    func fetchStudyGroupDetailsPageDeduplicatesMemberProfileRequests() async throws {
+        // 같은 멤버(10/20)를 가진 그룹 2개를 한 페이지에 담는다.
+        let pageJSON = Fixture.studyGroupsPage(
+            [Fixture.studyGroupDetailObject, Fixture.studyGroupDetailObject],
+            nextCursor: nil,
+            hasNext: false
+        )
+        let (sut, stub) = makeRepository(.success(Fixture.success(pageJSON)))
+
+        _ = try await sut.fetchStudyGroupDetailsPage(cursor: nil, size: 20)
+
+        #expect(stub.memberProfilePaths.count == 2)   // 4명이 아니라 고유 2명
+    }
+
+    /// 보강 실패가 목록 자체를 막으면 안 된다 — 그룹은 그대로 오고 두 값만 nil 로 남는다.
+    @Test("fetchStudyGroupDetail — 프로필 조회가 실패해도 그룹은 반환되고 보강만 비어 있다")
+    func fetchStudyGroupDetailSurvivesSupplementFailure() async throws {
+        let (sut, _) = makeRepository(
+            .success(Fixture.success(Fixture.studyGroupDetailObject)),
+            memberProfileResponder: failingMemberProfileResponder
+        )
+
+        let info = try await sut.fetchStudyGroupDetail(groupId: "42")
+
+        #expect(info.serverID == "42")
+        #expect(info.mentors.first?.name == "멘토")     // 그룹 응답 값은 그대로
+        #expect(info.mentors.first?.challengerID == nil)
+        #expect(info.mentors.first?.nickname == nil)
+    }
+
+    /// 일부 멤버만 실패해도 성공한 멤버의 보강은 살아 있어야 한다.
+    @Test("fetchStudyGroupDetail — 일부 멤버 프로필만 실패하면 나머지 보강은 유지된다")
+    func fetchStudyGroupDetailKeepsPartialSupplements() async throws {
+        let (sut, _) = makeRepository(
+            .success(Fixture.success(Fixture.studyGroupDetailObject)),
+            memberProfileResponder: { memberID in
+                guard memberID == "10" else {
+                    return .failure(StubNetworkRequesting.StubError.noOutcomeQueued)
+                }
+                return .success(
+                    Fixture.success(
+                        Fixture.memberProfile(
+                            memberID: "10",
+                            challengerID: "C10",
+                            nickname: "닉10"
+                        )
+                    )
+                )
+            }
+        )
+
+        let info = try await sut.fetchStudyGroupDetail(groupId: "42")
+
+        #expect(info.mentors.first?.challengerID == "C10")
+        #expect(info.members.first?.challengerID == nil)
+    }
+
+    /// `challengerId` 와 `memberId` 는 서로 다른 식별자다. 보강 실패 시 `memberId` 로 대체하면
+    /// 잘못된 대상으로 서버를 호출하게 되므로 `nil` 로 남겨야 한다.
+    @Test("fetchStudyGroupDetail — 보강 실패 시 challengerID 를 memberId 로 대체하지 않는다")
+    func fetchStudyGroupDetailDoesNotSubstituteMemberIDForChallengerID() async throws {
+        let (sut, _) = makeRepository(
+            .success(Fixture.success(Fixture.studyGroupDetailObject)),
+            memberProfileResponder: failingMemberProfileResponder
+        )
+
+        let info = try await sut.fetchStudyGroupDetail(groupId: "42")
+
+        #expect(info.mentors.first?.challengerID != "10")
+        #expect(info.members.first?.challengerID != "20")
     }
 }
 
@@ -374,7 +607,11 @@ struct StudyRepositoryResolveChallengerTests {
             (preferred: Optional("8"), contextGisuId: Optional("70"), expected: "C8"),
             (preferred: Optional<String>.none, contextGisuId: Optional("80"), expected: "C8"),
             (preferred: Optional<String>.none, contextGisuId: Optional("70"), expected: "C7"),
-            (preferred: Optional<String>.none, contextGisuId: Optional<String>.none, expected: "C7")
+            (
+                preferred: Optional<String>.none,
+                contextGisuId: Optional<String>.none,
+                expected: "C7"
+            )
         ]
     )
     func resolveChallengerIdAppliesPriority(
@@ -382,9 +619,11 @@ struct StudyRepositoryResolveChallengerTests {
         contextGisuId: String?,
         expected: String
     ) async throws {
+        // FIFO 큐의 프로필 픽스처를 그대로 쓰기 위해 경로 분리 responder 를 끈다.
         let (sut, _) = makeRepository(
             .success(Fixture.success(Fixture.memberProfileObject)),
-            context: StubStudyContext(gisuId: contextGisuId)
+            context: StubStudyContext(gisuId: contextGisuId),
+            memberProfileResponder: nil
         )
 
         let challengerId = try await sut.resolveChallengerId(
@@ -398,7 +637,8 @@ struct StudyRepositoryResolveChallengerTests {
     @Test("resolveChallengerId — 적격 레코드가 없으면 nil 을 반환한다")
     func resolveChallengerIdReturnsNilWhenNoEligibleRecord() async throws {
         let (sut, stub) = makeRepository(
-            .success(Fixture.success(Fixture.memberProfileNoEligibleObject))
+            .success(Fixture.success(Fixture.memberProfileNoEligibleObject)),
+            memberProfileResponder: nil
         )
 
         let challengerId = try await sut.resolveChallengerId(


### PR DESCRIPTION
resolves #1015
resolves #1040

## ✨ PR 유형

🐛 [Fix] — 서버가 주지 않는 필드에 의존하던 계약 불일치 해소

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 테스트 성공 스크린샷 + 커버리지 첨부 예정 (CI 미적용 기간 한시 정책) -->

## 🛠️ 작업내용

### #1015 — 베스트 워크북 포인트

**조사 결과 이슈에 적힌 (B) 클라이언트 계산 복원은 불가능합니다.**

레거시가 쓰던 `GET /api/v1/member/profile/{memberId}` 는 타인 조회 시 상벌점을 의도적으로 제거해 응답합니다.

```
MemberQueryController#getMemberProfile → assembler.fromMemberIdToPublic
  └ MemberInfoResponse.toPublic() → ChallengerInfoResponse.toPublic()
      └ .challengerPoints(List.of())   // "상벌점 정보는 공개하지 않음"
```

즉 이 엔드포인트는 **모든 멤버에 빈 배열**을 주므로, 레거시 계산식(`abs(sum(BEST_WORKBOOK)) × 10`)은 전원 0 을 반환합니다.

이 필터링은 서버 `e92c54fe`(2026-03-12)에 도입됐고, 레거시 계산 DTO 는 2026-02-24 작성입니다. **이식 과정에서 유실된 게 아니라 서버 변경으로 레거시도 함께 깨진 상태**입니다. 이슈 본문의 "레거시에서는 값이 표시되던 항목" 은 2026-03-12 이전 기준입니다.

우회 경로도 모두 막혀 있습니다.

| 경로 | 상태 |
|---|---|
| 스터디 그룹 응답 | `bestWorkbookPoint` 필드 자체가 없음 |
| `/member/profile/{memberId}` | `challengerPoints: []` |
| `/challenger/{challengerId}` | full points 제공 ✅ 하지만 그룹 응답에 `challengerId` 가 없어 해석에 다시 프로필 조회 필요 → 2N+1 |
| `/challenger/search/*` | `pointSum`(전 타입 합계)만, 타입별 분해 불가 |

→ **(A) 서버 필드 추가 요청**을 채택했습니다. 집계 규칙은 `BEST_WORKBOOK`·`BEST_WORKBOOK_V2` **선정 횟수 합 × 5** 로 확정했습니다. 두 타입은 배점 관례만 다른 동일 사건(베스트 워크북 선정)이고, 레거시 데이터만 있는 멤버는 기존 표시값과 정확히 일치합니다.

클라이언트 쪽으로는 `toDomain(bestWorkbookPointByMemberID:)` 의 **미사용 파라미터를 제거**하고, 서버 미제공 상태를 정의부 `- Note:` 로 명시했습니다. `bestWorkbookPoint` DTO 필드는 서버가 채울 자리라 남겨 뒀고, 추가되면 코드 변경 없이 반영됩니다.

### #1040 — 스터디 그룹 DTO 계약 정렬 (위 조사 중 발견)

`bestWorkbookPoint` 는 증상 하나였고, 같은 DTO 가 **7개 필드에서** 서버 계약과 어긋나 있었습니다. 모든 필드가 `decodeIfPresent` + 기본값 폴백이라 디코딩 에러 없이 조용히 빈 값이 됩니다.

실행 중인 dev 서버가 생성한 OpenAPI 스키마(`GET /docs-json`, 인증 불필요)로 실제 계약을 확인했습니다.

| iOS 기존 | 서버 실제 | 고치기 전 결과 |
|---|---|---|
| `groupId` | `studyGroupId` | `serverID` = `""` → **운영진 화면이 모든 그룹을 "서버 미저장"으로 판정해 수정·삭제·멤버 변경 CRUD 전체 차단** |
| 멤버 `name` | `memberName` | 멤버 칩·리더 행 이름 공백 |
| `part` | `studyPart` | 모든 그룹이 iOS 파트로 표시 |
| 그룹 `schools[].schoolName` | 멤버별 `schoolName` | `university` 공백 |
| `partDisplayName` · `memberCount` | 없음 | 소비처 0건 / 도메인이 computed 로 계산 → **제거** |
| 멤버 `challengerId` · `nickname` | 없음 | 멤버·멘토 추가/삭제 가드 실패 → **프로필로 보강** |

`university` 는 그룹 대표 학교가 아니라 **멤버별 `schoolName`** 에서 채웁니다. 한 그룹에 여러 학교 멤버가 섞일 수 있어 대표값으로 뭉개면 틀린 학교가 표시됩니다.

`challengerId`·`nickname` 은 `/member/profile/{memberId}` 로 해석합니다. 이 엔드포인트가 상벌점만 걸러내고 두 값은 보존하므로 **한 번의 호출로 둘 다** 얻습니다.

미사용 `StudyGroupSchoolDTO` 와, 서버가 보내지 않는 `leader` 폴백 분기도 함께 제거했습니다.

## 📋 추후 진행 상황

- 서버에 스터디 그룹 응답의 멤버별 `bestWorkbookPoint` 추가 요청 (집계 규칙은 #1015 에 명세 기록)
- 서버가 `challengerId`·`nickname` 까지 그룹 응답에 포함하면 본 PR 의 보강 단계는 통째로 제거 가능

## 📌 리뷰 포인트

**① N+1 보강 트레이드오프** — `StudyRepository.fetchMemberSupplements`

서버 필드 추가를 기다리지 않고 클라이언트에서 해석하는 쪽을 택했습니다. 멤버 수만큼 요청이 늘어나므로:
- 동시 요청을 **8개 창(window)** 으로 제한 (페이지당 그룹 100개면 멤버가 수백 명)
- 중복 `memberId` 는 한 번만 조회 (페이지 단위 — 페이지 간 중복은 남으며 주석에 명시)
- 개별 실패는 삼켜 그룹 목록 표시를 막지 않음

이 선택이 적절한지 봐주세요.

**② `challengerID` 를 `memberId` 로 대체하지 않음** — `StudyGroupDetailDTO.makeMember`

보강 실패 시 `nil` 로 둡니다. 챌린저와 멤버는 서로 다른 식별자라 대체하면 잘못된 대상으로 서버를 호출하게 됩니다. 회귀 테스트로 고정했습니다.

**③ 테스트 스텁 구조 변경** — `StudyRepositoryTests.StubNetworkRequesting`

보강 호출이 병렬이라 (1) 기록에 `NSLock` 추가, (2) 멤버 프로필 요청을 경로로 분리했습니다. 분리하지 않으면 보강 요청이 FIFO 큐에서 **다음 페이지 응답을 소비**해 페이지네이션 테스트가 깨집니다.

**④ 픽스처 교체** — 기존 픽스처가 iOS 기대 키(`groupId`/`part`/`schools`)를 그대로 써서 계약 어긋남을 가리고 있었습니다. 전부 실제 서버 키로 바꿨습니다. 이게 이 결함이 리뷰·테스트를 통과했던 이유입니다.

검증: `make test SCHEME=ActivityData` 206 케이스 통과, `make build SCHEME=ActivityData` · `make build SCHEME=ActivityPresentation` 성공. develop rebase 후 재검증 완료.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
