### PR TITLE
🐛 [Fix] 커리큘럼 미등록 상태 전용 안내 복원

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
@@ -100,6 +100,12 @@ public enum DomainError: Error, LocalizedError, Equatable {
     /// 현재 운영 중이 아닌 기수라 커리큘럼 조회 불가
     case curriculumUnavailableForGeneration
 
+    /// 서버에 커리큘럼이 아직 등록되지 않음 (`CURRICULUM-0001`)
+    ///
+    /// 학기 초처럼 커리큘럼 등록 전 기간에는 **정상 상황**이므로, 일반 서버 오류가 아니라
+    /// 전용 안내로 표시해야 합니다.
+    case curriculumNotRegistered
+
     // MARK: - 커뮤니티
 
     /// 게시글을 찾을 수 없음
@@ -144,6 +150,8 @@ public enum DomainError: Error, LocalizedError, Equatable {
             return "링크를 입력해주세요."
         case .curriculumUnavailableForGeneration:
             return "현재 운영중인 기수가 아니어서 커리큘럼을 조회할 수 없습니다."
+        case .curriculumNotRegistered:
+            return "아직 커리큘럼이 등록되지 않았어요. 조금만 기다려주세요!"
         case .postNotFound:
             return "게시글을 찾을 수 없습니다."
         case .cannotDeletePost:

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
@@ -45,6 +45,11 @@ public final class StudyRepository: StudyRepositoryProtocol, @unchecked Sendable
         /// 한 페이지에 그룹이 100개면 멤버가 수백 명이 될 수 있어, 무제한으로 띄우면 서버와
         /// 연결 풀에 과부하가 걸린다. 창(window)을 두고 완료되는 만큼만 새로 채운다.
         static let memberSupplementConcurrencyLimit = 8
+
+        /// 서버가 커리큘럼 미등록을 알리는 에러 코드.
+        ///
+        /// 서버 `CurriculumErrorCode.CURRICULUM_NOT_FOUND`(HTTP 404) 와 짝을 이룬다.
+        static let curriculumNotRegisteredCode = "CURRICULUM-0001"
     }
 
     // MARK: - Init
@@ -296,26 +301,56 @@ private extension StudyRepository {
     /// 현재 운영 기수(`gisuId`)가 없으면 네트워크 호출 없이
     /// ``DomainError/curriculumUnavailableForGeneration`` 을 던진다.
     ///
-    /// - Note: 레거시는 `CURRICULUM-0001`(커리큘럼 미등록) 본문을 별도 도메인 에러로
-    ///   승격했으나, 신규 모듈에는 대응 case 가 아직 없어 서버 실패는 표준
-    ///   ``RepositoryError/serverError(code:message:)`` 경로로 노출한다(도메인 vocabulary
-    ///   추가 시 후속 보강).
+    /// 커리큘럼이 아직 등록되지 않아 서버가 `CURRICULUM-0001` 로 응답하면
+    /// ``DomainError/curriculumNotRegistered`` 로 승격한다. 학기 초에는 미등록이 정상
+    /// 상황이라 화면이 오류 카드 대신 전용 안내를 띄워야 하기 때문이다. 그 외 실패는
+    /// 원본 에러를 그대로 전파한다.
+    ///
+    /// 요청을 `do` 블록 안에 두어야 비-2xx 응답으로 발생한
+    /// ``NetworkError/requestFailed(statusCode:data:)`` 가 이 변환을 거친다.
+    ///
     /// - Returns: 디코딩한 ``CurriculumDTO`` 와 조회에 사용한 파트 문자열
     func fetchCurriculum() async throws -> (dto: CurriculumDTO, part: String) {
         guard let gisuId = context.gisuId else {
             throw DomainError.curriculumUnavailableForGeneration
         }
         let part = context.part
-        let response = try await networkRequesting.request(
-            StudyRouter.getCurriculum(
-                query: CurriculumOverviewQuery(gisuId: gisuId, part: part, weekNo: nil)
+        let response: Response
+        do {
+            response = try await networkRequesting.request(
+                StudyRouter.getCurriculum(
+                    query: CurriculumOverviewQuery(gisuId: gisuId, part: part, weekNo: nil)
+                )
             )
-        )
+        } catch let error as NetworkError {
+            throw Self.mapCurriculumNotRegistered(error) ?? error
+        }
         let apiResponse = try decoder.decode(
             APIResponse<CurriculumDTO>.self,
             from: response.data
         )
         return (try apiResponse.unwrap(), part)
+    }
+
+    /// 커리큘럼 조회 실패 본문이 미등록 코드인지 판별한다.
+    ///
+    /// 미등록 코드일 때만 ``DomainError/curriculumNotRegistered`` 를 돌려주고, 다른 코드·
+    /// 비-`requestFailed` 실패는 `nil` 을 반환해 원본 에러가 그대로 전파되게 한다. 범위를
+    /// 코드로 좁히지 않으면 401·5xx 까지 미등록 안내로 뭉개진다.
+    ///
+    /// - Note: 본문 파싱에 `JSONSerialization` 을 쓰는 이유는 서버가 실패 응답의 `result` 에
+    ///   객체가 아니라 **문자열**(예외 메시지)을 담기 때문이다. `APIResponse<EmptyResult>` 로
+    ///   디코딩하면 그 문자열에서 실패해 `code` 를 읽지 못한다.
+    static func mapCurriculumNotRegistered(_ error: NetworkError) -> DomainError? {
+        guard
+            case .requestFailed(_, let data) = error,
+            let data,
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            json["code"] as? String == Constants.curriculumNotRegisteredCode
+        else {
+            return nil
+        }
+        return .curriculumNotRegistered
     }
 
     // MARK: - 멤버 프로필 보강

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/StudyRepository.swift
@@ -338,9 +338,9 @@ private extension StudyRepository {
     /// 비-`requestFailed` 실패는 `nil` 을 반환해 원본 에러가 그대로 전파되게 한다. 범위를
     /// 코드로 좁히지 않으면 401·5xx 까지 미등록 안내로 뭉개진다.
     ///
-    /// - Note: 본문 파싱에 `JSONSerialization` 을 쓰는 이유는 서버가 실패 응답의 `result` 에
-    ///   객체가 아니라 **문자열**(예외 메시지)을 담기 때문이다. `APIResponse<EmptyResult>` 로
-    ///   디코딩하면 그 문자열에서 실패해 `code` 를 읽지 못한다.
+    /// - Note: 본문 파싱은 같은 모듈의 ``AttendanceRepository`` 가 실패 본문을 읽는 방식과
+    ///   맞춰 `JSONSerialization` 을 쓴다. 서버는 실패 응답의 `result` 에 객체가 아니라
+    ///   예외 메시지 문자열을 담는데, 이 방식은 `result` 모양과 무관하게 `code` 만 읽는다.
     static func mapCurriculumNotRegistered(_ error: NetworkError) -> DomainError? {
         guard
             case .requestFailed(_, let data) = error,

--- a/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
@@ -263,9 +263,9 @@ private enum Fixture {
 
     /// 비-2xx 실패 응답 본문 — 서버 `ApiErrorResponseFactory` 의 실제 모양.
     ///
-    /// 서버는 `result` 에 객체가 아니라 **예외 메시지 문자열**을 담는다. 이 모양을 그대로
-    /// 재현해 두어야, 본문을 `APIResponse<EmptyResult>` 로 디코딩하는 파싱이 그 문자열에서
-    /// 실패해 코드를 놓치는 회귀를 잡을 수 있다.
+    /// 서버는 `result` 에 객체가 아니라 **예외 메시지 문자열**을 담는다(`BusinessException`
+    /// 의 메시지). 이 모양을 그대로 재현해야 파싱이 실제 응답에서 `code` 를 읽어내는지
+    /// 검증된다 — `result` 를 비운 본문으로만 테스트하면 그 차이를 못 잡는다.
     static func errorBody(code: String?, message: String) -> Data {
         var fields: [String] = ["\"success\": false"]
         if let code { fields.append("\"code\": \"\(code)\"") }

--- a/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRepositoryTests.swift
@@ -260,6 +260,25 @@ private enum Fixture {
         if let message { fields.append("\"message\": \"\(message)\"") }
         return Data("{ \(fields.joined(separator: ", ")) }".utf8)
     }
+
+    /// 비-2xx 실패 응답 본문 — 서버 `ApiErrorResponseFactory` 의 실제 모양.
+    ///
+    /// 서버는 `result` 에 객체가 아니라 **예외 메시지 문자열**을 담는다. 이 모양을 그대로
+    /// 재현해 두어야, 본문을 `APIResponse<EmptyResult>` 로 디코딩하는 파싱이 그 문자열에서
+    /// 실패해 코드를 놓치는 회귀를 잡을 수 있다.
+    static func errorBody(code: String?, message: String) -> Data {
+        var fields: [String] = ["\"success\": false"]
+        if let code { fields.append("\"code\": \"\(code)\"") }
+        fields.append("\"message\": \"\(message)\"")
+        fields.append("\"result\": \"\(message)\"")
+        return Data("{ \(fields.joined(separator: ", ")) }".utf8)
+    }
+
+    /// 서버가 커리큘럼 미등록에 실제로 내려주는 404 본문.
+    static let curriculumNotRegisteredBody = errorBody(
+        code: "CURRICULUM-0001",
+        message: "커리큘럼을 찾을 수 없어요. 선택한 커리큘럼을 확인해주세요."
+    )
 }
 
 private typealias RepositoryPair = (StudyRepository, StubNetworkRequesting)
@@ -382,6 +401,67 @@ struct StudyRepositoryCurriculumTests {
 
         await #expect(throws: RepositoryError.serverError(code: "CUR404", message: "커리큘럼 없음")) {
             try await sut.fetchCurriculumOverview()
+        }
+    }
+
+    // MARK: - 커리큘럼 미등록 승격
+
+    /// 서버는 커리큘럼 미등록을 404 + `CURRICULUM-0001` 로 알린다. 학기 초에는 정상 상황이라
+    /// 일반 서버 오류로 흘리면 사용자에게 "알 수 없는 오류" 카드로 보인다.
+    ///
+    /// 두 조회는 같은 `fetchCurriculum()` 헬퍼를 공유하므로 형제 대칭으로 함께 고정한다.
+    ///
+    /// 파라미터 타입 `CurriculumFetch` 가 file-private 이라 메서드도 fileprivate 로 맞춘다.
+    @Test(
+        "커리큘럼 미등록(404 CURRICULUM-0001)은 두 조회 모두 전용 도메인 에러로 승격된다",
+        arguments: [CurriculumFetch.overview, .weeklyOptions]
+    )
+    fileprivate func promotesCurriculumNotRegistered(_ fetch: CurriculumFetch) async {
+        let (sut, _) = makeRepository(
+            .failure(
+                NetworkError.requestFailed(
+                    statusCode: 404,
+                    data: Fixture.curriculumNotRegisteredBody
+                )
+            )
+        )
+
+        await #expect(throws: DomainError.curriculumNotRegistered) {
+            try await fetch.run(sut)
+        }
+    }
+
+    /// 승격 범위를 코드로 좁히지 않으면 401·5xx 같은 진짜 오류까지 "커리큘럼 준비 중"
+    /// 안내로 뭉개져 전역 에러 처리를 우회한다.
+    @Test(
+        "미등록 코드가 아닌 실패는 원본 NetworkError 를 그대로 전파한다",
+        arguments: [
+            (404, Fixture.errorBody(code: "CURRICULUM-0014", message: "주차 없음")),
+            (500, Fixture.errorBody(code: nil, message: "서버 오류")),
+            (403, nil)
+        ] as [(Int, Data?)]
+    )
+    func propagatesNonCurriculumFailures(statusCode: Int, body: Data?) async {
+        let networkError = NetworkError.requestFailed(statusCode: statusCode, data: body)
+        let (sut, _) = makeRepository(.failure(networkError))
+
+        await #expect(throws: networkError) {
+            try await sut.fetchCurriculumOverview()
+        }
+    }
+}
+
+/// ``fetchCurriculum()`` 헬퍼를 공유하는 두 공개 조회 — 미등록 승격을 형제 대칭으로 검증한다.
+private enum CurriculumFetch: Sendable {
+    case overview
+    case weeklyOptions
+
+    func run(_ sut: StudyRepository) async throws {
+        switch self {
+        case .overview:
+            _ = try await sut.fetchCurriculumOverview()
+        case .weeklyOptions:
+            _ = try await sut.fetchWeeklyCurriculumOptions()
         }
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerStudyView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerStudyView.swift
@@ -90,12 +90,24 @@ struct ChallengerStudyView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    /// 실패 상태를 에러 성격에 따라 나눠 렌더합니다.
+    ///
+    /// 커리큘럼 미등록·조회 불가는 재시도해도 결과가 달라지지 않는 **정상 상황**이므로
+    /// 재시도 버튼 없는 안내로만 표시하고, 나머지 실패만 재시도 경로로 보냅니다.
+    /// 미등록 안내는 미션이 빈 성공 응답(``emptyCurriculumGuide``)과 시각적으로 동일합니다.
     @ViewBuilder
     private func errorView(
         error: AppError,
         viewModel: ChallengerStudyViewModel
     ) -> some View {
-        if case .domain(.curriculumUnavailableForGeneration) = error {
+        if case .domain(.curriculumNotRegistered) = error {
+            ContentUnavailableView {
+                Label("커리큘럼 준비 중", systemImage: "clock.badge.questionmark")
+            } description: {
+                Text(error.userMessage)
+                    .multilineTextAlignment(.center)
+            }
+        } else if case .domain(.curriculumUnavailableForGeneration) = error {
             ContentUnavailableView {
                 Label("커리큘럼 조회 불가", systemImage: "info.circle")
             } description: {

--- a/UMCApp/Features/Activity/Presentation/Tests/ChallengerStudyViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/ChallengerStudyViewModelTests.swift
@@ -108,6 +108,9 @@ private final class SlowMockFetchCurriculumOverviewUseCase: @unchecked Sendable,
 private enum ErrorMappingCase: CaseIterable {
     case appErrorPassthrough
     case domain
+    /// 커리큘럼 미등록 — 화면이 전용 안내를 띄우려면 `.unknown` 으로 뭉개지지 않고
+    /// 도메인 에러 그대로 도달해야 한다.
+    case curriculumNotRegistered
     case network
     case repository
     case unknownFallback
@@ -118,6 +121,8 @@ private enum ErrorMappingCase: CaseIterable {
             return AppError.repository(.decodingError(detail: "이미 래핑됨"))
         case .domain:
             return DomainError.curriculumUnavailableForGeneration
+        case .curriculumNotRegistered:
+            return DomainError.curriculumNotRegistered
         case .network:
             return NetworkError.unauthorized
         case .repository:
@@ -135,6 +140,8 @@ private enum ErrorMappingCase: CaseIterable {
             return .repository(.decodingError(detail: "이미 래핑됨"))
         case .domain:
             return .domain(.curriculumUnavailableForGeneration)
+        case .curriculumNotRegistered:
+            return .domain(.curriculumNotRegistered)
         case .network:
             return .network(.unauthorized)
         case .repository:


### PR DESCRIPTION
resolves #1058

## ✨ PR 유형

버그 수정 — 커리큘럼 미등록(학기 초 정상 상황)이 일반 오류 카드로 노출되던 문제를 전용 안내로 복원

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 테스트 성공 캡쳐 + 커버리지 첨부 (CI 미적용 기간 한시 정책) -->

## 🛠️ 작업내용

서버는 커리큘럼 미등록을 `CURRICULUM-0001`(HTTP 404)로 알리는데, UMCApp 은 이를 일반 서버 오류로
흘려보내 학기 초 정상 상황이 "알 수 없는 오류" 카드로 보였습니다. 미등록을 1급 도메인 상태로
복원했습니다.

| 레이어 | 변경 |
|---|---|
| `DomainError` | `curriculumNotRegistered` case 추가 |
| `StudyRepository` | 404 본문의 `code` 가 `CURRICULUM-0001` 일 때만 도메인 에러로 승격 |
| `ChallengerStudyView` | 미등록 전용 안내(재시도 버튼 없음) 분기 복원 |

## 📋 추후 진행 상황

- 주차 옵션 조회(`fetchWeeklyCurriculumOptions`)도 같은 `fetchCurriculum()` 헬퍼를 쓰므로
  미등록 승격을 함께 받습니다. 다만 `StudyScheduleRegistrationView`(#1061)의 `.failed`
  분기는 에러 종류와 무관하게 고정 문구를 쓰므로 화면 표시는 그대로입니다. 그쪽에도 전용
  안내가 필요하면 별도 티켓으로 다루면 됩니다.

## 📌 리뷰 포인트

**1. 승격 범위를 에러 코드로 좁혔습니다**

`CURRICULUM-0001` 일 때만 승격하고 그 외 상태·코드는 원본 `NetworkError` 를 그대로 재전파합니다.
범위를 넓히면 401·5xx 같은 진짜 오류까지 "커리큘럼 준비 중" 으로 뭉개져 전역 에러 처리를
우회합니다. `404+다른 코드` / `500+코드 없음` / `403+본문 없음` 3케이스로 회귀를 고정했습니다.

**2. 본문 파싱 방식**

같은 모듈 `AttendanceRepository` 가 실패 본문을 읽는 방식(`JSONSerialization`)에 맞췄습니다.
서버 실패 응답은 `result` 에 객체가 아니라 예외 메시지 문자열을 담는데, 이 방식은 `result`
모양과 무관하게 `code` 만 읽습니다. 테스트 픽스처도 `result` 를 문자열로 담은 **실제 응답
모양** 그대로 두어, 비어 있는 본문으로만 검증해 실제와 어긋나는 일이 없게 했습니다.

**3. 형제 대칭**

`fetchCurriculumOverview` / `fetchWeeklyCurriculumOptions` 가 같은 `fetchCurriculum()` 을
공유하므로 두 경로 모두 파라미터화로 함께 검증했습니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
