### PR TITLE
♻️ [Refactor] ChallengerAttendanceSessionView 화면 계층 이식 — SessionList · MyAttendanceCard 포함

### DIFF
--- a/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/MyAttendanceItemModel.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/Attendance/MyAttendanceItemModel.swift
@@ -23,6 +23,25 @@ public struct MyAttendanceItemModel: Equatable, Identifiable, Sendable {
     public let status: MyAttendanceItemStatus
     public let category: ScheduleIconCategory
 
+    /// 일정에 설정된 출석 정책 (`nil` = 아직 조회되지 않음)
+    ///
+    /// 출석 이력 카드를 펼쳤을 때 보여줄 정책 3개 시각의 원본입니다.
+    public let attendancePolicy: ScheduleAttendancePolicy?
+
+    /// 장소명 (`nil` = 장소 미지정)
+    ///
+    /// - Note: 현재 두 변환 경로(`Session` / `AttendanceHistoryItem`) 모두 장소명을
+    ///   싣지 않아 항상 `nil` 입니다. 장소를 담은 일정 상세(`ScheduleDetailData`)는
+    ///   Home 도메인 소유이고 Activity 는 Home 에 의존하지 않으므로, 값을 채우려면
+    ///   해당 페이로드를 Activity 가 읽을 수 있는 경로가 먼저 생겨야 합니다.
+    ///   그때 변환 경로만 값을 채우면 카드는 그대로 동작합니다.
+    public let locationName: String?
+
+    /// 비대면 진행 여부
+    ///
+    /// - Note: `locationName` 과 같은 사유로 현재는 항상 `false` 입니다.
+    public let isOnline: Bool
+
     public init(
         id: UUID = .init(),
         week: Int,
@@ -30,7 +49,10 @@ public struct MyAttendanceItemModel: Equatable, Identifiable, Sendable {
         startTime: Date,
         endTime: Date,
         status: MyAttendanceItemStatus,
-        category: ScheduleIconCategory = .general
+        category: ScheduleIconCategory = .general,
+        attendancePolicy: ScheduleAttendancePolicy? = nil,
+        locationName: String? = nil,
+        isOnline: Bool = false
     ) {
         self.id = id
         self.week = week
@@ -39,6 +61,9 @@ public struct MyAttendanceItemModel: Equatable, Identifiable, Sendable {
         self.endTime = endTime
         self.status = status
         self.category = category
+        self.attendancePolicy = attendancePolicy
+        self.locationName = locationName
+        self.isOnline = isOnline
     }
 
     // MARK: - Computed
@@ -48,12 +73,28 @@ public struct MyAttendanceItemModel: Equatable, Identifiable, Sendable {
         "\(week)주차"
     }
 
-    /// 시간 범위 텍스트 (예: "14:00 - 18:00")
-    public var timeRange: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return "\(formatter.string(from: startTime)) - \(formatter.string(from: endTime))"
+    /// 날짜 표시 텍스트 (예: "6월 11일 (목)")
+    public var dateText: String {
+        Self.kstDateFormatter.string(from: startTime)
     }
+
+    /// 시간 범위 텍스트 (예: "14:00 - 18:00")
+    ///
+    /// 서버 시각은 KST 기준이므로 기기 타임존과 무관하게 같은 문자열이 나오도록
+    /// KST 고정 포맷터(`Date.timeRange(to:)`)를 사용합니다.
+    public var timeRange: String {
+        startTime.timeRange(to: endTime)
+    }
+
+    // MARK: - Formatter
+
+    private static let kstDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = .kst
+        formatter.dateFormat = "M월 d일 (E)"
+        return formatter
+    }()
 }
 
 // MARK: - Session Conversion
@@ -63,9 +104,14 @@ public extension MyAttendanceItemModel {
     /// - Parameters:
     ///   - session: 변환할 세션
     ///   - category: ML 분류 결과 (기본값: .general)
+    ///   - attendancePolicy: 해당 세션의 출석 정책 (기본값: nil — 아직 조회 전)
     /// - Note: pending 상태는 nil 반환
     @MainActor
-    init?(from session: Session, category: ScheduleIconCategory = .general) {
+    init?(
+        from session: Session,
+        category: ScheduleIconCategory = .general,
+        attendancePolicy: ScheduleAttendancePolicy? = nil
+    ) {
         guard let itemStatus = MyAttendanceItemStatus(from: session.attendanceStatus) else {
             return nil
         }
@@ -77,6 +123,9 @@ public extension MyAttendanceItemModel {
         self.endTime = session.info.endTime
         self.status = itemStatus
         self.category = category
+        self.attendancePolicy = attendancePolicy
+        self.locationName = nil
+        self.isOnline = false
     }
 }
 
@@ -104,6 +153,9 @@ public extension MyAttendanceItemModel {
         self.endTime = parsedEnd
         self.status = itemStatus
         self.category = .general
+        self.attendancePolicy = nil
+        self.locationName = nil
+        self.isOnline = false
     }
 }
 

--- a/UMCApp/Features/Activity/Domain/Tests/Attendance/MyAttendanceItemModelTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/Attendance/MyAttendanceItemModelTests.swift
@@ -33,6 +33,22 @@ struct MyAttendanceItemModelTests {
         )
     }
 
+    /// 2026-05-07 (목) KST 의 지정 시각. 기기 타임존과 무관하게 같은 절대 시각을 만든다.
+    private func makeKSTDate(hour: Int, minute: Int = 0) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 5
+        components.day = 7
+        components.hour = hour
+        components.minute = minute
+
+        guard let date = Calendar.kstGregorian.date(from: components) else {
+            Issue.record("Failed to construct KST test date")
+            return Date(timeIntervalSince1970: 0)
+        }
+        return date
+    }
+
     private func makeSessionInfo() -> SessionInfo {
         SessionInfo(
             sessionId: SessionID(value: "S-1"),
@@ -42,6 +58,19 @@ struct MyAttendanceItemModelTests {
             startTime: Date(timeIntervalSince1970: 0),
             endTime: Date(timeIntervalSince1970: 3600),
             location: Coordinate(latitude: 0, longitude: 0)
+        )
+    }
+
+    /// 상태만 의미가 있는 출석 기록. 세션을 `beforeAttendance` 밖으로 꺼내는 용도라
+    /// 나머지 필드는 변환 결과에 영향을 주지 않는 고정값이다.
+    private func makeAttendance(
+        status: AttendanceStatus = .present
+    ) -> Attendance {
+        Attendance(
+            sessionId: SessionID(value: "S-1"),
+            userId: UserID(value: "U-1"),
+            type: .gps,
+            status: status
         )
     }
 
@@ -60,34 +89,31 @@ struct MyAttendanceItemModelTests {
         #expect(model.weekText == "3주차")
     }
 
-    @Test("timeRange 는 'HH:mm - HH:mm' 형태이다")
+    @Test("timeRange 는 기기 타임존과 무관하게 KST 기준 'HH:mm - HH:mm' 이다")
     func timeRangeFormat() {
-        // 시스템 타임존을 고려하여 컴포넌트 기반으로 Date 생성
-        var startComponents = DateComponents()
-        startComponents.year = 2026
-        startComponents.month = 5
-        startComponents.day = 7
-        startComponents.hour = 14
-        startComponents.minute = 0
-
-        var endComponents = startComponents
-        endComponents.hour = 16
-
-        guard let start = Calendar.current.date(from: startComponents),
-              let end = Calendar.current.date(from: endComponents) else {
-            Issue.record("Failed to construct test dates")
-            return
-        }
-
         let model = MyAttendanceItemModel(
             week: 1,
             title: "Test",
-            startTime: start,
-            endTime: end,
+            startTime: makeKSTDate(hour: 14),
+            endTime: makeKSTDate(hour: 16),
             status: .present
         )
 
         #expect(model.timeRange == "14:00 - 16:00")
+    }
+
+    @Test("dateText 는 KST 기준 'M월 d일 (E)' 형태이다")
+    func dateTextFormat() {
+        // 2026-05-07 은 목요일 (KST)
+        let model = MyAttendanceItemModel(
+            week: 1,
+            title: "Test",
+            startTime: makeKSTDate(hour: 14),
+            endTime: makeKSTDate(hour: 16),
+            status: .present
+        )
+
+        #expect(model.dateText == "5월 7일 (목)")
     }
 
     // MARK: - Init from AttendanceHistoryItem
@@ -137,13 +163,7 @@ struct MyAttendanceItemModelTests {
     @Test("Session(loaded(present)) 변환 시 status 는 present")
     @MainActor
     func initFromSessionPresent() {
-        let attendance = Attendance(
-            sessionId: SessionID(value: "S-1"),
-            userId: UserID(value: "U-1"),
-            type: .gps,
-            status: .present
-        )
-        let session = Session(info: makeSessionInfo(), initialAttendance: attendance)
+        let session = Session(info: makeSessionInfo(), initialAttendance: makeAttendance())
 
         let model = MyAttendanceItemModel(from: session, category: .study)
 
@@ -160,6 +180,43 @@ struct MyAttendanceItemModelTests {
         let model = MyAttendanceItemModel(from: session)
 
         #expect(model == nil)
+    }
+
+    @Test("Session 변환 시 주입한 출석 정책이 그대로 실린다")
+    @MainActor
+    func initFromSessionCarriesAttendancePolicy() {
+        let policy = ScheduleAttendancePolicy(
+            checkInStartAt: makeKSTDate(hour: 13, minute: 50),
+            onTimeEndAt: makeKSTDate(hour: 14, minute: 10),
+            lateEndAt: makeKSTDate(hour: 15)
+        )
+        let session = Session(info: makeSessionInfo(), initialAttendance: makeAttendance())
+
+        let model = MyAttendanceItemModel(from: session, attendancePolicy: policy)
+
+        #expect(model?.attendancePolicy == policy)
+    }
+
+    /// 회귀 박제 — 두 변환 경로 **모두** 장소/비대면 정보를 싣지 않는다는 정의부 `- Note:` 를
+    /// 고정한다. Schedule 모듈이 해당 페이로드를 들여올 때 이 테스트가 함께 바뀌어야 한다.
+    @Test("Session 변환은 장소·비대면 정보를 싣지 않는다 (Schedule 모듈 대기)")
+    @MainActor
+    func initFromSessionHasNoLocationPayload() {
+        let session = Session(info: makeSessionInfo(), initialAttendance: makeAttendance())
+
+        let model = MyAttendanceItemModel(from: session)
+
+        #expect(model?.locationName == nil)
+        #expect(model?.isOnline == false)
+    }
+
+    @Test("AttendanceHistoryItem 변환도 장소·비대면 정보를 싣지 않는다 (형제 대칭)")
+    func initFromHistoryItemHasNoLocationPayload() {
+        let model = MyAttendanceItemModel(from: makeHistoryItem())
+
+        #expect(model?.locationName == nil)
+        #expect(model?.isOnline == false)
+        #expect(model?.attendancePolicy == nil)
     }
 
     // MARK: - parseTimeString

--- a/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
@@ -52,16 +52,13 @@ private struct DebugActivityHarnessView: View {
 
     // MARK: - Init
 
-    /// 운영진 모드로 시작한다.
+    /// 레거시와 동일하게 챌린저 모드로 시작한다.
     ///
-    /// 레거시 기본 모드는 챌린저지만, 그 기본 섹션인 출석 체크 화면
-    /// (`ChallengerAttendanceSessionView`)이 아직 이식되지 않아 진입 화면이 안내 문구가 된다.
-    /// 하네스의 목적은 이식된 화면 확인이므로, 실제로 볼 수 있는 출석 화면이 바로 뜨도록
-    /// 운영진 모드를 초기값으로 둔다. 툴바 버튼으로 챌린저 모드로 전환할 수 있다.
+    /// `ChallengerAttendanceSessionView` 이식 전에는 진입 화면이 안내 문구가 돼서 운영진
+    /// 모드를 초기값으로 뒀지만, 이식이 끝나 기본 섹션(출석 체크)이 실제 화면을 보여준다.
+    /// 운영진 화면은 툴바 버튼으로 전환해 확인한다.
     init() {
-        let session = previewCreateCapableSession()
-        session.toggleAdminMode()
-        _userSession = State(wrappedValue: session)
+        _userSession = State(wrappedValue: previewCreateCapableSession())
     }
 
     // MARK: - Computed Property
@@ -122,10 +119,8 @@ private struct DebugActivityHarnessView: View {
     private var sectionContent: some View {
         switch currentSection {
         case .attendanceCheck:
-            // `ChallengerAttendanceSessionView`는 아직 이식되지 않았다.
-            notPortedGuide(
-                title: "출석 체크",
-                description: "챌린저 출석 화면은 아직 이식되지 않았습니다.\n운영진 모드로 전환하면 출석 관리 화면을 확인할 수 있습니다."
+            AttendancePreviewData.sessionScreen(
+                sessions: AttendancePreviewData.mixedSessions
             )
 
         case .studyActivity:
@@ -194,13 +189,6 @@ private struct DebugActivityHarnessView: View {
         }
     }
 
-    private func notPortedGuide(title: String, description: String) -> some View {
-        ContentUnavailableView {
-            Label(title, systemImage: "hammer")
-        } description: {
-            Text(description)
-        }
-    }
 }
 
 // MARK: - Section Catalog

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceReasonSheet.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceReasonSheet.swift
@@ -1,0 +1,98 @@
+//
+//  ChallengerAttendanceReasonSheet.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/2/26.
+//
+
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+
+/// 출석 사유 작성 시트
+///
+/// GPS 출석이 어려운 경우 사유를 작성하여 출석을 요청할 수 있는 시트입니다.
+struct ChallengerAttendanceReasonSheet: View {
+
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var reason: String = ""
+
+    let onSubmit: (String) async -> Void
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let sheetHeight: CGFloat = 230
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    reasonTextField
+                } header: {
+                    SectionHeaderView(title: "지각 사유 입력")
+                } footer: {
+                    descriptionText
+                }
+            }
+            .toolbar {
+                ToolBarCollection.CancelBtn {
+                    dismiss()
+                }
+
+                // 제출이 끝난 뒤에 닫아야 하므로 버튼의 자동 dismiss 는 끄고
+                // await 완료 후 직접 닫는다. (기본값을 쓰면 제출 중에 시트가 사라진다)
+                ToolBarCollection.ConfirmBtn(
+                    action: {
+                        Task {
+                            await onSubmit(reason)
+                            dismiss()
+                        }
+                    },
+                    dismissOnTap: false
+                )
+            }
+            .scrollContentBackground(.hidden)
+            .scrollDisabled(true)
+            .presentationDetents([.height(Constants.sheetHeight)])
+            .presentationDragIndicator(.visible)
+        }
+    }
+
+    // MARK: - View Components
+
+    private var reasonTextField: some View {
+        TextField(
+            "",
+            text: $reason,
+            prompt: Text("길이 막혀요..")
+        )
+        .submitLabel(.done)
+    }
+
+    private var descriptionText: some View {
+        Text(
+            "위치 인증이 어려운 경우 사유를 작성하여 출석을 요청할 수 있습니다. "
+                + "(예: GPS 오류, 지각, 개인 사정 등)"
+        )
+        .appFont(.footnote, color: .grey500)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .multilineTextAlignment(.leading)
+    }
+}
+
+#if DEBUG
+// MARK: - Preview
+
+#Preview {
+    Text("Preview Trigger")
+        .sheet(isPresented: .constant(true)) {
+            ChallengerAttendanceReasonSheet { _ in }
+        }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceSessionList.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceSessionList.swift
@@ -1,0 +1,126 @@
+//
+//  ChallengerAttendanceSessionList.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/2/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import SwiftUI
+import UMCFoundation
+
+/// 출석 세션 목록을 표시하는 리스트 컴포넌트
+///
+/// 세션별 출석 카드와 확장 시 출석 상세 뷰를 함께 표시합니다.
+struct ChallengerAttendanceSessionList: View, Equatable {
+
+    // MARK: - Property
+
+    private let sessions: [Session]
+    private let expandedSessionId: Session.ID?
+    private let attendanceViewModel: ChallengerAttendanceViewModel
+    private let userId: UserID
+    private let mapViewModelProvider: (Session) -> BaseMapViewModel?
+    private let onSessionTap: (Session.ID) -> Void
+
+    // MARK: - Init
+
+    /// - Parameter mapViewModelProvider: 세션별 지도 상태 모델 제공자. 서버 일정 ID가
+    ///   아직 해석되지 않은 세션은 `nil` 을 돌려주며, 상세는 지도 대신 플레이스홀더를 띄운다.
+    init(
+        sessions: [Session],
+        expandedSessionId: Session.ID?,
+        attendanceViewModel: ChallengerAttendanceViewModel,
+        userId: UserID,
+        mapViewModelProvider: @escaping (Session) -> BaseMapViewModel?,
+        onSessionTap: @escaping (Session.ID) -> Void
+    ) {
+        self.sessions = sessions
+        self.expandedSessionId = expandedSessionId
+        self.attendanceViewModel = attendanceViewModel
+        self.userId = userId
+        self.mapViewModelProvider = mapViewModelProvider
+        self.onSessionTap = onSessionTap
+    }
+
+    /// - Note: 일정 ID 가 뒤늦게 채워져 지도 모델이 생기는 전환은 이 비교에 포함되지 않는다.
+    ///   지도는 카드를 펼칠 때(또는 세션 목록이 바뀔 때) 반영되며, 그 전까지 상세가 열려
+    ///   있어도 플레이스홀더가 유지된다. 버튼 활성화는 `@Observable` 관찰로 즉시 따라온다.
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.sessions.map(\.id) == rhs.sessions.map(\.id)
+            && lhs.expandedSessionId == rhs.expandedSessionId
+            && lhs.userId == rhs.userId
+    }
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let listSpacing: CGFloat = 12
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        LazyVStack(spacing: Constants.listSpacing) {
+            ForEach(sessions) { session in
+                sessionItem(for: session)
+            }
+        }
+    }
+
+    // MARK: - View Components
+
+    @ViewBuilder
+    private func sessionItem(for session: Session) -> some View {
+        let isExpanded = expandedSessionId == session.id
+
+        VStack(spacing: DefaultSpacing.spacing12) {
+            ChallengerSessionCard(
+                session: session,
+                isExpanded: isExpanded
+            ) {
+                onSessionTap(session.id)
+            }
+            .equatable()
+
+            if isExpanded {
+                ChallengerAttendanceView(
+                    mapViewModel: mapViewModelProvider(session),
+                    attendanceViewModel: attendanceViewModel,
+                    userId: userId,
+                    session: session
+                )
+                .equatable()
+                .transition(.asymmetric(
+                    insertion: .scale(scale: DefaultConstant.transitionScale)
+                        .combined(with: .opacity),
+                    removal: .scale(scale: DefaultConstant.transitionScale)
+                        .combined(with: .opacity)
+                ))
+            }
+        }
+    }
+}
+
+#if DEBUG
+// MARK: - Preview
+
+#Preview("두 번째 세션 펼침", traits: .sizeThatFitsLayout) {
+    let sessions = AttendancePreviewData.mixedSessions.filter(\.isAttendanceAvailable)
+
+    ZStack {
+        Color.grey100.frame(height: 600)
+
+        ChallengerAttendanceSessionList(
+            sessions: sessions,
+            expandedSessionId: sessions.first?.id,
+            attendanceViewModel: AttendancePreviewData.viewModel(sessions: sessions),
+            userId: AttendancePreviewData.userId,
+            mapViewModelProvider: { _ in nil },
+            onSessionTap: { _ in }
+        )
+        .padding()
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceView.swift
@@ -1,0 +1,391 @@
+//
+//  ChallengerAttendanceView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/2/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UIKit
+import UMCFoundation
+
+/// 챌린저(일반 참여자)의 출석 체크 화면
+///
+/// 지도와 출석 버튼을 표시하며, 지오펜싱 상태에 따라 버튼 활성화를 제어합니다.
+struct ChallengerAttendanceView: View, Equatable {
+
+    // MARK: - Property
+
+    private let mapViewModel: BaseMapViewModel?
+    private let attendanceViewModel: ChallengerAttendanceViewModel
+    private let userId: UserID
+    private let session: Session
+
+    @Namespace private var attendanceNamespace
+    @State private var showReasonSheet: Bool = false
+    @State private var showPolicyPopover: Bool = false
+    @State private var isMapReady: Bool = false
+
+    // MARK: - Init
+
+    /// - Parameter mapViewModel: 지도 상태 모델. 서버 일정 ID가 아직 해석되지 않아
+    ///   지오펜스를 등록할 수 없는 세션은 `nil` 이 들어오며, 지도 대신 플레이스홀더를
+    ///   표시합니다. (임의의 대체 ID를 넘기면 지오펜스가 항상 어긋납니다)
+    init(
+        mapViewModel: BaseMapViewModel?,
+        attendanceViewModel: ChallengerAttendanceViewModel,
+        userId: UserID,
+        session: Session
+    ) {
+        self.mapViewModel = mapViewModel
+        self.attendanceViewModel = attendanceViewModel
+        self.userId = userId
+        self.session = session
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.userId == rhs.userId
+            && lhs.session.id == rhs.session.id
+            && lhs.session.attendanceStatus == rhs.session.attendanceStatus
+            // 일정 ID 가 해석되면 지도 모델이 nil → 인스턴스로 바뀐다. 이 축을 빼면
+            // 상위가 .equatable() 로 감싸는 탓에 플레이스홀더가 그대로 굳는다.
+            && lhs.mapViewModel === rhs.mapViewModel
+    }
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let mapCornerRadius: Edge.Corner.Style = 24
+        static let mapLoadDelay: Duration = .milliseconds(100)
+        static let mapPlaceholderHeight: CGFloat = 200
+        static let attendanceActionId = "attendance-action"
+        static let statusAnimationResponse: Double = 0.4
+        static let statusAnimationDamping: Double = 0.75
+        static let mapReadyAnimationDuration: Double = 0.2
+        static let actionTransitionScale: CGFloat = 0.95
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing16) {
+            ZStack(alignment: .topTrailing) {
+                mapSection
+
+                scheduleInfoButton
+                    .padding(DefaultSpacing.spacing12)
+            }
+
+            attendanceGuidanceLine
+            attendanceActionView
+
+            if attendanceViewModel.shouldShowReasonButton(for: session) {
+                lateReasonButton
+            }
+        }
+        .animation(
+            .spring(
+                response: Constants.statusAnimationResponse,
+                dampingFraction: Constants.statusAnimationDamping
+            ),
+            value: session.attendanceStatus
+        )
+        .animation(.easeInOut(duration: Constants.mapReadyAnimationDuration), value: isMapReady)
+        .task {
+            // 카드 펼침 애니메이션과 지도 초기화가 겹치면 프레임이 튀어 한 틱 뒤로 미룬다.
+            try? await Task.sleep(for: Constants.mapLoadDelay)
+            isMapReady = true
+        }
+        .sheet(isPresented: $showReasonSheet) {
+            ChallengerAttendanceReasonSheet { reason in
+                // 진입점(사유 버튼)이 scheduleId 없이는 눌리지 않으므로 여기 도달하면
+                // 항상 값이 있다. 시트가 열린 사이 값이 사라지는 경우만 방어하며, 사용자가
+                // 작성한 사유가 조용히 버려지지 않도록 게이트는 버튼 쪽에 둔다.
+                guard let scheduleId else { return }
+
+                await attendanceViewModel.submitAttendanceReason(
+                    userId: userId,
+                    session: session,
+                    reason: reason,
+                    scheduleId: scheduleId
+                )
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    /// 출석·사유 제출에 필요한 서버 일정 ID (`nil` = 아직 해석 전)
+    ///
+    /// 이 값이 없으면 어떤 제출도 서버에 도달할 수 없으므로, 액션 버튼을 모두 비활성화해
+    /// 사용자가 입력을 낭비하지 않게 합니다.
+    private var scheduleId: String? {
+        attendanceViewModel.scheduleId(for: session.info.sessionId)
+    }
+
+    // MARK: - View Components
+
+    @ViewBuilder
+    private var mapSection: some View {
+        if let mapViewModel {
+            if isMapReady {
+                ActivityCompactMapView(mapViewModel: mapViewModel)
+            } else {
+                mapPlaceholder { ProgressView().tint(.grey400) }
+            }
+        } else {
+            // 일정 ID 가 없으면 지오펜스를 등록할 수 없다. 곧 로드될 것처럼 보이는 스피너
+            // 대신 정적 안내를 띄운다 — 실제로는 대기해도 지도가 나타나지 않는다.
+            mapPlaceholder {
+                VStack(spacing: DefaultSpacing.spacing8) {
+                    Image(systemName: "mappin.slash")
+                        .font(.title2)
+                        .foregroundStyle(Color.grey400)
+                    Text("위치 정보를 아직 불러올 수 없어요")
+                        .appFont(.footnote, color: .grey500)
+                }
+            }
+        }
+    }
+
+    /// Map 자리를 차지하는 회색 플레이스홀더
+    private func mapPlaceholder(
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        ConcentricRectangle(corners: Constants.mapCornerRadius, isUniform: true)
+            .fill(Color.grey100)
+            .frame(height: Constants.mapPlaceholderHeight)
+            .overlay { content() }
+    }
+
+    /// 출석 정책 팝오버를 여는 정보 버튼 (지도 우상단 오버레이)
+    private var scheduleInfoButton: some View {
+        Button {
+            showPolicyPopover = true
+        } label: {
+            Image(systemName: "info.circle")
+                .font(.title3)
+                .foregroundStyle(Color.grey700)
+                .padding(DefaultSpacing.spacing8)
+        }
+        .glassEffect(.regular.interactive(), in: .circle)
+        .accessibilityLabel("출석 정책 보기")
+        .popover(isPresented: $showPolicyPopover) {
+            policyPopoverContent
+                .presentationCompactAdaptation(.popover)
+        }
+    }
+
+    /// 출석 정책 3개 시각 팝오버 콘텐츠
+    ///
+    /// 시트 대신 ⓘ 버튼에 앵커된 말풍선으로 정책만 간편하게 확인합니다.
+    /// 첫 마운트 직후 정책이 비어 있으면 배경 갱신으로 채웁니다.
+    @ViewBuilder
+    private var policyPopoverContent: some View {
+        if let policy = attendanceViewModel.attendancePolicy(for: session.info.sessionId) {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+                Text("출석 정책")
+                    .appFont(.callout, weight: .semibold, color: .grey900)
+
+                // 세 시각 모두 체크인 시작을 기준일로 삼아, 자정을 넘긴 마감만 날짜를 덧붙인다.
+                let anchor = policy.checkInStartAt
+                policyRow(role: .checkIn, date: anchor, anchor: anchor)
+                policyRow(role: .onTime, date: policy.onTimeEndAt, anchor: anchor)
+                policyRow(role: .late, date: policy.lateEndAt, anchor: anchor)
+            }
+            .padding(DefaultSpacing.spacing16)
+        } else {
+            // 갱신을 요청하되 "불러오는 중" 이라고 단정하지 않는다. 일정 조회가 결선되기
+            // 전까지 refreshAvailableSchedules() 는 no-op 이라 기다려도 채워지지 않는다.
+            Text("등록된 출석 정책이 없어요")
+                .appFont(.footnote, color: .grey500)
+                .padding(DefaultSpacing.spacing16)
+                .task {
+                    await attendanceViewModel.refreshAvailableSchedules()
+                }
+        }
+    }
+
+    /// 정책 행 (아이콘 + 라벨 + 시각)
+    private func policyRow(
+        role: AttendancePolicyRole,
+        date: Date,
+        anchor: Date
+    ) -> some View {
+        let timeText = date.attendancePolicyText(anchoredAt: anchor)
+
+        return HStack(spacing: DefaultSpacing.spacing8) {
+            Image(systemName: role.iconName)
+                .font(.caption)
+                .foregroundStyle(role.tintColor)
+            Text(role.label)
+                .appFont(.footnote, color: .grey600)
+            Spacer(minLength: DefaultSpacing.spacing16)
+            Text(timeText)
+                .appFont(.footnote, weight: .semibold, color: .grey700)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(role.label): \(timeText)")
+    }
+
+    /// 출석 버튼 위 시간대별 동적 안내 라인
+    ///
+    /// 분 단위로 갱신되며, 출석 전 상태에서만 표시됩니다.
+    /// 정책 시각이 로드되면 마감 시각과 남은 시간을 함께 보여줍니다.
+    private var attendanceGuidanceLine: some View {
+        TimelineView(.everyMinute) { context in
+            if let guidance = attendanceViewModel.attendanceGuidanceText(
+                for: session,
+                at: context.date
+            ) {
+                let isLateWindow = attendanceViewModel.timeWindow(for: session) == .lateWindow
+
+                HStack(spacing: DefaultSpacing.spacing4) {
+                    Image(systemName: "clock")
+                        .font(.caption)
+                    Text(guidance)
+                }
+                .appFont(.footnote, color: isLateWindow ? .orange : .grey600)
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    /// 출석 상태에 따른 액션 뷰 (버튼 또는 승인 대기 카드)
+    @ViewBuilder
+    private var attendanceActionView: some View {
+        GlassEffectContainer {
+            switch session.attendanceStatus {
+            case .pendingApproval:
+                // 승인 대기 카드 (버튼에서 모핑 전환)
+                ChallengerPendingApprovalView()
+                    .glassEffect(
+                        .regular,
+                        in: .rect(
+                            corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                            isUniform: true
+                        )
+                    )
+                    .glassEffectID(Constants.attendanceActionId, in: attendanceNamespace)
+                    .transition(actionTransition)
+
+            case .beforeAttendance:
+                // 지각 시간대에는 사유 제출이 기본 액션으로 승격, 그 외에는 GPS 출석 버튼
+                Group {
+                    if attendanceViewModel.timeWindow(for: session) == .lateWindow {
+                        lateReasonPrimaryButton
+                    } else {
+                        attendanceButton
+                    }
+                }
+                .glassEffectID(Constants.attendanceActionId, in: attendanceNamespace)
+                .transition(actionTransition)
+
+            case .present, .late, .absent:
+                // 확정 상태 - 버튼 비활성화
+                attendanceButton
+                    .transition(actionTransition)
+            }
+        }
+    }
+
+    private var actionTransition: AnyTransition {
+        .asymmetric(
+            insertion: .scale(scale: Constants.actionTransitionScale).combined(with: .opacity),
+            removal: .scale(scale: Constants.actionTransitionScale).combined(with: .opacity)
+        )
+    }
+
+    private var attendanceButton: some View {
+        MainButton(attendanceViewModel.buttonTitle(for: session)) {
+            triggerImpactHaptic()
+
+            Task {
+                guard let scheduleId else { return }
+
+                await attendanceViewModel.attendanceButtonTapped(
+                    userId: userId,
+                    session: session,
+                    scheduleId: scheduleId
+                )
+                triggerSuccessHaptic()
+            }
+        }
+        .buttonStyle(.glassProminent)
+        .disabled(!attendanceViewModel.isAttendanceAvailable(for: session) || scheduleId == nil)
+    }
+
+    /// 지각 시간대의 기본 액션 버튼 — 사유 제출 시트 열기
+    ///
+    /// 비활성 GPS 버튼 + 보조 링크의 중복 구조를 대체합니다.
+    private var lateReasonPrimaryButton: some View {
+        MainButton("지각 사유 제출하기") {
+            triggerImpactHaptic()
+            showReasonSheet = true
+        }
+        .buttonStyle(.glassProminent)
+        .disabled(!canOpenReasonSheet)
+    }
+
+    /// 사유 제출 보조 링크 (정시/시작 전 시간대 전용)
+    private var lateReasonButton: some View {
+        Button {
+            showReasonSheet = true
+        } label: {
+            Text("위치 인증이 안 되나요? 사유 제출하기")
+                .appFont(.caption1, color: .grey500)
+                .underline()
+        }
+        .buttonStyle(.plain)
+        .disabled(!canOpenReasonSheet)
+    }
+
+    /// 사유 시트를 열어도 되는지 — 도메인 조건 + 제출 경로 확보 여부
+    ///
+    /// 일정 ID 가 없으면 사유를 받아도 서버로 보낼 수 없으므로 시트 자체를 막습니다.
+    /// (열어두면 사용자가 작성·확인한 사유가 조용히 버려집니다)
+    private var canOpenReasonSheet: Bool {
+        attendanceViewModel.isReasonSubmittable(for: session) && scheduleId != nil
+    }
+
+    // MARK: - Haptic Feedback
+
+    private func triggerImpactHaptic() {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+
+    private func triggerSuccessHaptic() {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+    }
+}
+
+#if DEBUG
+// MARK: - Preview
+
+#Preview("정시 출석 가능", traits: .sizeThatFitsLayout) {
+    AttendancePreviewData.attendanceScenario(
+        subtitle: "GPS 출석 버튼 활성화, 사유 제출 보조 링크도 노출",
+        timeWindow: .onTime
+    )
+}
+
+#Preview("지각 사유 제출", traits: .sizeThatFitsLayout) {
+    AttendancePreviewData.attendanceScenario(
+        subtitle: "지각 시간대에서는 사유 제출이 기본 버튼으로 승격",
+        timeWindow: .lateWindow
+    )
+}
+
+#Preview("승인 대기 상태", traits: .sizeThatFitsLayout) {
+    AttendancePreviewData.attendanceScenario(
+        subtitle: "사유 제출 완료 상태라 버튼 대신 승인 대기 카드 표시",
+        timeWindow: .lateWindow,
+        attendanceStatus: .pendingApproval
+    )
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
@@ -1,0 +1,270 @@
+//
+//  ChallengerMyAttendanceCard.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/2/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+// MARK: - ChallengerMyAttendanceCard
+
+/// 나의 출석 현황 카드
+///
+/// 접힌 상태에서는 제목/일시/상태 뱃지만 표시하고,
+/// 탭하여 펼치면 장소(또는 비대면)와 출석 정책 시각을 표시합니다.
+/// 펼치기 인터랙션은 출석 가능한 세션 카드(``ChallengerSessionCard``)와 동일한 문법을 따릅니다.
+struct ChallengerMyAttendanceCard: View {
+
+    // MARK: - Property
+
+    private let model: MyAttendanceItemModel
+    private let isExpanded: Bool
+    private let onTap: () -> Void
+
+    // MARK: - Init
+
+    init(
+        model: MyAttendanceItemModel,
+        isExpanded: Bool = false,
+        onTap: @escaping () -> Void = {}
+    ) {
+        self.model = model
+        self.isExpanded = isExpanded
+        self.onTap = onTap
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        MyAttendanceItemPresenter(
+            model: model,
+            isExpanded: isExpanded,
+            onTap: onTap
+        )
+        .equatable()
+    }
+}
+
+// MARK: - Presenter
+
+/// 카드의 렌더링 담당 (`Equatable` 로 클로저를 비교에서 제외)
+private struct MyAttendanceItemPresenter: View, Equatable {
+    let model: MyAttendanceItemModel
+    let isExpanded: Bool
+    var onTap: () -> Void
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.model == rhs.model && lhs.isExpanded == rhs.isExpanded
+    }
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let cardSpacing: CGFloat = 12
+        static let contentSectionSpacing: CGFloat = 4
+        static let statusRadius: CGFloat = 8
+        static let infoIconSpacing: CGFloat = 4
+        static let policyCornerRadius: CGFloat = 12
+        static let policyColumnSpacing: CGFloat = 2
+        static let policyTextScaleFactor: CGFloat = 0.8
+        static let titleLineLimit: Int = 2
+    }
+
+    /// 펼쳤을 때 보여줄 추가 정보(정책/장소/비대면)가 있는지
+    private var hasExpandableContent: Bool {
+        model.attendancePolicy != nil || model.isOnline || model.locationName != nil
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            header
+
+            if isExpanded {
+                expandedSection
+                    .transition(.asymmetric(
+                        insertion: .scale(scale: DefaultConstant.transitionScale)
+                            .combined(with: .opacity),
+                        removal: .scale(scale: DefaultConstant.transitionScale)
+                            .combined(with: .opacity)
+                    ))
+            }
+        }
+        .padding(DefaultConstant.defaultListPadding)
+        .background(.white)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard hasExpandableContent else { return }
+            onTap()
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: Constants.cardSpacing) {
+            CardIconImage(
+                image: model.category.symbol,
+                color: model.category.color,
+                isLoading: .constant(false)
+            )
+
+            contentSection
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            statusBadge
+
+            if hasExpandableContent {
+                Image(
+                    systemName: isExpanded
+                        ? DefaultConstant.chevronUpImage
+                        : DefaultConstant.chevronDownImage
+                )
+                .foregroundStyle(Color.grey400)
+            }
+        }
+    }
+
+    private var contentSection: some View {
+        VStack(alignment: .leading, spacing: Constants.contentSectionSpacing) {
+            Text(model.title)
+                .appFont(.callout, weight: .semibold, color: .grey900)
+                .lineLimit(Constants.titleLineLimit)
+
+            // 날짜+시간을 한 줄에 합치면 뱃지/셰브론과 폭을 경쟁해 잘리므로 두 줄로 분리
+            infoRow(systemName: "calendar", text: model.dateText)
+            infoRow(systemName: "clock", text: model.timeRange)
+        }
+    }
+
+    private func infoRow(systemName: String, text: String) -> some View {
+        HStack(spacing: Constants.infoIconSpacing) {
+            Image(systemName: systemName)
+                .font(.caption)
+            Text(text)
+                .lineLimit(1)
+        }
+        .appFont(.footnote, color: .grey500)
+    }
+
+    private var statusBadge: some View {
+        Text(model.status.text)
+            .appFont(.caption1, weight: .semibold, color: model.status.fontColor)
+            .padding(DefaultConstant.badgePadding)
+            .background(
+                model.status.backgroundColor,
+                in: RoundedRectangle(cornerRadius: Constants.statusRadius)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
+            .glassEffect(
+                .clear,
+                in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
+            )
+    }
+
+    // MARK: - Expanded Section
+
+    /// 일정 등록 시 입력한 출석 정보 (장소/비대면 + 출석 정책 시각)
+    private var expandedSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            if model.isOnline {
+                infoRow(systemName: "video", text: "비대면 진행")
+            } else if let locationName = model.locationName {
+                infoRow(systemName: "mappin.and.ellipse", text: locationName)
+            }
+
+            if let policy = model.attendancePolicy {
+                policySummary(policy)
+            }
+        }
+    }
+
+    // MARK: - Policy Summary
+
+    /// 일정 등록 시 입력한 출석 정책 3개 시각 요약
+    ///
+    /// 출석 체크 화면의 정책 팝오버와 용어·아이콘·색상 시맨틱을 통일한 축소판입니다.
+    private func policySummary(_ policy: ScheduleAttendancePolicy) -> some View {
+        HStack(spacing: .zero) {
+            policyColumn(
+                role: .checkIn,
+                date: policy.checkInStartAt,
+                anchor: policy.checkInStartAt
+            )
+
+            Divider()
+
+            policyColumn(
+                role: .onTime,
+                date: policy.onTimeEndAt,
+                anchor: policy.checkInStartAt
+            )
+
+            Divider()
+
+            policyColumn(
+                role: .late,
+                date: policy.lateEndAt,
+                anchor: policy.checkInStartAt
+            )
+        }
+        .frame(maxWidth: .infinity)
+        .background(
+            Color.grey100,
+            in: RoundedRectangle(cornerRadius: Constants.policyCornerRadius)
+        )
+    }
+
+    private func policyColumn(
+        role: AttendancePolicyRole,
+        date: Date,
+        anchor: Date
+    ) -> some View {
+        VStack(spacing: Constants.policyColumnSpacing) {
+            HStack(spacing: Constants.infoIconSpacing) {
+                Image(systemName: role.iconName)
+                    .font(.caption2)
+                    .foregroundStyle(role.tintColor)
+                Text(role.label)
+                    .appFont(.caption2, color: .grey500)
+                    .lineLimit(1)
+                    .minimumScaleFactor(Constants.policyTextScaleFactor)
+            }
+
+            Text(date.attendancePolicyText(anchoredAt: anchor))
+                .appFont(.footnote, weight: .semibold, color: .grey700)
+                .lineLimit(1)
+                .minimumScaleFactor(Constants.policyTextScaleFactor)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, DefaultSpacing.spacing8)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(role.label): \(date.attendancePolicyText(anchoredAt: anchor))"
+        )
+    }
+}
+
+#if DEBUG
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    let model = AttendancePreviewData.myAttendanceItem()
+
+    ZStack {
+        Color.grey100.frame(height: 400)
+
+        VStack(spacing: DefaultSpacing.spacing8) {
+            ChallengerMyAttendanceCard(model: model)
+            ChallengerMyAttendanceCard(model: model, isExpanded: true)
+        }
+        .padding()
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceStatusView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceStatusView.swift
@@ -1,0 +1,91 @@
+//
+//  ChallengerMyAttendanceStatusView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/2/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+
+// MARK: - ChallengerMyAttendanceStatusView
+
+/// 나의 출석 현황 섹션
+///
+/// 카드를 탭하면 출석 정책/장소 상세가 펼쳐지며,
+/// 출석 가능한 세션 목록과 동일하게 한 번에 하나만 펼쳐지는 아코디언으로 동작합니다.
+///
+/// - Note: 레거시에는 일정 상세 페이로드를 그대로 받는 이니셜라이저도 있었으나,
+///   해당 타입(`ScheduleDetailData`)은 Home 도메인 소유라 Activity 모듈에서 참조할 수
+///   없습니다. 변환은 호출부가 담당하고 여기서는 표시 모델만 받습니다 — 호출부가 빈 상태
+///   분기를 위해 어차피 변환 결과 개수를 먼저 알아야 하므로 책임 배치도 여기가 맞습니다.
+struct ChallengerMyAttendanceStatusView: View {
+
+    // MARK: - Property
+
+    private let models: [MyAttendanceItemModel]
+
+    /// 현재 펼쳐진 카드 (아코디언 — 한 번에 하나만)
+    @State private var expandedItemId: MyAttendanceItemModel.ID?
+
+    // MARK: - Init
+
+    init(models: [MyAttendanceItemModel]) {
+        self.models = models
+    }
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let listSpacing: CGFloat = 0
+        static let animationResponse: Double = 0.35
+        static let animationDamping: Double = 0.8
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        LazyVStack(spacing: Constants.listSpacing) {
+            ForEach(models) { model in
+                ChallengerMyAttendanceCard(
+                    model: model,
+                    isExpanded: expandedItemId == model.id
+                ) {
+                    withAnimation(.spring(Spring(
+                        response: Constants.animationResponse,
+                        dampingRatio: Constants.animationDamping
+                    ))) {
+                        expandedItemId = expandedItemId == model.id ? nil : model.id
+                    }
+                }
+
+                // 마지막 아이템이 아닐 때만 Divider
+                if model.id != models.last?.id {
+                    Divider()
+                }
+            }
+        }
+        .clipShape(ConcentricRectangle(
+            corners: .concentric(minimum: DefaultConstant.concentricRadius),
+            isUniform: true
+        ))
+        .glass()
+    }
+}
+
+#if DEBUG
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    ZStack {
+        Color.grey100.frame(height: 600)
+
+        ChallengerMyAttendanceStatusView(
+            models: AttendancePreviewData.myAttendanceItems
+        )
+        .padding()
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Extensions/AttendancePolicyDisplay.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Extensions/AttendancePolicyDisplay.swift
@@ -1,0 +1,80 @@
+//
+//  AttendancePolicyDisplay.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/2/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+import UMCFoundation
+
+// MARK: - AttendancePolicyRole
+
+/// 출석 정책 3개 시각의 표시 메타데이터
+///
+/// 출석 체크 화면의 정책 팝오버(``ChallengerAttendanceView``)와 출석 이력 카드
+/// (``ChallengerMyAttendanceCard``)가 같은 아이콘·라벨·색상을 쓰도록 한 곳에 모읍니다.
+enum AttendancePolicyRole {
+    case checkIn
+    case onTime
+    case late
+
+    var iconName: String {
+        switch self {
+        case .checkIn: "door.right.hand.open"
+        case .onTime: "clock.badge.checkmark"
+        case .late: "xmark.circle"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .checkIn: "출석 시작"
+        case .onTime: "출석 인정 마감"
+        case .late: "지각 인정 마감"
+        }
+    }
+
+    var tintColor: Color {
+        switch self {
+        case .checkIn: .green
+        case .onTime: .orange
+        case .late: .red
+        }
+    }
+}
+
+// MARK: - Policy Time Formatting
+
+extension Date {
+    /// 출석 정책 시각 표시 문자열
+    ///
+    /// 기준점(보통 `checkInStartAt`)과 같은 날이면 `"HH:mm"`, 자정을 넘긴 정책처럼
+    /// 다른 날이면 `"M/d HH:mm"` 로 날짜를 함께 보여줍니다.
+    ///
+    /// - Note: 레거시는 팝오버와 이력 카드가 같은 값을 서로 다른 포맷으로 보여줘 이식하면서
+    ///   하나로 통일했습니다.
+    /// - Important: 날짜 부분에 공용 `toMonthDay()` 를 쓰면 안 됩니다. 그 헬퍼는 타임존을
+    ///   지정하지 않아 **기기 타임존**으로 포맷하는데, 같은 날 판정(`isSameDay`)과 시각
+    ///   부분(`toHourMinutes()`)은 KST 고정입니다. 섞으면 KST 가 아닌 기기에서 "날짜는
+    ///   로컬, 시각은 KST" 인 어긋난 문자열이 나옵니다 — 예를 들어 KST 5/8 00:30 마감이
+    ///   미국 기기에서 "5/7 00:30" 으로 보여 마감이 하루 앞당겨진 것처럼 읽힙니다.
+    func attendancePolicyText(anchoredAt anchor: Date) -> String {
+        isSameDay(anchor)
+            ? toHourMinutes()
+            : "\(Self.kstMonthDayFormatter.string(from: self)) \(toHourMinutes())"
+    }
+
+    /// KST 고정 "M/d" 포맷터
+    ///
+    /// 로케일별 표기 흔들림(ko_KR 은 "05. 08." 처럼 점·공백을 붙임)을 막기 위해
+    /// `en_US_POSIX` 로 고정합니다.
+    private static let kstMonthDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .kst
+        formatter.dateFormat = "M/d"
+        return formatter
+    }()
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/AttendancePreviewSupport.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/AttendancePreviewSupport.swift
@@ -1,0 +1,312 @@
+//
+//  AttendancePreviewSupport.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/2/26.
+//
+
+#if DEBUG
+import ActivityDomain
+import CoreDesignSystem
+import CoreDI
+import Foundation
+import SwiftUI
+import UMCFoundation
+
+// MARK: - Preview UseCase
+
+/// 프리뷰 전용 스텁 UseCase — 시간대·지오펜스 판정을 주입값으로 고정하고, 제출은 no-op.
+final class PreviewChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProtocol {
+
+    let isInsideGeofence: Bool
+    let isLocationAuthorized: Bool
+
+    private let timeWindow: AttendanceTimeWindow
+
+    init(
+        timeWindow: AttendanceTimeWindow = .onTime,
+        isInsideGeofence: Bool = true,
+        isLocationAuthorized: Bool = true
+    ) {
+        self.timeWindow = timeWindow
+        self.isInsideGeofence = isInsideGeofence
+        self.isLocationAuthorized = isLocationAuthorized
+    }
+
+    func requestGPSAttendance(
+        sessionId: SessionID,
+        userId: UserID,
+        scheduleId: String
+    ) async throws -> Attendance {
+        Attendance(sessionId: sessionId, userId: userId, type: .gps, status: .present)
+    }
+
+    func submitLateReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance {
+        Attendance(
+            sessionId: sessionId,
+            userId: userId,
+            type: .reason,
+            status: .pendingApproval,
+            reason: reason
+        )
+    }
+
+    func submitAbsentReason(
+        sessionId: SessionID,
+        userId: UserID,
+        reason: String,
+        scheduleId: String
+    ) async throws -> Attendance {
+        Attendance(
+            sessionId: sessionId,
+            userId: userId,
+            type: .reason,
+            status: .pendingApproval,
+            reason: reason
+        )
+    }
+
+    func isWithinAttendanceTime(info: SessionInfo, now: Date) -> AttendanceTimeWindow {
+        timeWindow
+    }
+
+    func getAddressToCurrentLocation() async throws -> Address {
+        Address(fullAddress: "서울특별시 성북구 삼선교로16길 116", city: "서울특별시", district: "성북구")
+    }
+
+    func stopGeofenceMonitoring() async {}
+}
+
+// MARK: - Preview Data
+
+/// 출석 화면 프리뷰용 고정 데이터·팩토리 모음
+enum AttendancePreviewData {
+
+    // MARK: - 고정값
+
+    /// 한성대학교 좌표 — 지도 프리뷰의 앵커
+    static let campusCoordinate = Coordinate(latitude: 37.582_2, longitude: 127.010_4)
+
+    static let userId = UserID(value: "U-preview")
+
+    /// 프리뷰 기준 시각 (2026-06-11 14:00 KST). 카드의 날짜/시간 표시를 결정론적으로 만든다.
+    static let referenceDate = Date(timeIntervalSince1970: 1_781_154_000)
+
+    /// 이력 카드의 정책 요약 표시용 — `referenceDate` 에 고정되어 렌더가 매번 같다.
+    static let displayPolicy = ScheduleAttendancePolicy(
+        checkInStartAt: referenceDate.addingTimeInterval(-10 * 60),
+        onTimeEndAt: referenceDate.addingTimeInterval(10 * 60),
+        lateEndAt: referenceDate.addingTimeInterval(60 * 60)
+    )
+
+    /// 요청한 시간대가 실제로 그 시간대로 렌더되도록 **현재 시각 기준**으로 만든 정책
+    ///
+    /// ViewModel 의 시간대 판정은 정책이 있으면 UseCase 폴백을 건너뛰므로, 고정 과거
+    /// 시각으로 정책을 만들면 어떤 시나리오를 요청하든 전부 `.expired` 로 보입니다.
+    static func policy(
+        for window: AttendanceTimeWindow,
+        now: Date = .now
+    ) -> ScheduleAttendancePolicy {
+        let minute: TimeInterval = 60
+        switch window {
+        case .tooEarly:
+            return .init(
+                checkInStartAt: now.addingTimeInterval(10 * minute),
+                onTimeEndAt: now.addingTimeInterval(30 * minute),
+                lateEndAt: now.addingTimeInterval(60 * minute)
+            )
+        case .onTime:
+            return .init(
+                checkInStartAt: now.addingTimeInterval(-10 * minute),
+                onTimeEndAt: now.addingTimeInterval(10 * minute),
+                lateEndAt: now.addingTimeInterval(60 * minute)
+            )
+        case .lateWindow:
+            return .init(
+                checkInStartAt: now.addingTimeInterval(-60 * minute),
+                onTimeEndAt: now.addingTimeInterval(-10 * minute),
+                lateEndAt: now.addingTimeInterval(30 * minute)
+            )
+        case .expired:
+            return .init(
+                checkInStartAt: now.addingTimeInterval(-180 * minute),
+                onTimeEndAt: now.addingTimeInterval(-120 * minute),
+                lateEndAt: now.addingTimeInterval(-60 * minute)
+            )
+        }
+    }
+
+    // MARK: - Session
+
+    @MainActor
+    static func session(
+        id: String,
+        title: String,
+        week: Int,
+        status: AttendanceStatus = .beforeAttendance
+    ) -> Session {
+        let info = SessionInfo(
+            sessionId: SessionID(value: id),
+            category: .study,
+            iconName: ScheduleIconCategory.study.rawValue,
+            title: title,
+            week: week,
+            startTime: referenceDate,
+            endTime: referenceDate.addingTimeInterval(2 * 3_600),
+            location: campusCoordinate
+        )
+        guard status != .beforeAttendance else {
+            return Session(info: info, initialAttendance: nil)
+        }
+        return Session(
+            info: info,
+            initialAttendance: Attendance(
+                sessionId: info.sessionId,
+                userId: userId,
+                type: .gps,
+                status: status
+            )
+        )
+    }
+
+    /// 출석 가능 세션 + 확정 이력이 섞인 목록
+    @MainActor
+    static var mixedSessions: [Session] {
+        [
+            session(id: "S-1", title: "8주차 정기 세션", week: 8),
+            session(id: "S-2", title: "7주차 정기 세션", week: 7, status: .present),
+            session(id: "S-3", title: "6주차 데모데이", week: 6, status: .late),
+        ]
+    }
+
+    /// 모두 출석이 확정되어 출석 가능 세션이 없는 목록
+    @MainActor
+    static var completedSessions: [Session] {
+        [
+            session(id: "S-2", title: "7주차 정기 세션", week: 7, status: .present),
+            session(id: "S-3", title: "6주차 데모데이", week: 6, status: .absent),
+        ]
+    }
+
+    /// 아직 아무도 출석하지 않아 이력이 비는 목록
+    @MainActor
+    static var upcomingSessions: [Session] {
+        [session(id: "S-1", title: "8주차 정기 세션", week: 8)]
+    }
+
+    // MARK: - MyAttendanceItemModel
+
+    /// 펼침 가능한(정책·장소를 가진) 출석 이력 항목
+    static func myAttendanceItem(
+        title: String = "8주차 정기 세션",
+        status: MyAttendanceItemStatus = .present
+    ) -> MyAttendanceItemModel {
+        MyAttendanceItemModel(
+            week: 8,
+            title: title,
+            startTime: referenceDate,
+            endTime: referenceDate.addingTimeInterval(2 * 3_600),
+            status: status,
+            category: .study,
+            attendancePolicy: displayPolicy,
+            locationName: "공학관 6층 세미나실"
+        )
+    }
+
+    static var myAttendanceItems: [MyAttendanceItemModel] {
+        [
+            myAttendanceItem(title: "8주차 정기 세션", status: .present),
+            myAttendanceItem(title: "7주차 정기 세션", status: .late),
+            myAttendanceItem(title: "6주차 데모데이", status: .absent),
+        ]
+    }
+
+    // MARK: - ViewModel / Container
+
+    /// - Parameter sessions: 이 세션들에 대해 시간대 정책과 서버 일정 ID를 함께 채운다.
+    ///   일정 ID가 없으면 화면이 출석·사유 버튼을 비활성화하므로 프리뷰가 비어 보인다.
+    @MainActor
+    static func viewModel(
+        timeWindow: AttendanceTimeWindow = .onTime,
+        sessions: [Session] = []
+    ) -> ChallengerAttendanceViewModel {
+        let viewModel = ChallengerAttendanceViewModel(
+            errorHandler: ErrorHandler(),
+            challengerAttendanceUseCase: PreviewChallengerAttendanceUseCase(
+                timeWindow: timeWindow
+            )
+        )
+        let sessionIds = sessions.map(\.info.sessionId)
+        viewModel.updateSchedulePolicies(
+            Dictionary(uniqueKeysWithValues: sessionIds.map { ($0, policy(for: timeWindow)) })
+        )
+        viewModel.updateScheduleIds(
+            Dictionary(uniqueKeysWithValues: sessionIds.map { ($0, "SCH-\($0.value)") })
+        )
+        return viewModel
+    }
+
+    /// 화면 init 의 `container:` 를 채우기 위한 스텁 컨테이너
+    ///
+    /// 프리뷰는 ViewModel 을 직접 주입하므로 이 등록이 실제로 resolve 되지는 않지만,
+    /// 주입 없이 쓰는 호출부가 생겨도 크래시하지 않도록 등록해 둡니다.
+    static var container: DIContainer {
+        let container = DIContainer()
+        container.register(ChallengerAttendanceUseCaseProtocol.self) {
+            PreviewChallengerAttendanceUseCase()
+        }
+        return container
+    }
+
+    // MARK: - View Factory
+
+    /// 출석 체크 상세 한 건을 시나리오 설명과 함께 감싼 프리뷰
+    ///
+    /// 지도 모델은 실제 위치 권한·지오펜스를 잡으므로 프리뷰에서는 `nil` 을 넘겨
+    /// 플레이스홀더로 렌더한다. (일정 ID 자체는 주입되어 액션 버튼은 활성 상태다)
+    @MainActor
+    static func attendanceScenario(
+        subtitle: String,
+        timeWindow: AttendanceTimeWindow,
+        attendanceStatus: AttendanceStatus = .beforeAttendance
+    ) -> some View {
+        let session = session(
+            id: "S-preview",
+            title: "8주차 정기 세션",
+            week: 8,
+            status: attendanceStatus
+        )
+
+        return VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text(subtitle)
+                .appFont(.footnote, color: .grey600)
+
+            ChallengerAttendanceView(
+                mapViewModel: nil,
+                attendanceViewModel: viewModel(timeWindow: timeWindow, sessions: [session]),
+                userId: userId,
+                session: session
+            )
+        }
+        .padding()
+        .background(Color.grey100)
+    }
+
+    /// 출석 진입 화면 전체 프리뷰
+    @MainActor
+    static func sessionScreen(sessions: [Session]) -> some View {
+        ChallengerAttendanceSessionView(
+            container: container,
+            errorHandler: ErrorHandler(),
+            sessions: sessions,
+            userId: userId,
+            viewModel: viewModel(sessions: sessions)
+        )
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
@@ -43,6 +43,11 @@ final class ChallengerAttendanceViewModel {
     /// 우선하도록 보관합니다. Schedule 모듈 결선 전까지는 비어 있습니다.
     private var schedulePolicies: [SessionID: ScheduleAttendancePolicy] = [:]
 
+    /// 세션별 서버 일정 ID 캐시 (available schedules 조회 결과에서 추출)
+    ///
+    /// 출석·사유 제출 API가 요구하는 값입니다. Schedule 모듈 결선 전까지는 비어 있습니다.
+    private var scheduleIds: [SessionID: String] = [:]
+
     /// 폴링 설정
     private enum PollingConfig {
         static let intervalSeconds: Int = 30
@@ -122,9 +127,20 @@ final class ChallengerAttendanceViewModel {
     }
 
     /// SessionID → scheduleId 매핑 (available schedules 기반)
+    ///
+    /// 값이 없으면 출석·사유 제출을 서버로 보낼 수 없으므로, 화면은 이 값이 `nil` 인 동안
+    /// 액션 진입점을 비활성화해야 합니다.
     func scheduleId(for sessionId: SessionID) -> String? {
-        // TODO: Schedule 모듈 이식 후 available schedules 페이로드에서 조회 - [26.06.12] 이재원
-        nil
+        scheduleIds[sessionId]
+    }
+
+    /// available schedules 조회 결과의 세션별 서버 일정 ID를 반영합니다.
+    ///
+    /// `updateSchedulePolicies(_:)` 와 같은 시점에 채워지는 짝입니다 — 정책만 있고 일정 ID가
+    /// 없으면 시간대 판정은 되는데 제출은 못 하는 반쪽 상태가 됩니다.
+    // TODO: Schedule 모듈 이식 후 refreshAvailableSchedules() 내부에서 호출하도록 결선 - [26.06.12] 이재원
+    func updateScheduleIds(_ ids: [SessionID: String]) {
+        scheduleIds = ids
     }
 
     /// 폴링으로 받은 서버 상태를 Session 객체에 동기화
@@ -363,6 +379,14 @@ final class ChallengerAttendanceViewModel {
     // TODO: Schedule 모듈 이식 후 refreshAvailableSchedules() 내부에서 호출하도록 결선 - [26.06.12] 이재원
     func updateSchedulePolicies(_ policies: [SessionID: ScheduleAttendancePolicy]) {
         schedulePolicies = policies
+    }
+
+    /// 세션의 출석 정책 (`nil` = 아직 조회 전)
+    ///
+    /// 시간대 판정과 같은 캐시를 읽으므로, 화면이 보여주는 정책 시각과 실제 판정 기준이
+    /// 어긋나지 않습니다. 정책 팝오버·출석 이력 카드가 표시용으로 사용합니다.
+    func attendancePolicy(for sessionId: SessionID) -> ScheduleAttendancePolicy? {
+        schedulePolicies[sessionId]
     }
 
     // MARK: - Helper Methods

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -1,0 +1,322 @@
+//
+//  ChallengerAttendanceSessionView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/2/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreDI
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+// MARK: - MapViewModelCache
+
+/// Session별 `BaseMapViewModel` 인스턴스를 캐싱합니다.
+///
+/// 지도 모델은 지오펜스 모니터링을 소유하므로 body 가 재평가될 때마다 새로 만들면
+/// 등록이 반복됩니다. Reference type 으로 두어 body 평가 중 mutation 을 안전하게 처리합니다.
+@MainActor
+private final class MapViewModelCache {
+    private var cache: [Session.ID: BaseMapViewModel] = [:]
+
+    func get(for sessionId: Session.ID) -> BaseMapViewModel? {
+        cache[sessionId]
+    }
+
+    func set(_ viewModel: BaseMapViewModel, for sessionId: Session.ID) {
+        cache[sessionId] = viewModel
+    }
+}
+
+// MARK: - ChallengerAttendanceSessionView
+
+/// 챌린저 출석 진입 화면
+///
+/// 출석 가능한 세션 목록과 나의 출석 현황을 한 화면에 세로로 배치합니다.
+/// 세션 카드를 탭하면 지도·출석 버튼이 있는 상세가 펼쳐집니다.
+struct ChallengerAttendanceSessionView: View {
+
+    // MARK: - Property
+
+    @State private var attendanceViewModel: ChallengerAttendanceViewModel
+    @State private var mapViewModelCache = MapViewModelCache()
+    @State private var expandedSessionId: Session.ID?
+    @Environment(\.scenePhase) private var scenePhase
+
+    private let errorHandler: ErrorHandler
+    private let sessions: [Session]
+    private let userId: UserID
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - container: 출석 UseCase 를 resolve 할 DI 컨테이너
+    ///   - errorHandler: 흐름 중단형 전역 에러 처리기
+    ///   - sessions: 상위(일정 화면)가 소유한 세션 목록
+    ///   - userId: 출석 주체
+    ///   - viewModel: 프리뷰/테스트용 주입 지점 (기본값: container 로 생성)
+    init(
+        container: DIContainer,
+        errorHandler: ErrorHandler,
+        sessions: [Session],
+        userId: UserID,
+        viewModel: ChallengerAttendanceViewModel? = nil
+    ) {
+        self.errorHandler = errorHandler
+        self.sessions = sessions
+        self.userId = userId
+        _attendanceViewModel = State(
+            initialValue: viewModel ?? ChallengerAttendanceViewModel(
+                errorHandler: errorHandler,
+                challengerAttendanceUseCase: container.resolve(
+                    ChallengerAttendanceUseCaseProtocol.self
+                )
+            )
+        )
+    }
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let animationResponse: Double = 0.35
+        static let animationDamping: Double = 0.8
+        static let emptyStateVerticalPadding: CGFloat = 32
+    }
+
+    // MARK: - Computed Properties
+
+    /// 출석 가능한 세션만 필터링 (beforeAttendance, pendingApproval)
+    private var availableSessions: [Session] {
+        sessions.filter(\.isAttendanceAvailable)
+    }
+
+    /// 출석이 확정된 세션만 이력 표시 모델로 변환
+    ///
+    /// 출석 전(`beforeAttendance`) 세션은 변환되지 않으므로, 빈 상태 판단은 원본 세션
+    /// 개수가 아니라 변환 결과 개수로 해야 가이드가 정상 표시됩니다.
+    private var attendanceHistoryItems: [MyAttendanceItemModel] {
+        sessions.compactMap { session in
+            MyAttendanceItemModel(
+                from: session,
+                category: session.info.category,
+                attendancePolicy: attendanceViewModel
+                    .attendancePolicy(for: session.info.sessionId)
+            )
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: DefaultSpacing.spacing48) {
+                attendanceSessionSection
+                myAttendanceStatusSection
+            }
+            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+            .safeAreaPadding(.bottom, DefaultConstant.defaultSafeBottom)
+        }
+        .contentMargins(
+            .trailing,
+            DefaultConstant.defaultContentTrailingMargins,
+            for: .scrollContent
+        )
+        .contentMargins(
+            .bottom,
+            DefaultConstant.defaultContentBottomMargins,
+            for: .scrollContent
+        )
+        .task {
+            // configurePollingSessions 는 반드시 loadOnAppear 보다 먼저 호출.
+            // 세션 상태 동기화가 pollingSessions 에 의존한다.
+            attendanceViewModel.configurePollingSessions(sessions, userId: userId)
+            await attendanceViewModel.loadOnAppear()
+        }
+        .task {
+            await attendanceViewModel.startPollingIfNeeded(sessions: sessions)
+        }
+        .onChange(of: sessions.map(\.id)) { _, _ in
+            // 상위가 세션 배열을 교체한 경우(일정 추가/삭제) 폴링 대상과 일정 정보를
+            // 최신 세션에 맞춰 재구성한다.
+            attendanceViewModel.configurePollingSessions(sessions, userId: userId)
+            Task { await attendanceViewModel.refreshAvailableSchedules() }
+        }
+        .onChange(of: scenePhase) { _, phase in
+            guard phase == .active else { return }
+            Task { await attendanceViewModel.refreshAfterForeground() }
+        }
+        .onDisappear {
+            Task { await attendanceViewModel.geofenceCleanup() }
+        }
+    }
+
+    // MARK: - Attendance Session Section
+
+    @ViewBuilder
+    private var attendanceSessionSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+            sectionHeader("출석 가능한 세션")
+
+            // TODO: Schedule 모듈 이식 후 일정 조회 로딩/실패 상태 분기 복원 - [26.08.02] 이재원
+            // — 세션 목록은 아직 상위 화면이 소유하고, ViewModel 의 availableSchedules
+            //   Loadable 은 Schedule 모듈과 함께 동결되어 있다. 재조회 UI 는 그때 붙인다.
+            if availableSessions.isEmpty {
+                emptySessionView
+            } else {
+                ChallengerAttendanceSessionList(
+                    sessions: availableSessions,
+                    expandedSessionId: expandedSessionId,
+                    attendanceViewModel: attendanceViewModel,
+                    userId: userId,
+                    mapViewModelProvider: mapViewModel(for:)
+                ) { sessionId in
+                    withAnimation(.spring(Spring(
+                        response: Constants.animationResponse,
+                        dampingRatio: Constants.animationDamping
+                    ))) {
+                        expandedSessionId = expandedSessionId == sessionId ? nil : sessionId
+                    }
+                }
+                .equatable()
+            }
+        }
+    }
+
+    private var emptySessionView: some View {
+        emptyStateCard(
+            systemImage: "checkmark.circle.fill",
+            tint: .green,
+            title: "모든 세션 출석을 완료했어요",
+            description: "지금은 출석할 수 있는 세션이 없어요.\n새로운 세션이 열리면 이곳에 표시됩니다."
+        )
+    }
+
+    // MARK: - My Attendance Status Section
+
+    @ViewBuilder
+    private var myAttendanceStatusSection: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+            sectionHeader("나의 출석 현황")
+
+            // TODO: Schedule 모듈 이식 후 출석 이력 전용 조회로 교체 - [26.08.02] 이재원
+            // — 현재 이력은 상위가 넘긴 `sessions` 창에서 파생하므로, 그 창 밖의 과거
+            //   기록은 보이지 않는다(빈 상태 가이드가 뜰 수 있음). 레거시의 myHistory
+            //   API 는 ViewModel 의 Loadable 과 함께 동결되어 있다.
+            let items = attendanceHistoryItems
+            if items.isEmpty {
+                emptyHistoryView
+            } else {
+                ChallengerMyAttendanceStatusView(models: items)
+            }
+        }
+    }
+
+    private var emptyHistoryView: some View {
+        emptyStateCard(
+            systemImage: "clock.badge.checkmark",
+            tint: .indigo400,
+            title: "아직 출석 기록이 없어요",
+            description: "출석 가능한 세션에서 출석을 완료하면\n이곳에 나의 출석 현황이 표시됩니다."
+        )
+    }
+
+    // MARK: - Shared View Components
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .appFont(.body, weight: .semibold, color: .grey900)
+            .padding(.leading, DefaultConstant.sectionLeadingHeader)
+    }
+
+    private func emptyStateCard(
+        systemImage: String,
+        tint: Color,
+        title: String,
+        description: String
+    ) -> some View {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            // 빈 상태는 전환이 아니라 처음부터 표시되는 화면이므로
+            // 전환 효과(symbolDrawOn)는 심볼이 그려지지 않아 정적 렌더로 표시합니다.
+            Image(systemName: systemImage)
+                .font(.system(size: DefaultConstant.iconSize))
+                .foregroundStyle(tint)
+
+            VStack(spacing: DefaultSpacing.spacing4) {
+                Text(title)
+                    .appFont(.callout, weight: .semibold, color: .grey700)
+
+                Text(description)
+                    .appFont(.footnote, color: .grey500)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Constants.emptyStateVerticalPadding)
+        .padding(.horizontal, DefaultSpacing.spacing16)
+        .background {
+            ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+            .fill(.white)
+            .glass()
+        }
+    }
+
+    // MARK: - Function
+
+    /// Session별 지도 모델을 캐시에서 가져오거나 새로 생성합니다.
+    ///
+    /// 지오펜스는 서버 일정 ID 로 등록해야 출석 판정과 같은 대상을 가리킵니다.
+    /// 아직 일정 ID 가 해석되지 않았다면 `nil` 을 돌려주고, 상세는 지도 대신
+    /// 플레이스홀더를 표시합니다 — `sessionId` 를 대신 넘기면 컴파일은 되지만
+    /// 지오펜스가 항상 어긋나 출석이 거부됩니다.
+    private func mapViewModel(for session: Session) -> BaseMapViewModel? {
+        if let cached = mapViewModelCache.get(for: session.id) {
+            return cached
+        }
+
+        guard let scheduleId = attendanceViewModel.scheduleId(for: session.info.sessionId) else {
+            return nil
+        }
+
+        let newViewModel = BaseMapViewModel(
+            info: session.info,
+            scheduleId: scheduleId,
+            errorHandler: errorHandler
+        )
+        mapViewModelCache.set(newViewModel, for: session.id)
+        return newViewModel
+    }
+}
+
+#if DEBUG
+// MARK: - Preview
+
+#Preview("출석 가능 세션 + 이력") {
+    ZStack {
+        Color.grey100.ignoresSafeArea()
+
+        AttendancePreviewData.sessionScreen(sessions: AttendancePreviewData.mixedSessions)
+    }
+}
+
+#Preview("모든 세션 완료 (빈 상태)") {
+    ZStack {
+        Color.grey100.ignoresSafeArea()
+
+        AttendancePreviewData.sessionScreen(sessions: AttendancePreviewData.completedSessions)
+    }
+}
+
+#Preview("기록 없음 (빈 상태)") {
+    ZStack {
+        Color.grey100.ignoresSafeArea()
+
+        AttendancePreviewData.sessionScreen(sessions: AttendancePreviewData.upcomingSessions)
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Tests/AttendancePolicyDisplayTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/AttendancePolicyDisplayTests.swift
@@ -1,0 +1,73 @@
+//
+//  AttendancePolicyDisplayTests.swift
+//  ActivityPresentationTests
+//
+//  Created by jaewon Lee on 8/2/26.
+//
+
+import Foundation
+import Testing
+import UMCFoundation
+
+@testable import ActivityPresentation
+
+// MARK: - Helper
+
+/// 지정한 KST 시각. 기기 타임존과 무관하게 같은 절대 시각을 만든다.
+private func makeKSTDate(
+    year: Int = 2026,
+    month: Int = 5,
+    day: Int,
+    hour: Int,
+    minute: Int = 0
+) -> Date {
+    var components = DateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    components.hour = hour
+    components.minute = minute
+
+    guard let date = Calendar.kstGregorian.date(from: components) else {
+        Issue.record("Failed to construct KST test date")
+        return Date(timeIntervalSince1970: 0)
+    }
+    return date
+}
+
+// MARK: - 정책 시각 표기
+
+@Suite("출석 정책 시각 표기 (도메인 규칙)")
+struct AttendancePolicyDisplayTests {
+
+    @Test("기준일과 같은 날이면 시각만 표시한다")
+    func sameDayShowsTimeOnly() {
+        let anchor = makeKSTDate(day: 7, hour: 13, minute: 50)
+        let onTimeEnd = makeKSTDate(day: 7, hour: 14, minute: 10)
+
+        #expect(onTimeEnd.attendancePolicyText(anchoredAt: anchor) == "14:10")
+    }
+
+    @Test("자정을 넘긴 마감은 날짜를 함께 표시한다")
+    func crossMidnightShowsDate() {
+        let anchor = makeKSTDate(day: 7, hour: 23, minute: 50)
+        let lateEnd = makeKSTDate(day: 8, hour: 0, minute: 30)
+
+        #expect(lateEnd.attendancePolicyText(anchoredAt: anchor) == "5/8 00:30")
+    }
+
+    /// 회귀 박제 — 날짜 부분을 공용 `toMonthDay()` 로 되돌리면 여기서 깨진다.
+    ///
+    /// 그 헬퍼는 (1) 타임존 미지정이라 기기 타임존을 따르고(자정 근처에서 KST 시각과
+    /// 하루가 어긋남), (2) 로케일에 따라 `"05. 08."` 처럼 다르게 렌더한다.
+    /// 두 결함 모두 이 단언의 `"5/8"` 을 통과하지 못한다.
+    @Test("날짜 부분은 KST 기준 M/d 표기를 유지한다")
+    func crossMidnightKeepsKSTMonthDayFormat() {
+        let anchor = makeKSTDate(day: 7, hour: 23, minute: 50)
+        let lateEnd = makeKSTDate(day: 8, hour: 0, minute: 30)
+
+        let text = lateEnd.attendancePolicyText(anchoredAt: anchor)
+
+        #expect(text.hasPrefix("5/8"))
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Tests/ChallengerAttendanceViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/ChallengerAttendanceViewModelTests.swift
@@ -484,6 +484,48 @@ struct ChallengerAttendanceViewModelTimeWindowTests {
 
         #expect(window == expected)
     }
+
+    // MARK: - 정책 조회 (표시용)
+
+    @Test("주입한 정책은 판정과 같은 캐시에서 조회된다")
+    func attendancePolicyReadsInjectedCache() {
+        let viewModel = makeViewModel(useCase: MockChallengerAttendanceUseCase())
+        let session = makeSession()
+        let policy = makePolicy()
+        viewModel.updateSchedulePolicies([session.info.sessionId: policy])
+
+        #expect(viewModel.attendancePolicy(for: session.info.sessionId) == policy)
+    }
+
+    @Test("정책 미조회 세션은 nil 을 반환한다")
+    func attendancePolicyReturnsNilWhenNotFetched() {
+        let viewModel = makeViewModel(useCase: MockChallengerAttendanceUseCase())
+        let session = makeSession()
+
+        #expect(viewModel.attendancePolicy(for: session.info.sessionId) == nil)
+    }
+
+    // MARK: - 서버 일정 ID 조회 (제출 경로)
+
+    @Test("주입한 서버 일정 ID가 조회된다")
+    func scheduleIdReadsInjectedCache() {
+        let viewModel = makeViewModel(useCase: MockChallengerAttendanceUseCase())
+        let session = makeSession()
+        viewModel.updateScheduleIds([session.info.sessionId: "SCH-1"])
+
+        #expect(viewModel.scheduleId(for: session.info.sessionId) == "SCH-1")
+    }
+
+    /// 회귀 박제 — 일정 ID가 없으면 출석·사유 제출이 서버에 도달할 수 없다.
+    /// 화면은 이 nil 을 근거로 액션 버튼을 비활성화해, 사용자가 작성한 사유가
+    /// 조용히 버려지지 않게 한다.
+    @Test("일정 ID 미조회 세션은 nil 을 반환한다")
+    func scheduleIdReturnsNilWhenNotFetched() {
+        let viewModel = makeViewModel(useCase: MockChallengerAttendanceUseCase())
+        let session = makeSession()
+
+        #expect(viewModel.scheduleId(for: session.info.sessionId) == nil)
+    }
 }
 
 // MARK: - 출석 안내 문구


### PR DESCRIPTION
resolves #1013

## ✨ PR 유형

♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/a7486643-7ea4-4c7d-b4f8-25d241bdd576" />


## 🛠️ 작업내용

레거시 챌린저 출석 화면 계층 6종을 `ActivityPresentation` 모듈로 이식했습니다.
이로써 레거시 `Components/Challenger/Attendance/` 7종이 전부 이식 완료됩니다 (기존 2종 + 본 PR 5종).

| 화면 | 역할 |
|---|---|
| `ChallengerAttendanceSessionView` | 진입 화면 — 출석 가능 세션 + 나의 출석 현황 |
| `ChallengerAttendanceSessionList` | 세션 카드 목록 + 펼침 상세 |
| `ChallengerAttendanceView` | 지도 · 출석 버튼 · 정책 팝오버 |
| `ChallengerMyAttendanceStatusView` | 출석 이력 아코디언 섹션 |
| `ChallengerMyAttendanceCard` | 이력 카드 (정책 3열 요약) |
| `ChallengerAttendanceReasonSheet` | 사유 제출 시트 |

부수 변경

- `MyAttendanceItemModel` — `attendancePolicy`/`locationName`/`isOnline` 필드와 `dateText` 추가, `timeRange` 를 KST 고정으로 교정
- `ChallengerAttendanceViewModel` — `attendancePolicy(for:)` 조회 + `updateScheduleIds(_:)` 주입 seam 추가
- `AttendancePolicyDisplay` — 정책 시각 표기와 `AttendancePolicyRole` 통합

## 📋 추후 진행 상황

- **#994 (출석 세션 목록·이력·일정 등록 결선)** — 본 PR이 우회한 동결 지점을 해제합니다. 복원 대상은 `availableSchedules`/`myHistory` Loadable 분기, 재조회 UI, `scheduleId` 해석(→ 지도 자동 활성화), 이력 전용 조회이며 **해당 위치는 코드에 TODO로 표시해 두었습니다.** `updateSchedulePolicies(_:)`/`updateScheduleIds(_:)` 가 실 페이로드를 받는 착지점입니다
- Activity 탭 라우팅 결선 (#996 / #1036) — **현재 이 화면은 프로덕션 진입점이 없습니다.** 위 두 주입 지점을 호출하는 프로덕션 코드도 아직 없어, #994 결선 전까지는 화면이 동작하지 않습니다

## 📌 리뷰 포인트

### 1. 레거시를 1:1로 옮기지 않은 지점

| 항목 | 판단 |
|---|---|
| 일정 조회 Loadable 분기 | 이식된 ViewModel 에 해당 상태가 없어(Schedule 모듈 동결) 상위가 넘긴 `sessions` 에서 직접 렌더. 재조회 UI 가 빠진 사유는 TODO 로 명시 |
| `categoryFor` 파라미터 | 레거시에서 저장만 되고 body 에서 미사용 → 제거하고 `session.info.category` 로 대체 |
| `PolicyRole` · 정책 시각 포맷 | 레거시가 두 파일에 각각 선언 + 같은 값을 다른 포맷(`MM.dd` vs `M/d`)으로 표시 → 하나로 통합 |
| `ConfirmBtn` | 제출 완료 후 닫도록 `dismissOnTap: false`. 레거시는 제출 중 시트가 먼저 닫혔습니다 |

### 2. 서버 일정 ID 미해결 시 액션 차단 — `ChallengerAttendanceView`

`scheduleId` 가 없으면 사유를 작성해도 서버로 보낼 수 없어, 출석·사유 버튼을 모두 비활성화했습니다. 게이트를 버튼에 두고 제출 클로저의 `guard` 는 방어용으로 남겼습니다. 열어두면 사용자가 작성·확인한 사유가 조용히 버려집니다.

### 3. 지도 모델을 Optional 로 승격

`BaseMapViewModel` 은 지오펜스를 **서버 일정 ID** 로 등록합니다. 미해결 세션에 `sessionId` 를 대신 넘기면 컴파일은 되지만 출석이 항상 거부되므로, `nil` → 플레이스홀더로 처리했습니다.

### 4. 정책 시각 타임존 — `AttendancePolicyDisplay`

한 문자열 안에서 날짜는 기기 타임존, 시각은 KST 로 갈리면 자정을 넘긴 마감이 하루 어긋나 보입니다(KST 5/8 00:30 → 비-KST 기기에서 5/7). 날짜·시각 모두 KST 고정으로 맞추고 회귀 테스트로 고정했습니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
