### PR TITLE
🐛 [Fix] 스터디 그룹 생성 RepositoryError 권한 코드 범위 게이트

### DIFF
--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/OperatorStudyManagementViewModel.swift
@@ -26,6 +26,23 @@ final class OperatorStudyManagementViewModel {
         /// 낙관적 삽입으로 만든 로컬 placeholder 그룹의 serverID 접두사.
         /// 서버 호출 대상이 아님을 구분하는 표식 — 백그라운드 새로고침으로 곧 교체됩니다.
         static let localGroupIDPrefix = "new_"
+
+        /// 그룹 생성 실패를 로컬 Alert 로 소화해도 되는 "권한 없음" 업무 코드.
+        ///
+        /// `NetworkError` 경로의 `statusCode == 403` 게이트와 같은 역할이다.
+        /// `RepositoryError.serverError` 의 첫 값은 HTTP 상태가 아니라 업무 코드이므로,
+        /// 서버가 403(FORBIDDEN)으로 정의한 코드만 여기 담는다.
+        ///
+        /// - Note: 접두사(`AUTHORIZATION-`) 매칭을 쓰지 않는다. 같은 접두사에 권한과 무관한
+        ///   코드가 섞여 있고(`-0003` 400, `-0004` 500, `-0010` 404, `-0011` 501), 반대로
+        ///   스터디 그룹 전용 권한 거부는 다른 접두사(`ORGANIZATION-0031`)를 쓰기 때문이다.
+        ///   판별이 애매한 코드는 넣지 않는다 — 누락은 전역 Alert 로 끝나지만, 과다 포함은
+        ///   errorHandler(세션 만료·로깅)를 우회시킨다.
+        static let permissionDeniedServerCodes: Set<String> = [
+            "AUTHORIZATION-0001",  // PERMISSION_DENIED
+            "AUTHORIZATION-0002",  // RESOURCE_ACCESS_DENIED (@CheckAccess 거부)
+            "ORGANIZATION-0031"    // STUDY_GROUP_ACCESS_DENIED (학교 운영진 아님)
+        ]
     }
 
     private let errorHandler: ErrorHandler
@@ -759,13 +776,23 @@ final class OperatorStudyManagementViewModel {
     }
 
     private func presentStudyGroupCreateAlert(from error: RepositoryError) -> Bool {
-        guard case .serverError(_, let message) = error,
-              let message,
-              !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard case .serverError(let code, let message) = error else {
             return false
         }
 
-        presentAlert(title: "그룹 생성 실패", message: message)
+        // 로컬 Alert 로 소화하는 대상은 권한 거부 코드뿐이다(형제 `NetworkError` 오버로드의
+        // `statusCode == 403` 게이트와 동일 범위). 그 외 실패(세션 만료·5xx·미정의 코드)는
+        // message 가 있더라도 여기서 처리하지 않고 false 를 반환해, 호출부가
+        // errorHandler(로깅/세션 처리)로 흘려보내도록 한다.
+        let errorCode = code?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard Constants.permissionDeniedServerCodes.contains(errorCode) else {
+            return false
+        }
+
+        let trimmed = message?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return false }
+
+        presentAlert(title: "그룹 생성 실패", message: trimmed)
         return true
     }
 

--- a/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/OperatorStudyManagementViewModelTests.swift
@@ -441,6 +441,86 @@ struct OperatorStudyManagementViewModelCreateTests {
         // 에러는 errorHandler 경로로 흘러간다.
         #expect(viewModel.alertPrompt == nil)
     }
+
+    // MARK: - RepositoryError 경로 (NetworkError 오버로드와 동일한 범위 게이트)
+
+    @Test(
+        "생성 RepositoryError — 권한 거부 코드는 서버 메시지를 로컬 Alert 로 보여준다",
+        arguments: ["AUTHORIZATION-0001", "AUTHORIZATION-0002", "ORGANIZATION-0031"]
+    )
+    func createPresentsAlertForRepositoryPermissionCode(code: String) async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        useCase.createError = RepositoryError.serverError(
+            code: code,
+            message: "스터디 그룹을 만들 권한이 없어요."
+        )
+        let viewModel = makeViewModel(useCase: useCase, gisuId: "11")
+
+        let created = await viewModel.createGroup(
+            name: "iOS 스터디",
+            part: .front(type: .ios),
+            mentors: [makeChallenger(memberId: "9", challengerId: "909")],
+            members: []
+        )
+
+        #expect(created == false)
+        #expect(viewModel.alertPrompt?.title == "그룹 생성 실패")
+        #expect(viewModel.alertPrompt?.message == "스터디 그룹을 만들 권한이 없어요.")
+    }
+
+    /// 권한 거부가 아닌 실패는 message 가 있어도 로컬 Alert 로 소화하지 않는다.
+    ///
+    /// `AUTHORIZATION-0003`(400)·`-0004`(500)·`-0010`(404) 는 권한 코드와 **접두사가 같지만**
+    /// 권한 거부가 아니다 — 접두사 매칭으로 게이트하면 이 케이스들이 잘못 소화된다.
+    @Test(
+        "생성 RepositoryError — 권한 거부가 아닌 코드는 소화하지 않고 errorHandler 로 전파",
+        arguments: [
+            "JWT-0002",             // 세션 만료 (401)
+            "AUTHORIZATION-0003",   // 같은 접두사지만 400 (권한 값 오류)
+            "AUTHORIZATION-0004",   // 같은 접두사지만 500 (정책 평가 실패)
+            "AUTHORIZATION-0010",   // 같은 접두사지만 404 (역할 없음)
+            "COMMON-500",           // 서버 오류
+            "STUDY-9999"            // 미정의 코드
+        ]
+    )
+    func createDoesNotSwallowRepositoryNonPermissionCode(code: String) async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        useCase.createError = RepositoryError.serverError(
+            code: code,
+            message: "서버가 내려준 실패 메시지"
+        )
+        let viewModel = makeViewModel(useCase: useCase, gisuId: "11")
+
+        let created = await viewModel.createGroup(
+            name: "iOS 스터디",
+            part: .front(type: .ios),
+            mentors: [makeChallenger(memberId: "9", challengerId: "909")],
+            members: []
+        )
+
+        #expect(created == false)
+        #expect(viewModel.alertPrompt == nil)
+    }
+
+    @Test("생성 RepositoryError — 권한 코드라도 message 가 비면 소화하지 않고 전파")
+    func createDoesNotSwallowRepositoryPermissionCodeWithoutMessage() async {
+        let useCase = MockOperatorStudyManagementUseCase()
+        useCase.createError = RepositoryError.serverError(
+            code: "AUTHORIZATION-0002",
+            message: "   "
+        )
+        let viewModel = makeViewModel(useCase: useCase, gisuId: "11")
+
+        let created = await viewModel.createGroup(
+            name: "iOS 스터디",
+            part: .front(type: .ios),
+            mentors: [makeChallenger(memberId: "9", challengerId: "909")],
+            members: []
+        )
+
+        #expect(created == false)
+        #expect(viewModel.alertPrompt == nil)
+    }
 }
 
 // MARK: - 그룹 수정 / 삭제


### PR DESCRIPTION
resolves #1054

## ✨ PR 유형

🐛 버그 수정 — 그룹 생성 실패 처리의 범위 게이트 누락

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 테스트 성공 캡쳐 + 커버리지 리포트 첨부 예정 (CI 미적용 기간 한시 정책) -->

## 🛠️ 작업내용

`presentStudyGroupCreateAlert(from: RepositoryError)` 에 권한 코드 범위 게이트를 추가했습니다.

기존에는 서버 응답에 `message` 만 있으면 **실패 종류와 무관하게** 로컬 Alert 로 소화하고
`return true` → 호출부 early return 으로 전역 `errorHandler`(로깅·세션 만료 처리)를 우회했습니다.
형제 오버로드 `presentStudyGroupCreateAlert(from: NetworkError)` 는 이미 `statusCode == 403`
게이트를 갖고 있어 같은 화면의 두 실패 경로가 어긋나 있었고, 이번 수정으로 대칭을 맞췄습니다.

### 게이트를 접두사 매칭이 아니라 명시 허용 목록으로 둔 이유

`RepositoryError.serverError` 의 첫 연관값은 HTTP 상태가 아니라 **업무 코드**입니다.
서버 에러 코드 정의(`AuthorizationErrorCode` · `OrganizationErrorCode`)를 대조한 결과,
`AUTHORIZATION-` 접두사 매칭은 **양방향으로 틀립니다.**

| 업무 코드 | HTTP | 의미 | 접두사 매칭 결과 |
|---|---|---|---|
| `AUTHORIZATION-0001` | 403 | 권한 없음 | ✅ |
| `AUTHORIZATION-0002` | 403 | 리소스 접근 거부 (`@CheckAccess` 거부) | ✅ |
| `ORGANIZATION-0031` | 403 | 스터디 그룹 접근 거부 | ❌ **누락** |
| `AUTHORIZATION-0003` | 400 | 권한 값 오류 | ❌ **오소화** |
| `AUTHORIZATION-0004/5/6/9` | 500 | 정책 평가 실패 | ❌ **오소화** |
| `AUTHORIZATION-0010` | 404 | 역할 없음 | ❌ **오소화** |
| `AUTHORIZATION-0011` | 501 | 미지원 | ❌ **오소화** |

접두사로 게이트하면 400/404/5xx 를 로컬 Alert 로 삼켜 같은 결함이 되살아나고, 정작 스터디 그룹
전용 권한 거부(`ORGANIZATION-0031`)는 놓칩니다. 그래서 403 코드 3종만 명시 허용했습니다.

`COMMON-403` 은 **제외**했습니다. 서버가 인증 실패(`AccessDeniedException` — "로그인이 필요해요")도
같은 코드로 내려주므로, 포함하면 세션 만료를 로컬 Alert 로 삼킬 수 있습니다.
누락은 전역 Alert 로 끝나지만 과다 포함은 세션 처리를 건너뛰므로 좁은 쪽을 택했습니다.

### 검증

`make test SCHEME=ActivityPresentation` — **184 tests / 41 suites 전체 통과** (신규 10 케이스 포함).

## 📋 추후 진행 상황

없음 (단일 결함 수정).

## 📌 리뷰 포인트

- **허용 목록 범위 판단** — 403 코드 3종만 넣고 `COMMON-403` 을 뺀 트레이드오프가 타당한지가
  이 PR의 핵심 결정입니다.
- **도달 경로** — 비-2xx 는 네트워크 계층에서 `NetworkError` 로 던져지므로 실제 403 은 형제
  오버로드가 처리합니다. 본 `RepositoryError` 경로는 2xx + `isSuccess:false` 봉투 실패용
  방어 경로인데, 게이트가 없던 탓에 **모든** 봉투 실패를 삼키고 있었습니다.
- **테스트 대칭성** — 형제 `NetworkError` 파라미터화 테스트와 같은 구조로 권한/비권한을 나눴습니다.
  `AUTHORIZATION-0003 / 0004 / 0010` 케이스가 "접두사 매칭은 틀리다"를 회귀로 고정합니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
