### PR TITLE
♻️ [Refactor] StudyScheduleRegistrationView 이식 — ViewModel만 이식된 반쪽 상태 해소

### DIFF
--- a/UMCApp/Core/UIComponents/Sources/Schedule/AttendancePolicyTimeSection.swift
+++ b/UMCApp/Core/UIComponents/Sources/Schedule/AttendancePolicyTimeSection.swift
@@ -1,0 +1,152 @@
+//
+//  AttendancePolicyTimeSection.swift
+//  CoreUIComponents
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import SwiftUI
+
+/// 출석 정책 세 시각(출석 시작 · 출석 인정 마감 · 지각 인정 마감) 입력 섹션.
+///
+/// 세 행 모두 ``DateTimeRow`` + ``DatePickerRow``/``TimePickerRow`` 조합을 그대로 쓰고,
+/// 시각이 바뀌면 ``onTimesChanged`` 로 호출부의 dirty 표시·검증 갱신을 트리거한다.
+///
+/// - Note: "어느 피커가 열려 있는가" 는 이 섹션 밖에서 의미가 없는 순수 표시 상태라 내부
+///   `@State` 로 가진다. 열림 상태를 슬롯 하나(`Optional`)로 들고 있으므로 두 피커가 동시에
+///   열리는 상태 자체가 표현 불가능하다. 여러 개의 `Bool` 을 호출부에서 받아 매번 "나머지를
+///   닫는" 방식은 그 불변식을 호출부마다 다시 지켜야 해서 깨지기 쉽다.
+public struct AttendancePolicyTimeSection: View {
+
+    // MARK: - Property
+
+    /// 체크인 시작 시각
+    @Binding private var checkInStartAt: Date
+    /// 정시 출석 종료 시각
+    @Binding private var onTimeEndAt: Date
+    /// 지각 종료 시각
+    @Binding private var lateEndAt: Date
+
+    /// 시각 변경 콜백 (dirty 표시 + 검증 갱신)
+    private let onTimesChanged: () -> Void
+
+    /// 현재 열려 있는 피커 슬롯. `nil` 이면 모두 접힌 상태다.
+    @State private var openSlot: PickerSlot?
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - checkInStartAt: 체크인 시작 시각 바인딩
+    ///   - onTimeEndAt: 정시 출석 종료 시각 바인딩
+    ///   - lateEndAt: 지각 종료 시각 바인딩
+    ///   - onTimesChanged: 세 시각 중 하나라도 바뀌었을 때 호출되는 콜백
+    public init(
+        checkInStartAt: Binding<Date>,
+        onTimeEndAt: Binding<Date>,
+        lateEndAt: Binding<Date>,
+        onTimesChanged: @escaping () -> Void
+    ) {
+        self._checkInStartAt = checkInStartAt
+        self._onTimeEndAt = onTimeEndAt
+        self._lateEndAt = lateEndAt
+        self.onTimesChanged = onTimesChanged
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Group {
+            timeRow(title: "출석 시작", date: $checkInStartAt, field: .checkIn)
+            timeRow(title: "출석 인정 마감", date: $onTimeEndAt, field: .onTime)
+            timeRow(title: "지각 인정 마감", date: $lateEndAt, field: .late)
+        }
+        .onChange(of: checkInStartAt) { onTimesChanged() }
+        .onChange(of: onTimeEndAt) { onTimesChanged() }
+        .onChange(of: lateEndAt) { onTimesChanged() }
+    }
+
+    // MARK: - Function
+
+    /// 한 시각의 입력 행 + 펼쳐진 피커를 함께 그린다.
+    @ViewBuilder
+    private func timeRow(
+        title: String,
+        date: Binding<Date>,
+        field: PickerSlot.Field
+    ) -> some View {
+        let dateSlot = PickerSlot(field: field, component: .date)
+        let timeSlot = PickerSlot(field: field, component: .time)
+
+        DateTimeRow(
+            title: title,
+            date: date.wrappedValue,
+            isAllDay: false,
+            isDatePickerActive: openSlot == dateSlot,
+            isTimePickerActive: openSlot == timeSlot,
+            dateTap: { toggle(dateSlot) },
+            timeTap: { toggle(timeSlot) }
+        )
+        .equatable()
+
+        if openSlot == dateSlot {
+            DatePickerRow(date: date)
+        }
+
+        if openSlot == timeSlot {
+            TimePickerRow(date: date)
+        }
+    }
+
+    /// 같은 슬롯을 다시 누르면 접고, 다른 슬롯을 누르면 그쪽으로 옮긴다.
+    private func toggle(_ slot: PickerSlot) {
+        withAnimation {
+            openSlot = (openSlot == slot) ? nil : slot
+        }
+    }
+
+    // MARK: - PickerSlot
+
+    /// 열려 있을 수 있는 피커 하나를 가리키는 식별자.
+    ///
+    /// "어느 시각(`field`)의 어느 피커(`component`)" 를 한 값으로 묶어, 열림 상태를
+    /// `PickerSlot?` 하나로 표현할 수 있게 한다.
+    private struct PickerSlot: Hashable {
+
+        /// 세 출석 정책 시각 중 하나
+        enum Field: Hashable {
+            case checkIn
+            case onTime
+            case late
+        }
+
+        /// 같은 시각을 편집하는 두 피커 중 하나
+        enum Component: Hashable {
+            case date
+            case time
+        }
+
+        let field: Field
+        let component: Component
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("AttendancePolicyTimeSection") {
+    @Previewable @State var checkIn: Date = .now
+    @Previewable @State var onTime: Date = .now.addingTimeInterval(600)
+    @Previewable @State var late: Date = .now.addingTimeInterval(1_200)
+
+    return Form {
+        Section("출석 정책") {
+            AttendancePolicyTimeSection(
+                checkInStartAt: $checkIn,
+                onTimeEndAt: $onTime,
+                lateEndAt: $late,
+                onTimesChanged: {}
+            )
+        }
+    }
+}
+#endif

--- a/UMCApp/Core/UIComponents/Sources/Schedule/DatePickerRow.swift
+++ b/UMCApp/Core/UIComponents/Sources/Schedule/DatePickerRow.swift
@@ -1,0 +1,65 @@
+//
+//  DatePickerRow.swift
+//  CoreUIComponents
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+
+/// 달력(Graphical) 스타일 날짜 선택 행.
+///
+/// ``DateTimeRow`` 의 날짜 버튼을 탭했을 때 그 아래에 펼쳐지는 피커다.
+public struct DatePickerRow: View, Equatable {
+
+    // MARK: - Property
+
+    /// 선택된 날짜
+    @Binding private var date: Date
+    /// 선택 가능한 날짜 범위 (`nil` 이면 제한 없음)
+    private let range: ClosedRange<Date>?
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - date: 선택된 날짜 바인딩
+    ///   - range: 선택 가능한 날짜 범위. 제한이 없으면 `nil`
+    public init(date: Binding<Date>, range: ClosedRange<Date>? = nil) {
+        self._date = date
+        self.range = range
+    }
+
+    // MARK: - Equatable
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.date == rhs.date
+            && lhs.range?.lowerBound == rhs.range?.lowerBound
+            && lhs.range?.upperBound == rhs.range?.upperBound
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Group {
+            if let range {
+                DatePicker("", selection: $date, in: range, displayedComponents: .date)
+            } else {
+                DatePicker("", selection: $date, displayedComponents: .date)
+            }
+        }
+        .datePickerStyle(.graphical)
+        .labelsHidden()
+        .tint(.indigo500)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("DatePickerRow") {
+    Form {
+        DatePickerRow(date: .constant(.now))
+    }
+}
+#endif

--- a/UMCApp/Core/UIComponents/Sources/Schedule/DateTimeRow.swift
+++ b/UMCApp/Core/UIComponents/Sources/Schedule/DateTimeRow.swift
@@ -1,0 +1,143 @@
+//
+//  DateTimeRow.swift
+//  CoreUIComponents
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+
+/// 날짜와 시간을 각각 탭해서 여닫는 폼 행.
+///
+/// 행 자체는 값을 바꾸지 않고 "무엇이 선택돼 있는지"와 "어느 피커가 열려 있는지"만 그린다.
+/// 실제 값 변경은 이 행 아래에 붙는 ``DatePickerRow``/``TimePickerRow`` 가 담당하므로,
+/// 열림 상태는 호출부가 소유한다.
+///
+/// 일정 등록(스터디·홈)에서 시작/종료·출석 정책 시각을 같은 모양으로 입력받기 위해 공유한다.
+public struct DateTimeRow: View, Equatable {
+
+    // MARK: - Property
+
+    /// 행의 제목 (예: 시작, 종료)
+    private let title: String
+    /// 표시할 날짜 및 시간
+    private let date: Date
+    /// 하루 종일 여부 — `true` 면 시간 버튼을 감춘다
+    private let isAllDay: Bool
+    /// 날짜 피커가 열려 있는지 여부 (텍스트 강조에 사용)
+    private let isDatePickerActive: Bool
+    /// 시간 피커가 열려 있는지 여부 (텍스트 강조에 사용)
+    private let isTimePickerActive: Bool
+    /// 날짜 버튼 탭 액션
+    private let dateTap: () -> Void
+    /// 시간 버튼 탭 액션
+    private let timeTap: () -> Void
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - title: 행의 제목
+    ///   - date: 표시할 날짜 및 시간
+    ///   - isAllDay: 하루 종일 여부 (시간 버튼 표시 여부)
+    ///   - isDatePickerActive: 날짜 피커 열림 여부
+    ///   - isTimePickerActive: 시간 피커 열림 여부
+    ///   - dateTap: 날짜 버튼 탭 액션
+    ///   - timeTap: 시간 버튼 탭 액션
+    public init(
+        title: String,
+        date: Date,
+        isAllDay: Bool,
+        isDatePickerActive: Bool,
+        isTimePickerActive: Bool,
+        dateTap: @escaping () -> Void,
+        timeTap: @escaping () -> Void
+    ) {
+        self.title = title
+        self.date = date
+        self.isAllDay = isAllDay
+        self.isDatePickerActive = isDatePickerActive
+        self.isTimePickerActive = isTimePickerActive
+        self.dateTap = dateTap
+        self.timeTap = timeTap
+    }
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        /// 날짜/시간 버튼 내부 패딩
+        static let buttonPadding = EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
+    }
+
+    // MARK: - Equatable
+
+    /// 탭 클로저는 매 렌더마다 새로 만들어지므로 비교에서 제외한다.
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.title == rhs.title
+            && lhs.date == rhs.date
+            && lhs.isAllDay == rhs.isAllDay
+            && lhs.isDatePickerActive == rhs.isDatePickerActive
+            && lhs.isTimePickerActive == rhs.isTimePickerActive
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        HStack {
+            Text(title)
+
+            Spacer()
+
+            valueButton(
+                text: date.toYearMonthDay(),
+                isActive: isDatePickerActive,
+                action: dateTap
+            )
+
+            if !isAllDay {
+                valueButton(
+                    text: date.toHourMinutes(),
+                    isActive: isTimePickerActive,
+                    action: timeTap
+                )
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    /// 날짜/시간 값을 보여주는 알약 버튼.
+    ///
+    /// 열려 있는 피커의 값만 강조색으로 바꿔, 어느 피커를 조작 중인지 한눈에 보이게 한다.
+    private func valueButton(
+        text: String,
+        isActive: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(text)
+                .appFont(.body, color: isActive ? Color.red500 : Color.grey900)
+                .padding(Constants.buttonPadding)
+                .background(Color.grey200, in: .capsule)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("DateTimeRow") {
+    Form {
+        DateTimeRow(
+            title: "시작",
+            date: .now,
+            isAllDay: false,
+            isDatePickerActive: false,
+            isTimePickerActive: true,
+            dateTap: {},
+            timeTap: {}
+        )
+    }
+}
+#endif

--- a/UMCApp/Core/UIComponents/Sources/Schedule/InPersonToggle.swift
+++ b/UMCApp/Core/UIComponents/Sources/Schedule/InPersonToggle.swift
@@ -1,0 +1,46 @@
+//
+//  InPersonToggle.swift
+//  CoreUIComponents
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+
+/// 대면/비대면 전환 토글.
+///
+/// `isInPerson == true` 이면 대면 일정이며, 호출부는 이때만 장소 입력을 노출한다.
+public struct InPersonToggle: View {
+
+    // MARK: - Property
+
+    @Binding private var isInPerson: Bool
+
+    // MARK: - Initializer
+
+    /// - Parameter isInPerson: 대면 일정 여부 바인딩
+    public init(isInPerson: Binding<Bool>) {
+        self._isInPerson = isInPerson
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Toggle(isOn: $isInPerson) {
+            Text("대면 일정")
+                .appFont(.body, color: Color.grey900)
+        }
+        .tint(.indigo500)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("InPersonToggle") {
+    Form {
+        InPersonToggle(isInPerson: .constant(true))
+    }
+}
+#endif

--- a/UMCApp/Core/UIComponents/Sources/Schedule/TimePickerRow.swift
+++ b/UMCApp/Core/UIComponents/Sources/Schedule/TimePickerRow.swift
@@ -1,0 +1,65 @@
+//
+//  TimePickerRow.swift
+//  CoreUIComponents
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+
+/// 휠(Wheel) 스타일 시각 선택 행.
+///
+/// ``DateTimeRow`` 의 시간 버튼을 탭했을 때 그 아래에 펼쳐지는 피커다.
+public struct TimePickerRow: View, Equatable {
+
+    // MARK: - Property
+
+    /// 선택된 시각
+    @Binding private var date: Date
+    /// 선택 가능한 시각 범위 (`nil` 이면 제한 없음)
+    private let range: ClosedRange<Date>?
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - date: 선택된 시각 바인딩
+    ///   - range: 선택 가능한 시각 범위. 제한이 없으면 `nil`
+    public init(date: Binding<Date>, range: ClosedRange<Date>? = nil) {
+        self._date = date
+        self.range = range
+    }
+
+    // MARK: - Equatable
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.date == rhs.date
+            && lhs.range?.lowerBound == rhs.range?.lowerBound
+            && lhs.range?.upperBound == rhs.range?.upperBound
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Group {
+            if let range {
+                DatePicker("", selection: $date, in: range, displayedComponents: .hourAndMinute)
+            } else {
+                DatePicker("", selection: $date, displayedComponents: .hourAndMinute)
+            }
+        }
+        .datePickerStyle(.wheel)
+        .labelsHidden()
+        .tint(.indigo500)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("TimePickerRow") {
+    Form {
+        TimePickerRow(date: .constant(.now))
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
@@ -122,6 +122,7 @@ private struct DebugActivityHarnessView: View {
                 )
                 modeToggleItem
                 studyGroupCreateItem
+                studyScheduleRegistrationItem
             }
             .navigationDestination(isPresented: $showsStudyGroupCreate) {
                 OperatorStudyGroupCreateView(
@@ -218,6 +219,29 @@ private struct DebugActivityHarnessView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 Button("생성 폼") {
                     showsStudyGroupCreate = true
+                }
+            }
+        }
+    }
+
+    /// 일정 등록 화면 진입 버튼
+    ///
+    /// 카드의 일정 버튼은 "담당 멘토 본인" 권한 검사를 거치는데, 하네스 세션의 챌린저 ID는
+    /// 샘플 그룹의 멘토와 달라 그 경로로는 열리지 않는다. 라우팅·DI 조립까지 실제 경로
+    /// 그대로 확인할 수 있도록 카드가 보내는 것과 같은 목적지를 하네스에서 직접 push 한다.
+    @ToolbarContentBuilder
+    private var studyScheduleRegistrationItem: some ToolbarContent {
+        if currentSection == .studyManage,
+            let group = OperatorStudyPreviewData.groups.first {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("일정 등록") {
+                    pathStore.push(
+                        ActivityDestination.studyScheduleRegistration(
+                            studyName: group.name,
+                            studyGroupId: group.serverID
+                        ),
+                        on: .activity
+                    )
                 }
             }
         }

--- a/UMCApp/Features/Activity/Presentation/Sources/Navigation/ActivityRoutingView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Navigation/ActivityRoutingView.swift
@@ -34,27 +34,63 @@ struct ActivityRoutingView: View {
 
     var body: some View {
         switch destination {
-        case .studyScheduleRegistration(let studyName, _):
-            // 화면(`StudyScheduleRegistrationView`)은 ViewModel 만 이식된 상태다.
-            // 경로는 먼저 열어 두고, 화면 이식 시 이 분기만 실제 뷰로 교체한다.
-            // TODO: #1014 StudyScheduleRegistrationView 이식 후 화면 연결 - [26.07.30] 이재원
-            unsupportedScreen(
-                title: "일정 등록 준비 중",
-                message: "\(studyName)의 일정 등록 화면은 곧 연결됩니다."
+        case .studyScheduleRegistration(let studyName, let studyGroupId):
+            StudyScheduleRegistrationRoute(
+                studyName: studyName,
+                studyGroupId: studyGroupId
             )
 
         case .attendanceDetail(let scheduleId):
             OperatorAttendanceDetailRoute(scheduleId: scheduleId)
         }
     }
+}
 
-    // MARK: - Function
+// MARK: - Study Schedule Registration
 
-    private func unsupportedScreen(title: String, message: String) -> some View {
-        ContentUnavailableView {
-            Label(title, systemImage: "hammer")
-        } description: {
-            Text(message)
+/// 스터디 일정 등록 화면의 조립 지점.
+///
+/// 목적지는 스터디 이름과 그룹 식별자만 들고 오므로, 화면이 필요로 하는 ViewModel 은 여기서
+/// DI 로 만든다. 탭 재진입마다 새로 만들지 않도록 첫 등장 때 한 번만 생성한다.
+private struct StudyScheduleRegistrationRoute: View {
+
+    // MARK: - Property
+
+    @Environment(\.di) private var di
+    @Environment(ErrorHandler.self) private var errorHandler
+
+    @State private var viewModel: StudyScheduleRegistrationViewModel?
+
+    private let studyName: String
+    private let studyGroupId: String
+
+    // MARK: - Init
+
+    init(studyName: String, studyGroupId: String) {
+        self.studyName = studyName
+        self.studyGroupId = studyGroupId
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            if let viewModel {
+                StudyScheduleRegistrationView(viewModel: viewModel)
+            } else {
+                ProgressView()
+            }
+        }
+        .task {
+            guard viewModel == nil else { return }
+            viewModel = StudyScheduleRegistrationViewModel(
+                studyName: studyName,
+                studyGroupId: studyGroupId,
+                studyMembersUseCase: di.resolve(FetchStudyMembersUseCaseProtocol.self),
+                studyRepository: di.resolve(StudyRepositoryProtocol.self),
+                registerScheduleUseCase: di.resolve(RegisterStudyScheduleUseCaseProtocol.self),
+                errorHandler: errorHandler
+            )
         }
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/StudyScheduleRegistrationPreviewSupport.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/StudyScheduleRegistrationPreviewSupport.swift
@@ -1,0 +1,130 @@
+//
+//  StudyScheduleRegistrationPreviewSupport.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+#if DEBUG
+import ActivityDomain
+import Foundation
+import HomeDomain
+import UMCFoundation
+
+// MARK: - Preview Stubs
+
+/// 프리뷰 전용 멤버 조회 스텁 — 고정된 스터디원 목록을 돌려준다.
+final class PreviewStudyScheduleMembersUseCase: FetchStudyMembersUseCaseProtocol {
+
+    func fetchStudyGroupMembers(groupId: String) async throws -> [StudyGroupMember] {
+        [
+            StudyGroupMember(
+                serverID: "1",
+                memberID: "1",
+                name: "김스터디",
+                university: "한성대학교"
+            ),
+            StudyGroupMember(
+                serverID: "2",
+                memberID: "2",
+                name: "이참여",
+                university: "한성대학교"
+            ),
+        ]
+    }
+}
+
+/// 프리뷰 전용 스터디 Repository 스텁.
+///
+/// 일정 등록 화면은 주차 커리큘럼 옵션만 조회하므로 그 메서드만 값을 돌려주고, 나머지는
+/// 프리뷰에서 호출될 일이 없어 계약 밖으로 둔다.
+final class PreviewStudyScheduleRepository: StudyRepositoryProtocol {
+
+    func fetchWeeklyCurriculumOptions() async throws -> [WeeklyCurriculumOption] {
+        [
+            WeeklyCurriculumOption(weeklyCurriculumId: "1", weekNo: "1", title: "OT"),
+            WeeklyCurriculumOption(weeklyCurriculumId: "2", weekNo: "2", title: "Git & GitHub"),
+        ]
+    }
+
+    func fetchCurriculumOverview() async throws -> CurriculumOverview {
+        throw DomainError.custom(message: "프리뷰 계약 밖")
+    }
+
+    func fetchStudyGroupDetails() async throws -> [StudyGroupInfo] { [] }
+
+    func fetchStudyGroupDetailsPage(
+        cursor: String?,
+        size: Int
+    ) async throws -> StudyGroupDetailsPage {
+        throw DomainError.custom(message: "프리뷰 계약 밖")
+    }
+
+    func fetchStudyGroupDetail(groupId: String) async throws -> StudyGroupInfo {
+        throw DomainError.custom(message: "프리뷰 계약 밖")
+    }
+
+    func resolveChallengerId(
+        memberId: String,
+        preferredGeneration: String?
+    ) async throws -> String? {
+        nil
+    }
+
+    func createStudyGroup(
+        gisuId: String,
+        name: String,
+        part: UMCPartType,
+        memberIds: [String],
+        mentorIds: [String]
+    ) async throws {}
+
+    func updateStudyGroup(groupId: String, name: String) async throws {}
+
+    func deleteStudyGroup(groupId: String) async throws {}
+
+    func addStudyGroupMember(groupId: String, memberId: String) async throws {}
+
+    func removeStudyGroupMember(groupId: String, memberId: String) async throws {}
+
+    func addStudyGroupMentor(groupId: String, mentorId: String) async throws {}
+
+    func removeStudyGroupMentor(groupId: String, mentorId: String) async throws {}
+
+    func linkStudyGroupSchedule(
+        scheduleId: String,
+        studyGroupId: String,
+        weeklyCurriculumId: String
+    ) async throws {}
+}
+
+/// 프리뷰 전용 일정 등록 UseCase 스텁 — 서버 호출 없이 성공한 척한다.
+final class PreviewRegisterStudyScheduleUseCase: RegisterStudyScheduleUseCaseProtocol {
+
+    func createSchedule(_ request: ScheduleCreationRequest) async throws -> String { "1" }
+
+    func linkStudyGroupSchedule(
+        scheduleId: String,
+        studyGroupId: String,
+        weeklyCurriculumId: String
+    ) async throws {}
+
+    func deleteSchedule(scheduleId: String) async throws {}
+}
+
+// MARK: - Preview Factory
+
+/// 주차 옵션과 참여자가 채워지는 프리뷰용 일정 등록 ViewModel.
+@MainActor
+func previewStudyScheduleRegistrationViewModel() -> StudyScheduleRegistrationViewModel {
+    StudyScheduleRegistrationViewModel(
+        studyName: "iOS 스터디",
+        studyGroupId: "1",
+        studyMembersUseCase: PreviewStudyScheduleMembersUseCase(),
+        studyRepository: PreviewStudyScheduleRepository(),
+        registerScheduleUseCase: PreviewRegisterStudyScheduleUseCase(),
+        errorHandler: ErrorHandler(),
+        currentMemberId: nil
+    )
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/StudyScheduleRegistrationViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/StudyScheduleRegistrationViewModel.swift
@@ -267,9 +267,7 @@ final class StudyScheduleRegistrationViewModel {
     ///   - coordinate: 선택한 장소 좌표
     func placeSelectionChanged(name: String, address: String, coordinate: Coordinate) {
         guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            placeName = ""
-            placeAddress = ""
-            placeCoordinate = nil
+            clearPlaceSelection()
             return
         }
         placeName = name
@@ -283,10 +281,17 @@ final class StudyScheduleRegistrationViewModel {
     func inPersonModeToggleChanged(to isInPerson: Bool) {
         isOnline = !isInPerson
         if isOnline {
-            placeName = ""
-            placeAddress = ""
-            placeCoordinate = nil
+            clearPlaceSelection()
         }
+    }
+
+    /// 장소 선택을 완전히 비웁니다.
+    ///
+    /// 이름·주소·좌표는 항상 함께 채워지고 함께 비워져야 하므로 해제 경로를 한 곳에 모읍니다.
+    private func clearPlaceSelection() {
+        placeName = ""
+        placeAddress = ""
+        placeCoordinate = nil
     }
 
     /// 스케줄 등록 실행 (2단계)

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/StudyScheduleRegistrationViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/StudyScheduleRegistrationViewModel.swift
@@ -42,20 +42,22 @@ final class StudyScheduleRegistrationViewModel {
 
     /// 선택된 장소 이름
     ///
-    /// 장소 선택 UI(`PlaceSelectView`/`MapPlacePickerView`)와 좌표 모델(`PlaceSelection`)은
-    /// CoreUIComponents로 이식이 완료되어 결선 준비가 되어 있습니다(#1018). 본 뷰모델의
-    /// 실제 View 결선은 `StudyScheduleRegistrationView` 이식 이슈(#1014)에서 진행되며,
-    /// 그 전까지는 입력 이름만 보관합니다.
+    /// `StudyScheduleRegistrationView` 의 `PlaceSelectView` 가 선택 결과를 여기에 반영합니다.
     var placeName: String = ""
+
+    /// 선택된 장소 주소
+    ///
+    /// 등록 페이로드에는 실리지 않고 장소 선택 UI 의 부제로만 표시됩니다. 그럼에도 뷰가 아닌
+    /// 여기에 두는 이유는, 장소 선택 상태를 뷰와 뷰모델이 나눠 가지면 비대면 전환처럼
+    /// 뷰모델만 아는 사건에서 두 벌이 어긋나기 때문입니다. 선택 상태의 단일 소유자를
+    /// 뷰모델로 두어 ``inPersonModeToggleChanged(to:)`` 한 번으로 전부 비워집니다.
+    var placeAddress: String = ""
 
     /// 선택된 장소 좌표
     ///
     /// 출석 지오펜스의 중심이 되는 값이라 대면 일정에서는 필수입니다. 좌표 없이 이름만으로
     /// 등록하면 (0, 0) 을 기준으로 하는 지오펜스가 생겨 GPS 출석이 성립하지 않으므로,
     /// ``canSubmit`` 이 좌표를 요구합니다.
-    ///
-    /// 좌표를 채우는 장소 선택 UI(`PlaceSelectView`/`MapPlacePickerView`) 결선은
-    /// `StudyScheduleRegistrationView` 이식 이슈(#1014)에서 진행합니다.
     var placeCoordinate: Coordinate?
 
     /// 비대면 일정 여부
@@ -93,17 +95,6 @@ final class StudyScheduleRegistrationViewModel {
     /// 참여자 로딩 상태
     private(set) var participantsState: Loadable<[StudyGroupMember]> = .idle
 
-    // MARK: - DatePicker Toggle State
-
-    /// 시작 날짜 DatePicker 표시 여부
-    var showStartDatePicker = false
-    /// 시작 시간 DatePicker 표시 여부
-    var showStartTimePicker = false
-    /// 종료 날짜 DatePicker 표시 여부
-    var showEndDatePicker = false
-    /// 종료 시간 DatePicker 표시 여부
-    var showEndTimePicker = false
-
     // MARK: - Attendance Policy
 
     /// 체크인 시작 시각
@@ -118,19 +109,6 @@ final class StudyScheduleRegistrationViewModel {
 
     /// 사용자가 출석 정책 시각을 직접 수정한 적이 있는지 여부 (자동 prefill 차단용)
     private var isAttendancePolicyDirty: Bool = false
-
-    /// 체크인 시작 날짜 DatePicker 표시 여부
-    var showCheckInStartDatePicker: Bool = false
-    /// 체크인 시작 시간 DatePicker 표시 여부
-    var showCheckInStartTimePicker: Bool = false
-    /// 정시 종료 날짜 DatePicker 표시 여부
-    var showOnTimeEndDatePicker: Bool = false
-    /// 정시 종료 시간 DatePicker 표시 여부
-    var showOnTimeEndTimePicker: Bool = false
-    /// 지각 종료 날짜 DatePicker 표시 여부
-    var showLateEndDatePicker: Bool = false
-    /// 지각 종료 시간 DatePicker 표시 여부
-    var showLateEndTimePicker: Bool = false
 
     // MARK: - Computed Property
 
@@ -182,8 +160,14 @@ final class StudyScheduleRegistrationViewModel {
     // MARK: - Loading
 
     /// 스터디 그룹 멤버(멘토 + 스터디원)를 조회해 본인을 제외하고 보관합니다.
+    ///
+    /// 화면이 `.task` 로 호출하므로 빠른 이탈·탭 전환에서 `CancellationError` 또는
+    /// `URLError(.cancelled)` 가 던져집니다. 취소는 실패가 아니라 "안 하기로 한 것" 이라
+    /// 이전 상태로 되돌리고 에러 UI 를 띄우지 않습니다. 두 타입 판별은 형제 ViewModel 과
+    /// 같은 canonical 헬퍼 `Error.isCancellation` 에 위임합니다.
     func loadParticipantMembers() async {
         if case .loading = participantsState { return }
+        let previousState = participantsState
         participantsState = .loading
         do {
             let allMembers = try await studyMembersUseCase
@@ -193,6 +177,8 @@ final class StudyScheduleRegistrationViewModel {
             } ?? allMembers
             participantMembers = filtered
             participantsState = .loaded(filtered)
+        } catch let error where error.isCancellation {
+            participantsState = previousState
         } catch let error as DomainError {
             participantsState = .failed(.domain(error))
         } catch let error as AppError {
@@ -205,8 +191,12 @@ final class StudyScheduleRegistrationViewModel {
     /// 주차 커리큘럼 옵션 목록을 서버에서 불러옵니다.
     ///
     /// 선택값이 아직 없으면 첫 옵션을 자동 선택합니다.
+    ///
+    /// ``loadParticipantMembers()`` 와 같은 이유로 `CancellationError` 등 취소는 실패가 아니라
+    /// 이전 상태 롤백으로 처리합니다.
     func loadWeeklyOptions() async {
         if case .loading = weeklyOptionsState { return }
+        let previousState = weeklyOptionsState
         weeklyOptionsState = .loading
         do {
             let options = try await studyRepository.fetchWeeklyCurriculumOptions()
@@ -215,6 +205,8 @@ final class StudyScheduleRegistrationViewModel {
             if selectedWeeklyOption == nil {
                 selectedWeeklyOption = options.first
             }
+        } catch let error where error.isCancellation {
+            weeklyOptionsState = previousState
         } catch let error as DomainError {
             weeklyOptionsState = .failed(.domain(error))
         } catch let error as AppError {
@@ -264,6 +256,27 @@ final class StudyScheduleRegistrationViewModel {
 
     // MARK: - Function
 
+    /// 장소 선택 결과를 반영합니다.
+    ///
+    /// 이름이 비면 "선택 해제" 로 보고 좌표까지 함께 비웁니다. 이름만 지우고 좌표를 남기면
+    /// 화면에는 장소가 없는데 페이로드에는 (0, 0) 같은 지오펜스 중심이 실릴 수 있습니다.
+    ///
+    /// - Parameters:
+    ///   - name: 선택한 장소 이름
+    ///   - address: 선택한 장소 주소 (표시 전용)
+    ///   - coordinate: 선택한 장소 좌표
+    func placeSelectionChanged(name: String, address: String, coordinate: Coordinate) {
+        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            placeName = ""
+            placeAddress = ""
+            placeCoordinate = nil
+            return
+        }
+        placeName = name
+        placeAddress = address
+        placeCoordinate = coordinate
+    }
+
     /// 대면/비대면 전환 토글 변경을 처리합니다.
     ///
     /// 비대면으로 전환 시 장소 입력을 초기화합니다.
@@ -271,6 +284,7 @@ final class StudyScheduleRegistrationViewModel {
         isOnline = !isInPerson
         if isOnline {
             placeName = ""
+            placeAddress = ""
             placeCoordinate = nil
         }
     }

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/StudyScheduleRegistrationView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/StudyScheduleRegistrationView.swift
@@ -1,0 +1,295 @@
+//
+//  StudyScheduleRegistrationView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreLocation
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 스터디 일정 등록 화면.
+///
+/// 스터디 그룹 카드의 "일정 등록" 을 탭하면 푸시된다. 스터디명·주차 커리큘럼·일시·출석
+/// 정책·장소를 입력받아 일정 생성과 스터디 그룹 연결 두 단계를 뷰모델에 위임한다.
+///
+/// `navigationDestination` 으로 실리므로 자체 `NavigationStack` 을 만들지 않는다.
+struct StudyScheduleRegistrationView: View {
+
+    // MARK: - Property
+
+    @Bindable private var viewModel: StudyScheduleRegistrationViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// 현재 펼쳐진 시작/종료 피커. `nil` 이면 모두 접힌 상태다.
+    ///
+    /// 어느 피커가 열려 있는지는 이 화면 밖에서 의미가 없어 뷰가 소유한다. 슬롯 하나로
+    /// 들고 있으므로 두 피커가 동시에 열리는 상태를 표현할 수 없다.
+    @State private var openScheduleSlot: ScheduleDateSlot?
+
+    // MARK: - Initializer
+
+    /// - Parameter viewModel: 일정 등록 상태를 관리하는 뷰 모델
+    init(viewModel: StudyScheduleRegistrationViewModel) {
+        self.viewModel = viewModel
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Form {
+            Section {
+                studyNameField
+            }
+
+            Section("주차 커리큘럼") {
+                weeklyCurriculumPicker
+            }
+
+            Section("일시") {
+                scheduleDateTimeSection
+            }
+
+            Section("출석 정책") {
+                attendancePolicySection
+            }
+
+            placeSection
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .navigation(
+            naviTitle: NavigationTitle.Activity.studyScheduleRegistration,
+            displayMode: .inline
+        )
+        .toolbar {
+            ToolBarCollection.ConfirmBtn(
+                action: submitSchedule,
+                disable: !viewModel.canSubmit,
+                isLoading: viewModel.isSubmitting,
+                // 등록은 두 단계라 성공 여부가 확정된 뒤에 닫아야 한다.
+                dismissOnTap: false
+            )
+        }
+        .alertPrompt(item: $viewModel.alertPrompt)
+        .task {
+            async let weekly: Void = viewModel.loadWeeklyOptions()
+            async let participants: Void = viewModel.loadParticipantMembers()
+            _ = await (weekly, participants)
+        }
+        .onChange(of: viewModel.startDate) {
+            viewModel.prefillAttendancePolicyIfNeeded()
+        }
+    }
+
+    // MARK: - Sections
+
+    /// 스터디명 입력 필드
+    private var studyNameField: some View {
+        TextField(
+            "",
+            text: $viewModel.studyName,
+            prompt: Text("스터디명")
+                .foregroundStyle(Color.grey400)
+        )
+        .appFont(.body, color: Color.grey900)
+        .submitLabel(.next)
+        .tint(.indigo500)
+    }
+
+    /// 주차 커리큘럼 선택 Picker
+    @ViewBuilder
+    private var weeklyCurriculumPicker: some View {
+        switch viewModel.weeklyOptionsState {
+        case .idle, .loading:
+            HStack {
+                Text("주차 목록 불러오는 중…")
+                    .appFont(.body, color: Color.grey500)
+                Spacer()
+                ProgressView()
+            }
+
+        case .failed:
+            HStack {
+                Text("주차 목록을 불러오지 못했어요")
+                    .appFont(.body, color: Color.grey500)
+                Spacer()
+                Button("재시도") {
+                    Task { await viewModel.loadWeeklyOptions() }
+                }
+                .appFont(.footnote, color: Color.indigo500)
+            }
+
+        case .loaded(let options) where options.isEmpty:
+            Text("등록된 주차 커리큘럼이 없어요")
+                .appFont(.body, color: Color.grey500)
+
+        case .loaded(let options):
+            Picker("주차 커리큘럼", selection: $viewModel.selectedWeeklyOption) {
+                ForEach(options) { option in
+                    Text("\(option.weekNo)주차 · \(option.title)")
+                        .tag(Optional(option))
+                }
+            }
+            .pickerStyle(.menu)
+            .tint(.indigo500)
+        }
+    }
+
+    /// 시작/종료 일시 선택 섹션
+    @ViewBuilder
+    private var scheduleDateTimeSection: some View {
+        dateTimeRow(title: "시작", date: $viewModel.startDate, field: .start)
+        dateTimeRow(title: "종료", date: $viewModel.endDate, field: .end)
+    }
+
+    /// 출석 정책 3개 시각 입력 + 인라인 검증 에러
+    @ViewBuilder
+    private var attendancePolicySection: some View {
+        AttendancePolicyTimeSection(
+            checkInStartAt: $viewModel.attendanceCheckInStartAt,
+            onTimeEndAt: $viewModel.attendanceOnTimeEndAt,
+            lateEndAt: $viewModel.attendanceLateEndAt,
+            onTimesChanged: viewModel.attendanceTimesChanged
+        )
+
+        if let message = viewModel.attendancePolicyError?.message {
+            Text(message)
+                .appFont(.footnote, color: Color.red500)
+        }
+    }
+
+    /// 대면/비대면 토글 + 장소 선택 섹션
+    private var placeSection: some View {
+        Section {
+            InPersonToggle(
+                isInPerson: Binding(
+                    get: { !viewModel.isOnline },
+                    set: { viewModel.inPersonModeToggleChanged(to: $0) }
+                )
+            )
+
+            if viewModel.isOnline {
+                Text("비대면 스터디는 장소가 자동으로 비워집니다")
+                    .appFont(.footnote, color: Color.grey500)
+            } else {
+                PlaceSelectView(place: placeBinding)
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    /// 장소 선택 UI 와 뷰모델을 잇는 바인딩.
+    ///
+    /// `PlaceSelection` 은 표시용 묶음이고 뷰모델은 이름·주소·좌표를 각각 들고 있어, 여기서
+    /// 한 번만 변환한다. 선택 해제(빈 이름)의 의미 부여는 뷰모델이 판단한다.
+    private var placeBinding: Binding<PlaceSelection> {
+        Binding(
+            get: {
+                guard let coordinate = viewModel.placeCoordinate else { return .empty }
+                return PlaceSelection(
+                    name: viewModel.placeName,
+                    address: viewModel.placeAddress,
+                    coordinate: CLLocationCoordinate2D(
+                        latitude: coordinate.latitude,
+                        longitude: coordinate.longitude
+                    )
+                )
+            },
+            set: { selected in
+                viewModel.placeSelectionChanged(
+                    name: selected.name,
+                    address: selected.address,
+                    coordinate: Coordinate(
+                        latitude: selected.coordinate.latitude,
+                        longitude: selected.coordinate.longitude
+                    )
+                )
+            }
+        )
+    }
+
+    /// 시작/종료 한 행 + 펼쳐진 피커를 함께 그린다.
+    @ViewBuilder
+    private func dateTimeRow(
+        title: String,
+        date: Binding<Date>,
+        field: ScheduleDateSlot.Field
+    ) -> some View {
+        let dateSlot = ScheduleDateSlot(field: field, component: .date)
+        let timeSlot = ScheduleDateSlot(field: field, component: .time)
+
+        DateTimeRow(
+            title: title,
+            date: date.wrappedValue,
+            isAllDay: false,
+            isDatePickerActive: openScheduleSlot == dateSlot,
+            isTimePickerActive: openScheduleSlot == timeSlot,
+            dateTap: { toggleScheduleSlot(dateSlot) },
+            timeTap: { toggleScheduleSlot(timeSlot) }
+        )
+        .equatable()
+
+        if openScheduleSlot == dateSlot {
+            DatePickerRow(date: date)
+        }
+
+        if openScheduleSlot == timeSlot {
+            TimePickerRow(date: date)
+        }
+    }
+
+    /// 같은 슬롯을 다시 누르면 접고, 다른 슬롯을 누르면 그쪽으로 옮긴다.
+    private func toggleScheduleSlot(_ slot: ScheduleDateSlot) {
+        withAnimation {
+            openScheduleSlot = (openScheduleSlot == slot) ? nil : slot
+        }
+    }
+
+    /// 등록 요청. 중복 제출 방지는 뷰모델의 ``isSubmitting`` 이 단독으로 담당한다.
+    private func submitSchedule() {
+        Task {
+            if await viewModel.submitSchedule() {
+                dismiss()
+            }
+        }
+    }
+
+    // MARK: - ScheduleDateSlot
+
+    /// 시작/종료 일시에서 열려 있을 수 있는 피커 하나를 가리키는 식별자.
+    fileprivate struct ScheduleDateSlot: Hashable {
+
+        /// 일정의 시작/종료 중 하나
+        enum Field: Hashable {
+            case start
+            case end
+        }
+
+        /// 같은 일시를 편집하는 두 피커 중 하나
+        enum Component: Hashable {
+            case date
+            case time
+        }
+
+        let field: Field
+        let component: Component
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("StudyScheduleRegistrationView") {
+    NavigationStack {
+        StudyScheduleRegistrationView(
+            viewModel: previewStudyScheduleRegistrationViewModel()
+        )
+    }
+    .environment(ErrorHandler())
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Tests/StudyScheduleRegistrationViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/StudyScheduleRegistrationViewModelTests.swift
@@ -397,13 +397,21 @@ struct StudyScheduleRegistrationViewModelPrefillTests {
 @Suite("StudyScheduleRegistrationViewModel — 대면/비대면 토글 (도메인 규칙)")
 struct StudyScheduleRegistrationViewModelToggleTests {
 
-    @Test("비대면 전환 → isOnline true + 장소 초기화")
+    @Test("비대면 전환 → isOnline true + 이름·주소·좌표를 함께 비운다")
     func switchingToOnlineClearsPlace() {
         let viewModel = makeViewModel()
-        viewModel.placeName = "한성대 상상관"
+        viewModel.placeSelectionChanged(
+            name: "한성대 상상관",
+            address: "서울 성북구 삼선교로16길 116",
+            coordinate: Coordinate(latitude: 37.5, longitude: 127.0)
+        )
+
         viewModel.inPersonModeToggleChanged(to: false)
+
         #expect(viewModel.isOnline == true)
         #expect(viewModel.placeName.isEmpty)
+        #expect(viewModel.placeAddress.isEmpty)
+        #expect(viewModel.placeCoordinate == nil)
     }
 
     @Test("대면 전환 → isOnline false + 장소 보존")
@@ -413,6 +421,100 @@ struct StudyScheduleRegistrationViewModelToggleTests {
         viewModel.inPersonModeToggleChanged(to: true)
         #expect(viewModel.isOnline == false)
         #expect(viewModel.placeName == "한성대 상상관")
+    }
+}
+
+// MARK: - 장소 선택 반영
+
+@MainActor
+@Suite("StudyScheduleRegistrationViewModel — 장소 선택 반영 (도메인 규칙)")
+struct StudyScheduleRegistrationViewModelPlaceSelectionTests {
+
+    @Test("장소 선택 → 이름·주소·좌표를 모두 반영한다")
+    func selectingPlaceStoresAllFields() {
+        let viewModel = makeViewModel()
+
+        viewModel.placeSelectionChanged(
+            name: "한성대 상상관",
+            address: "서울 성북구 삼선교로16길 116",
+            coordinate: Coordinate(latitude: 37.582, longitude: 127.010)
+        )
+
+        #expect(viewModel.placeName == "한성대 상상관")
+        #expect(viewModel.placeAddress == "서울 성북구 삼선교로16길 116")
+        #expect(viewModel.placeCoordinate == Coordinate(latitude: 37.582, longitude: 127.010))
+    }
+
+    @Test(
+        "이름이 공백/개행뿐 → 선택 해제로 보고 좌표까지 비운다",
+        arguments: ["", "   ", "\n", " \n "]
+    )
+    func selectingBlankNameClearsCoordinate(name: String) {
+        let viewModel = makeViewModel()
+        viewModel.placeSelectionChanged(
+            name: "한성대 상상관",
+            address: "서울 성북구 삼선교로16길 116",
+            coordinate: Coordinate(latitude: 37.582, longitude: 127.010)
+        )
+
+        viewModel.placeSelectionChanged(
+            name: name,
+            address: "",
+            coordinate: Coordinate(latitude: 0, longitude: 0)
+        )
+
+        #expect(viewModel.placeName.isEmpty)
+        #expect(viewModel.placeAddress.isEmpty)
+        #expect(viewModel.placeCoordinate == nil)
+    }
+}
+
+// MARK: - 로딩 취소
+
+@MainActor
+@Suite("StudyScheduleRegistrationViewModel — 로딩 취소 (도메인 규칙)")
+struct StudyScheduleRegistrationViewModelCancellationTests {
+
+    @Test("주차 옵션 조회 취소 → 실패로 전이하지 않고 직전 결과를 유지한다")
+    func cancelledWeeklyOptionsKeepsPreviousState() async {
+        let repository = MockStudyScheduleRepository()
+        let option = makeOption()
+        repository.weeklyOptionsResult = .success([option])
+        let viewModel = makeViewModel(repository: repository)
+        await viewModel.loadWeeklyOptions()
+
+        repository.weeklyOptionsResult = .failure(CancellationError())
+        await viewModel.loadWeeklyOptions()
+
+        #expect(viewModel.weeklyOptionsState == .loaded([option]))
+    }
+
+    @Test("참여자 조회 취소 → 실패로 전이하지 않고 직전 결과를 유지한다")
+    func cancelledParticipantsKeepsPreviousState() async {
+        let useCase = MockFetchStudyMembersUseCase()
+        let member = makeMember(memberID: "M-1")
+        useCase.result = .success([member])
+        let viewModel = makeViewModel(membersUseCase: useCase)
+        await viewModel.loadParticipantMembers()
+
+        useCase.result = .failure(CancellationError())
+        await viewModel.loadParticipantMembers()
+
+        #expect(viewModel.participantsState == .loaded([member]))
+    }
+
+    @Test("네트워크 요청 취소(URLError.cancelled)도 같은 취소로 다룬다")
+    func cancelledURLErrorKeepsPreviousState() async {
+        let repository = MockStudyScheduleRepository()
+        let option = makeOption()
+        repository.weeklyOptionsResult = .success([option])
+        let viewModel = makeViewModel(repository: repository)
+        await viewModel.loadWeeklyOptions()
+
+        repository.weeklyOptionsResult = .failure(URLError(.cancelled))
+        await viewModel.loadWeeklyOptions()
+
+        #expect(viewModel.weeklyOptionsState == .loaded([option]))
     }
 }
 
@@ -721,18 +823,6 @@ struct StudyScheduleRegistrationViewModelPayloadTests {
         #expect(request.attendancePolicy?.checkInStartAt == viewModel.attendanceCheckInStartAt)
         #expect(request.attendancePolicy?.onTimeEndAt == viewModel.attendanceOnTimeEndAt)
         #expect(request.attendancePolicy?.lateEndAt == viewModel.attendanceLateEndAt)
-    }
-
-    @Test("비대면 전환 → 장소명과 좌표를 함께 비운다")
-    func switchingToOnlineClearsPlace() {
-        let viewModel = makeViewModel()
-        viewModel.placeName = "한성대 상상관"
-        viewModel.placeCoordinate = Coordinate(latitude: 37.5, longitude: 127.0)
-
-        viewModel.inPersonModeToggleChanged(to: false)
-
-        #expect(viewModel.placeName.isEmpty)
-        #expect(viewModel.placeCoordinate == nil)
     }
 }
 


### PR DESCRIPTION
resolves #1014

## ✨ PR 유형

♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)

<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/6f7abe05-33fc-4acb-acfd-64a96464ae6a" />

## 🛠️ 작업내용

`StudyScheduleRegistrationViewModel`만 이식(#975)되고 대응 View가 없어 도달 불가였던 일정 등록 기능을 화면까지 연결했습니다.

| 구분 | 내용 |
|---|---|
| 화면 이식 | `StudyScheduleRegistrationView` → `Features/Activity/Presentation/Sources/Views/Operator/` |
| 라우팅 결선 | `ActivityRoutingView`의 `.studyScheduleRegistration` placeholder("준비 중" 안내)를 실제 화면으로 교체. ViewModel은 형제 `OperatorAttendanceDetailRoute`와 동일하게 라우팅 지점에서 DI 조립 |
| 공용 컴포넌트 승격 | `DateTimeRow`·`DatePickerRow`·`TimePickerRow`·`InPersonToggle`·`AttendancePolicyTimeSection` 5종을 `Core/UIComponents/Sources/Schedule/`에 신설 |
| 장소 선택 결선 | `PlaceSelectView`(CoreUIComponents, #1018 이식분)를 그대로 사용. ViewModel에 `placeAddress`를 추가해 선택 상태의 단일 소유자를 ViewModel로 유지 |
| 하네스 진입점 | DEBUG 하네스(`ActivityFeatureView`)에 일정 등록 진입 버튼 추가 |

### 공용 컴포넌트를 Core에 둔 이유

5종은 레거시에서 Home의 `ScheduleRegistrationView`(미이식)와 **공유**하던 자산입니다. Activity 안에 두면 Home 이식 시 같은 컴포넌트가 두 벌 생기므로 Core에 canonical로 배치했습니다.

### 이식하며 정규화한 항목

- **picker 열림 상태 `Bool` 10개 → 슬롯 하나(`Optional`)**: 기존 구조는 상태를 ViewModel이 갖고 "동시에 두 개가 열리지 않게" 하는 보장은 컴포넌트의 `closeOthers`가 담당해 분리돼 있었습니다. 화면 밖에서 쓰이지 않는 순수 표시 상태라 View/컴포넌트 소유로 옮기고, 슬롯 하나로 표현해 동시 열림 상태 자체를 표현 불가능하게 했습니다.
- **로딩 취소 처리 추가**: `.task`로 호출되는 주차 옵션·참여자 조회가 취소 시 generic catch에 걸려 `.failed(.unknown)`으로 전이했습니다. 화면이 붙는 순간(빠른 이탈·탭 전환) 정상 상황에 "알 수 없는 오류"가 뜨는 경로라, 형제 ViewModel(`HomeViewModel`/`MyPageViewModel`) 관례대로 이전 상태 롤백으로 수정했습니다.
- **제출 상태 단일화**: 레거시는 View와 ViewModel이 각각 `isSubmitting`을 들고 있었는데 ViewModel 단일 소스로 정리했습니다.

### 하네스 진입점을 따로 둔 이유

카드의 일정 버튼은 `canRegisterSchedule` — "서버 실재 그룹 + 담당 멘토 본인" 권한 검사를 거칩니다. 하네스 세션의 챌린저 ID는 샘플 그룹의 멘토와 달라 이 경로로는 화면이 열리지 않아(권한 없음 안내가 정상 동작), 같은 섹션의 `생성 폼` 버튼과 동일한 이유로 하네스 전용 진입점을 뒀습니다. 카드가 보내는 것과 **같은 목적지를 push** 하므로 라우팅·DI 조립까지 실제 경로 그대로 확인됩니다.

## 📋 추후 진행 상황

- Home `ScheduleRegistrationView` 이식 시 이번에 Core로 올린 일정 폼 컴포넌트 5종 재사용 (재생성 금지)
- `StudyGroupCard`의 "오늘 미팅" 뱃지 산정 로직 (별도 이슈)

## 📌 리뷰 포인트

| 파일 | 확인 요청 |
|---|---|
| `Core/UIComponents/Sources/Schedule/*` | 공용 컴포넌트 5종의 Core 배치 위치와 `public` API 형태가 Home 이식 때도 그대로 쓸 만한지 |
| `.../ViewModels/StudyScheduleRegistrationViewModel.swift` | picker 플래그 10개 삭제가 다른 소비자에 영향 없는지(현재 참조 0건), 취소 롤백이 재진입 가드와 짝으로 맞는지 |
| `.../Views/Operator/StudyScheduleRegistrationView.swift` | `PlaceSelection` ↔ ViewModel 변환 바인딩. 좌표 없으면 `.empty`를 돌려주고, 빈 이름 선택은 ViewModel이 "선택 해제"로 해석해 좌표까지 비웁니다 |
| `.../Navigation/ActivityRoutingView.swift` | 라우팅 지점 DI 조립이 탭 재진입마다 ViewModel을 재생성하지 않는지 |

### 검증

`origin/develop` 리베이스 후 `make build SCHEME=ActivityPresentation` BUILD SUCCEEDED, `make test SCHEME=ActivityPresentation` 전 케이스 통과(exit 0).

iPhone 17 Pro 시뮬레이터에서 실제 라우팅 경로로 확인한 항목:

| 확인 | 결과 |
|---|---|
| 스터디 관리 → 일정 등록 push | 목적지 payload(스터디명) 표시, DI 조립 정상 |
| 주차 커리큘럼 조회 실패 | "주차 목록을 불러오지 못했어요" + 재시도 (`.failed` 분기) |
| 날짜/시간 피커 | 시간 피커를 열면 날짜 피커가 닫힘 — 동시 열림 없음 |
| 장소 선택 | 지도에서 선택 → 이름·주소 표시 → 해제 시 전부 비워짐 |
| 카드의 일정 버튼(권한 없음 계정) | "담당 파트장(멘토)만 일정을 등록할 수 있습니다" 안내 — 게이팅 정상 |

> 참고: 인자 없는 `make test`(기본 `SCHEME=UMCApp`)는 앱 스킴 테스트만 실행하고 `ActivityPresentationTests`는 한 개도 돌지 않습니다. 모듈 테스트는 `SCHEME`을 지정해 확인했습니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
