### PR TITLE
🛠️ [Chore] 카카오 로그인 우회 stub 세션 + Activity 화면 확인 하네스

### DIFF
--- a/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import CoreDesignSystem
 import CoreDI
 import CoreDomain
+import CoreUIComponents
 import UMCFoundation
 #endif
 
@@ -27,136 +28,110 @@ public struct ActivityFeatureView: View {
 
 #if DEBUG
 
-// MARK: - Harness Entry
+// MARK: - Harness
 
 /// 이식 완료된 Activity 화면을 서버·로그인 없이 확인하기 위한 DEBUG 전용 하네스
 ///
-/// Activity 라우터·탭바 실연결(#997) 전까지 쓰는 임시 진입점이다. 각 화면은 스텁
-/// UseCase(`PreviewSupport`)로 조립한 ViewModel을 주입받으므로 네트워크를 타지 않는다.
-/// 상위 `RootTabView`가 탭별 `NavigationStack`을 제공하므로 여기서 스택을 만들지 않는다.
-/// // TODO: Activity 라우터·탭바 실연결 후 실제 배선으로 교체 - [26.08.03] 이재원
-private struct DebugActivityHarnessView: View {
-
-    // MARK: - Body
-
-    var body: some View {
-        List {
-            Section {
-                ForEach(DebugActivityScreen.allCases) { screen in
-                    // 상위 `RootTabView`의 `NavigationStack`이 `[NavigationDestination]`
-                    // 타입 경로를 쓰므로, 다른 타입의 value 링크는 무시된다. 하네스는
-                    // 앱 라우팅에 끼어들지 않도록 목적지 뷰를 직접 들고 있는 링크를 쓴다.
-                    NavigationLink {
-                        DebugActivityScreenView(screen: screen)
-                    } label: {
-                        row(for: screen)
-                    }
-                }
-            } header: {
-                Text("이식 완료 화면")
-            } footer: {
-                Text("서버·로그인 없이 스텁 데이터로 렌더됩니다. 실제 배선은 Activity 탭 연결 이슈에서 교체됩니다.")
-            }
-        }
-        .navigationTitle("Activity 하네스")
-    }
-
-    // MARK: - View Components
-
-    private func row(for screen: DebugActivityScreen) -> some View {
-        Label {
-            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
-                Text(screen.title)
-                    .appFont(.callout)
-
-                Text(screen.detail)
-                    .appFont(.footnote, color: .grey500)
-            }
-        } icon: {
-            Image(systemName: screen.systemImageName)
-                .foregroundStyle(Color.indigo500)
-        }
-    }
-}
-
-// MARK: - Screen Catalog
-
-/// 하네스가 노출하는 화면 목록
-private enum DebugActivityScreen: String, CaseIterable, Identifiable, Hashable {
-    case challengerStudy
-    case challengerMemberList
-    case operatorAttendance
-    case operatorMemberManagement
-    case operatorStudyManagement
-    case operatorStudyGroupCreate
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .challengerStudy: "챌린저 — 스터디(커리큘럼)"
-        case .challengerMemberList: "챌린저 — 구성원 목록"
-        case .operatorAttendance: "운영진 — 출석 관리"
-        case .operatorMemberManagement: "운영진 — 멤버 관리"
-        case .operatorStudyManagement: "운영진 — 스터디 관리"
-        case .operatorStudyGroupCreate: "운영진 — 스터디 그룹 생성 폼"
-        }
-    }
-
-    var detail: String {
-        switch self {
-        case .challengerStudy: "진행률 게이지 + 주차별 미션 카드"
-        case .challengerMemberList: "파트별 그룹핑 · 검색 · 멤버 상세 시트"
-        case .operatorAttendance: "일정 목록 → 상세 · 승인 대기 결정 · 위치 변경"
-        case .operatorMemberManagement: "멤버 목록 + 상벌점 부여/삭제 시트"
-        case .operatorStudyManagement: "스터디 그룹 목록 · 멘토/스터디원 관리"
-        case .operatorStudyGroupCreate: "그룹 생성 폼 (운영 화면에서는 게이팅됨)"
-        }
-    }
-
-    var systemImageName: String {
-        switch self {
-        case .challengerStudy: "book.closed"
-        case .challengerMemberList: "person.2"
-        case .operatorAttendance: "checkmark.circle"
-        case .operatorMemberManagement: "person.badge.shield.checkmark"
-        case .operatorStudyManagement: "rectangle.grid.2x2"
-        case .operatorStudyGroupCreate: "plus.rectangle.on.folder"
-        }
-    }
-}
-
-// MARK: - Screen Host
-
-/// 선택한 화면을 스텁 의존성으로 조립해 표시한다.
+/// 레거시 `AppProduct`의 `ActivityView`와 같은 구성을 따른다 — 탭 진입 시 기본 섹션(출석)을
+/// 바로 보여주고, 상단 타이틀 메뉴로 섹션을 전환한다. 챌린저/운영진 모드 전환은 레거시가
+/// 하단 액세서리에서 처리하지만, 하네스는 그 배선이 없어 툴바 버튼으로 대신한다.
 ///
-/// 화면마다 필요한 ViewModel·세션이 달라, 조립은 각 `case`에서 직접 수행한다.
-/// `ErrorHandler`는 하네스가 소유해 화면 전환 간에도 알럿 상태가 유지되게 한다.
-private struct DebugActivityScreenView: View {
+/// 각 화면은 스텁 UseCase(`PreviewSupport`)로 조립한 ViewModel을 주입받아 네트워크를 타지
+/// 않는다. 상위 `RootTabView`가 탭별 `NavigationStack`을 제공하므로 여기서 스택을 만들지 않는다.
+/// // TODO: Activity 라우터·탭바 실연결 후 실제 배선으로 교체 - [26.08.03] 이재원
+@MainActor
+private struct DebugActivityHarnessView: View {
 
     // MARK: - Property
 
-    let screen: DebugActivityScreen
-
+    /// 하네스가 소유하는 세션. 운영진 권한 계정으로 두어 모드 전환을 확인할 수 있다.
+    @State private var userSession: UserSessionManager
     @State private var errorHandler = ErrorHandler()
+    @State private var selectedSection: DebugActivitySection?
+    @State private var showsStudyGroupCreate = false
+
+    // MARK: - Init
+
+    /// 운영진 모드로 시작한다.
+    ///
+    /// 레거시 기본 모드는 챌린저지만, 그 기본 섹션인 출석 체크 화면
+    /// (`ChallengerAttendanceSessionView`)이 아직 이식되지 않아 진입 화면이 안내 문구가 된다.
+    /// 하네스의 목적은 이식된 화면 확인이므로, 실제로 볼 수 있는 출석 화면이 바로 뜨도록
+    /// 운영진 모드를 초기값으로 둔다. 툴바 버튼으로 챌린저 모드로 전환할 수 있다.
+    init() {
+        let session = previewCreateCapableSession()
+        session.toggleAdminMode()
+        _userSession = State(wrappedValue: session)
+    }
+
+    // MARK: - Computed Property
+
+    private var mode: ActivityMode {
+        userSession.currentActivityMode
+    }
+
+    private var availableSections: [DebugActivitySection] {
+        DebugActivitySection.sections(for: mode)
+    }
+
+    private var currentSection: DebugActivitySection {
+        selectedSection ?? DebugActivitySection.defaultSection(for: mode)
+    }
+
+    private var sectionBinding: Binding<DebugActivitySection> {
+        Binding(
+            get: { currentSection },
+            set: { selectedSection = $0 }
+        )
+    }
 
     // MARK: - Body
 
     var body: some View {
-        content
-            .navigationTitle(screen.title)
+        sectionContent
+            .navigationTitle(currentSection.title)
             .navigationBarTitleDisplayMode(.inline)
+            .umcDefaultBackground()
+            .toolbar {
+                ToolBarCollection.ToolBarCenterMenu(
+                    items: availableSections,
+                    selection: sectionBinding,
+                    itemLabel: { $0.title },
+                    itemIcon: { $0.icon }
+                )
+                modeToggleItem
+                studyGroupCreateItem
+            }
+            .navigationDestination(isPresented: $showsStudyGroupCreate) {
+                OperatorStudyGroupCreateView(
+                    viewModel: previewOperatorStudyManagementViewModel()
+                )
+            }
+            // 레거시 `ActivityView`와 동일하게, 모드가 바뀌면 보고 있던 섹션을
+            // 대응 섹션으로 옮겨 같은 성격의 화면을 유지한다.
+            .onChange(of: mode) { oldMode, newMode in
+                let previous = selectedSection
+                    ?? DebugActivitySection.defaultSection(for: oldMode)
+                selectedSection = previous.mapped(to: newMode)
+            }
     }
 
     // MARK: - View Components
 
     @ViewBuilder
-    private var content: some View {
-        switch screen {
-        case .challengerStudy:
+    private var sectionContent: some View {
+        switch currentSection {
+        case .attendanceCheck:
+            // `ChallengerAttendanceSessionView`는 아직 이식되지 않았다.
+            notPortedGuide(
+                title: "출석 체크",
+                description: "챌린저 출석 화면은 아직 이식되지 않았습니다.\n운영진 모드로 전환하면 출석 관리 화면을 확인할 수 있습니다."
+            )
+
+        case .studyActivity:
             ChallengerStudyView(viewModel: MissionPreviewData.makeViewModel())
 
-        case .challengerMemberList:
+        case .members:
             ChallengerMemberListView(
                 container: DIContainer(),
                 errorHandler: errorHandler,
@@ -166,32 +141,132 @@ private struct DebugActivityScreenView: View {
                 )
             )
 
-        case .operatorAttendance:
+        case .attendanceManage:
             OperatorAttendanceView(
                 errorHandler: errorHandler,
                 useCase: PreviewOperatorAttendanceUseCase()
             )
 
-        case .operatorMemberManagement:
+        case .studyManage:
+            OperatorStudyManagementView(
+                viewModel: previewOperatorStudyManagementViewModel(),
+                userSession: userSession
+            )
+
+        case .memberManage:
             OperatorMemberManagementView(
                 container: DIContainer(),
                 errorHandler: errorHandler,
                 viewModel: previewMemberListViewModel(
                     errorHandler: errorHandler,
-                    session: previewCreateCapableSession()
+                    session: userSession
                 )
             )
+        }
+    }
 
-        case .operatorStudyManagement:
-            OperatorStudyManagementView(
-                viewModel: previewOperatorStudyManagementViewModel(),
-                userSession: previewCreateCapableSession()
-            )
+    /// 챌린저 ↔ 운영진 모드 전환 버튼 (레거시의 하단 액세서리 토글 대체)
+    private var modeToggleItem: some ToolbarContent {
+        ToolbarItem(placement: .topBarLeading) {
+            Button {
+                userSession.toggleAdminMode()
+            } label: {
+                Label(
+                    mode == .admin ? "운영진" : "챌린저",
+                    systemImage: mode == .admin ? "person.badge.shield.checkmark" : "person"
+                )
+            }
+        }
+    }
 
-        case .operatorStudyGroupCreate:
-            OperatorStudyGroupCreateView(
-                viewModel: previewOperatorStudyManagementViewModel()
-            )
+    /// 스터디 그룹 생성 폼 진입 버튼
+    ///
+    /// 운영 화면에서는 멘토·스터디원 선택 이식 전까지 진입점이 게이팅("준비 중")돼 있어,
+    /// 하네스에서만 직접 열 수 있게 둔다.
+    @ToolbarContentBuilder
+    private var studyGroupCreateItem: some ToolbarContent {
+        if currentSection == .studyManage {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("생성 폼") {
+                    showsStudyGroupCreate = true
+                }
+            }
+        }
+    }
+
+    private func notPortedGuide(title: String, description: String) -> some View {
+        ContentUnavailableView {
+            Label(title, systemImage: "hammer")
+        } description: {
+            Text(description)
+        }
+    }
+}
+
+// MARK: - Section Catalog
+
+/// 하네스가 노출하는 Activity 섹션
+///
+/// 레거시 `ActivitySection`과 같은 구성이다. 프로덕션 `ActivitySection`은 Activity 탭 루트
+/// 이식 이슈에서 별도로 들어오므로, 하네스는 DEBUG 전용 사본을 쓴다.
+private enum DebugActivitySection: String, Identifiable, Hashable, CaseIterable {
+    case attendanceCheck
+    case studyActivity
+    case members
+    case attendanceManage
+    case studyManage
+    case memberManage
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .attendanceCheck: "출석 체크"
+        case .studyActivity: "스터디/활동"
+        case .members: "구성원"
+        case .attendanceManage: "출석 관리"
+        case .studyManage: "스터디 관리"
+        case .memberManage: "멤버 관리"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .attendanceCheck, .attendanceManage: "checkmark.circle"
+        case .studyActivity, .studyManage: "book.pages"
+        case .members, .memberManage: "person.3"
+        }
+    }
+
+    static func sections(for mode: ActivityMode) -> [DebugActivitySection] {
+        switch mode {
+        case .challenger: [.attendanceCheck, .studyActivity, .members]
+        case .admin: [.attendanceManage, .studyManage, .memberManage]
+        }
+    }
+
+    static func defaultSection(for mode: ActivityMode) -> DebugActivitySection {
+        switch mode {
+        case .challenger: .attendanceCheck
+        case .admin: .attendanceManage
+        }
+    }
+
+    /// 모드 전환 시 같은 성격의 섹션으로 매핑한다.
+    func mapped(to mode: ActivityMode) -> DebugActivitySection {
+        switch mode {
+        case .challenger:
+            switch self {
+            case .attendanceCheck, .attendanceManage: .attendanceCheck
+            case .studyActivity, .studyManage: .studyActivity
+            case .members, .memberManage: .members
+            }
+        case .admin:
+            switch self {
+            case .attendanceCheck, .attendanceManage: .attendanceManage
+            case .studyActivity, .studyManage: .studyManage
+            case .members, .memberManage: .memberManage
+            }
         }
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
@@ -7,7 +7,10 @@
 
 import SwiftUI
 #if DEBUG
+import CoreDesignSystem
+import CoreDI
 import CoreDomain
+import UMCFoundation
 #endif
 
 public struct ActivityFeatureView: View {
@@ -15,7 +18,7 @@ public struct ActivityFeatureView: View {
 
     public var body: some View {
         #if DEBUG
-        debugOperatorStudyHarness
+        DebugActivityHarnessView()
         #else
         Text("Activity Feature")
         #endif
@@ -23,49 +26,172 @@ public struct ActivityFeatureView: View {
 }
 
 #if DEBUG
-extension ActivityFeatureView {
-    /// 운영진 스터디 관리 화면 DEBUG 하네스 진입점
-    @MainActor
-    fileprivate var debugOperatorStudyHarness: some View {
-        DebugOperatorStudyHarnessView()
+
+// MARK: - Harness Entry
+
+/// 이식 완료된 Activity 화면을 서버·로그인 없이 확인하기 위한 DEBUG 전용 하네스
+///
+/// Activity 라우터·탭바 실연결(#997) 전까지 쓰는 임시 진입점이다. 각 화면은 스텁
+/// UseCase(`PreviewSupport`)로 조립한 ViewModel을 주입받으므로 네트워크를 타지 않는다.
+/// 상위 `RootTabView`가 탭별 `NavigationStack`을 제공하므로 여기서 스택을 만들지 않는다.
+/// // TODO: Activity 라우터·탭바 실연결 후 실제 배선으로 교체 - [26.08.03] 이재원
+private struct DebugActivityHarnessView: View {
+
+    // MARK: - Body
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(DebugActivityScreen.allCases) { screen in
+                    // 상위 `RootTabView`의 `NavigationStack`이 `[NavigationDestination]`
+                    // 타입 경로를 쓰므로, 다른 타입의 value 링크는 무시된다. 하네스는
+                    // 앱 라우팅에 끼어들지 않도록 목적지 뷰를 직접 들고 있는 링크를 쓴다.
+                    NavigationLink {
+                        DebugActivityScreenView(screen: screen)
+                    } label: {
+                        row(for: screen)
+                    }
+                }
+            } header: {
+                Text("이식 완료 화면")
+            } footer: {
+                Text("서버·로그인 없이 스텁 데이터로 렌더됩니다. 실제 배선은 Activity 탭 연결 이슈에서 교체됩니다.")
+            }
+        }
+        .navigationTitle("Activity 하네스")
+    }
+
+    // MARK: - View Components
+
+    private func row(for screen: DebugActivityScreen) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                Text(screen.title)
+                    .appFont(.callout)
+
+                Text(screen.detail)
+                    .appFont(.footnote, color: .grey500)
+            }
+        } icon: {
+            Image(systemName: screen.systemImageName)
+                .foregroundStyle(Color.indigo500)
+        }
     }
 }
 
-/// 운영진 스터디 관리 화면의 DEBUG 전용 하네스
-///
-/// Activity 라우터·DI 배선 이식 전까지, 스텁 UseCase(PreviewSupport)로 이식 화면을
-/// 서버·로그인 없이 Activity 탭에서 직접 확인하기 위한 임시 진입점. 앱 타깃이 이
-/// 화면들을 참조해야 static 링크에 포함되므로, UMCApp 스킴의 Canvas 프리뷰 호스팅도
-/// 이 참조로 활성화된다. 생성 폼은 운영 화면에서 진입점이 게이팅("준비 중")된 상태라
-/// 하네스 전용 버튼으로 직접 진입한다. 상위 RootTabView가 탭별 NavigationStack을
-/// 제공하므로 여기서 스택을 만들지 않는다.
-/// // TODO: Activity 라우터·DIContainer 이식 후 실제 배선으로 교체 - [26.07.24] 이재원
-@MainActor
-private struct DebugOperatorStudyHarnessView: View {
-    @State private var viewModel: OperatorStudyManagementViewModel
-    @State private var userSession: UserSessionManager
-    @State private var showsCreateForm = false
+// MARK: - Screen Catalog
 
-    init() {
-        _viewModel = State(wrappedValue: previewOperatorStudyManagementViewModel())
-        _userSession = State(wrappedValue: previewCreateCapableSession())
+/// 하네스가 노출하는 화면 목록
+private enum DebugActivityScreen: String, CaseIterable, Identifiable, Hashable {
+    case challengerStudy
+    case challengerMemberList
+    case operatorAttendance
+    case operatorMemberManagement
+    case operatorStudyManagement
+    case operatorStudyGroupCreate
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .challengerStudy: "챌린저 — 스터디(커리큘럼)"
+        case .challengerMemberList: "챌린저 — 구성원 목록"
+        case .operatorAttendance: "운영진 — 출석 관리"
+        case .operatorMemberManagement: "운영진 — 멤버 관리"
+        case .operatorStudyManagement: "운영진 — 스터디 관리"
+        case .operatorStudyGroupCreate: "운영진 — 스터디 그룹 생성 폼"
+        }
     }
 
-    var body: some View {
-        OperatorStudyManagementView(
-            viewModel: viewModel,
-            userSession: userSession
-        )
-        .navigationTitle("스터디 관리")
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Button("생성 폼") {
-                    showsCreateForm = true
-                }
-            }
+    var detail: String {
+        switch self {
+        case .challengerStudy: "진행률 게이지 + 주차별 미션 카드"
+        case .challengerMemberList: "파트별 그룹핑 · 검색 · 멤버 상세 시트"
+        case .operatorAttendance: "일정 목록 → 상세 · 승인 대기 결정 · 위치 변경"
+        case .operatorMemberManagement: "멤버 목록 + 상벌점 부여/삭제 시트"
+        case .operatorStudyManagement: "스터디 그룹 목록 · 멘토/스터디원 관리"
+        case .operatorStudyGroupCreate: "그룹 생성 폼 (운영 화면에서는 게이팅됨)"
         }
-        .navigationDestination(isPresented: $showsCreateForm) {
-            OperatorStudyGroupCreateView(viewModel: viewModel)
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .challengerStudy: "book.closed"
+        case .challengerMemberList: "person.2"
+        case .operatorAttendance: "checkmark.circle"
+        case .operatorMemberManagement: "person.badge.shield.checkmark"
+        case .operatorStudyManagement: "rectangle.grid.2x2"
+        case .operatorStudyGroupCreate: "plus.rectangle.on.folder"
+        }
+    }
+}
+
+// MARK: - Screen Host
+
+/// 선택한 화면을 스텁 의존성으로 조립해 표시한다.
+///
+/// 화면마다 필요한 ViewModel·세션이 달라, 조립은 각 `case`에서 직접 수행한다.
+/// `ErrorHandler`는 하네스가 소유해 화면 전환 간에도 알럿 상태가 유지되게 한다.
+private struct DebugActivityScreenView: View {
+
+    // MARK: - Property
+
+    let screen: DebugActivityScreen
+
+    @State private var errorHandler = ErrorHandler()
+
+    // MARK: - Body
+
+    var body: some View {
+        content
+            .navigationTitle(screen.title)
+            .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - View Components
+
+    @ViewBuilder
+    private var content: some View {
+        switch screen {
+        case .challengerStudy:
+            ChallengerStudyView(viewModel: MissionPreviewData.makeViewModel())
+
+        case .challengerMemberList:
+            ChallengerMemberListView(
+                container: DIContainer(),
+                errorHandler: errorHandler,
+                viewModel: previewMemberListViewModel(
+                    errorHandler: errorHandler,
+                    session: previewChallengerSession()
+                )
+            )
+
+        case .operatorAttendance:
+            OperatorAttendanceView(
+                errorHandler: errorHandler,
+                useCase: PreviewOperatorAttendanceUseCase()
+            )
+
+        case .operatorMemberManagement:
+            OperatorMemberManagementView(
+                container: DIContainer(),
+                errorHandler: errorHandler,
+                viewModel: previewMemberListViewModel(
+                    errorHandler: errorHandler,
+                    session: previewCreateCapableSession()
+                )
+            )
+
+        case .operatorStudyManagement:
+            OperatorStudyManagementView(
+                viewModel: previewOperatorStudyManagementViewModel(),
+                userSession: previewCreateCapableSession()
+            )
+
+        case .operatorStudyGroupCreate:
+            OperatorStudyGroupCreateView(
+                viewModel: previewOperatorStudyManagementViewModel()
+            )
         }
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/MemberListPreviewSupport.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/MemberListPreviewSupport.swift
@@ -1,0 +1,254 @@
+//
+//  MemberListPreviewSupport.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import ActivityDomain
+import CoreDomain
+import Foundation
+import UMCFoundation
+
+// MARK: - Preview Stub UseCase
+
+/// 네트워크 없이 구성원 목록·상세 시트를 확인하기 위한 프리뷰 전용 UseCase (절대규칙 #5)
+///
+/// 상벌점 부여·삭제는 서버 왕복 대신 로컬 히스토리에 반영해, 화면이 갱신 결과를 다시
+/// 조회하는 경로(`fetchPointHistory`)까지 그대로 태운다.
+final class PreviewMemberListUseCase: FetchMembersUseCaseProtocol, @unchecked Sendable {
+
+    // MARK: - Property
+
+    private let lock = NSLock()
+    private var members: [MemberManagementItem]
+    private var historyByChallenger: [String: [OperatorMemberPenaltyHistory]]
+
+    // MARK: - Init
+
+    init(members: [MemberManagementItem] = MemberListPreviewData.members) {
+        self.members = members
+        self.historyByChallenger = Dictionary(
+            uniqueKeysWithValues: members.compactMap { member in
+                member.challengerID.map { ($0, member.penaltyHistory) }
+            }
+        )
+    }
+
+    // MARK: - Function
+
+    func execute() async throws -> [MemberManagementItem] {
+        lock.lock()
+        defer { lock.unlock() }
+        return members
+    }
+
+    func executePage(page: Int) async throws -> MemberPage {
+        lock.lock()
+        defer { lock.unlock() }
+        // 프리뷰 픽스처는 1페이지 분량만 제공하므로 이후 페이지는 빈 결과로 종료한다.
+        guard page == 0 else {
+            return MemberPage(members: [], hasNext: false, currentPage: page)
+        }
+        return MemberPage(members: members, hasNext: false, currentPage: page)
+    }
+
+    func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws {
+        lock.lock()
+        defer { lock.unlock() }
+        let record = OperatorMemberPenaltyHistory(
+            challengerPointId: "preview-\(historyByChallenger[challengerId]?.count ?? 0)",
+            date: MemberListPreviewData.referenceDate,
+            reason: description,
+            penaltyScore: Double(pointValue),
+            pointType: pointType
+        )
+        historyByChallenger[challengerId, default: []].insert(record, at: 0)
+    }
+
+    func deletePoint(challengerPointId: String) async throws {
+        lock.lock()
+        defer { lock.unlock() }
+        for (challengerId, records) in historyByChallenger {
+            historyByChallenger[challengerId] = records.filter {
+                $0.challengerPointId != challengerPointId
+            }
+        }
+    }
+
+    func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory] {
+        lock.lock()
+        defer { lock.unlock() }
+        return historyByChallenger[challengerId] ?? []
+    }
+
+    func fetchAllGenerations(memberId: String) async throws -> String {
+        MemberListPreviewData.generations
+    }
+
+    func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary] {
+        MemberListPreviewData.generationPointSummaries
+    }
+
+    func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord] {
+        MemberListPreviewData.attendanceRecords
+    }
+}
+
+// MARK: - Preview Data
+
+/// 구성원 목록 화면 프리뷰 픽스처
+enum MemberListPreviewData {
+
+    /// 픽스처 기준 시각 (2026-08-03 19:00 KST)
+    static let referenceDate = Date(timeIntervalSince1970: 1_785_492_000)
+
+    static let generations = "11, 12"
+
+    static let generationPointSummaries: [GenerationPointSummary] = [
+        GenerationPointSummary(gisu: 12, reward: 5, penalty: 6),
+        GenerationPointSummary(gisu: 11, reward: 4, penalty: 0),
+    ]
+
+    static let attendanceRecords: [MemberAttendanceRecord] = [
+        MemberAttendanceRecord(sessionTitle: "1주차 OT", week: 1, status: .present),
+        MemberAttendanceRecord(sessionTitle: "2주차 세미나", week: 2, status: .late),
+        MemberAttendanceRecord(sessionTitle: "3주차 스터디", week: 3, status: .absent),
+        MemberAttendanceRecord(sessionTitle: "4주차 데모데이", week: 4, status: .beforeAttendance),
+    ]
+
+    static let members: [MemberManagementItem] = [
+        makeMember(
+            id: "11",
+            name: "김챌린",
+            nickname: "챌린",
+            part: .front(type: .ios),
+            position: "챌린저",
+            team: .challenger,
+            penalty: 6,
+            reward: 5
+        ),
+        makeMember(
+            id: "12",
+            name: "박안드",
+            nickname: "안드",
+            part: .front(type: .android),
+            position: "챌린저",
+            team: .challenger,
+            penalty: 0,
+            reward: 3
+        ),
+        makeMember(
+            id: "13",
+            name: "이서버",
+            nickname: "서버",
+            part: .server(type: .spring),
+            position: "파트장",
+            team: .schoolPartLeader,
+            penalty: 2,
+            reward: 8
+        ),
+        makeMember(
+            id: "14",
+            name: "최기획",
+            nickname: "기획",
+            part: .pm,
+            position: "회장",
+            team: .schoolPresident,
+            penalty: 0,
+            reward: 12,
+            badge: true
+        ),
+        makeMember(
+            id: "15",
+            name: "정디자",
+            nickname: "디자",
+            part: .design,
+            position: "챌린저",
+            team: .challenger,
+            penalty: 4,
+            reward: 1
+        ),
+    ]
+
+    // MARK: - Helper
+
+    private static func makeMember(
+        id: String,
+        name: String,
+        nickname: String,
+        part: UMCPartType,
+        position: String,
+        team: ManagementTeam,
+        penalty: Double,
+        reward: Double,
+        badge: Bool = false
+    ) -> MemberManagementItem {
+        MemberManagementItem(
+            memberID: id,
+            challengerID: "1\(id)",
+            profile: nil,
+            name: name,
+            nickname: nickname,
+            generation: "12",
+            school: "한성대학교",
+            position: position,
+            part: part,
+            penalty: penalty,
+            rewardPoints: reward,
+            badge: badge,
+            managementTeam: team,
+            attendanceRecords: attendanceRecords,
+            penaltyHistory: penalty > 0 ? penaltyHistory : [],
+            generationPoints: generationPointSummaries
+        )
+    }
+
+    private static let penaltyHistory: [OperatorMemberPenaltyHistory] = [
+        OperatorMemberPenaltyHistory(
+            challengerPointId: "9001",
+            date: referenceDate.addingTimeInterval(-604_800),
+            reason: "스터디 지각",
+            penaltyScore: 2,
+            pointType: .studyLate
+        ),
+        OperatorMemberPenaltyHistory(
+            challengerPointId: "9002",
+            date: referenceDate.addingTimeInterval(-1_209_600),
+            reason: "워크북 미제출",
+            penaltyScore: 4,
+            pointType: .noWorkbookMission
+        ),
+    ]
+}
+
+// MARK: - Preview ViewModel
+
+/// 프리뷰용 `MemberListViewModel` 을 조립한다.
+///
+/// - Parameter session: 화면이 참조하는 권한 세션. 운영진 화면은 상벌점 부여 권한이 열린
+///   세션을, 챌린저 화면은 기본 세션을 넘긴다.
+@MainActor
+func previewMemberListViewModel(
+    errorHandler: ErrorHandler,
+    session: UserSessionManager
+) -> MemberListViewModel {
+    MemberListViewModel(
+        fetchMembersUseCase: PreviewMemberListUseCase(),
+        errorHandler: errorHandler,
+        userSessionManager: session
+    )
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/OperatorAttendancePreviewSupport.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/OperatorAttendancePreviewSupport.swift
@@ -1,0 +1,183 @@
+//
+//  OperatorAttendancePreviewSupport.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import ActivityDomain
+import Foundation
+import UMCFoundation
+
+// MARK: - Preview Stub UseCase
+
+/// 네트워크 없이 운영진 출석 화면을 확인하기 위한 프리뷰 전용 UseCase (절대규칙 #5)
+///
+/// 결정(`decideAttendances`)은 로컬 상태를 바꾸지 않고 요청한 결정을 그대로 반영한 결과만
+/// 돌려준다. 화면의 낙관적 갱신 경로를 그대로 태우기 위함이다.
+final class PreviewOperatorAttendanceUseCase: OperatorAttendanceUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let schedules: [ScheduleAttendanceInfo]
+
+    // MARK: - Init
+
+    init(schedules: [ScheduleAttendanceInfo] = OperatorAttendancePreviewData.schedules) {
+        self.schedules = schedules
+    }
+
+    // MARK: - Function
+
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> [ScheduleAttendanceInfo] {
+        guard let attendanceStatus else { return schedules }
+        return schedules.filter { schedule in
+            schedule.participants.contains { $0.attendanceStatus == attendanceStatus }
+        }
+    }
+
+    func fetchAttendanceDetail(
+        scheduleId: String,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> ScheduleAttendanceInfo {
+        guard let matched = schedules.first(where: { $0.scheduleId == scheduleId }) else {
+            throw ActivityPreviewError.notFound(scheduleId)
+        }
+        return matched
+    }
+
+    func decideAttendances(
+        scheduleId: String,
+        decisions: [AttendanceDecisionInput]
+    ) async throws -> [AttendanceDecisionResult] {
+        decisions.map { decision in
+            AttendanceDecisionResult(
+                status: decision.isApproved ? .present : .absent,
+                decidedAt: OperatorAttendancePreviewData.referenceDate,
+                decisionReason: decision.reason,
+                excuseReason: nil,
+                latitude: nil,
+                longitude: nil,
+                decisionMakerMemberInfo: AttendanceDecisionResult.DecisionMakerInfo(
+                    memberId: "1",
+                    name: "김유엠",
+                    nickname: "유엠",
+                    schoolId: "3",
+                    schoolName: "한성대학교"
+                ),
+                isPendingDecision: false
+            )
+        }
+    }
+
+    func updateScheduleLocation(
+        scheduleId: String,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    ) async throws {}
+}
+
+// MARK: - Preview Data
+
+/// 운영진 출석 화면 프리뷰 픽스처
+///
+/// 시간 의존 값은 `Date(timeIntervalSince1970:)` 기준으로 고정해 실행 시점과 무관하게
+/// 같은 화면이 나오도록 한다.
+enum OperatorAttendancePreviewData {
+
+    /// 픽스처 기준 시각 (2026-08-03 19:00 KST)
+    static let referenceDate = Date(timeIntervalSince1970: 1_785_492_000)
+
+    static let schedules: [ScheduleAttendanceInfo] = [
+        ScheduleAttendanceInfo(
+            scheduleId: "801",
+            name: "iOS 파트 정기 세미나",
+            description: "주차별 커리큘럼 세미나입니다.",
+            startsAt: referenceDate,
+            endsAt: referenceDate.addingTimeInterval(7_200),
+            location: ScheduleLocation(
+                latitude: 37.582_573,
+                longitude: 127.010_111,
+                locationName: "한성대학교 상상관 5층"
+            ),
+            isOnline: false,
+            authorMemberId: "1",
+            attendancePolicy: ScheduleAttendancePolicy(
+                checkInStartAt: referenceDate.addingTimeInterval(-1_800),
+                onTimeEndAt: referenceDate.addingTimeInterval(600),
+                lateEndAt: referenceDate.addingTimeInterval(1_800)
+            ),
+            tags: ["세미나"],
+            participants: [
+                makeParticipant(id: "11", name: "김챌린", status: .presentPending),
+                makeParticipant(id: "12", name: "박지각", status: .latePending),
+                makeParticipant(
+                    id: "13",
+                    name: "이사유",
+                    status: .excusedPending,
+                    excuseReason: "학과 전공 필수 수업과 시간이 겹칩니다."
+                ),
+                makeParticipant(id: "14", name: "최출석", status: .present),
+                makeParticipant(id: "15", name: "정결석", status: .absent),
+            ]
+        ),
+        ScheduleAttendanceInfo(
+            scheduleId: "802",
+            name: "중앙 연합 워크숍",
+            description: "전국 지부 합동 워크숍입니다.",
+            startsAt: referenceDate.addingTimeInterval(604_800),
+            endsAt: referenceDate.addingTimeInterval(612_000),
+            location: nil,
+            isOnline: true,
+            authorMemberId: "1",
+            attendancePolicy: nil,
+            tags: ["워크숍", "온라인"],
+            participants: [
+                makeParticipant(id: "11", name: "김챌린", status: .present),
+                makeParticipant(id: "12", name: "박지각", status: .late),
+            ]
+        ),
+    ]
+
+    // MARK: - Helper
+
+    private static func makeParticipant(
+        id: String,
+        name: String,
+        status: ParticipantAttendanceStatus,
+        excuseReason: String? = nil
+    ) -> ParticipantAttendance {
+        ParticipantAttendance(
+            memberId: id,
+            name: name,
+            nickname: "\(name)닉",
+            profileImageURL: "",
+            schoolId: "3",
+            schoolName: "한성대학교",
+            attendanceStatus: status,
+            isLocationVerified: status == .present,
+            excuseReason: excuseReason
+        )
+    }
+}
+
+// MARK: - Preview Error
+
+/// 프리뷰 스텁이 요청 대상을 못 찾았을 때 던지는 에러
+enum ActivityPreviewError: LocalizedError {
+    case notFound(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notFound(let id):
+            "프리뷰 데이터에 없는 항목입니다: \(id)"
+        }
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/DIContainer+StubSession.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/DIContainer+StubSession.swift
@@ -1,0 +1,45 @@
+//
+//  DIContainer+StubSession.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import AuthDomain
+import CoreDI
+import CoreDomain
+import HomeDomain
+import NoticeDomain
+import os.log
+
+extension DIContainer {
+
+    /// stub 세션용 Repository 오버라이드를 등록한다.
+    ///
+    /// `DIContainer.register`는 마지막 등록이 이기므로(last-wins), 실제 의존성 등록이 모두
+    /// 끝난 뒤 · 최초 `resolve` 이전(= `UMCAppApp.init()` 내부)에 호출해야 한다.
+    /// Repository 계층만 교체하므로 UseCase/도메인 로직(승인 판정, 프로필 동기화,
+    /// 최근 공지 5건 절삭 등)은 실물 그대로 동작한다.
+    func registerStubSessionOverrides() {
+        register(AuthRepositoryProtocol.self) {
+            StubAuthRepository()
+        }
+        register(MemberProfileRepositoryProtocol.self) {
+            StubMemberProfileRepository()
+        }
+        register(HomeRepositoryProtocol.self) {
+            StubHomeRepository()
+        }
+        register(ScheduleRepositoryProtocol.self) {
+            StubScheduleRepository()
+        }
+        register(NoticeRepositoryProtocol.self) {
+            StubNoticeRepository()
+        }
+
+        Logger(subsystem: "UMCApp", category: "StubSession")
+            .notice("Stub 세션 모드 활성화 — 인증·홈·공지 데이터가 픽스처로 대체됩니다.")
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubAuthRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubAuthRepository.swift
@@ -1,0 +1,47 @@
+//
+//  StubAuthRepository.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import AuthDomain
+
+/// 카카오 로그인 서버 미등록 기간 한정 인증 Repository stub (절대규칙 #5).
+///
+/// `hasSession()`이 항상 `true`이므로 부트스트랩(`CheckAuthStatusUseCase`)이 토큰 검사를
+/// 통과하고, stub 프로필 조회 → 승인 판정을 거쳐 로그인 화면 없이 홈으로 직행한다.
+/// 소셜 로그인은 전부 기존 회원 성공으로 처리한다 (SDK 호출 이전 단계는 각 Manager 소관이라
+/// 카카오 버튼 실탭은 여전히 SDK에서 실패할 수 있음 — 이메일 로그인은 SDK 미경유라 동작).
+struct StubAuthRepository: AuthRepositoryProtocol {
+
+    func hasSession() async -> Bool {
+        true
+    }
+
+    func refreshSession() async throws {}
+
+    func logout() async throws {}
+
+    func loginKakao(accessToken: String, email: String) async throws -> OAuthLoginResult {
+        .existingMember
+    }
+
+    func loginApple(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    ) async throws -> OAuthLoginResult {
+        .existingMember
+    }
+
+    func loginGoogle(accessToken: String) async throws -> OAuthLoginResult {
+        .existingMember
+    }
+
+    func loginByEmail(email: String, password: String) async throws -> LoginByIdPwResult {
+        LoginByIdPwResult(memberId: StubSessionFixtures.profile.memberId)
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubHomeRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubHomeRepository.swift
@@ -1,0 +1,20 @@
+//
+//  StubHomeRepository.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import HomeDomain
+
+/// 카카오 로그인 서버 미등록 기간 한정 홈 프로필 Repository stub (절대규칙 #5).
+///
+/// 시즌 카드/세대별 상벌점 카드 픽스처를 반환한다.
+struct StubHomeRepository: HomeRepositoryProtocol {
+
+    func fetchMyProfile(forceRefresh: Bool) async throws -> HomeProfileResult {
+        StubSessionFixtures.homeProfileResult
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubMemberProfileRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubMemberProfileRepository.swift
@@ -1,0 +1,25 @@
+//
+//  StubMemberProfileRepository.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import CoreDomain
+
+/// 카카오 로그인 서버 미등록 기간 한정 정본 프로필 Repository stub (절대규칙 #5).
+///
+/// 항상 승인된(`isApproved`) 픽스처 프로필을 반환해 부트스트랩이 `.approved`로 판정되게 한다.
+/// `primeCache`/`invalidateCache`는 프로토콜 기본 구현(no-op)을 그대로 사용한다.
+struct StubMemberProfileRepository: MemberProfileRepositoryProtocol {
+
+    func fetchMyProfile() async throws -> Profile {
+        StubSessionFixtures.profile
+    }
+
+    func fetchMyProfile(forceRefresh: Bool) async throws -> Profile {
+        StubSessionFixtures.profile
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubNoticeRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubNoticeRepository.swift
@@ -1,0 +1,152 @@
+//
+//  StubNoticeRepository.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import Foundation
+import NoticeDomain
+
+/// stub 세션에서 지원하지 않는 쓰기 동작에 대한 에러.
+///
+/// ErrorHandler 전역 Alert로 표면화되어 "stub 미지원" 사실이 UI에서 바로 드러난다.
+enum StubSessionError: LocalizedError {
+    case unsupported(action: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupported(let action):
+            "Stub 세션에서는 지원하지 않는 동작입니다: \(action)"
+        }
+    }
+}
+
+/// 카카오 로그인 서버 미등록 기간 한정 공지 Repository stub (절대규칙 #5).
+///
+/// 홈 최근 공지 5건(`FetchRecentNoticesUseCase` → `getAllNotices`)과 공지 상세
+/// (`NoticeUseCase` → `getDetailNotice`)가 같은 프로토콜을 공유하므로 이 stub 하나로
+/// 목록·상세가 함께 동작한다. 읽기는 픽스처, 참여형(읽음/투표)은 no-op 성공,
+/// 생성·수정·삭제·리마인더는 `StubSessionError`를 던져 미지원임을 알린다.
+struct StubNoticeRepository: NoticeRepositoryProtocol {
+
+    // MARK: - 공지 조회 (픽스처)
+
+    func getAllNotices(request: NoticeListRequest) async throws -> NoticePage {
+        NoticePage(
+            items: StubSessionFixtures.notices,
+            hasNext: false,
+            totalElements: String(StubSessionFixtures.notices.count)
+        )
+    }
+
+    func getDetailNotice(noticeId: String) async throws -> NoticeDetail {
+        if let detail = StubSessionFixtures.noticeDetails[noticeId] {
+            return detail
+        }
+        guard let fallback = StubSessionFixtures.notices.first else {
+            throw StubSessionError.unsupported(action: "공지 상세 조회 (\(noticeId))")
+        }
+        return fallback.toNoticeDetail()
+    }
+
+    func getReadStatics(noticeId: String) async throws -> NoticeReadStatics {
+        StubSessionFixtures.readStatics
+    }
+
+    func getReadStatusList(
+        noticeId: String,
+        cursorId: String,
+        filterType: String,
+        organizationIds: [String],
+        status: String
+    ) async throws -> NoticeReadStatusPage {
+        StubSessionFixtures.readStatusPage
+    }
+
+    func searchNotice(
+        keyword: String,
+        request: NoticeListRequest
+    ) async throws -> NoticePage {
+        let matched = StubSessionFixtures.notices.filter {
+            $0.title.localizedCaseInsensitiveContains(keyword)
+                || $0.content.localizedCaseInsensitiveContains(keyword)
+        }
+        return NoticePage(
+            items: matched,
+            hasNext: false,
+            totalElements: String(matched.count)
+        )
+    }
+
+    // MARK: - 참여형 액션 (no-op 성공)
+
+    func readNotice(noticeId: String) async throws {}
+
+    func submitVoteResponse(noticeId: String, optionIds: [String]) async throws {}
+
+    func updateVoteResponse(noticeId: String, optionIds: [String]) async throws {}
+
+    // MARK: - 생성/수정/삭제 (미지원)
+
+    func createNotice(
+        title: String,
+        content: String,
+        shouldNotify: Bool,
+        targetInfo: NoticeTargetInfo,
+        links: [String],
+        imageIds: [String]
+    ) async throws -> NoticeDetail {
+        throw StubSessionError.unsupported(action: "공지 생성")
+    }
+
+    func addVote(
+        noticeId: String,
+        title: String,
+        isAnonymous: Bool,
+        allowMultipleChoice: Bool,
+        startsAt: Date,
+        endsAtExclusive: Date,
+        options: [String]
+    ) async throws -> String {
+        throw StubSessionError.unsupported(action: "투표 추가")
+    }
+
+    func addLink(noticeId: String, links: [String]) async throws -> NoticeItemModel {
+        throw StubSessionError.unsupported(action: "링크 추가")
+    }
+
+    func addImage(noticeId: String, imageIds: [String]) async throws -> NoticeItemModel {
+        throw StubSessionError.unsupported(action: "이미지 추가")
+    }
+
+    func sendReminder(noticeId: String, targetIds: [String]) async throws {
+        throw StubSessionError.unsupported(action: "리마인더 발송")
+    }
+
+    func updateNotice(
+        noticeId: String,
+        title: String,
+        content: String
+    ) async throws -> NoticeDetail {
+        throw StubSessionError.unsupported(action: "공지 수정")
+    }
+
+    func updateLinks(noticeId: String, links: [String]) async throws -> NoticeDetail {
+        throw StubSessionError.unsupported(action: "링크 수정")
+    }
+
+    func updateImages(noticeId: String, imageIds: [String]) async throws -> NoticeDetail {
+        throw StubSessionError.unsupported(action: "이미지 수정")
+    }
+
+    func deleteNotice(noticeId: String) async throws {
+        throw StubSessionError.unsupported(action: "공지 삭제")
+    }
+
+    func deleteVote(noticeId: String) async throws {
+        throw StubSessionError.unsupported(action: "투표 삭제")
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubScheduleRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubScheduleRepository.swift
@@ -1,0 +1,25 @@
+//
+//  StubScheduleRepository.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import Foundation
+import HomeDomain
+
+/// 카카오 로그인 서버 미등록 기간 한정 홈 일정 Repository stub (절대규칙 #5).
+///
+/// 요청 기간 기준 상대 날짜로 픽스처를 생성하므로 달을 이동해도 일정이 표시된다.
+struct StubScheduleRepository: ScheduleRepositoryProtocol {
+
+    func fetchMySchedules(
+        from: Date,
+        to: Date,
+        isAttendanceRequired: Bool
+    ) async throws -> [Date: [ScheduleDetailData]] {
+        StubSessionFixtures.schedules(from: from, to: to)
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubSessionFixtures.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubSessionFixtures.swift
@@ -1,0 +1,337 @@
+//
+//  StubSessionFixtures.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import CoreDomain
+import Foundation
+import HomeDomain
+import NoticeDomain
+import UMCFoundation
+
+/// stub 세션에서 사용하는 픽스처 데이터 모음 (단일 파일 집약).
+///
+/// 서버 정수 필드는 절대규칙 #2에 따라 전부 `String`으로 유지한다.
+/// UI 확인용 데이터를 조정할 때는 이 파일만 수정하면 된다.
+enum StubSessionFixtures {
+
+    // MARK: - Profile
+
+    /// 부트스트랩 승인 판정(`isApproved` = `generations` 비어있지 않음)을 통과하는 프로필.
+    ///
+    /// - Note: 관리자 UI 테스트가 필요하면 `roles`의 `roleType`을
+    ///   `.schoolPresident` 등으로 바꾸면 된다 — `SyncProfileStorageUseCase`(실물)가
+    ///   `UserSessionManager.currentRole`에 그대로 반영한다.
+    static let profile = Profile(
+        memberId: "1",
+        name: "김유엠",
+        nickname: "유엠",
+        generations: ["12", "11"],
+        schoolId: "3",
+        schoolName: "한성대학교",
+        latestChallengerId: "100",
+        latestGisuId: "10",
+        chapterId: "2",
+        chapterName: "GACI",
+        responsiblePart: "IOS",
+        roles: [
+            ProfileRole(
+                id: "1",
+                challengerId: "100",
+                gisu: "12",
+                gisuId: "10",
+                roleType: .challenger,
+                organizationType: .school,
+                organizationId: "3",
+                responsiblePart: "IOS"
+            )
+        ],
+        email: "stub@umc.test"
+    )
+
+    // MARK: - Home
+
+    /// 홈 시즌 카드/세대별 상벌점 카드 픽스처 (HomeView #Preview 데이터 기반).
+    static let homeProfileResult = HomeProfileResult(
+        memberId: "1",
+        seasonTypes: [.gens(["11", "12"]), .days(128)],
+        generations: [
+            HomeGeneration(
+                gisuId: "10",
+                gen: "12",
+                penaltyPoint: 6,
+                rewardPoint: 5,
+                pointLogs: [
+                    PointLog(id: "1", reason: "스터디 지각", date: "03.26", point: -2, isReward: false),
+                    PointLog(id: "2", reason: "우수 워크북", date: "03.28", point: 2, isReward: true),
+                    PointLog(id: "3", reason: "세미나 무단 결석", date: "04.02", point: -4, isReward: false),
+                    PointLog(id: "4", reason: "데모데이 우수팀", date: "04.15", point: 3, isReward: true),
+                ]
+            ),
+            HomeGeneration(gisuId: "9", gen: "11", penaltyPoint: 0, rewardPoint: 4, pointLogs: [
+                PointLog(id: "5", reason: "회의록 우수 작성", date: "10.11", point: 4, isReward: true)
+            ]),
+        ]
+    )
+
+    // MARK: - Notice
+
+    /// 최근 공지 목록 픽스처 (홈 최근 공지 5건 + 상세 화면 공용).
+    ///
+    /// 첨부 이미지는 실제 URL 로드가 발생하지 않도록 빈 배열로 둔다.
+    static let notices: [NoticeItemModel] = [
+        NoticeItemModel(
+            noticeId: "9001",
+            generation: "12",
+            scope: .central,
+            category: .general,
+            mustRead: true,
+            isAlert: true,
+            date: Date(timeIntervalSinceNow: -3_600),
+            title: "12기 중앙 해커톤 일정 안내",
+            content: """
+            안녕하세요, 중앙운영사무국입니다.
+
+            12기 중앙 해커톤 일정을 안내드립니다. 이번 해커톤은 전국 지부가 함께 참여하는 \
+            연합 행사로 진행되며, 참가 신청은 이번 주 금요일까지입니다.
+
+            - 일시: 8월 23일(토) ~ 24일(일)
+            - 장소: 추후 공지
+            - 준비물: 노트북, 열정
+
+            자세한 내용은 첨부 링크를 확인해주세요.
+            """,
+            writer: "운영진",
+            authorNickname: "메이커",
+            authorName: "김중앙",
+            links: ["https://umc.makeus.in"],
+            images: [],
+            vote: vote,
+            viewCount: "128"
+        ),
+        NoticeItemModel(
+            noticeId: "9002",
+            generation: "12",
+            scope: .branch,
+            category: .general,
+            mustRead: false,
+            isAlert: false,
+            date: Date(timeIntervalSinceNow: -14_400),
+            title: "GACI 지부 연합 스터디 모집",
+            content: """
+            GACI 지부에서 파트별 연합 스터디를 모집합니다.
+
+            iOS / Android / Web / Server 파트별로 주 1회 진행되며, \
+            타 학교 챌린저와 함께 성장할 수 있는 기회입니다.
+            """,
+            writer: "지부장",
+            authorNickname: "가치",
+            authorName: "박지부",
+            links: [],
+            images: [],
+            vote: nil,
+            viewCount: "56",
+            scopeDisplayName: "GACI"
+        ),
+        NoticeItemModel(
+            noticeId: "9003",
+            generation: "12",
+            scope: .campus,
+            category: .part(.front(type: .ios)),
+            mustRead: true,
+            isAlert: false,
+            date: Date(timeIntervalSinceNow: -86_400),
+            title: "iOS 파트 주차별 워크북 제출 안내",
+            content: """
+            iOS 파트 챌린저 여러분, 이번 주 워크북 제출 마감은 일요일 23시 59분입니다.
+
+            제출이 늦어지면 벌점이 부과되니 기한을 꼭 지켜주세요.
+            """,
+            writer: "파트장",
+            authorNickname: "스위프트",
+            authorName: "이파트",
+            links: [],
+            images: [],
+            vote: nil,
+            viewCount: "34",
+            scopeDisplayName: "한성대",
+            parts: [.front(type: .ios)]
+        ),
+        NoticeItemModel(
+            noticeId: "9004",
+            generation: "12",
+            scope: .campus,
+            category: .general,
+            mustRead: false,
+            isAlert: false,
+            date: Date(timeIntervalSinceNow: -172_800),
+            title: "동아리방 이용 수칙 안내",
+            content: "동아리방 이용 후에는 정리정돈을 부탁드립니다. 다음 사용자를 위한 배려입니다.",
+            writer: "총무",
+            authorNickname: "정리왕",
+            authorName: "최총무",
+            links: [],
+            images: [],
+            vote: nil,
+            viewCount: "21",
+            scopeDisplayName: "한성대"
+        ),
+        NoticeItemModel(
+            noticeId: "9005",
+            generation: "12",
+            scope: .central,
+            category: .general,
+            mustRead: false,
+            isAlert: false,
+            date: Date(timeIntervalSinceNow: -259_200),
+            title: "8월 회비 납부 안내",
+            content: "8월 회비 납부 기한은 8월 10일까지입니다. 계좌는 개별 안내를 확인해주세요.",
+            writer: "운영진",
+            authorNickname: "메이커",
+            authorName: "김중앙",
+            links: [],
+            images: [],
+            vote: nil,
+            viewCount: "87"
+        ),
+    ]
+
+    /// 해커톤 공지에 첨부되는 투표 픽스처 (상세 화면 투표 UI 확인용).
+    static let vote = NoticeVote(
+        id: "500",
+        question: "해커톤 참가 의사를 알려주세요",
+        options: [
+            VoteOption(id: "1", title: "참가", voteCount: "18"),
+            VoteOption(id: "2", title: "불참", voteCount: "4"),
+            VoteOption(id: "3", title: "미정", voteCount: "6"),
+        ],
+        startDate: Date(timeIntervalSinceNow: -86_400),
+        endDate: Date(timeIntervalSinceNow: 604_800),
+        allowMultipleChoices: false,
+        isAnonymous: true,
+        userVotedOptionIds: []
+    )
+
+    /// noticeId → 상세 픽스처. 목록 아이템과 동일 데이터로 상세를 구성해 정합을 보장한다.
+    static let noticeDetails: [String: NoticeDetail] = Dictionary(
+        uniqueKeysWithValues: notices.map { ($0.noticeId, $0.toNoticeDetail()) }
+    )
+
+    /// 열람 통계 픽스처 (The Ping).
+    static let readStatics = NoticeReadStatics(
+        totalCount: "42",
+        readCount: "35",
+        unreadCount: "7",
+        readRate: "83.3"
+    )
+
+    /// 열람 현황 상세 픽스처.
+    static let readStatusPage = NoticeReadStatusPage(
+        users: [
+            ReadStatusUser(
+                id: "1",
+                name: "김유엠",
+                nickName: "유엠",
+                part: "iOS",
+                branch: "GACI",
+                campus: "한성대",
+                profileImageURL: nil,
+                isRead: true
+            ),
+            ReadStatusUser(
+                id: "2",
+                name: "박챌린",
+                nickName: "챌린",
+                part: "Android",
+                branch: "GACI",
+                campus: "한성대",
+                profileImageURL: nil,
+                isRead: false
+            ),
+        ],
+        nextCursor: "",
+        hasNext: false
+    )
+
+    // MARK: - Schedule
+
+    /// 요청 기간(`from ~ to`) 안에 상대 날짜로 일정 픽스처를 생성한다.
+    ///
+    /// 달을 이동해도 항상 일정이 보이도록 기간 기준으로 며칠을 골라 채우고,
+    /// 오늘이 기간에 포함되면 오늘 일정도 추가한다 (홈 진입 직후 리스트 확인용).
+    static func schedules(from: Date, to: Date) -> [Date: [ScheduleDetailData]] {
+        let calendar = Calendar.kstGregorian
+        var result: [Date: [ScheduleDetailData]] = [:]
+
+        let templates: [(dayOffset: Int, name: String, tags: [String], isOnline: Bool)] = [
+            (2, "iOS 파트 정기 스터디", ["스터디"], false),
+            (9, "중앙 연합 세미나", ["세미나"], true),
+            (16, "지부 네트워킹 데이", ["네트워킹"], false),
+            (23, "운영진 정기 회의", ["회의"], true),
+        ]
+
+        for (index, template) in templates.enumerated() {
+            guard
+                let day = calendar.date(byAdding: .day, value: template.dayOffset, to: from),
+                day <= to
+            else { continue }
+            appendSchedule(
+                id: "80\(index)",
+                name: template.name,
+                tags: template.tags,
+                isOnline: template.isOnline,
+                on: day,
+                calendar: calendar,
+                into: &result
+            )
+        }
+
+        let today = Date.now
+        if today >= from, today <= to {
+            appendSchedule(
+                id: "899",
+                name: "홈 화면 QA 모각작",
+                tags: ["스터디"],
+                isOnline: false,
+                on: today,
+                calendar: calendar,
+                into: &result
+            )
+        }
+
+        return result
+    }
+
+    // MARK: - Private Function
+
+    /// 지정 날짜 19:00(KST) 시작, 2시간짜리 일정을 만들어 날짜 버킷에 추가한다.
+    private static func appendSchedule(
+        id: String,
+        name: String,
+        tags: [String],
+        isOnline: Bool,
+        on day: Date,
+        calendar: Calendar,
+        into result: inout [Date: [ScheduleDetailData]]
+    ) {
+        let bucket = calendar.startOfDay(for: day)
+        let startsAt = calendar.date(
+            bySettingHour: 19, minute: 0, second: 0, of: day
+        ) ?? day
+        let schedule = ScheduleDetailData(
+            scheduleId: id,
+            name: name,
+            description: "stub 세션 일정입니다. UI 확인용 데이터로, 서버와 무관합니다.",
+            tags: tags,
+            startsAt: startsAt,
+            endsAt: startsAt.addingTimeInterval(7_200),
+            isParticipant: true,
+            isOnline: isOnline
+        )
+        result[bucket, default: []].append(schedule)
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubSessionMode.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubSessionMode.swift
@@ -1,0 +1,21 @@
+//
+//  StubSessionMode.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+/// 카카오 로그인 서버 미등록 기간 한정 stub 세션 토글 (단일 진실 원천).
+///
+/// 서버 팀이 카카오 개발자 콘솔에 iOS bundle id를 등록할 때까지 소셜 로그인이 불가능하므로,
+/// 이 플래그가 `true`이면 앱 시작 시 인증·홈 데이터 Repository를 stub 구현체로 교체해
+/// 로그인 없이 홈 화면에 진입한다 (`DIContainer+StubSession.swift`).
+///
+/// - Important: stub 모드 on/off는 **이 파일의 `isEnabled` 한 곳**에서만 제어한다.
+///   서버가 bundle id를 등록하면 `false`로 바꾸는 것만으로 실서버 경로로 복귀한다.
+///   릴리스 빌드에는 이 파일과 stub 구현 전체가 컴파일되지 않는다 (`#if DEBUG`).
+enum StubSessionMode {
+    static let isEnabled = true
+}
+#endif

--- a/UMCApp/UMCApp/Sources/UMCAppApp.swift
+++ b/UMCApp/UMCApp/Sources/UMCAppApp.swift
@@ -51,6 +51,13 @@ struct UMCAppApp: App {
         container.registerActivityDependencies()
         container.registerMyPageDependencies()
         container.registerMaintenanceDependencies()
+        #if DEBUG
+        // 카카오 로그인 서버 미등록 기간 한정 stub 세션 (StubSessionMode.swift 단일 토글).
+        // 실제 등록 뒤 · 최초 resolve 전에 호출해야 오버라이드가 안전하다 (last-wins).
+        if StubSessionMode.isEnabled {
+            container.registerStubSessionOverrides()
+        }
+        #endif
         _container = State(initialValue: container)
         // RemoteConfig 접근은 lazy이므로, FirebaseApp.configure() 이전에 이 ViewModel을
         // 만들어도 실제 RemoteConfig 인스턴스는 생성되지 않는다.


### PR DESCRIPTION
resolves #1049

## ✨ PR 유형

🛠️ [Chore] — 개발 전용(DEBUG) 도구 추가. 프로덕션 동작 변경 없음.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 활동 탭 진입 화면(출석 현황) · 섹션 메뉴 · 모드 전환 캡쳐 첨부 -->

## 🛠️ 작업내용

카카오 개발자 콘솔에 iOS bundle id가 등록되지 않아 소셜 로그인이 불가능한 상태입니다. 로그인을 못 하면 탭바에 진입할 수 없어 이식된 Activity 화면을 실행 검증할 수단이 없어, 이를 우회하는 개발 전용 경로를 만들었습니다.

**1. 로그인 우회 stub 세션** (`UMCApp/Sources/Debug/StubSession/`)

앱 조립 시점에 인증·홈 데이터 Repository만 스텁으로 교체합니다. `DIContainer.register`가 last-wins라 실제 등록 뒤·최초 `resolve` 전에 덮어쓰고, UseCase·도메인 로직(승인 판정, 프로필 동기화 등)은 실물이 그대로 돕니다.

- 교체 대상: `AuthRepositoryProtocol` · `MemberProfileRepositoryProtocol` · `HomeRepositoryProtocol` · `ScheduleRepositoryProtocol` · `NoticeRepositoryProtocol`
- `hasSession()`이 `true`를 반환해 부트스트랩이 승인 판정을 통과 → 로그인 화면 없이 홈 진입
- on/off는 `StubSessionMode.isEnabled` **한 곳**에서만 제어

**2. Activity 화면 확인 하네스** (`ActivityFeatureView`)

기존 하네스가 운영진 스터디 관리 1개 화면만 노출해, 이식된 나머지 화면에 진입 경로가 없었습니다. 레거시 `ActivityView`와 같은 구성으로 맞췄습니다 — 탭 진입 시 기본 섹션(출석)이 바로 뜨고, 상단 타이틀 메뉴로 섹션을 전환하며, 모드 전환 시 대응 섹션으로 매핑됩니다.

- 확인 가능 화면: 챌린저 스터디 · 구성원 목록 / 운영진 출석 관리 · 멤버 관리 · 스터디 관리 · 그룹 생성 폼
- 각 화면은 `PreviewSupport` 스텁 UseCase로 조립해 네트워크를 타지 않습니다

전 자산이 `#if DEBUG` 가드 안에 있어 릴리스 빌드에는 컴파일되지 않습니다.

## 📋 추후 진행 상황

- 서버가 bundle id를 등록하면 `StubSessionMode.isEnabled`를 `false`로 되돌려 실서버 경로로 복귀 (이후 스텁 자산 제거)
- 하네스는 Activity 탭 실연결(#997)·탭 루트 이식(#996) 시 실제 배선으로 교체
- 챌린저 출석 화면(#1013)이 이식되면 하네스 기본 모드를 레거시와 동일하게 챌린저로 되돌릴 수 있음

## 📌 리뷰 포인트

| 포인트 | 내용 |
|---|---|
| **스텁 주입 위치** | `UMCAppApp.swift` — 실제 등록 직후·`_container` 대입 전에 오버라이드합니다. 최초 `resolve` 전이어야 캐시가 오염되지 않는데, 이 순서가 맞는지 봐주세요 |
| **교체 범위** | Repository 계층만 바꾸고 UseCase는 실물을 태웠습니다. 검증 가치를 위한 선택인데 과한지/부족한지 의견 주세요 |
| **하네스 기본 모드** | 레거시 기본은 챌린저지만 그 기본 섹션(출석 체크)이 미이식이라 진입 화면이 안내 문구가 됩니다. 확인 가능한 운영진 모드를 초기값으로 뒀습니다 |
| **섹션 enum 위치** | 프로덕션 `ActivitySection`은 탭 루트 이식(#996) 범위라, 하네스는 `DebugActivitySection` 사본을 `#if DEBUG` 안에 뒀습니다. 나중에 충돌하지 않도록 한 조치입니다 |
| **네비게이션 방식** | 상위 `RootTabView`의 `NavigationStack`이 `[NavigationDestination]` 타입 경로라 다른 타입의 value 링크가 무시됩니다. 앱 라우팅에 끼어들지 않도록 목적지를 직접 들고 있는 링크를 썼습니다 |

Notice 모듈은 이번 범위에서 제외했습니다. 다만 작업 중 홈 → 공지 카드 탭 시 DI 미등록으로 크래시하는 것을 확인했고(`develop`에서도 재현), 상세는 #1049 본문에 기록해 뒀습니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
