### PR TITLE
♻️ [Refactor] 챌린저 검색 서브시스템 이식 — 스터디 그룹 생성·인원 추가 결선 복원

### DIFF
--- a/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerSearchCursorDTO.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerSearchCursorDTO.swift
@@ -1,0 +1,122 @@
+//
+//  ChallengerSearchCursorDTO.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import Foundation
+import UMCFoundation
+
+// MARK: - ChallengerSearchCursorResultDTO
+
+/// 챌린저 커서 검색 결과 DTO
+///
+/// `GET /api/v1/challenger/search/cursor`
+///
+/// 서버 응답은 `{ "cursor": { ... }, "partCounts": [ ... ] }` 형태입니다. `partCounts` 는
+/// 파트별 집계 UI 가 이식되기 전까지 소비처가 없어 디코딩하지 않습니다 — 쓰지 않는 필드를
+/// 실어 두면 서버 계약이 바뀌었을 때 검색 자체가 깨질 위험만 늘어납니다.
+struct ChallengerSearchCursorResultDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let cursor: ChallengerSearchCursorPageDTO
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case cursor
+    }
+
+    // MARK: - Init
+
+    init(cursor: ChallengerSearchCursorPageDTO) {
+        self.cursor = cursor
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        cursor = try container.decodeIfPresent(
+            ChallengerSearchCursorPageDTO.self,
+            forKey: .cursor
+        ) ?? .empty
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(cursor, forKey: .cursor)
+    }
+}
+
+// MARK: - ChallengerSearchCursorPageDTO
+
+/// 커서 페이지 메타 + 항목 목록
+///
+/// 항목 타입은 오프셋 검색과 동일한 서버 `SearchChallengerItemResponse` 라
+/// ``ChallengerSearchOffsetItemDTO`` 를 그대로 재사용합니다(중복 DTO 선언 금지).
+struct ChallengerSearchCursorPageDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let content: [ChallengerSearchOffsetItemDTO]
+
+    /// 다음 페이지 커서. 서버가 `Long` 으로 내려주는 페이지네이션 토큰이라 `Int?` 입니다.
+    let nextCursor: Int?
+
+    let hasNext: Bool
+
+    // MARK: - Empty
+
+    /// `cursor` 필드 부재 시 사용할 빈 페이지.
+    static let empty = ChallengerSearchCursorPageDTO(
+        content: [],
+        nextCursor: nil,
+        hasNext: false
+    )
+
+    // MARK: - CodingKeys
+
+    private enum CodingKeys: String, CodingKey {
+        case content
+        case nextCursor
+        case hasNext
+    }
+
+    // MARK: - Init
+
+    init(
+        content: [ChallengerSearchOffsetItemDTO],
+        nextCursor: Int?,
+        hasNext: Bool
+    ) {
+        self.content = content
+        self.nextCursor = nextCursor
+        self.hasNext = hasNext
+    }
+
+    // MARK: - Decodable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        content = try container.decodeIfPresent(
+            [ChallengerSearchOffsetItemDTO].self,
+            forKey: .content
+        ) ?? []
+        nextCursor = try container.decodeIntFlexibleIfPresent(forKey: .nextCursor)
+        hasNext = try container.decodeBoolFlexibleIfPresent(forKey: .hasNext) ?? false
+    }
+
+    // MARK: - Encodable
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(content, forKey: .content)
+        try container.encodeIfPresent(nextCursor, forKey: .nextCursor)
+        try container.encode(hasNext, forKey: .hasNext)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerSearchCursorQuery.swift
+++ b/UMCApp/Features/Activity/Data/Sources/DTOs/ChallengerSearchCursorQuery.swift
@@ -1,0 +1,64 @@
+//
+//  ChallengerSearchCursorQuery.swift
+//  ActivityData
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import Foundation
+
+/// 챌린저 커서 검색 Query DTO
+///
+/// `GET /api/v1/challenger/search/cursor`
+///
+/// 라우터 `task` 에 인라인 딕셔너리를 두지 않도록 쿼리 파라미터를 캡슐화합니다(절대 규칙 #6).
+///
+/// - Note: `cursor` 는 서버 `SearchChallengerCursorRequest.cursor` 가 `Long` 이라 `Int?` 로
+///   보냅니다. 응답 식별자를 `String` 으로 통일하는 절대 규칙 #2 는 **응답** 한정이며,
+///   Request/Query DTO 는 서버 계약 타입을 그대로 따릅니다(절대 규칙 #3 예외).
+/// - Note: `keyword` 는 이름·닉네임 통합 검색어입니다. 값이 없으면 파라미터에서 제외해
+///   서버가 전체 검색으로 처리하게 둡니다.
+struct ChallengerSearchCursorQuery: Sendable, Equatable {
+
+    // MARK: - Constants
+
+    /// 서버 기본값(20)보다 큰 한 화면 분량. 서버 상한은 50이라 그 이상은 잘립니다.
+    static let defaultSize = 50
+
+    // MARK: - Property
+
+    /// 이전 페이지의 마지막 챌린저 ID (첫 페이지는 `nil`)
+    let cursor: Int?
+
+    /// 한 페이지에 조회할 항목 수
+    let size: Int
+
+    /// 이름 또는 닉네임 통합 검색 키워드
+    let keyword: String?
+
+    // MARK: - Init
+
+    init(
+        cursor: Int? = nil,
+        size: Int = ChallengerSearchCursorQuery.defaultSize,
+        keyword: String? = nil
+    ) {
+        self.cursor = cursor
+        self.size = size
+        self.keyword = keyword
+    }
+
+    // MARK: - Parameters
+
+    /// Query Parameter Dictionary 변환.
+    var toParameters: [String: Any] {
+        var parameters: [String: Any] = ["size": size]
+        if let cursor {
+            parameters["cursor"] = cursor
+        }
+        if let keyword, !keyword.isEmpty {
+            parameters["keyword"] = keyword
+        }
+        return parameters
+    }
+}

--- a/UMCApp/Features/Activity/Data/Sources/Repositories/MemberRepository.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Repositories/MemberRepository.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ActivityDomain
+import CoreDomain
 import CoreNetwork
 import UMCFoundation
 import Moya
@@ -102,6 +103,35 @@ public final class MemberRepository: MemberRepositoryProtocol, @unchecked Sendab
             members: members,
             hasNext: pageResult.hasNext,
             currentPage: pageResult.page
+        )
+    }
+
+    // MARK: - 챌린저 검색
+
+    public func searchChallengers(
+        keyword: String?,
+        cursor: Int?,
+        size: Int
+    ) async throws -> ChallengerSearchPage {
+        let response = try await networkRequesting.request(
+            StudyRouter.searchChallengersCursor(
+                query: ChallengerSearchCursorQuery(
+                    cursor: cursor,
+                    size: size,
+                    keyword: keyword
+                )
+            )
+        )
+        let result = try decoder.decode(
+            APIResponse<ChallengerSearchCursorResultDTO>.self,
+            from: response.data
+        ).unwrap()
+        let page = result.cursor
+
+        return ChallengerSearchPage(
+            challengers: page.content.compactMap(makeChallengerInfo),
+            hasNext: page.hasNext,
+            nextCursor: page.nextCursor
         )
     }
 
@@ -289,6 +319,46 @@ private extension MemberRepository {
                 fallbackPenalty: max(0, item.pointSum)
             )
         }
+    }
+
+    /// 검색 항목을 Core canonical ``CoreDomain/ChallengerInfo`` 로 매핑합니다.
+    ///
+    /// `memberId` 가 비면 선택 키(`selectionKey`)를 만들 수 없고 그룹 추가 API 도 호출할 수
+    /// 없으므로 그 항목은 제외합니다(`compactMap`).
+    ///
+    /// - Note: `gen` 은 `"9기"` 같은 표시 문구가 아니라 **기수 번호 문자열**(`"9"`)입니다.
+    ///   `StudyRepository.resolveChallengerId(memberId:preferredGeneration:)` 가 이 값을
+    ///   `Int` 로 바꿔 챌린저 레코드의 `gisu` 와 비교하기 때문입니다. 기수를 알 수 없으면
+    ///   빈 문자열을 둬 호출부가 "기수 미지정"으로 다루게 합니다.
+    func makeChallengerInfo(
+        from item: ChallengerSearchOffsetItemDTO
+    ) -> ChallengerInfo? {
+        guard !item.memberId.isEmpty else { return nil }
+
+        return ChallengerInfo(
+            memberId: item.memberId,
+            challengerId: item.challengerId.nonEmpty,
+            gen: gisuNumberText(generation: item.generation, gisu: item.gisu),
+            name: item.name,
+            nickname: item.nickname,
+            schoolName: item.schoolName,
+            profileImage: item.profileImageURL,
+            part: UMCPartType(apiValue: item.part) ?? .pm
+        )
+    }
+
+    /// 기수 번호를 문자열로 반환합니다 (알 수 없으면 빈 문자열).
+    ///
+    /// 서버는 같은 값을 `generation`·`gisu` 두 키로 내려주며(`gisu` 는 FE 이관용 별칭),
+    /// 한쪽만 채워 오는 경우에 대비해 순서대로 확인합니다.
+    func gisuNumberText(generation: Int?, gisu: Int?) -> String {
+        if let generation, generation > 0 {
+            return "\(generation)"
+        }
+        if let gisu, gisu > 0 {
+            return "\(gisu)"
+        }
+        return ""
     }
 
     /// 각 디스크립터의 멤버 프로필을 조회해 상벌점·역할을 보강하고 정렬합니다.

--- a/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
+++ b/UMCApp/Features/Activity/Data/Sources/Routers/StudyRouter.swift
@@ -43,6 +43,8 @@ enum StudyRouter: Sendable {
 
     /// 학교 단위 챌린저 오프셋 검색 — `GET /api/v1/challenger/search/offset`
     case searchChallengersOffset(query: ChallengerSearchQuery)
+    /// 키워드 챌린저 커서 검색 — `GET /api/v1/challenger/search/cursor`
+    case searchChallengersCursor(query: ChallengerSearchCursorQuery)
     /// 챌린저 포인트 부여 — `POST /api/v1/challenger/{challengerId}/points`
     case createChallengerPoint(challengerId: String, body: ChallengerPointCreateRequestDTO)
     /// 챌린저 포인트 삭제 — `DELETE /api/v1/challenger/points/{challengerPointId}`
@@ -90,6 +92,8 @@ extension StudyRouter: BaseTargetType {
             return "/api/v2/curriculums/workbook-submissions"
         case .searchChallengersOffset:
             return "/api/v1/challenger/search/offset"
+        case .searchChallengersCursor:
+            return "/api/v1/challenger/search/cursor"
         case .createChallengerPoint(let challengerId, _):
             return "/api/v1/challenger/\(challengerId)/points"
         case .deleteChallengerPoint(let challengerPointId):
@@ -124,6 +128,7 @@ extension StudyRouter: BaseTargetType {
              .getStudyGroupNames,
              .getStudyMemberSubmissions,
              .searchChallengersOffset,
+             .searchChallengersCursor,
              .getChallengerProfile:
             return .get
         case .createStudyGroup,
@@ -157,6 +162,11 @@ extension StudyRouter: BaseTargetType {
                 encoding: URLEncoding.queryString
             )
         case .searchChallengersOffset(let query):
+            return .requestParameters(
+                parameters: query.toParameters,
+                encoding: URLEncoding.queryString
+            )
+        case .searchChallengersCursor(let query):
             return .requestParameters(
                 parameters: query.toParameters,
                 encoding: URLEncoding.queryString

--- a/UMCApp/Features/Activity/Data/Tests/DTOs/ChallengerSearchCursorDTOTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/DTOs/ChallengerSearchCursorDTOTests.swift
@@ -1,0 +1,88 @@
+//
+//  ChallengerSearchCursorDTOTests.swift
+//  ActivityDataTests
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import Testing
+import Foundation
+import UMCFoundation
+@testable import ActivityData
+
+// MARK: - Suite: 챌린저 커서 검색 디코딩 계약
+
+@Suite("ChallengerSearchCursorDTO — 디코딩 매핑 (서버 contract)")
+struct ChallengerSearchCursorDTODecodingTests {
+
+    private func decode(_ json: String) throws -> ChallengerSearchCursorResultDTO {
+        try JSONDecoder().decode(
+            ChallengerSearchCursorResultDTO.self,
+            from: Data(json.utf8)
+        )
+    }
+
+    @Test("cursor 래퍼의 content·nextCursor·hasNext 를 매핑한다")
+    func decodesCursorEnvelope() throws {
+        let json = """
+        {
+          "cursor": {
+            "content": [
+              {
+                "challengerId": 7, "memberId": 100, "gisuId": 70,
+                "generation": 9, "gisu": 9, "part": "IOS", "name": "홍길동",
+                "nickname": "길동", "schoolName": "한성대", "pointSum": 3,
+                "profileImageLink": "https://img/1.png",
+                "roleTypes": ["CHALLENGER"]
+              }
+            ],
+            "nextCursor": 12,
+            "hasNext": true
+          },
+          "partCounts": [{ "part": "IOS", "count": 1 }]
+        }
+        """
+
+        let result = try decode(json)
+        let item = try #require(result.cursor.content.first)
+
+        #expect(result.cursor.nextCursor == 12)
+        #expect(result.cursor.hasNext)
+        #expect(item.challengerId == "7")
+        #expect(item.memberId == "100")
+        #expect(item.gisu == 9)
+        #expect(item.profileImageURL == "https://img/1.png")
+    }
+
+    @Test("nextCursor 를 문자열로 내려줘도 Int 로 해석한다")
+    func decodesStringNextCursorAsInt() throws {
+        let json = """
+        { "cursor": { "content": [], "nextCursor": "31", "hasNext": true } }
+        """
+
+        let result = try decode(json)
+
+        #expect(result.cursor.nextCursor == 31)
+    }
+
+    @Test("마지막 페이지는 nextCursor 가 null, hasNext 가 false 다")
+    func decodesLastPage() throws {
+        let json = """
+        { "cursor": { "content": [], "nextCursor": null, "hasNext": false } }
+        """
+
+        let result = try decode(json)
+
+        #expect(result.cursor.nextCursor == nil)
+        #expect(result.cursor.hasNext == false)
+    }
+
+    @Test("cursor 필드가 없으면 빈 페이지로 폴백한다")
+    func missingCursorFallsBackToEmpty() throws {
+        let result = try decode("{}")
+
+        #expect(result.cursor.content.isEmpty)
+        #expect(result.cursor.nextCursor == nil)
+        #expect(result.cursor.hasNext == false)
+    }
+}

--- a/UMCApp/Features/Activity/Data/Tests/MemberRepositoryTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/MemberRepositoryTests.swift
@@ -9,6 +9,7 @@ import Testing
 import Foundation
 import Moya
 import ActivityDomain
+import CoreDomain
 import UMCFoundation
 @testable import ActivityData
 
@@ -119,6 +120,24 @@ private enum Fixture {
             "page": \(page), "size": 20, "totalElements": \(items.count),
             "totalPages": 1, "hasNext": \(hasNext), "hasPrevious": false
           }
+        }
+        """
+    }
+
+    /// 커서 검색 결과 페이지.
+    static func cursorPage(
+        items: [String],
+        nextCursor: Int? = nil,
+        hasNext: Bool = false
+    ) -> String {
+        let cursorValue = nextCursor.map(String.init) ?? "null"
+        return """
+        {
+          "cursor": {
+            "content": [\(items.joined(separator: ","))],
+            "nextCursor": \(cursorValue), "hasNext": \(hasNext)
+          },
+          "partCounts": []
         }
         """
     }
@@ -397,6 +416,132 @@ struct MemberRepositoryListTests {
 
         await #expect(throws: (any Error).self) {
             try await sut.fetchMembers()
+        }
+    }
+}
+
+// MARK: - Suite: 챌린저 커서 검색 계약
+
+@Suite("MemberRepository — 챌린저 커서 검색 (도메인 규칙)")
+struct MemberRepositoryChallengerSearchTests {
+
+    @Test("커서 검색 엔드포인트를 GET 으로 호출한다")
+    func callsCursorSearchEndpoint() async throws {
+        let (sut, stub) = makeRepository(
+            .success(Fixture.success(Fixture.cursorPage(items: [])))
+        )
+
+        _ = try await sut.searchChallengers(keyword: "길동", cursor: nil, size: 50)
+
+        #expect(stub.requestCount == 1)
+        #expect(stub.lastPath == "/api/v1/challenger/search/cursor")
+        #expect(stub.lastMethod == .get)
+    }
+
+    @Test("검색 항목을 ChallengerInfo 로 매핑하고 커서 정보를 보존한다")
+    func mapsItemsToChallengerInfo() async throws {
+        let page = Fixture.cursorPage(
+            items: [
+                Fixture.offsetItem(
+                    memberId: "100",
+                    challengerId: "C100",
+                    part: "IOS",
+                    name: "홍길동",
+                    nickname: "길동",
+                    gisu: 9
+                )
+            ],
+            nextCursor: 12,
+            hasNext: true
+        )
+        let (sut, _) = makeRepository(.success(Fixture.success(page)))
+
+        let result = try await sut.searchChallengers(keyword: "길동", cursor: nil, size: 50)
+        let challenger = try #require(result.challengers.first)
+
+        #expect(challenger.memberId == "100")
+        #expect(challenger.challengerId == "C100")
+        #expect(challenger.name == "홍길동")
+        #expect(challenger.nickname == "길동")
+        #expect(challenger.schoolName == "한성대")
+        #expect(challenger.part == .front(type: .ios))
+        #expect(result.hasNext)
+        #expect(result.nextCursor == 12)
+    }
+
+    @Test("기수는 '9기' 표시 문구가 아니라 챌린저 ID 해석에 쓰는 숫자 문자열이다")
+    func mapsGenerationAsPlainNumber() async throws {
+        let page = Fixture.cursorPage(
+            items: [Fixture.offsetItem(memberId: "100", gisu: 9)]
+        )
+        let (sut, _) = makeRepository(.success(Fixture.success(page)))
+
+        let result = try await sut.searchChallengers(keyword: nil, cursor: nil, size: 50)
+        let challenger = try #require(result.challengers.first)
+
+        // selectionKey 구성과 resolveChallengerId(preferredGeneration:) 비교가
+        // 숫자 문자열을 전제한다.
+        #expect(challenger.gen == "9")
+        #expect(challenger.selectionKey == "100|9|IOS")
+    }
+
+    @Test("기수 정보가 없으면 gen 을 빈 문자열로 둔다")
+    func mapsMissingGenerationAsEmpty() async throws {
+        let item = """
+        {
+          "challengerId": "C100", "memberId": "100", "gisuId": "70",
+          "part": "IOS", "name": "홍길동", "nickname": "길동",
+          "schoolName": "한성대", "pointSum": 0, "roleTypes": []
+        }
+        """
+        let (sut, _) = makeRepository(
+            .success(Fixture.success(Fixture.cursorPage(items: [item])))
+        )
+
+        let result = try await sut.searchChallengers(keyword: nil, cursor: nil, size: 50)
+        let challenger = try #require(result.challengers.first)
+
+        // 빈 문자열은 호출부(OperatorStudyManagementViewModel)가 "기수 미지정"으로 읽는 신호다.
+        #expect(challenger.gen.isEmpty)
+    }
+
+    @Test("memberId 가 없는 항목은 선택 키를 만들 수 없어 제외한다")
+    func skipsItemsWithoutMemberId() async throws {
+        let page = Fixture.cursorPage(
+            items: [
+                Fixture.offsetItem(memberId: ""),
+                Fixture.offsetItem(memberId: "100")
+            ]
+        )
+        let (sut, _) = makeRepository(.success(Fixture.success(page)))
+
+        let result = try await sut.searchChallengers(keyword: nil, cursor: nil, size: 50)
+
+        #expect(result.challengers.count == 1)
+        #expect(result.challengers.first?.memberId == "100")
+    }
+
+    @Test("마지막 페이지는 hasNext 가 false 이고 커서가 없다")
+    func mapsLastPage() async throws {
+        let page = Fixture.cursorPage(
+            items: [Fixture.offsetItem(memberId: "100")],
+            nextCursor: nil,
+            hasNext: false
+        )
+        let (sut, _) = makeRepository(.success(Fixture.success(page)))
+
+        let result = try await sut.searchChallengers(keyword: nil, cursor: 3, size: 50)
+
+        #expect(result.hasNext == false)
+        #expect(result.nextCursor == nil)
+    }
+
+    @Test("네트워크 실패는 그대로 전파한다")
+    func propagatesNetworkFailure() async {
+        let (sut, _) = makeRepository(.failure(TestError.network))
+
+        await #expect(throws: TestError.network) {
+            _ = try await sut.searchChallengers(keyword: "길동", cursor: nil, size: 50)
         }
     }
 }

--- a/UMCApp/Features/Activity/Data/Tests/StudyRouterMemberPointTests.swift
+++ b/UMCApp/Features/Activity/Data/Tests/StudyRouterMemberPointTests.swift
@@ -41,6 +41,9 @@ struct StudyRouterMemberPointPathMethodTests {
         let search = StudyRouter.searchChallengersOffset(
             query: ChallengerSearchQuery(page: 0, size: 20, schoolId: "5")
         )
+        let cursorSearch = StudyRouter.searchChallengersCursor(
+            query: ChallengerSearchCursorQuery(keyword: "길동")
+        )
         let create = StudyRouter.createChallengerPoint(
             challengerId: "7", body: makePointBody()
         )
@@ -48,19 +51,24 @@ struct StudyRouterMemberPointPathMethodTests {
         let profile = StudyRouter.getChallengerProfile(challengerId: "7")
 
         #expect(search.path == "/api/v1/challenger/search/offset")
+        #expect(cursorSearch.path == "/api/v1/challenger/search/cursor")
         #expect(create.path == "/api/v1/challenger/7/points")
         #expect(delete.path == "/api/v1/challenger/points/99")
         #expect(profile.path == "/api/v1/challenger/7")
     }
 
-    @Test("searchChallengersOffset / getChallengerProfile 의 method 는 GET 이다")
+    @Test("검색(오프셋·커서) / getChallengerProfile 의 method 는 GET 이다")
     func getMethods() {
         let search = StudyRouter.searchChallengersOffset(
             query: ChallengerSearchQuery(page: 0, size: 20, schoolId: "5")
         )
+        let cursorSearch = StudyRouter.searchChallengersCursor(
+            query: ChallengerSearchCursorQuery(keyword: "길동")
+        )
         let profile = StudyRouter.getChallengerProfile(challengerId: "7")
 
         #expect(search.method == .get)
+        #expect(cursorSearch.method == .get)
         #expect(profile.method == .get)
     }
 
@@ -95,6 +103,20 @@ struct StudyRouterMemberPointTaskTests {
         #expect(extracted.parameters["page"] as? Int == 2)
         #expect(extracted.parameters["size"] as? Int == 20)
         #expect(extracted.parameters["schoolId"] as? String == "5")
+        #expect((extracted.encoding as? URLEncoding)?.destination == .queryString)
+    }
+
+    @Test("searchChallengersCursor 는 query DTO 를 queryString 으로 인코딩한다")
+    func cursorSearchTaskEncodesQueryString() throws {
+        let router = StudyRouter.searchChallengersCursor(
+            query: ChallengerSearchCursorQuery(cursor: 42, size: 30, keyword: "길동")
+        )
+
+        let extracted = try #require(requestParameters(of: router.task))
+
+        #expect(extracted.parameters["cursor"] as? Int == 42)
+        #expect(extracted.parameters["size"] as? Int == 30)
+        #expect(extracted.parameters["keyword"] as? String == "길동")
         #expect((extracted.encoding as? URLEncoding)?.destination == .queryString)
     }
 
@@ -142,6 +164,34 @@ struct ChallengerSearchAndPointDTOEncodingTests {
         #expect(parameters["size"] as? Int == 20)
         #expect(parameters["schoolId"] as? String == "5")
         #expect(parameters["schoolId"] as? Int == nil)      // 식별자는 숫자가 아님
+    }
+
+    @Test("ChallengerSearchCursorQuery — cursor 는 서버 Long 계약대로 Int 로 실린다")
+    func cursorQueryKeepsIntCursor() {
+        let query = ChallengerSearchCursorQuery(cursor: 42, size: 30, keyword: "길동")
+
+        let parameters = query.toParameters
+
+        #expect(parameters.count == 3)
+        #expect(parameters["cursor"] as? Int == 42)
+        #expect(parameters["cursor"] as? String == nil)  // Request 는 서버 정수 계약 유지
+        #expect(parameters["size"] as? Int == 30)
+        #expect(parameters["keyword"] as? String == "길동")
+    }
+
+    @Test(
+        "ChallengerSearchCursorQuery — 빈 커서/키워드는 파라미터에서 제외한다",
+        arguments: [nil, ""]
+    )
+    func cursorQueryOmitsEmptyValues(keyword: String?) {
+        let query = ChallengerSearchCursorQuery(cursor: nil, size: 50, keyword: keyword)
+
+        let parameters = query.toParameters
+
+        #expect(parameters.count == 1)
+        #expect(parameters["size"] as? Int == 50)
+        #expect(parameters["cursor"] == nil)
+        #expect(parameters["keyword"] == nil)
     }
 
     @Test("ChallengerPointCreateRequestDTO — pointType 은 서버 rawValue, 배점은 정수로 직렬화한다")

--- a/UMCApp/Features/Activity/Domain/Sources/Interfaces/MemberRepositoryProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Interfaces/MemberRepositoryProtocol.swift
@@ -26,6 +26,23 @@ public protocol MemberRepositoryProtocol {
     /// - Parameter page: 0-based 페이지 인덱스
     func fetchMembersPage(page: Int) async throws -> MemberPage
 
+    // MARK: - 챌린저 검색
+
+    /// 이름/닉네임 키워드로 챌린저를 검색합니다 (cursor 기반).
+    ///
+    /// 멤버 목록 조회(``fetchMembersPage(page:)``)와 달리 학교 범위로 좁히지 않습니다 —
+    /// 스터디 그룹에 초대할 인원을 찾는 용도라 타 학교 챌린저도 결과에 나와야 합니다.
+    ///
+    /// - Parameters:
+    ///   - keyword: 이름 또는 닉네임 통합 검색어. `nil` 이면 전체 검색.
+    ///   - cursor: 이전 페이지의 마지막 챌린저 ID (첫 페이지는 `nil`)
+    ///   - size: 한 페이지에 조회할 항목 수
+    func searchChallengers(
+        keyword: String?,
+        cursor: Int?,
+        size: Int
+    ) async throws -> ChallengerSearchPage
+
     // MARK: - 상벌점 부여 / 삭제
 
     /// 챌린저에게 포인트를 부여합니다.

--- a/UMCApp/Features/Activity/Domain/Sources/Models/MemberManagement/ChallengerSearchPage.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/Models/MemberManagement/ChallengerSearchPage.swift
@@ -1,0 +1,44 @@
+//
+//  ChallengerSearchPage.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import CoreDomain
+import Foundation
+
+/// 챌린저 커서 검색 한 페이지
+///
+/// 스터디 그룹 생성·인원 추가 화면이 멘토/스터디원을 고를 때 쓰는 검색 결과입니다.
+/// 항목 모델은 Core canonical ``CoreDomain/ChallengerInfo`` 를 그대로 사용합니다 —
+/// 선택 결과가 그대로 `OperatorStudyManagementViewModel` 로 넘어가므로 feature 전용 모델을
+/// 따로 두면 경계마다 변환이 생기고 `selectionKey` 규칙이 갈립니다.
+public struct ChallengerSearchPage: Equatable {
+
+    // MARK: - Property
+
+    /// 현재 페이지의 챌린저 목록
+    public let challengers: [ChallengerInfo]
+
+    /// 다음 페이지 존재 여부
+    public let hasNext: Bool
+
+    /// 다음 페이지 조회용 커서.
+    ///
+    /// 서버가 `Long` 으로 내려주고 다음 요청에 그대로 돌려주는 페이지네이션 토큰이라 `Int?`
+    /// 입니다(식별자를 `String` 으로 통일하는 규칙은 화면이 다루는 서버 식별자 대상).
+    public let nextCursor: Int?
+
+    // MARK: - Init
+
+    public init(
+        challengers: [ChallengerInfo],
+        hasNext: Bool,
+        nextCursor: Int?
+    ) {
+        self.challengers = challengers
+        self.hasNext = hasNext
+        self.nextCursor = nextCursor
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/SearchChallengersUseCase.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/Implementations/SearchChallengersUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  SearchChallengersUseCase.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import Foundation
+
+/// `SearchChallengersUseCaseProtocol` 의 기본 구현체
+///
+/// 조회를 `MemberRepositoryProtocol` 에 위임하는 얇은 facade 입니다.
+public final class SearchChallengersUseCase: SearchChallengersUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: MemberRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: MemberRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(
+        keyword: String?,
+        cursor: Int?,
+        size: Int
+    ) async throws -> ChallengerSearchPage {
+        try await repository.searchChallengers(
+            keyword: keyword,
+            cursor: cursor,
+            size: size
+        )
+    }
+}

--- a/UMCApp/Features/Activity/Domain/Sources/UseCases/SearchChallengersUseCaseProtocol.swift
+++ b/UMCApp/Features/Activity/Domain/Sources/UseCases/SearchChallengersUseCaseProtocol.swift
@@ -1,0 +1,30 @@
+//
+//  SearchChallengersUseCaseProtocol.swift
+//  ActivityDomain
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import Foundation
+
+/// 챌린저 검색 도메인 진입점
+///
+/// 스터디 그룹 생성·인원 추가 화면이 이름/닉네임 키워드로 챌린저를 찾을 때 사용합니다.
+/// 커서 페이지네이션이라 첫 페이지는 `cursor` 를 `nil` 로 호출하고, 이후에는 직전 응답의
+/// ``ChallengerSearchPage/nextCursor`` 를 그대로 넘깁니다.
+///
+/// - SeeAlso: ``SearchChallengersUseCase``, ``MemberRepositoryProtocol``
+public protocol SearchChallengersUseCaseProtocol {
+
+    /// 키워드로 챌린저를 검색합니다.
+    ///
+    /// - Parameters:
+    ///   - keyword: 이름 또는 닉네임 통합 검색어. `nil` 이면 전체 검색.
+    ///   - cursor: 이전 페이지의 마지막 챌린저 ID (첫 페이지는 `nil`)
+    ///   - size: 한 페이지에 조회할 항목 수
+    func execute(
+        keyword: String?,
+        cursor: Int?,
+        size: Int
+    ) async throws -> ChallengerSearchPage
+}

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchMembersUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/FetchMembersUseCaseTests.swift
@@ -48,6 +48,8 @@ private final class MockMemberRepository: @unchecked Sendable, MemberRepositoryP
     enum MockError: Error {
         /// 에러 전파 경로 검증용 스텁 에러
         case stubbed
+        /// 본 UseCase 가 호출하면 안 되는 계약 메서드를 건드렸음을 알리는 표식
+        case unimplemented
     }
 
     /// 챌린저 포인트 부여 호출 1건을 기록하는 값 타입
@@ -93,6 +95,16 @@ private final class MockMemberRepository: @unchecked Sendable, MemberRepositoryP
         fetchMembersPageCalls.append(page)
         if let error { throw error }
         return fetchMembersPageResult
+    }
+
+    /// 본 UseCase 는 챌린저 검색을 노출하지 않는다 (``SearchChallengersUseCase`` 담당).
+    /// 계약 충족용 구현이며 호출되면 즉시 실패시켜 오배선을 드러낸다.
+    func searchChallengers(
+        keyword: String?,
+        cursor: Int?,
+        size: Int
+    ) async throws -> ChallengerSearchPage {
+        throw MockError.unimplemented
     }
 
     func grantPoint(

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/SearchChallengersUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/SearchChallengersUseCaseTests.swift
@@ -1,0 +1,190 @@
+//
+//  SearchChallengersUseCaseTests.swift
+//  ActivityDomainTests
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import CoreDomain
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityDomain
+
+#if DEBUG
+
+// MARK: - Helpers
+
+/// `memberId` 만 검증 대상이고, 나머지 필드는 init 충족용 임의 고정값입니다.
+private func makeChallenger(memberId: String) -> ChallengerInfo {
+    ChallengerInfo(
+        memberId: memberId,
+        challengerId: "C-\(memberId)",
+        gen: "9",
+        name: "홍길동",
+        nickname: "길동",
+        schoolName: "한성대학교",
+        profileImage: nil,
+        part: .front(type: .ios)
+    )
+}
+
+private func makeUseCase(
+    repository: MockSearchMemberRepository = MockSearchMemberRepository()
+) -> SearchChallengersUseCase {
+    SearchChallengersUseCase(repository: repository)
+}
+
+// MARK: - Mocks
+
+/// `searchChallengers` 만 컨트롤하는 포커스드 Mock.
+/// 본 UseCase 가 호출하지 않는 나머지 계약 메서드는 호출 시 즉시 실패하도록 `unimplemented` 를 던집니다.
+private final class MockSearchMemberRepository: @unchecked Sendable, MemberRepositoryProtocol {
+
+    enum MockError: Error {
+        /// 본 UseCase 가 호출하면 안 되는 계약 메서드를 건드렸음을 알리는 표식
+        case unimplemented
+        /// 에러 전파 경로 검증용 — Repository 가 의도적으로 실패할 때 던지는 스텁 에러
+        case stubbed
+    }
+
+    /// 검색 호출 1건의 인자를 기록하는 값 타입
+    struct SearchCall: Equatable {
+        let keyword: String?
+        let cursor: Int?
+        let size: Int
+    }
+
+    // MARK: 입출력 기록
+
+    var searchResult = ChallengerSearchPage(challengers: [], hasNext: false, nextCursor: nil)
+    var searchError: Error?
+    private(set) var searchCalls: [SearchCall] = []
+
+    // MARK: 본 UseCase 가 사용하는 메서드
+
+    func searchChallengers(
+        keyword: String?,
+        cursor: Int?,
+        size: Int
+    ) async throws -> ChallengerSearchPage {
+        searchCalls.append(SearchCall(keyword: keyword, cursor: cursor, size: size))
+        if let searchError { throw searchError }
+        return searchResult
+    }
+
+    // MARK: 본 UseCase 미사용 — 호출 시 unimplemented
+
+    func fetchMembers() async throws -> [MemberManagementItem] {
+        throw MockError.unimplemented
+    }
+
+    func fetchMembersPage(page: Int) async throws -> MemberPage {
+        throw MockError.unimplemented
+    }
+
+    func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws {
+        throw MockError.unimplemented
+    }
+
+    func deletePoint(challengerPointId: String) async throws {
+        throw MockError.unimplemented
+    }
+
+    func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory] {
+        throw MockError.unimplemented
+    }
+
+    func fetchAllGenerations(memberId: String) async throws -> String {
+        throw MockError.unimplemented
+    }
+
+    func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary] {
+        throw MockError.unimplemented
+    }
+
+    func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord] {
+        throw MockError.unimplemented
+    }
+}
+
+// MARK: - Suite: 위임 계약
+
+@Suite("SearchChallengersUseCase — Repository 위임 (도메인 규칙)")
+struct SearchChallengersUseCaseDelegationTests {
+
+    @Test("검색 인자를 변형 없이 Repository 로 전달한다")
+    func forwardsArgumentsUnchanged() async throws {
+        let repository = MockSearchMemberRepository()
+        let sut = makeUseCase(repository: repository)
+
+        _ = try await sut.execute(keyword: "길동", cursor: 12, size: 30)
+
+        #expect(
+            repository.searchCalls == [
+                .init(keyword: "길동", cursor: 12, size: 30)
+            ]
+        )
+    }
+
+    @Test("키워드·커서가 없으면 nil 그대로 전달한다 (전체 검색 첫 페이지)")
+    func forwardsNilArguments() async throws {
+        let repository = MockSearchMemberRepository()
+        let sut = makeUseCase(repository: repository)
+
+        _ = try await sut.execute(keyword: nil, cursor: nil, size: 50)
+
+        #expect(
+            repository.searchCalls == [
+                .init(keyword: nil, cursor: nil, size: 50)
+            ]
+        )
+    }
+
+    @Test("Repository 페이지를 가공 없이 반환한다")
+    func returnsRepositoryPageUnchanged() async throws {
+        let repository = MockSearchMemberRepository()
+        repository.searchResult = ChallengerSearchPage(
+            challengers: [makeChallenger(memberId: "100")],
+            hasNext: true,
+            nextCursor: 12
+        )
+        let sut = makeUseCase(repository: repository)
+
+        let page = try await sut.execute(keyword: "길동", cursor: nil, size: 50)
+
+        #expect(page.challengers.map(\.memberId) == ["100"])
+        #expect(page.hasNext)
+        #expect(page.nextCursor == 12)
+    }
+}
+
+// MARK: - Suite: 에러 전파
+
+@Suite("SearchChallengersUseCase — 에러 전파 (도메인 규칙)")
+struct SearchChallengersUseCaseErrorTests {
+
+    @Test("Repository 에러를 삼키지 않고 그대로 전파한다")
+    func propagatesRepositoryError() async {
+        let repository = MockSearchMemberRepository()
+        repository.searchError = MockSearchMemberRepository.MockError.stubbed
+        let sut = makeUseCase(repository: repository)
+
+        await #expect(throws: MockSearchMemberRepository.MockError.stubbed) {
+            _ = try await sut.execute(keyword: "길동", cursor: nil, size: 50)
+        }
+    }
+}
+
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
@@ -72,7 +72,6 @@ private struct DebugActivityHarnessView: View {
     @State private var userSession: UserSessionManager
     @State private var errorHandler = ErrorHandler()
     @State private var selectedSection: DebugActivitySection?
-    @State private var showsStudyGroupCreate = false
 
     // MARK: - Init
 
@@ -121,13 +120,7 @@ private struct DebugActivityHarnessView: View {
                     itemIcon: { $0.icon }
                 )
                 modeToggleItem
-                studyGroupCreateItem
                 studyScheduleRegistrationItem
-            }
-            .navigationDestination(isPresented: $showsStudyGroupCreate) {
-                OperatorStudyGroupCreateView(
-                    viewModel: previewOperatorStudyManagementViewModel()
-                )
             }
             // 레거시 `ActivityView`와 동일하게, 모드가 바뀌면 보고 있던 섹션을
             // 대응 섹션으로 옮겨 같은 성격의 화면을 유지한다.
@@ -209,21 +202,6 @@ private struct DebugActivityHarnessView: View {
         }
     }
 
-    /// 스터디 그룹 생성 폼 진입 버튼
-    ///
-    /// 운영 화면에서는 멘토·스터디원 선택 이식 전까지 진입점이 게이팅("준비 중")돼 있어,
-    /// 하네스에서만 직접 열 수 있게 둔다.
-    @ToolbarContentBuilder
-    private var studyGroupCreateItem: some ToolbarContent {
-        if currentSection == .studyManage {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button("생성 폼") {
-                    showsStudyGroupCreate = true
-                }
-            }
-        }
-    }
-
     /// 일정 등록 화면 진입 버튼
     ///
     /// 카드의 일정 버튼은 "담당 멘토 본인" 권한 검사를 거치는데, 하네스 세션의 챌린저 ID는
@@ -246,7 +224,6 @@ private struct DebugActivityHarnessView: View {
             }
         }
     }
-
 }
 
 // MARK: - Section Catalog

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/ChallengerFormView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/ChallengerFormView.swift
@@ -1,0 +1,166 @@
+//
+//  ChallengerFormView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import CoreDesignSystem
+import CoreDomain
+import SwiftUI
+import UMCFoundation
+
+/// 챌린저 목록을 파트별 섹션으로 묶어 보여주는 폼.
+///
+/// 검색 결과 선택(체크박스), 선택된 인원 확인·삭제 두 상황에서 함께 씁니다.
+struct ChallengerFormView: View {
+
+    // MARK: - Property
+
+    /// 표시할 챌린저 목록
+    @Binding var challengers: [ChallengerInfo]
+
+    /// 선택된 행 식별 키 집합 (선택 모드일 때만 사용)
+    @Binding var selectedKeys: Set<String>
+
+    /// 스와이프 삭제 허용 여부
+    let isDeleteEnabled: Bool
+
+    /// 선택 상태 체크 아이콘 표시 여부
+    let showCheckBox: Bool
+
+    /// 행 탭 액션
+    let onTap: ((ChallengerInfo) -> Void)?
+
+    /// 마지막 행이 나타났을 때 호출 (페이지네이션)
+    let onBottomReached: (() -> Void)?
+
+    /// 삭제할 수 없는 멤버 ID 집합 (본인 보호 등)
+    let nonDeletableMemberIds: Set<String>
+
+    // MARK: - Init
+
+    init(
+        challengers: Binding<[ChallengerInfo]>,
+        selectedKeys: Binding<Set<String>> = .constant([]),
+        isDeleteEnabled: Bool = false,
+        showCheckBox: Bool = false,
+        onTap: ((ChallengerInfo) -> Void)? = nil,
+        onBottomReached: (() -> Void)? = nil,
+        nonDeletableMemberIds: Set<String> = []
+    ) {
+        self._challengers = challengers
+        self._selectedKeys = selectedKeys
+        self.isDeleteEnabled = isDeleteEnabled
+        self.showCheckBox = showCheckBox
+        self.onTap = onTap
+        self.onBottomReached = onBottomReached
+        self.nonDeletableMemberIds = nonDeletableMemberIds
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Form {
+            ForEach(sortedParts, id: \.self) { part in
+                section(part: part)
+            }
+        }
+    }
+
+    // MARK: - View Components
+
+    @ViewBuilder
+    private func section(part: UMCPartType) -> some View {
+        Section {
+            let rows = ForEach(groupedByPart[part] ?? [], id: \.selectionKey) { challenger in
+                row(challenger)
+            }
+
+            if isDeleteEnabled {
+                rows.onDelete(perform: deleteRows)
+            } else {
+                rows
+            }
+        } header: {
+            Text(part.name)
+                .appFont(.subheadline, weight: .medium, color: .grey500)
+        }
+    }
+
+    private func row(_ challenger: ChallengerInfo) -> some View {
+        ChallengerSearchCard(
+            challenger: challenger,
+            showCheck: showCheckBox,
+            isSelected: selectedKeys.contains(challenger.selectionKey)
+        )
+        .equatable()
+        .contentShape(Rectangle())  // 여백까지 탭 영역으로 확장
+        .deleteDisabled(nonDeletableMemberIds.contains(challenger.memberId))
+        .onTapGesture {
+            onTap?(challenger)
+        }
+        .task {
+            guard challenger.selectionKey == challengers.last?.selectionKey else { return }
+            onBottomReached?()
+        }
+    }
+
+    // MARK: - Function
+
+    private func deleteRows(at offsets: IndexSet) {
+        challengers.remove(atOffsets: offsets)
+    }
+
+    /// 파트별로 묶고, 각 파트 안에서는 최신 기수 → 이름 순으로 정렬합니다.
+    private var groupedByPart: [UMCPartType: [ChallengerInfo]] {
+        Dictionary(grouping: challengers) { $0.part }
+            .mapValues { challengers in
+                challengers.sorted { lhs, rhs in
+                    // 기수는 서버 응답 String 이라 비교 시점에만 Int 로 변환한다.
+                    let lhsGen = Int(lhs.gen) ?? 0
+                    let rhsGen = Int(rhs.gen) ?? 0
+                    if lhsGen != rhsGen {
+                        return lhsGen > rhsGen
+                    }
+                    return lhs.name < rhs.name
+                }
+            }
+    }
+
+    /// 파트 섹션 순서 — 도메인 표준 정렬(`UMCPartType.sortOrder`)을 따릅니다.
+    private var sortedParts: [UMCPartType] {
+        groupedByPart.keys.sorted { $0.sortOrder < $1.sortOrder }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("ChallengerFormView · 선택 모드") {
+    @Previewable @State var challengers = OperatorStudyPreviewData.challengers
+    @Previewable @State var selectedKeys: Set<String> = []
+
+    ChallengerFormView(
+        challengers: $challengers,
+        selectedKeys: $selectedKeys,
+        showCheckBox: true,
+        onTap: { challenger in
+            if selectedKeys.contains(challenger.selectionKey) {
+                selectedKeys.remove(challenger.selectionKey)
+            } else {
+                selectedKeys.insert(challenger.selectionKey)
+            }
+        }
+    )
+}
+
+#Preview("ChallengerFormView · 삭제 모드") {
+    @Previewable @State var challengers = OperatorStudyPreviewData.challengers
+
+    ChallengerFormView(
+        challengers: $challengers,
+        isDeleteEnabled: true
+    )
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/ChallengerSearchCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/ChallengerSearchCard.swift
@@ -1,0 +1,119 @@
+//
+//  ChallengerSearchCard.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import CoreDesignSystem
+import CoreDomain
+import CoreUIComponents
+import SwiftUI
+
+/// 챌린저 검색 결과 리스트의 단일 행.
+///
+/// 프로필·이름/닉네임/기수·학교를 보여주고, 선택 모드에서는 체크 아이콘으로 선택 상태를
+/// 표시합니다.
+struct ChallengerSearchCard: View, Equatable {
+
+    // MARK: - Property
+
+    /// 표시할 챌린저 정보
+    let challenger: ChallengerInfo
+
+    /// 선택 상태 체크 아이콘 표시 여부
+    let showCheck: Bool
+
+    /// 현재 행이 선택된 상태인지 여부
+    let isSelected: Bool
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let imageSize: CGFloat = 30
+        static let checkImage: String = "checkmark.circle"
+        static let uncheckImage: String = "circle"
+    }
+
+    // MARK: - Init
+
+    init(
+        challenger: ChallengerInfo,
+        showCheck: Bool = false,
+        isSelected: Bool = false
+    ) {
+        self.challenger = challenger
+        self.showCheck = showCheck
+        self.isSelected = isSelected
+    }
+
+    // MARK: - Equatable
+
+    /// 행 식별 키와 선택 상태만 비교합니다 (리스트 재렌더 최소화).
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.challenger.selectionKey == rhs.challenger.selectionKey
+            && lhs.showCheck == rhs.showCheck
+            && lhs.isSelected == rhs.isSelected
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            profileImage
+            challengerSummary
+            Spacer()
+
+            if showCheck {
+                Image(systemName: isSelected ? Constants.checkImage : Constants.uncheckImage)
+                    .foregroundStyle(isSelected ? Color.green : Color.grey500)
+                    .font(.app(.title3))
+            }
+        }
+    }
+
+    // MARK: - View Components
+
+    private var profileImage: some View {
+        RemoteImage(
+            urlString: challenger.profileImage ?? "",
+            size: CGSize(width: Constants.imageSize, height: Constants.imageSize),
+            cornerRadius: Constants.imageSize / 2,
+            placeholderImage: "person.fill"
+        )
+    }
+
+    private var challengerSummary: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+            Text(displayName)
+                .appFont(.callout, weight: .semibold, color: .grey900)
+            Text(challenger.schoolName)
+                .appFont(.subheadline, color: .grey600)
+        }
+    }
+
+    /// `이름/닉네임(9기)` — 기수를 모르면 기수 표기를 생략합니다.
+    private var displayName: String {
+        let base = "\(challenger.name)/\(challenger.nickname)"
+        guard !challenger.gen.isEmpty else { return base }
+        return "\(base)(\(challenger.gen)기)"
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("ChallengerSearchCard") {
+    List {
+        ChallengerSearchCard(
+            challenger: OperatorStudyPreviewData.challengers[0],
+            showCheck: true,
+            isSelected: true
+        )
+        ChallengerSearchCard(
+            challenger: OperatorStudyPreviewData.challengers[1],
+            showCheck: true
+        )
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SearchChallengerView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SearchChallengerView.swift
@@ -1,0 +1,226 @@
+//
+//  SearchChallengerView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreDomain
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+import UniformTypeIdentifiers
+
+/// 챌린저를 이름/닉네임으로 검색해 선택하는 화면.
+///
+/// 상위 화면이 들고 있는 선택 목록(`selectedChallengers`)을 바인딩으로 받아, 확인 시 확정된
+/// 선택으로 갱신합니다. CSV 파일로 다수 인원을 한 번에 고를 수도 있습니다.
+///
+/// `SelectedChallengerView` 의 `NavigationStack` 안으로 push 되므로 자체 스택을 만들지 않습니다.
+struct SearchChallengerView: View {
+
+    // MARK: - Property
+
+    /// 상위 화면과 공유하는 선택된 챌린저 목록
+    @Binding var selectedChallengers: [ChallengerInfo]
+
+    @State private var viewModel: SearchChallengerViewModel
+
+    /// 검색창 입력 (로컬 상태로 둬 입력 지연을 피한다)
+    @State private var searchText = ""
+
+    /// 디바운스용 검색 Task
+    @State private var searchTask: Task<Void, Never>?
+
+    /// 화면 진입 시점의 선택 목록 — 확인 시 순서 보존 기준
+    @State private var initialSelection: [ChallengerInfo] = []
+
+    /// 진입 선택 복원을 1회로 제한하는 플래그.
+    ///
+    /// `initialSelection.isEmpty` 로 판단하면 "선택 없이 진입한 경우"에 `.task` 가 다시 돌 때
+    /// 아직 확정하지 않은 선택이 통째로 초기화된다(`selectedChallengers` 는 확인 시점에만 갱신).
+    @State private var didRestoreSelection = false
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let searchDebounce: Duration = .milliseconds(300)
+        static let searchPrompt: String = "이름 또는 닉네임으로 검색해보세요"
+        static let loadingMessage: String = "챌린저 목록을 불러오는 중입니다."
+        static let failedTitle: String = "챌린저 검색에 실패했어요"
+        static let failedSystemImage: String = "exclamationmark.triangle"
+        static let idleTitle: String = "검색된 챌린저가 없습니다"
+        static let idleDescription: String = "이름 또는 닉네임으로 챌린저를 검색해보세요."
+        static let idleSystemImage: String = "magnifyingglass"
+        static let emptyTitle: String = "검색 결과가 없습니다"
+    }
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - useCase: 챌린저 검색 UseCase (상위에서 DI 로 해석해 주입)
+    ///   - selectedChallengers: 상위 화면의 선택 목록 바인딩
+    init(
+        useCase: SearchChallengersUseCaseProtocol,
+        selectedChallengers: Binding<[ChallengerInfo]>
+    ) {
+        self._selectedChallengers = selectedChallengers
+        self._viewModel = State(
+            initialValue: SearchChallengerViewModel(searchChallengersUseCase: useCase)
+        )
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        stateContent
+            .searchable(text: $searchText, prompt: Constants.searchPrompt)
+            .searchPresentationToolbarBehavior(.avoidHidingContent)
+            .navigationTitle(NavigationTitle.Activity.searchChallenger.rawValue)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolBarCollection.ConfirmBtn(action: confirmSelection)
+            }
+            .fileImporter(
+                isPresented: $viewModel.showCSVImporter,
+                allowedContentTypes: [.commaSeparatedText, .plainText],
+                allowsMultipleSelection: false
+            ) { result in
+                handleCSVImport(result)
+            }
+            .alertPrompt(item: $viewModel.alertPrompt)
+            .task {
+                guard !didRestoreSelection else { return }
+                didRestoreSelection = true
+                initialSelection = selectedChallengers
+                viewModel.initializeSelection(with: selectedChallengers)
+            }
+            .onChange(of: searchText) { _, newValue in
+                handleSearchChanged(newValue)
+            }
+            .onDisappear {
+                searchTask?.cancel()
+            }
+    }
+
+    // MARK: - View Components
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch viewModel.loadState {
+        case .idle:
+            idleView
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .loading:
+            Progress(message: Constants.loadingMessage, size: .regular)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .loaded:
+            if viewModel.allChallengers.isEmpty {
+                emptyResultView
+            } else {
+                resultList
+            }
+
+        case .failed(let error):
+            RetryContentUnavailableView(
+                title: Constants.failedTitle,
+                systemImage: Constants.failedSystemImage,
+                description: error.userMessage,
+                isRetrying: viewModel.loadState.isLoading
+            ) {
+                await viewModel.retrySearch()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var resultList: some View {
+        ChallengerFormView(
+            challengers: .constant(viewModel.allChallengers),
+            selectedKeys: $viewModel.selectedKeys,
+            showCheckBox: true,
+            onTap: viewModel.toggleSelection,
+            onBottomReached: {
+                Task { await viewModel.fetchNextPage() }
+            }
+        )
+    }
+
+    private var idleView: some View {
+        ContentUnavailableView(
+            Constants.idleTitle,
+            systemImage: Constants.idleSystemImage,
+            description: Text(Constants.idleDescription)
+        )
+    }
+
+    private var emptyResultView: some View {
+        ContentUnavailableView(
+            Constants.emptyTitle,
+            systemImage: Constants.idleSystemImage,
+            description: Text("'\(searchText)'에 대한 검색 결과를 찾을 수 없습니다.\n다른 검색어를 입력해보세요.")
+        )
+    }
+
+    // MARK: - Function
+
+    /// 검색어 변경 시 디바운스 후 검색을 실행합니다.
+    private func handleSearchChanged(_ newValue: String) {
+        searchTask?.cancel()
+
+        let keyword = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !keyword.isEmpty else {
+            viewModel.clearSearch()
+            return
+        }
+
+        // 대기 중임을 즉시 보여줘 입력과 결과 사이의 공백을 없앤다.
+        viewModel.showLoading()
+        searchTask = Task {
+            try? await Task.sleep(for: Constants.searchDebounce)
+            guard !Task.isCancelled else { return }
+            await viewModel.performSearch(keyword: keyword)
+        }
+    }
+
+    /// 선택을 확정해 상위 화면 목록에 반영합니다.
+    private func confirmSelection() {
+        selectedChallengers = viewModel.confirmedSelection(
+            previousSelection: initialSelection
+        )
+    }
+
+    private func handleCSVImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            viewModel.importCSV(from: url)
+
+        case .failure(let error):
+            viewModel.alertPrompt = AlertPrompt(
+                title: "CSV 가져오기 실패",
+                message: "파일 선택 실패: \(error.localizedDescription)",
+                positiveBtnTitle: "확인"
+            )
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("SearchChallengerView") {
+    @Previewable @State var selected: [ChallengerInfo] = []
+
+    NavigationStack {
+        SearchChallengerView(
+            useCase: PreviewSearchChallengersUseCase(),
+            selectedChallengers: $selected
+        )
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SearchChallengerView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SearchChallengerView.swift
@@ -118,19 +118,21 @@ struct SearchChallengerView: View {
             Progress(message: Constants.loadingMessage, size: .regular)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-        case .loaded:
-            if viewModel.allChallengers.isEmpty {
+        case .loaded(let challengers):
+            if challengers.isEmpty {
                 emptyResultView
             } else {
-                resultList
+                resultList(challengers)
             }
 
         case .failed(let error):
+            // 재시도를 누르면 `.loading` 으로 전이돼 위 분기가 스피너를 그리므로,
+            // 이 분기에서는 재시도 진행 표시가 필요 없다(형제 `ChallengerMemberListView` 동일).
             RetryContentUnavailableView(
                 title: Constants.failedTitle,
                 systemImage: Constants.failedSystemImage,
                 description: error.userMessage,
-                isRetrying: viewModel.loadState.isLoading
+                isRetrying: false
             ) {
                 await viewModel.retrySearch()
             }
@@ -138,9 +140,9 @@ struct SearchChallengerView: View {
         }
     }
 
-    private var resultList: some View {
+    private func resultList(_ challengers: [ChallengerInfo]) -> some View {
         ChallengerFormView(
-            challengers: .constant(viewModel.allChallengers),
+            challengers: .constant(challengers),
             selectedKeys: $viewModel.selectedKeys,
             showCheckBox: true,
             onTap: viewModel.toggleSelection,

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SelectedChallengerView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SelectedChallengerView.swift
@@ -5,35 +5,51 @@
 //  Created by jaewon Lee on 7/15/26.
 //
 
+import ActivityDomain
 import CoreDesignSystem
+import CoreDI
 import CoreDomain
 import CoreUIComponents
 import SwiftUI
 import UMCFoundation
 
-/// 선택된 챌린저(멘토/스터디원) 목록을 확인·삭제하는 최소 스텁 뷰.
+/// 선택된 챌린저(멘토/스터디원) 목록을 확인·삭제하고, 검색으로 새 인원을 추가하는 화면.
 ///
-/// 원본(`AppProduct`)의 `SelectedChallengerView` 는 `SearchChallengerView` 검색 서브시스템에
-/// 의존하는데, 해당 Home 서브시스템(검색 API 포함)이 아직 UMCApp 으로 이식되지 않았다.
-/// 그래서 이 스텁은 **이미 선택된 목록의 확인·삭제** 까지만 담당하고, "검색으로 추가" 진입은
-/// 검색 서브시스템 이식 시점에 결선한다(#894 범위 밖, 사용자 결정으로 최소 스텁 채택).
-/// // TODO: SearchChallengerView(챌린저 검색 서브시스템) 이식 후 검색-추가 결선 - [26.07.15] 이재원
+/// 스터디 그룹 생성 폼과 그룹 관리 화면이 시트로 띄우므로 자체 `NavigationStack` 을 가집니다.
 struct SelectedChallengerView: View {
 
     // MARK: - Property
 
     @Environment(\.dismiss) private var dismiss
 
+    @Environment(\.di) private var container
+
     /// 상위 뷰와 공유하는 선택된 챌린저 목록
     @Binding var challenger: [ChallengerInfo]
 
-    /// 검색-추가 미이식 안내 표시 여부
-    @State private var showSearchUnavailable = false
+    /// 검색 화면 push 여부
+    @State private var showsSearch = false
+
+    /// 검색 UseCase 주입 지점 — 프리뷰/테스트용. 미지정 시 DI 컨테이너에서 해석합니다.
+    private let searchUseCase: SearchChallengersUseCaseProtocol?
 
     /// 현재 사용자의 memberId (본인은 삭제 방지)
     private var myMemberIdSet: Set<String> {
         guard let id = AppStorageKey.memberIdString() else { return [] }
         return [id]
+    }
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - challenger: 상위 화면의 선택 목록 바인딩
+    ///   - searchUseCase: 검색 UseCase (기본값 `nil` — DI 컨테이너에서 해석)
+    init(
+        challenger: Binding<[ChallengerInfo]>,
+        searchUseCase: SearchChallengersUseCaseProtocol? = nil
+    ) {
+        self._challenger = challenger
+        self.searchUseCase = searchUseCase
     }
 
     // MARK: - Body
@@ -54,14 +70,14 @@ struct SelectedChallengerView: View {
                     }
 
                     ToolBarCollection.AddBtn(action: {
-                        // 검색-추가는 검색 서브시스템 미이식으로 아직 결선되지 않았다.
-                        showSearchUnavailable = true
+                        showsSearch = true
                     })
                 }
-                .alert("준비 중", isPresented: $showSearchUnavailable) {
-                    Button("확인", role: .cancel) {}
-                } message: {
-                    Text("챌린저 검색·추가 기능은 검색 화면 이식 후 연결됩니다.")
+                .navigationDestination(isPresented: $showsSearch) {
+                    SearchChallengerView(
+                        useCase: resolvedSearchUseCase,
+                        selectedChallengers: $challenger
+                    )
                 }
         }
     }
@@ -118,6 +134,10 @@ struct SelectedChallengerView: View {
 
     // MARK: - Function
 
+    private var resolvedSearchUseCase: SearchChallengersUseCaseProtocol {
+        searchUseCase ?? container.resolve(SearchChallengersUseCaseProtocol.self)
+    }
+
     private func removeChallenger(_ info: ChallengerInfo) {
         challenger.removeAll { $0.id == info.id }
     }
@@ -128,6 +148,17 @@ struct SelectedChallengerView: View {
 #if DEBUG
 #Preview("SelectedChallengerView") {
     @Previewable @State var challengers = OperatorStudyPreviewData.challengers
-    SelectedChallengerView(challenger: $challengers)
+    SelectedChallengerView(
+        challenger: $challengers,
+        searchUseCase: PreviewSearchChallengersUseCase()
+    )
+}
+
+#Preview("SelectedChallengerView · 빈 목록") {
+    @Previewable @State var challengers: [ChallengerInfo] = []
+    SelectedChallengerView(
+        challenger: $challengers,
+        searchUseCase: PreviewSearchChallengersUseCase()
+    )
 }
 #endif

--- a/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/OperatorStudyPreviewSupport.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/OperatorStudyPreviewSupport.swift
@@ -97,6 +97,28 @@ enum PreviewSampleError: Error {
     case failed
 }
 
+/// 프리뷰 전용 챌린저 검색 스텁 — 키워드와 무관하게 샘플 목록을 한 페이지로 돌려줍니다.
+final class PreviewSearchChallengersUseCase: SearchChallengersUseCaseProtocol {
+
+    private let challengers: [ChallengerInfo]
+
+    init(challengers: [ChallengerInfo] = OperatorStudyPreviewData.challengers) {
+        self.challengers = challengers
+    }
+
+    func execute(
+        keyword: String?,
+        cursor: Int?,
+        size: Int
+    ) async throws -> ChallengerSearchPage {
+        ChallengerSearchPage(
+            challengers: challengers,
+            hasNext: false,
+            nextCursor: nil
+        )
+    }
+}
+
 // MARK: - Preview Data
 
 /// 프리뷰 공용 샘플 데이터.

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/SearchChallengerViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/SearchChallengerViewModel.swift
@@ -1,0 +1,413 @@
+//
+//  SearchChallengerViewModel.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import ActivityDomain
+import CoreDomain
+import Foundation
+import UMCFoundation
+
+/// 챌린저 검색 화면의 상태를 관리하는 ViewModel
+///
+/// 키워드 검색·커서 페이지네이션·선택 상태 유지·CSV 일괄 선택을 담당합니다.
+/// 조회는 `SearchChallengersUseCaseProtocol` 에만 의존합니다(Repository 직접 의존 금지).
+///
+/// - Note: 동시성 가드는 **요청 토큰(latest-wins)** 입니다. 검색은 키워드가 바뀔 때마다
+///   재요청되므로 형제 ViewModel 의 재진입 가드(`if state.isLoading { return }`)를 그대로
+///   쓰면 **나중 키워드가 무시**됩니다. 그래서 검색 경로는 토큰으로 stale 응답만 버리고,
+///   중복 요청 차단이 필요한 페이지네이션에만 `isFetchingNextPage` 가드를 둡니다.
+///   페이지 응답도 같은 토큰을 검증해 키워드 전환 중 도착한 페이지가 다른 키워드의 목록에
+///   섞이지 않게 합니다.
+@MainActor
+@Observable
+final class SearchChallengerViewModel {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        /// 한 번에 조회할 챌린저 수 (서버 상한 50)
+        static let pageSize = 50
+    }
+
+    // MARK: - Property
+
+    private let searchChallengersUseCase: SearchChallengersUseCaseProtocol
+
+    /// 현재 검색 결과 목록
+    private(set) var allChallengers: [ChallengerInfo] = []
+
+    /// 현재 선택된 챌린저들의 행 식별 키 목록
+    var selectedKeys: Set<String> = []
+
+    /// 선택된 챌린저 정보를 별도 보관 (검색 결과가 바뀌어도 선택 유지)
+    var selectedChallengersMap: [String: ChallengerInfo] = [:]
+
+    /// CSV 파일 가져오기 문서 피커 표시 여부
+    var showCSVImporter: Bool = false
+
+    /// 알림창 상태 (CSV 결과 통보, 에러 안내)
+    var alertPrompt: AlertPrompt?
+
+    /// 검색 결과 로드 상태
+    private(set) var loadState: Loadable<Bool> = .idle
+
+    /// 다음 페이지 존재 여부
+    private(set) var hasNext: Bool = false
+
+    /// 다음 페이지 커서 (서버가 돌려주는 페이지네이션 토큰)
+    private var nextCursor: Int?
+
+    /// 현재 검색 컨텍스트의 키워드
+    private var currentKeyword: String = ""
+
+    /// 최신 검색 요청 식별자 — 이 값과 다른 응답은 stale 로 버립니다.
+    private var latestRequestID: UUID = UUID()
+
+    /// 다음 페이지 중복 호출 방지 플래그
+    private var isFetchingNextPage: Bool = false
+
+    /// 검색 시작 직전의 상태 — 취소 시 되돌릴 지점.
+    ///
+    /// `.loading` 자체를 되돌릴 지점으로 삼으면 취소 후 스피너에서 못 빠져나옵니다.
+    /// 그래서 이미 `.loading` 인 동안에는 갱신하지 않습니다(디바운스로 `showLoading()` 이
+    /// 여러 번 불릴 수 있음).
+    private var stateBeforeSearch: Loadable<Bool> = .idle
+
+    // MARK: - Initializer
+
+    /// - Parameter searchChallengersUseCase: 챌린저 검색 UseCase
+    init(searchChallengersUseCase: SearchChallengersUseCaseProtocol) {
+        self.searchChallengersUseCase = searchChallengersUseCase
+    }
+
+    // MARK: - Function (검색)
+
+    /// 키워드로 챌린저를 검색합니다.
+    func performSearch(keyword: String) async {
+        let requestID = prepareSearch(keyword: keyword)
+        await fetchFirstPage(keyword: keyword, requestID: requestID)
+    }
+
+    /// 현재 검색 키워드로 재검색합니다 (재시도 용도).
+    func retrySearch() async {
+        guard !currentKeyword.isEmpty else {
+            resetSearchState()
+            return
+        }
+        let keyword = currentKeyword
+        let requestID = prepareSearch(keyword: keyword)
+        await fetchFirstPage(keyword: keyword, requestID: requestID)
+    }
+
+    /// 검색 상태를 초기화합니다 (검색어가 비었을 때).
+    func clearSearch() {
+        // 진행 중인 요청의 응답이 빈 화면을 덮어쓰지 않도록 토큰도 함께 갱신한다.
+        latestRequestID = UUID()
+        resetSearchState()
+    }
+
+    /// 디바운스 대기 중임을 즉시 알리기 위한 로딩 전환.
+    func showLoading() {
+        beginLoading()
+    }
+
+    /// 다음 페이지를 조회해 기존 목록에 이어 붙입니다.
+    func fetchNextPage() async {
+        guard hasNext, let cursor = nextCursor, !isFetchingNextPage else { return }
+
+        let requestID = latestRequestID
+        let keyword = currentKeyword
+        isFetchingNextPage = true
+        defer { isFetchingNextPage = false }
+
+        do {
+            let page = try await searchChallengersUseCase.execute(
+                keyword: keyword.nonEmptyKeyword,
+                cursor: cursor,
+                size: Constants.pageSize
+            )
+            // 페이지를 기다리는 사이 키워드가 바뀌었으면 다른 검색의 결과가 되므로 버린다.
+            guard latestRequestID == requestID else { return }
+
+            let knownKeys = Set(allChallengers.map(\.selectionKey))
+            let newChallengers = page.challengers.filter {
+                !knownKeys.contains($0.selectionKey)
+            }
+            allChallengers.append(contentsOf: newChallengers)
+            hasNext = page.hasNext
+            nextCursor = page.nextCursor
+        } catch {
+            // 추가 페이지 실패는 이미 보고 있는 목록을 지우지 않는다.
+            // 사용자는 스크롤을 다시 내려 재시도할 수 있고, 전체 실패 화면으로 바꾸면
+            // 이미 확인한 검색 결과가 사라져 선택 흐름이 끊긴다.
+            guard latestRequestID == requestID, !error.isCancellation else { return }
+            hasNext = false
+        }
+    }
+
+    // MARK: - Function (선택)
+
+    /// 챌린저 선택/해제 토글 (같은 `memberId` 형제를 함께 처리)
+    ///
+    /// 동일 인물이 기수·파트별로 여러 행에 나올 수 있는데, 그룹 추가 API 는 멤버 단위라
+    /// 한 행만 골라두면 나머지 행이 선택 안 된 상태로 남아 목록이 실제 선택과 어긋납니다.
+    func toggleSelection(_ challenger: ChallengerInfo) {
+        let isSelected = selectedKeys.contains(challenger.selectionKey)
+        let siblings = allChallengers.filter { $0.memberId == challenger.memberId }
+
+        for sibling in siblings {
+            let key = sibling.selectionKey
+            if isSelected {
+                selectedKeys.remove(key)
+                selectedChallengersMap.removeValue(forKey: key)
+            } else {
+                selectedKeys.insert(key)
+                selectedChallengersMap[key] = sibling
+            }
+        }
+    }
+
+    /// 상위 화면에서 이미 선택돼 있던 목록을 선택 상태에 반영합니다.
+    func initializeSelection(with challengers: [ChallengerInfo]) {
+        let selectionMap = Dictionary(
+            challengers.map { ($0.selectionKey, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        selectedKeys = Set(selectionMap.keys)
+        selectedChallengersMap = selectionMap
+    }
+
+    /// 확정된 선택 목록을 반환합니다.
+    ///
+    /// 기존 선택 순서를 먼저 보존하고, 이번 검색에서 새로 고른 항목을 뒤에 붙입니다.
+    /// 화면에 보이던 순서가 확인 한 번에 뒤섞이면 사용자가 무엇을 골랐는지 확인하기 어렵습니다.
+    ///
+    /// - Parameter previousSelection: 화면 진입 시점의 선택 목록
+    func confirmedSelection(
+        previousSelection: [ChallengerInfo]
+    ) -> [ChallengerInfo] {
+        var ordered: [ChallengerInfo] = []
+        var handledKeys: Set<String> = []
+
+        for challenger in previousSelection {
+            let key = challenger.selectionKey
+            guard let updated = selectedChallengersMap[key] else { continue }
+            guard handledKeys.insert(key).inserted else { continue }
+            ordered.append(updated)
+        }
+
+        let appended = selectedChallengersMap.values
+            .sorted { $0.selectionKey < $1.selectionKey }
+            .filter { handledKeys.insert($0.selectionKey).inserted }
+
+        return ordered + appended
+    }
+
+    // MARK: - Private (조회)
+
+    private func prepareSearch(keyword: String) -> UUID {
+        let requestID = UUID()
+        latestRequestID = requestID
+        beginLoading()
+        currentKeyword = keyword
+        nextCursor = nil
+        hasNext = false
+        isFetchingNextPage = false
+        return requestID
+    }
+
+    /// 로딩으로 전환하면서, 되돌릴 지점(`stateBeforeSearch`)을 한 번만 기록합니다.
+    private func beginLoading() {
+        if !loadState.isLoading {
+            stateBeforeSearch = loadState
+        }
+        loadState = .loading
+    }
+
+    /// 첫 페이지를 조회합니다.
+    ///
+    /// `.task`/디바운스 취소로 던져지는 `CancellationError`·`NSURLErrorCancelled` 는 실패가
+    /// 아니므로 이전 상태로 롤백합니다(형제 `MemberListViewModel` house 패턴).
+    private func fetchFirstPage(keyword: String, requestID: UUID) async {
+        do {
+            let page = try await searchChallengersUseCase.execute(
+                keyword: keyword.nonEmptyKeyword,
+                cursor: nil,
+                size: Constants.pageSize
+            )
+            guard latestRequestID == requestID else { return }
+            allChallengers = page.challengers
+            hasNext = page.hasNext
+            nextCursor = page.nextCursor
+            loadState = .loaded(true)
+        } catch is CancellationError {
+            guard latestRequestID == requestID else { return }
+            loadState = stateBeforeSearch
+        } catch let error as NSError
+            where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+            guard latestRequestID == requestID else { return }
+            loadState = stateBeforeSearch
+        } catch let error as AppError {
+            failSearch(with: error, requestID: requestID)
+        } catch let error as DomainError {
+            failSearch(with: .domain(error), requestID: requestID)
+        } catch let error as NetworkError {
+            failSearch(with: .network(error), requestID: requestID)
+        } catch let error as RepositoryError {
+            failSearch(with: .repository(error), requestID: requestID)
+        } catch {
+            failSearch(
+                with: .unknown(message: error.localizedDescription),
+                requestID: requestID
+            )
+        }
+    }
+
+    private func failSearch(with error: AppError, requestID: UUID) {
+        guard latestRequestID == requestID else { return }
+        allChallengers = []
+        nextCursor = nil
+        hasNext = false
+        loadState = .failed(error)
+    }
+
+    private func resetSearchState() {
+        allChallengers = []
+        currentKeyword = ""
+        nextCursor = nil
+        hasNext = false
+        isFetchingNextPage = false
+        loadState = .idle
+        // 초기화 이후 도착한 취소가 지워진 결과를 되살리지 않도록 롤백 지점도 함께 비운다.
+        stateBeforeSearch = .idle
+    }
+}
+
+// MARK: - CSV Import
+
+extension SearchChallengerViewModel {
+
+    /// CSV 파일에서 이름/닉네임이 일치하는 챌린저를 일괄 선택합니다.
+    ///
+    /// 매칭 대상은 **현재 검색 결과에 올라온 챌린저**입니다 — 서버 재조회 없이 화면에 있는
+    /// 목록만 훑기 때문에, 검색 결과 밖의 인원은 "매칭 실패"로 보고됩니다.
+    ///
+    /// - Parameter url: 사용자가 고른 CSV 파일 URL
+    func importCSV(from url: URL) {
+        guard url.startAccessingSecurityScopedResource() else {
+            presentImportFailure(message: "파일에 접근할 수 없습니다.")
+            return
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+
+        do {
+            let csvContent = try String(contentsOf: url, encoding: .utf8)
+            applyCSVContent(csvContent)
+        } catch {
+            presentImportFailure(
+                message: "CSV 파일을 읽을 수 없습니다: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    /// CSV 내용을 파싱해 매칭되는 챌린저를 선택합니다.
+    ///
+    /// 첫 행은 헤더로 간주해 제외하고, `이름, 닉네임` 순의 열을 읽습니다.
+    ///
+    /// - Note: 파일 접근(보안 스코프 획득·읽기)과 분리된 진입점입니다. 파일 선택은
+    ///   `fileImporter` 가 준 보안 스코프 URL 에서만 동작해 테스트로 재현할 수 없는 반면,
+    ///   매칭 규칙은 그 자체로 검증 가치가 있어 seam 을 나눴습니다.
+    func applyCSVContent(_ csvContent: String) {
+        let rows = csvContent
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard rows.count > 1 else {
+            presentImportFailure(message: "CSV 파일이 비어있습니다.")
+            return
+        }
+
+        let dataRows = Array(rows.dropFirst())
+        var matchedCount = 0
+        var unmatchedNames: [String] = []
+
+        for row in dataRows {
+            let columns = row
+                .components(separatedBy: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            guard let searchName = columns.first else { continue }
+            let searchNickname = columns.count > 1 ? columns[1] : ""
+
+            guard let matched = findChallenger(
+                name: searchName,
+                nickname: searchNickname
+            ) else {
+                unmatchedNames.append("\(searchName)/\(searchNickname)")
+                continue
+            }
+
+            selectAllSiblings(of: matched)
+            matchedCount += 1
+        }
+
+        presentImportResult(
+            totalRows: dataRows.count,
+            matchedCount: matchedCount,
+            unmatchedNames: unmatchedNames
+        )
+    }
+
+    /// 이름 또는 닉네임이 일치하는 첫 챌린저를 찾습니다.
+    private func findChallenger(name: String, nickname: String) -> ChallengerInfo? {
+        allChallengers.first { challenger in
+            challenger.name == name || challenger.nickname == nickname
+        }
+    }
+
+    /// 같은 `memberId` 를 가진 모든 행을 선택합니다 (탭 선택과 동일 규칙).
+    private func selectAllSiblings(of challenger: ChallengerInfo) {
+        let siblings = allChallengers.filter { $0.memberId == challenger.memberId }
+        for sibling in siblings {
+            selectedKeys.insert(sibling.selectionKey)
+            selectedChallengersMap[sibling.selectionKey] = sibling
+        }
+    }
+
+    private func presentImportResult(
+        totalRows: Int,
+        matchedCount: Int,
+        unmatchedNames: [String]
+    ) {
+        var message = "총 \(totalRows)명 중 \(matchedCount)명 매칭 완료"
+        if !unmatchedNames.isEmpty {
+            message += "\n\n매칭 실패:\n\(unmatchedNames.joined(separator: ", "))"
+        }
+
+        alertPrompt = AlertPrompt(
+            title: "CSV 가져오기 결과",
+            message: message,
+            positiveBtnTitle: "확인"
+        )
+    }
+
+    private func presentImportFailure(message: String) {
+        alertPrompt = AlertPrompt(
+            title: "CSV 가져오기 실패",
+            message: message,
+            positiveBtnTitle: "확인"
+        )
+    }
+}
+
+// MARK: - Helper
+
+private extension String {
+    /// 비어 있으면 `nil` — 서버가 전체 검색으로 처리하도록 키워드를 생략한다.
+    var nonEmptyKeyword: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/SearchChallengerViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/SearchChallengerViewModel.swift
@@ -37,7 +37,10 @@ final class SearchChallengerViewModel {
     private let searchChallengersUseCase: SearchChallengersUseCaseProtocol
 
     /// 현재 검색 결과 목록
-    private(set) var allChallengers: [ChallengerInfo] = []
+    ///
+    /// 상태(`loadState`)에서 파생합니다. 목록을 따로 저장하면 로드 상태와 어긋날 수 있어
+    /// 형제 `MemberListViewModel` 과 같이 단일 출처로 둡니다.
+    var allChallengers: [ChallengerInfo] { loadState.value ?? [] }
 
     /// 현재 선택된 챌린저들의 행 식별 키 목록
     var selectedKeys: Set<String> = []
@@ -52,7 +55,7 @@ final class SearchChallengerViewModel {
     var alertPrompt: AlertPrompt?
 
     /// 검색 결과 로드 상태
-    private(set) var loadState: Loadable<Bool> = .idle
+    private(set) var loadState: Loadable<[ChallengerInfo]> = .idle
 
     /// 다음 페이지 존재 여부
     private(set) var hasNext: Bool = false
@@ -74,7 +77,7 @@ final class SearchChallengerViewModel {
     /// `.loading` 자체를 되돌릴 지점으로 삼으면 취소 후 스피너에서 못 빠져나옵니다.
     /// 그래서 이미 `.loading` 인 동안에는 갱신하지 않습니다(디바운스로 `showLoading()` 이
     /// 여러 번 불릴 수 있음).
-    private var stateBeforeSearch: Loadable<Bool> = .idle
+    private var stateBeforeSearch: Loadable<[ChallengerInfo]> = .idle
 
     // MARK: - Initializer
 
@@ -117,6 +120,7 @@ final class SearchChallengerViewModel {
     /// 다음 페이지를 조회해 기존 목록에 이어 붙입니다.
     func fetchNextPage() async {
         guard hasNext, let cursor = nextCursor, !isFetchingNextPage else { return }
+        guard case .loaded(let existing) = loadState else { return }
 
         let requestID = latestRequestID
         let keyword = currentKeyword
@@ -132,11 +136,11 @@ final class SearchChallengerViewModel {
             // 페이지를 기다리는 사이 키워드가 바뀌었으면 다른 검색의 결과가 되므로 버린다.
             guard latestRequestID == requestID else { return }
 
-            let knownKeys = Set(allChallengers.map(\.selectionKey))
+            let knownKeys = Set(existing.map(\.selectionKey))
             let newChallengers = page.challengers.filter {
                 !knownKeys.contains($0.selectionKey)
             }
-            allChallengers.append(contentsOf: newChallengers)
+            loadState = .loaded(existing + newChallengers)
             hasNext = page.hasNext
             nextCursor = page.nextCursor
         } catch {
@@ -239,10 +243,9 @@ final class SearchChallengerViewModel {
                 size: Constants.pageSize
             )
             guard latestRequestID == requestID else { return }
-            allChallengers = page.challengers
             hasNext = page.hasNext
             nextCursor = page.nextCursor
-            loadState = .loaded(true)
+            loadState = .loaded(page.challengers)
         } catch is CancellationError {
             guard latestRequestID == requestID else { return }
             loadState = stateBeforeSearch
@@ -268,14 +271,12 @@ final class SearchChallengerViewModel {
 
     private func failSearch(with error: AppError, requestID: UUID) {
         guard latestRequestID == requestID else { return }
-        allChallengers = []
         nextCursor = nil
         hasNext = false
         loadState = .failed(error)
     }
 
     private func resetSearchState() {
-        allChallengers = []
         currentKeyword = ""
         nextCursor = nil
         hasNext = false

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyGroupCreateView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyGroupCreateView.swift
@@ -16,11 +16,8 @@ import UMCFoundation
 /// 운영진이 새로운 스터디 그룹을 생성하는 폼 화면입니다.
 /// `navigationDestination`으로 푸시되므로 자체 `NavigationStack` 없음.
 ///
-/// - Note: 이식은 완료됐으나 멘토·스터디원 선택이 미이식 상태인 챌린저 검색에 의존해
-///   저장을 완료할 수 없다. 그래서 현재 `OperatorStudyManagementView`의 + 버튼은 이 화면으로
-///   진입하지 않고 "준비 중" 안내만 표시한다(진입점 게이팅). 검색 서브시스템 이식 후
-///   `navigationDestination` 재연결로 활성화한다.
-///   // TODO: 챌린저 검색 이식 후 생성 진입점 재연결 - [26.07.20] 이재원
+/// 멘토·스터디원은 `SelectedChallengerView` 시트에서 고르며, 그 안의 검색 화면
+/// (`SearchChallengerView`)이 실제 인원 검색을 담당합니다.
 struct OperatorStudyGroupCreateView: View {
 
     // MARK: - Property

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyManagementView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyManagementView.swift
@@ -24,12 +24,8 @@ struct OperatorStudyManagementView: View {
 
     private let userSession: UserSessionManager
 
-    /// 스터디 그룹 생성 미결선 안내 표시 여부
-    ///
-    /// 생성 폼(`OperatorStudyGroupCreateView`)은 이식 완료됐으나, 멘토·스터디원 선택이
-    /// 미이식 상태인 챌린저 검색에 의존해 저장을 완료할 수 없다. 검색 서브시스템 이식 전까지
-    /// 진입점(+ 버튼)을 게이팅하고 안내만 표시한다. 이식 후 생성 폼 네비게이션을 복원한다.
-    @State private var showCreateUnavailable = false
+    /// 스터디 그룹 생성 화면 push 여부
+    @State private var showsGroupCreate = false
 
     /// 일정 등록 화면으로 이동을 상위(Activity 탭 루트)에 위임하는 콜백.
     ///
@@ -112,9 +108,14 @@ struct OperatorStudyManagementView: View {
             .toolbar {
                 if canCreateStudyGroup && selectedSection == .groups {
                     ToolBarCollection.AddBtn(action: {
-                        showCreateUnavailable = true
+                        showsGroupCreate = true
                     })
                 }
+            }
+            // 생성 폼은 같은 ViewModel 을 그대로 쓴다. 생성 성공 시 낙관적 삽입과 백그라운드
+            // 재조회가 이 화면의 목록 상태에 바로 반영되게 하려면 인스턴스가 하나여야 한다.
+            .navigationDestination(isPresented: $showsGroupCreate) {
+                OperatorStudyGroupCreateView(viewModel: viewModel)
             }
             .sheet(
                 item: $viewModel.addMemberGroup,
@@ -144,11 +145,6 @@ struct OperatorStudyManagementView: View {
                 )
             }
             .alertPrompt(item: $viewModel.alertPrompt)
-            .alert("준비 중", isPresented: $showCreateUnavailable) {
-                Button("확인", role: .cancel) {}
-            } message: {
-                Text("스터디 그룹 생성은 챌린저 검색 이식 후 연결됩니다.")
-            }
             .alert("준비 중", isPresented: $showWorkbookDetailUnavailable) {
                 Button("확인", role: .cancel) {}
             } message: {

--- a/UMCApp/Features/Activity/Presentation/Tests/SearchChallengerViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/SearchChallengerViewModelTests.swift
@@ -142,7 +142,7 @@ struct SearchChallengerViewModelSearchTests {
 
         await sut.performSearch(keyword: "길동")
 
-        #expect(sut.loadState == .loaded(true))
+        #expect(sut.loadState.value?.map(\.memberId) == ["1"])
         #expect(sut.allChallengers.map(\.memberId) == ["1"])
         #expect(sut.hasNext)
         #expect(useCase.calls == [.init(keyword: "길동", cursor: nil, size: 50)])
@@ -213,7 +213,7 @@ struct SearchChallengerViewModelSearchTests {
 
         #expect(useCase.calls.count == 2)
         #expect(useCase.calls.last?.keyword == "길동")
-        #expect(sut.loadState == .loaded(true))
+        #expect(sut.allChallengers.map(\.memberId) == ["1"])
     }
 
     @Test("검색한 적 없으면 retrySearch 는 서버를 호출하지 않고 idle 로 남는다")
@@ -268,7 +268,8 @@ struct SearchChallengerViewModelCancellationTests {
         sut.showLoading()
         await sut.performSearch(keyword: "철수")
 
-        #expect(sut.loadState == .loaded(true))
+        #expect(sut.loadState.isLoading == false)
+        #expect(sut.allChallengers.map(\.memberId) == ["1"])
     }
 
     @Test("검색 초기화 뒤 도착한 취소가 지워진 결과를 되살리지 않는다")
@@ -393,7 +394,7 @@ struct SearchChallengerViewModelPaginationTests {
         await sut.fetchNextPage()
 
         #expect(sut.allChallengers.map(\.memberId) == ["1"])
-        #expect(sut.loadState == .loaded(true))
+        #expect(sut.loadState.isLoading == false)
         #expect(sut.hasNext == false)
     }
 

--- a/UMCApp/Features/Activity/Presentation/Tests/SearchChallengerViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/SearchChallengerViewModelTests.swift
@@ -1,0 +1,578 @@
+//
+//  SearchChallengerViewModelTests.swift
+//  ActivityPresentationTests
+//
+//  Created by jaewon Lee on 8/3/26.
+//
+
+import ActivityDomain
+import CoreDomain
+import Foundation
+import Testing
+import UMCFoundation
+@testable import ActivityPresentation
+
+#if DEBUG
+
+// MARK: - Test Double
+
+/// 검색 UseCase 가짜 구현.
+///
+/// 응답을 큐로 넘겨 페이지 순서를 제어하고, 게이트로 특정 호출을 붙잡아 두어
+/// "느린 응답이 나중 검색을 덮어쓰는지" 같은 인터리빙을 결정론적으로 재현합니다.
+private final class MockSearchChallengersUseCase:
+    SearchChallengersUseCaseProtocol, @unchecked Sendable {
+
+    struct Call: Equatable {
+        let keyword: String?
+        let cursor: Int?
+        let size: Int
+    }
+
+    enum Outcome {
+        case page(ChallengerSearchPage)
+        case failure(Error)
+    }
+
+    private var outcomes: [Outcome]
+    private(set) var calls: [Call] = []
+
+    /// 설정하면 해당 인덱스(0-based)의 호출이 continuation 을 여기 걸어두고 대기한다.
+    var gateIndex: Int?
+    private(set) var gate: CheckedContinuation<Void, Never>?
+
+    init(_ outcomes: [Outcome]) {
+        self.outcomes = outcomes
+    }
+
+    var isGateArmed: Bool { gate != nil }
+
+    func releaseGate() {
+        gate?.resume()
+        gate = nil
+    }
+
+    func execute(
+        keyword: String?,
+        cursor: Int?,
+        size: Int
+    ) async throws -> ChallengerSearchPage {
+        let index = calls.count
+        calls.append(Call(keyword: keyword, cursor: cursor, size: size))
+
+        // 결과는 **호출 시점**에 집는다. 게이트 뒤에서 꺼내면 큐 소비 순서가 완료 순서를
+        // 따라가서, 붙잡아 둔 호출이 뒤에 온 호출의 결과를 가져가 버린다.
+        let outcome = outcomes.isEmpty ? nil : outcomes.removeFirst()
+
+        if gateIndex == index {
+            await withCheckedContinuation { continuation in
+                gate = continuation
+            }
+        }
+
+        switch outcome {
+        case .page(let page):
+            return page
+        case .failure(let error):
+            throw error
+        case nil:
+            return ChallengerSearchPage(challengers: [], hasNext: false, nextCursor: nil)
+        }
+    }
+}
+
+/// 에러 전파 검증용 테스트 에러.
+private enum TestError: Error {
+    case network
+}
+
+// MARK: - Helpers
+
+/// `memberId`·`gen`·`part` 만 검증 대상이고, 나머지는 init 충족용 고정값입니다.
+private func makeChallenger(
+    memberId: String,
+    gen: String = "9",
+    name: String = "홍길동",
+    nickname: String = "길동",
+    part: UMCPartType = .front(type: .ios)
+) -> ChallengerInfo {
+    ChallengerInfo(
+        memberId: memberId,
+        challengerId: "C-\(memberId)",
+        gen: gen,
+        name: name,
+        nickname: nickname,
+        schoolName: "한성대학교",
+        profileImage: nil,
+        part: part
+    )
+}
+
+private func makePage(
+    _ challengers: [ChallengerInfo],
+    hasNext: Bool = false,
+    nextCursor: Int? = nil
+) -> ChallengerSearchPage {
+    ChallengerSearchPage(
+        challengers: challengers,
+        hasNext: hasNext,
+        nextCursor: nextCursor
+    )
+}
+
+@MainActor
+private func makeViewModel(
+    _ outcomes: [MockSearchChallengersUseCase.Outcome]
+) -> (SearchChallengerViewModel, MockSearchChallengersUseCase) {
+    let useCase = MockSearchChallengersUseCase(outcomes)
+    return (SearchChallengerViewModel(searchChallengersUseCase: useCase), useCase)
+}
+
+// MARK: - Suite: 검색 상태 전이
+
+@Suite("SearchChallengerViewModel — 검색 상태 전이 (도메인 규칙)")
+@MainActor
+struct SearchChallengerViewModelSearchTests {
+
+    @Test("검색 성공 시 결과와 커서 정보를 반영한다")
+    func loadsFirstPage() async {
+        let (sut, useCase) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")], hasNext: true, nextCursor: 7))
+        ])
+
+        await sut.performSearch(keyword: "길동")
+
+        #expect(sut.loadState == .loaded(true))
+        #expect(sut.allChallengers.map(\.memberId) == ["1"])
+        #expect(sut.hasNext)
+        #expect(useCase.calls == [.init(keyword: "길동", cursor: nil, size: 50)])
+    }
+
+    @Test("검색 실패 시 목록을 비우고 실패 상태로 전이한다")
+    func failsSearch() async {
+        let (sut, _) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")])),
+            .failure(TestError.network)
+        ])
+        await sut.performSearch(keyword: "길동")
+
+        await sut.performSearch(keyword: "철수")
+
+        #expect(sut.allChallengers.isEmpty)
+        #expect(sut.hasNext == false)
+        if case .failed = sut.loadState {
+            // 기대하는 case
+        } else {
+            Issue.record("loadState 가 .failed 여야 함 — 실제: \(sut.loadState)")
+        }
+    }
+
+    @Test("도메인 에러는 사용자 메시지를 가진 AppError 로 승격한다")
+    func mapsDomainError() async {
+        let (sut, _) = makeViewModel([
+            .failure(DomainError.custom(message: "검색할 수 없습니다."))
+        ])
+
+        await sut.performSearch(keyword: "길동")
+
+        #expect(sut.loadState == .failed(.domain(.custom(message: "검색할 수 없습니다."))))
+    }
+
+    @Test("빈 키워드는 서버에 keyword 를 싣지 않는다 (전체 검색)")
+    func omitsEmptyKeyword() async {
+        let (sut, useCase) = makeViewModel([.page(makePage([]))])
+
+        await sut.performSearch(keyword: "")
+
+        #expect(useCase.calls.first?.keyword == nil)
+    }
+
+    @Test("clearSearch 는 결과를 비우고 idle 로 되돌린다")
+    func clearsSearch() async {
+        let (sut, _) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")], hasNext: true, nextCursor: 7))
+        ])
+        await sut.performSearch(keyword: "길동")
+
+        sut.clearSearch()
+
+        #expect(sut.loadState == .idle)
+        #expect(sut.allChallengers.isEmpty)
+        #expect(sut.hasNext == false)
+    }
+
+    @Test("retrySearch 는 직전 키워드로 다시 조회한다")
+    func retriesWithCurrentKeyword() async {
+        let (sut, useCase) = makeViewModel([
+            .failure(TestError.network),
+            .page(makePage([makeChallenger(memberId: "1")]))
+        ])
+        await sut.performSearch(keyword: "길동")
+
+        await sut.retrySearch()
+
+        #expect(useCase.calls.count == 2)
+        #expect(useCase.calls.last?.keyword == "길동")
+        #expect(sut.loadState == .loaded(true))
+    }
+
+    @Test("검색한 적 없으면 retrySearch 는 서버를 호출하지 않고 idle 로 남는다")
+    func retryWithoutKeywordResetsOnly() async {
+        let (sut, useCase) = makeViewModel([])
+
+        await sut.retrySearch()
+
+        #expect(useCase.calls.isEmpty)
+        #expect(sut.loadState == .idle)
+    }
+}
+
+// MARK: - Suite: 취소 처리
+
+@Suite("SearchChallengerViewModel — 취소 처리 (도메인 규칙)")
+@MainActor
+struct SearchChallengerViewModelCancellationTests {
+
+    @Test(
+        "취소는 실패가 아니므로 직전 상태로 롤백한다",
+        arguments: [
+            CancellationError() as Error,
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled) as Error
+        ]
+    )
+    func rollsBackOnCancellation(error: Error) async {
+        let (sut, _) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")])),
+            .failure(error)
+        ])
+        await sut.performSearch(keyword: "길동")
+        let stateBeforeCancellation = sut.loadState
+
+        await sut.performSearch(keyword: "철수")
+
+        // 취소를 .failed 로 전이시키면 정상 상황에 "알 수 없는 오류" 카드가 뜬다.
+        #expect(sut.loadState == stateBeforeCancellation)
+        #expect(sut.allChallengers.map(\.memberId) == ["1"])
+    }
+
+    @Test("디바운스 showLoading 뒤 취소돼도 스피너에 갇히지 않는다")
+    func doesNotStickInLoadingAfterDebouncedCancellation() async {
+        let (sut, _) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")])),
+            .failure(CancellationError())
+        ])
+        await sut.performSearch(keyword: "길동")
+
+        // 실제 화면은 입력 즉시 showLoading() 을 호출하고 디바운스 후 검색한다.
+        // 되돌릴 지점을 .loading 으로 잡으면 여기서 영영 스피너가 남는다.
+        sut.showLoading()
+        await sut.performSearch(keyword: "철수")
+
+        #expect(sut.loadState == .loaded(true))
+    }
+
+    @Test("검색 초기화 뒤 도착한 취소가 지워진 결과를 되살리지 않는다")
+    func clearedStateSurvivesLateCancellation() async {
+        let (sut, useCase) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")])),
+            .failure(CancellationError())
+        ])
+        await sut.performSearch(keyword: "길동")
+        useCase.gateIndex = 1
+
+        let cancelled = Task { await sut.performSearch(keyword: "철수") }
+        await drainUntil { useCase.isGateArmed }
+
+        sut.clearSearch()
+        useCase.releaseGate()
+        await cancelled.value
+
+        #expect(sut.loadState == .idle)
+        #expect(sut.allChallengers.isEmpty)
+    }
+}
+
+// MARK: - Suite: 요청 토큰 (latest-wins)
+
+@Suite("SearchChallengerViewModel — 요청 토큰 latest-wins (도메인 규칙)")
+@MainActor
+struct SearchChallengerViewModelRequestTokenTests {
+
+    @Test("늦게 도착한 이전 키워드 응답이 최신 검색 결과를 덮어쓰지 않는다")
+    func staleSearchResponseIsDiscarded() async {
+        let (sut, useCase) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "stale")])),
+            .page(makePage([makeChallenger(memberId: "fresh")]))
+        ])
+        useCase.gateIndex = 0
+
+        let slowSearch = Task { await sut.performSearch(keyword: "길동") }
+        await drainUntil { useCase.isGateArmed }
+
+        await sut.performSearch(keyword: "철수")
+        useCase.releaseGate()
+        await slowSearch.value
+
+        #expect(sut.allChallengers.map(\.memberId) == ["fresh"])
+    }
+
+    @Test("검색이 끝나기 전 clearSearch 하면 도착한 응답을 버린다")
+    func clearedSearchDiscardsInFlightResponse() async {
+        let (sut, useCase) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")]))
+        ])
+        useCase.gateIndex = 0
+
+        let search = Task { await sut.performSearch(keyword: "길동") }
+        await drainUntil { useCase.isGateArmed }
+
+        sut.clearSearch()
+        useCase.releaseGate()
+        await search.value
+
+        #expect(sut.loadState == .idle)
+        #expect(sut.allChallengers.isEmpty)
+    }
+}
+
+// MARK: - Suite: 페이지네이션
+
+@Suite("SearchChallengerViewModel — 커서 페이지네이션 (도메인 규칙)")
+@MainActor
+struct SearchChallengerViewModelPaginationTests {
+
+    @Test("다음 페이지를 기존 목록에 이어 붙이고 커서를 갱신한다")
+    func appendsNextPage() async {
+        let (sut, useCase) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")], hasNext: true, nextCursor: 7)),
+            .page(makePage([makeChallenger(memberId: "2")], hasNext: false, nextCursor: nil))
+        ])
+        await sut.performSearch(keyword: "길동")
+
+        await sut.fetchNextPage()
+
+        #expect(sut.allChallengers.map(\.memberId) == ["1", "2"])
+        #expect(sut.hasNext == false)
+        #expect(useCase.calls.last == .init(keyword: "길동", cursor: 7, size: 50))
+    }
+
+    @Test("이미 목록에 있는 행은 중복 추가하지 않는다")
+    func deduplicatesBySelectionKey() async {
+        let duplicated = makeChallenger(memberId: "1")
+        let (sut, _) = makeViewModel([
+            .page(makePage([duplicated], hasNext: true, nextCursor: 7)),
+            .page(makePage([duplicated, makeChallenger(memberId: "2")]))
+        ])
+        await sut.performSearch(keyword: "길동")
+
+        await sut.fetchNextPage()
+
+        #expect(sut.allChallengers.map(\.memberId) == ["1", "2"])
+    }
+
+    @Test("다음 페이지가 없으면 서버를 호출하지 않는다")
+    func skipsWhenNoNextPage() async {
+        let (sut, useCase) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")], hasNext: false, nextCursor: nil))
+        ])
+        await sut.performSearch(keyword: "길동")
+
+        await sut.fetchNextPage()
+
+        #expect(useCase.calls.count == 1)
+    }
+
+    @Test("페이지 조회 실패는 이미 보고 있는 목록을 지우지 않는다")
+    func keepsListWhenNextPageFails() async {
+        let (sut, _) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")], hasNext: true, nextCursor: 7)),
+            .failure(TestError.network)
+        ])
+        await sut.performSearch(keyword: "길동")
+
+        await sut.fetchNextPage()
+
+        #expect(sut.allChallengers.map(\.memberId) == ["1"])
+        #expect(sut.loadState == .loaded(true))
+        #expect(sut.hasNext == false)
+    }
+
+    @Test("키워드가 바뀐 뒤 도착한 페이지는 새 검색 결과에 섞이지 않는다")
+    func staleNextPageIsDiscarded() async {
+        let (sut, useCase) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")], hasNext: true, nextCursor: 7)),
+            .page(makePage([makeChallenger(memberId: "stale")])),
+            .page(makePage([makeChallenger(memberId: "fresh")]))
+        ])
+        await sut.performSearch(keyword: "길동")
+        useCase.gateIndex = 1
+
+        let slowPage = Task { await sut.fetchNextPage() }
+        await drainUntil { useCase.isGateArmed }
+
+        await sut.performSearch(keyword: "철수")
+        useCase.releaseGate()
+        await slowPage.value
+
+        #expect(sut.allChallengers.map(\.memberId) == ["fresh"])
+    }
+}
+
+// MARK: - Suite: 선택 상태
+
+@Suite("SearchChallengerViewModel — 선택 상태 (도메인 규칙)")
+@MainActor
+struct SearchChallengerViewModelSelectionTests {
+
+    /// 같은 인물이 기수/파트별로 두 행에 나오는 검색 결과.
+    private func makeSiblingPage() -> ChallengerSearchPage {
+        makePage([
+            makeChallenger(memberId: "1", gen: "9"),
+            makeChallenger(memberId: "1", gen: "10"),
+            makeChallenger(memberId: "2", gen: "9")
+        ])
+    }
+
+    @Test("선택 시 같은 memberId 의 모든 행이 함께 선택된다")
+    func selectsSiblingRowsTogether() async throws {
+        let (sut, _) = makeViewModel([.page(makeSiblingPage())])
+        await sut.performSearch(keyword: "길동")
+        let target = try #require(sut.allChallengers.first)
+
+        sut.toggleSelection(target)
+
+        #expect(sut.selectedKeys == ["1|9|IOS", "1|10|IOS"])
+    }
+
+    @Test("해제 시에도 같은 memberId 의 모든 행이 함께 풀린다")
+    func deselectsSiblingRowsTogether() async throws {
+        let (sut, _) = makeViewModel([.page(makeSiblingPage())])
+        await sut.performSearch(keyword: "길동")
+        let target = try #require(sut.allChallengers.first)
+        sut.toggleSelection(target)
+
+        sut.toggleSelection(target)
+
+        #expect(sut.selectedKeys.isEmpty)
+        #expect(sut.selectedChallengersMap.isEmpty)
+    }
+
+    @Test("검색 결과가 바뀌어도 이전 선택은 유지된다")
+    func keepsSelectionAcrossSearches() async throws {
+        let (sut, _) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")])),
+            .page(makePage([makeChallenger(memberId: "2")]))
+        ])
+        await sut.performSearch(keyword: "길동")
+        sut.toggleSelection(try #require(sut.allChallengers.first))
+
+        await sut.performSearch(keyword: "철수")
+
+        #expect(sut.selectedKeys == ["1|9|IOS"])
+    }
+
+    @Test("진입 시 상위 선택 목록을 선택 상태로 복원한다")
+    func restoresIncomingSelection() {
+        let (sut, _) = makeViewModel([])
+
+        sut.initializeSelection(with: [makeChallenger(memberId: "1")])
+
+        #expect(sut.selectedKeys == ["1|9|IOS"])
+        #expect(sut.selectedChallengersMap["1|9|IOS"]?.memberId == "1")
+    }
+
+    @Test("확정 목록은 기존 선택 순서를 앞에 두고 새 선택을 뒤에 붙인다")
+    func preservesPreviousSelectionOrder() async throws {
+        let previous = [makeChallenger(memberId: "2"), makeChallenger(memberId: "1")]
+        let (sut, _) = makeViewModel([
+            .page(makePage([
+                makeChallenger(memberId: "1"),
+                makeChallenger(memberId: "2"),
+                makeChallenger(memberId: "3")
+            ]))
+        ])
+        sut.initializeSelection(with: previous)
+        await sut.performSearch(keyword: "길동")
+        sut.toggleSelection(try #require(sut.allChallengers.last))
+
+        let confirmed = sut.confirmedSelection(previousSelection: previous)
+
+        #expect(confirmed.map(\.memberId) == ["2", "1", "3"])
+    }
+
+    @Test("확정 전에 해제한 항목은 결과에서 빠진다")
+    func dropsDeselectedFromConfirmedSelection() async throws {
+        let previous = [makeChallenger(memberId: "1")]
+        let (sut, _) = makeViewModel([
+            .page(makePage([makeChallenger(memberId: "1")]))
+        ])
+        sut.initializeSelection(with: previous)
+        await sut.performSearch(keyword: "길동")
+        sut.toggleSelection(try #require(sut.allChallengers.first))
+
+        let confirmed = sut.confirmedSelection(previousSelection: previous)
+
+        #expect(confirmed.isEmpty)
+    }
+}
+
+// MARK: - Suite: CSV 일괄 선택
+
+@Suite("SearchChallengerViewModel — CSV 일괄 선택 (도메인 규칙)")
+@MainActor
+struct SearchChallengerViewModelCSVTests {
+
+    private func makeLoadedViewModel() async -> SearchChallengerViewModel {
+        let (sut, _) = makeViewModel([
+            .page(makePage([
+                makeChallenger(memberId: "1", gen: "9", name: "홍길동", nickname: "길동"),
+                makeChallenger(memberId: "1", gen: "10", name: "홍길동", nickname: "길동"),
+                makeChallenger(memberId: "2", gen: "9", name: "박철수", nickname: "철수")
+            ]))
+        ])
+        await sut.performSearch(keyword: "")
+        return sut
+    }
+
+    @Test("이름이 일치하면 같은 memberId 의 모든 행을 선택한다")
+    func selectsMatchedSiblings() async {
+        let sut = await makeLoadedViewModel()
+
+        sut.applyCSVContent("이름,닉네임\n홍길동,길동")
+
+        #expect(sut.selectedKeys == ["1|9|IOS", "1|10|IOS"])
+    }
+
+    @Test("닉네임만 일치해도 선택한다")
+    func matchesByNicknameOnly() async {
+        let sut = await makeLoadedViewModel()
+
+        sut.applyCSVContent("이름,닉네임\n없는이름,철수")
+
+        #expect(sut.selectedKeys == ["2|9|IOS"])
+    }
+
+    @Test("매칭 실패 인원은 결과 Alert 에 명시한다")
+    func reportsUnmatchedNames() async {
+        let sut = await makeLoadedViewModel()
+
+        sut.applyCSVContent("이름,닉네임\n홍길동,길동\n없는사람,없음")
+
+        let prompt = sut.alertPrompt
+        #expect(prompt?.title == "CSV 가져오기 결과")
+        #expect(prompt?.message.contains("총 2명 중 1명 매칭 완료") == true)
+        #expect(prompt?.message.contains("없는사람/없음") == true)
+    }
+
+    @Test("헤더만 있는 CSV 는 실패 안내를 띄우고 선택을 바꾸지 않는다")
+    func rejectsHeaderOnlyCSV() async {
+        let sut = await makeLoadedViewModel()
+
+        sut.applyCSVContent("이름,닉네임")
+
+        #expect(sut.alertPrompt?.title == "CSV 가져오기 실패")
+        #expect(sut.selectedKeys.isEmpty)
+    }
+}
+
+#endif

--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -19,10 +19,19 @@ let project = featureProject(
             path: .relativeToRoot("Features/Home"),
             condition: .when([.ios])
         ),
+        // 챌린저 검색 결과(ChallengerSearchPage)가 Core canonical ChallengerInfo 를 담는다.
+        // CoreDomain 은 iOS 전용이므로 HomeDomain 과 같은 이유로 조건부 의존이다.
+        .project(
+            target: "CoreDomain",
+            path: .relativeToRoot("Core/Domain"),
+            condition: .when([.ios])
+        ),
     ],
     dataExtraDependencies: [
         // 출석 응답 DTO 가 HomeDomain 의 일정 장소/출석 정책 모델로 매핑한다.
         .project(target: "HomeDomain", path: .relativeToRoot("Features/Home")),
+        // 챌린저 검색 DTO 가 ChallengerInfo 로 매핑한다.
+        .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
     ],
     presentationExtraDependencies: [
         // 출석 ViewModel 이 ScheduleDetailData·ScheduleAttendancePolicy 를 직접 다룬다.
@@ -47,6 +56,12 @@ let project = featureProject(
             path: .relativeToRoot("Features/Home"),
             condition: .when([.ios])
         ),
+        // UseCase 테스트가 ChallengerSearchPage 픽스처의 ChallengerInfo 를 직접 만든다.
+        .project(
+            target: "CoreDomain",
+            path: .relativeToRoot("Core/Domain"),
+            condition: .when([.ios])
+        ),
         .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
     ],
     includesDataTests: true,
@@ -54,6 +69,8 @@ let project = featureProject(
         .external(name: "Moya"),
         // Repository 테스트가 매핑 결과의 ScheduleLocation/ScheduleAttendancePolicy 를 검증.
         .project(target: "HomeDomain", path: .relativeToRoot("Features/Home")),
+        // Repository 테스트가 챌린저 검색 매핑 결과(ChallengerInfo)를 검증.
+        .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
         // Repository 테스트가 도메인 반환 타입(ScheduleAttendanceInfo 등)과
         // 에러 enum(DomainError/RepositoryError/NetworkError)을 직접 참조하므로 명시 주입.
         .target(name: "ActivityDomain"),

--- a/UMCApp/UMCApp/Sources/DIContainer+Activity.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Activity.swift
@@ -100,6 +100,9 @@ extension DIContainer {
         register(FetchStudyMembersUseCaseProtocol.self) {
             FetchStudyMembersUseCase(repository: self.resolve(StudyRepositoryProtocol.self))
         }
+        register(SearchChallengersUseCaseProtocol.self) {
+            SearchChallengersUseCase(repository: self.resolve(MemberRepositoryProtocol.self))
+        }
         register(RegisterStudyScheduleUseCaseProtocol.self) {
             RegisterStudyScheduleUseCase(
                 scheduleRepository: self.resolve(ScheduleRepositoryProtocol.self),

--- a/UMCApp/UMCApp/Tests/DIContainerActivityTests.swift
+++ b/UMCApp/UMCApp/Tests/DIContainerActivityTests.swift
@@ -110,6 +110,9 @@ private let useCaseResolutions: [ActivityResolution] = [
     ActivityResolution(name: "FetchStudyMembersUseCaseProtocol") {
         $0.resolveIfRegistered(FetchStudyMembersUseCaseProtocol.self)
     },
+    ActivityResolution(name: "SearchChallengersUseCaseProtocol") {
+        $0.resolveIfRegistered(SearchChallengersUseCaseProtocol.self)
+    },
     ActivityResolution(name: "FetchUserIdUseCaseProtocol") {
         $0.resolveIfRegistered(FetchUserIdUseCaseProtocol.self)
     },


### PR DESCRIPTION
resolves #1056

## ✨ PR 유형

♻️ [Refactor]

## 📷 스크린샷 or 영상(UI 변경 시)
<!-- UI 관련 작업이라면 영상으로 올려주세요
그 외에는 스크린샷으로 올려도 무방합니다.
어떤 작업을 하였는지 시각적으로 바로 확인 가능하게 해주세요! -->

## 🛠️ 작업내용

레거시 Home 소속이라 Activity 이관에서 빠졌던 챌린저 검색 서브시스템을 `UMCApp` 으로 이식하고,
그에 의존해 게이팅돼 있던 진입점 2곳(그룹 생성 · 인원 추가)을 결선했습니다.

| 레이어 | 내용 |
|---|---|
| Data | 커서 검색 Query/Response DTO, `StudyRouter.searchChallengersCursor`, `MemberRepository.searchChallengers` |
| Domain | `ChallengerSearchPage`, `SearchChallengersUseCase(+Protocol)`, `MemberRepositoryProtocol` 계약 확장 |
| Presentation | `SearchChallengerViewModel`, `SearchChallengerView`, `ChallengerFormView`, `ChallengerSearchCard` |
| 결선 | `SelectedChallengerView` 검색-추가, 운영진 스터디 관리 `+` → 그룹 생성 화면 |

`SelectedChallengerView` · `OperatorStudyManagementView` 의 "준비 중" 안내와 대기 TODO 를 모두 제거했고,
하네스(`ActivityFeatureView`)에 임시로 열어 뒀던 "생성 폼" 버튼도 실제 진입점이 살아나 함께 걷어냈습니다.

## 📋 추후 진행 상황
- 서버가 함께 내려주는 파트별 집계(`partCounts`)는 소비 화면이 없어 디코딩하지 않았습니다. 파트 필터 UI 이식 시 추가 예정
- CSV 일괄 선택은 **현재 검색 결과에 올라온 인원**만 매칭합니다(레거시와 동일). 결과 밖 인원까지 매칭하려면 별도 조회 설계 필요

## 📌 리뷰 포인트

**1. DTO 재사용 — 항목 타입이 오프셋 검색과 동일**
서버 `search/cursor` 와 `search/offset` 은 같은 `SearchChallengerItemResponse` 를 돌려줍니다.
그래서 `ChallengerSearchCursorPageDTO` 의 `content` 는 기존 `ChallengerSearchOffsetItemDTO` 를 그대로 씁니다
(항목 DTO 중복 선언 0). 커서 래퍼만 신규입니다.

**2. Query DTO 의 `cursor` 는 `Int?` — 응답 String 통일 규칙의 적용 범위**
서버 요청 레코드가 `cursor` 를 `Long` 으로 받으므로 Query DTO 는 `Int?` 로 보냅니다.
"서버 정수는 전 레이어 String" 은 **응답** 한정 규칙이고 Request/Query DTO 는 예외라, 여기서는
서버 계약 타입을 그대로 따랐습니다. 이 판단이 맞는지 봐주시면 좋겠습니다.

**3. `ChallengerInfo.gen` 은 표시 문구가 아니라 기수 번호 문자열**
`MemberRepository` 의 기존 매핑(`resolvedGeneration`)은 `"9기"` 같은 표시용 텍스트를 만드는데,
검색 매핑은 `"9"` 를 넣습니다. `StudyRepository.resolveChallengerId(memberId:preferredGeneration:)` 가
이 값을 `Int` 로 바꿔 챌린저 레코드의 `gisu` 와 비교하기 때문입니다. 표시 문구를 넣으면 챌린저 ID
해석이 조용히 실패해 그룹 생성이 막힙니다 — 회귀 테스트로 고정해 뒀습니다.

**4. 동시성 — 요청 토큰 latest-wins + 취소 롤백**
검색은 키워드가 바뀔 때마다 재요청되므로 형제 ViewModel 의 재진입 가드(`isLoading` 조기 반환)를
그대로 쓰면 나중 키워드가 무시됩니다. 그래서 검색 경로는 토큰으로 stale 응답만 버리고, 중복 호출
차단이 필요한 페이지네이션에만 `isFetchingNextPage` 를 뒀습니다. **다음 페이지 응답도 같은 토큰을
검증**해 키워드 전환 중 도착한 페이지가 다른 검색 결과에 섞이지 않게 했습니다.
취소(`CancellationError`/`NSURLErrorCancelled`)는 catch 사다리 최상단에서 직전 상태로 롤백합니다.

**5. Tuist 의존성 추가 — `ActivityDomain` 만 조건부**
검색 결과가 Core canonical `ChallengerInfo` 를 담으므로 `ActivityDomain`·`ActivityData` 에 `CoreDomain`
의존을 추가했습니다. `ActivityDomain` 은 destination 이 watchOS 까지 열려 있어 같은 파일의 `HomeDomain`
선례대로 `condition: .when([.ios])` 를 붙였습니다.

**6. 그룹 생성 화면이 같은 ViewModel 인스턴스를 공유**
생성 성공 시 낙관적 삽입과 백그라운드 재조회가 목록 화면 상태에 바로 반영돼야 해서,
`navigationDestination` 에서 새 VM 을 만들지 않고 `OperatorStudyManagementView` 의 인스턴스를 넘깁니다.

**7. 인프라성 변경이 1건 섞여 있습니다 — `fix:` 커밋**
rebase 후 `ActivityPresentation` 이 빌드되지 않았는데, 원인이 이 PR 밖에 있었습니다.
#1059 가 `StudyRepositoryProtocol` 에 `fetchStudyGroupNames`/`fetchStudyMemberSubmissions` 를 추가했고,
그보다 앞서 분기한 #1061 의 `PreviewStudyScheduleRepository` 가 두 메서드를 구현하지 않은 채 머지돼
**현재 develop 자체가 conformance 실패**입니다. 서로 다른 파일이라 텍스트 충돌이 없었고 각 PR 은 단독으로
통과해서 머지 시점에 드러나지 않았습니다.

이 PR 의 빌드가 통째로 막혀 프리뷰 스텁 2개를 채웠고, 기능 변경과 섞이지 않도록 별도 커밋으로
분리했습니다. 이 PR 이 머지되면 develop 도 함께 복구됩니다 — 더 빨리 풀어야 하면 이 커밋만
따로 hotfix 로 빼도 됩니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
