### PR TITLE
🐛 [Fix] develop 빌드 복구 — PreviewStudyScheduleRepository 프로토콜 요구 구현

### DIFF
--- a/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/StudyScheduleRegistrationPreviewSupport.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/StudyScheduleRegistrationPreviewSupport.swift
@@ -71,6 +71,19 @@ final class PreviewStudyScheduleRepository: StudyRepositoryProtocol {
         nil
     }
 
+    func fetchStudyGroupNames() async throws -> [StudyGroupName] {
+        throw DomainError.custom(message: "프리뷰 계약 밖")
+    }
+
+    func fetchStudyMemberSubmissions(
+        studyGroupId: String?,
+        weekNos: [String],
+        cursor: String?,
+        size: Int
+    ) async throws -> StudyMemberSubmissionPage {
+        throw DomainError.custom(message: "프리뷰 계약 밖")
+    }
+
     func createStudyGroup(
         gisuId: String,
         name: String,


### PR DESCRIPTION
resolves #1063

## ✨ PR 유형

🐛 Fix — `develop` 빌드 복구

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경 없음 -->

## 🛠️ 작업내용

`PreviewStudyScheduleRepository` 에 누락돼 있던 `StudyRepositoryProtocol` 요구 2개를 구현했습니다.

머지 순서로 생긴 semantic conflict 입니다 — 두 PR 이 각자 브랜치에서는 통과했지만 합쳐지며 깨졌습니다.

| PR | 한 일 |
|----|------|
| #1059 | `StudyRepositoryProtocol` 에 `fetchStudyGroupNames()` / `fetchStudyMemberSubmissions(...)` 추가 |
| #1061 | `PreviewStudyScheduleRepository` 추가 — 위 2개 미구현 |

#1061 이 #1059 보다 먼저 분기해 새 요구를 못 본 채 각각 머지됐습니다.

## 📋 추후 진행 상황

없습니다. `develop` 복구 단독 목적입니다.

## 📌 리뷰 포인트

**스텁 본문을 `throw` 로 둔 이유**

두 메서드 모두 일정 등록 프리뷰에서 호출되지 않습니다.
파일이 이미 "프리뷰에서 호출될 일이 없어 계약 밖으로 둔다"는 방침으로
`fetchCurriculumOverview` / `fetchStudyGroupDetail` 등을
`throw DomainError.custom(message: "프리뷰 계약 밖")` 으로 두고 있어 같은 형태로 맞췄습니다.
빈 값을 돌려주면 "프리뷰가 이 경로를 지원한다"는 잘못된 신호가 되고,
나중에 실제로 호출됐을 때 조용히 빈 화면이 됩니다.

**검증**

| 명령 | 결과 |
|------|------|
| `make test SCHEME=ActivityPresentation` | `** TEST SUCCEEDED **` (272 tests / 54 suites) |
| `make build SCHEME=UMCApp` | `** BUILD SUCCEEDED **` |

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
