### PR TITLE
🛠️ [Chore] Activity 구성원·출석·스터디 stub 데이터 확장

### DIFF
--- a/UMCApp/UMCApp/Sources/Debug/StubSession/DIContainer+StubSession.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/DIContainer+StubSession.swift
@@ -41,9 +41,18 @@ extension DIContainer {
         register(StudyRepositoryProtocol.self) {
             StubStudyRepository()
         }
+        register(MemberRepositoryProtocol.self) {
+            StubMemberRepository()
+        }
+        register(ChallengerAttendanceRepositoryProtocol.self) {
+            StubAttendanceRepository()
+        }
+        register(OperatorAttendanceRepositoryProtocol.self) {
+            StubAttendanceRepository()
+        }
 
         Logger(subsystem: "UMCApp", category: "StubSession")
-            .notice("Stub 세션 모드 활성화 — 인증·홈·공지·스터디 데이터가 픽스처로 대체됩니다.")
+            .notice("Stub 세션 모드 활성화 — 인증·홈·공지·스터디·멤버·출석 데이터가 픽스처로 대체됩니다.")
     }
 }
 #endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubAttendanceRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubAttendanceRepository.swift
@@ -1,0 +1,85 @@
+//
+//  StubAttendanceRepository.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/4/26.
+//
+
+#if DEBUG
+import ActivityDomain
+import Foundation
+
+/// stub 세션에서 출석 화면을 서버 없이 표시하는 Repository.
+///
+/// 조회(목록/상세)는 픽스처를 반환한다. 챌린저 본인의 출석 액션과 운영진의 결정·위치
+/// 변경은 실제 요청으로 넘어가지 않도록 미지원 에러를 던진다.
+struct StubAttendanceRepository: ChallengerAttendanceRepositoryProtocol,
+                                  OperatorAttendanceRepositoryProtocol {
+
+    // MARK: - 조회 (운영진)
+
+    func fetchAttendanceList(
+        from: Date?,
+        to: Date?,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> [ScheduleAttendanceInfo] {
+        let schedules = StubSessionFixtures.attendanceSchedules()
+        guard let attendanceStatus else { return schedules }
+        return schedules.filter { schedule in
+            schedule.participants.contains { $0.attendanceStatus == attendanceStatus }
+        }
+    }
+
+    func fetchAttendanceDetail(
+        scheduleId: String,
+        attendanceStatus: ParticipantAttendanceStatus?
+    ) async throws -> ScheduleAttendanceInfo {
+        guard
+            let info = StubSessionFixtures.attendanceSchedules()
+                .first(where: { $0.scheduleId == scheduleId })
+        else {
+            throw StubSessionError.unsupported(action: "일정 출석 현황 조회")
+        }
+        return info
+    }
+
+    // MARK: - 액션 (운영진)
+
+    func decideAttendances(
+        scheduleId: String,
+        decisions: [AttendanceDecisionInput]
+    ) async throws -> [AttendanceDecisionResult] {
+        throw StubSessionError.unsupported(action: "출석 승인/반려")
+    }
+
+    func updateScheduleLocation(
+        scheduleId: String,
+        locationName: String,
+        latitude: Double,
+        longitude: Double
+    ) async throws {
+        throw StubSessionError.unsupported(action: "출석 위치 변경")
+    }
+
+    // MARK: - 액션 (챌린저)
+
+    func requestAttendance(
+        scheduleId: String,
+        latitude: Double,
+        longitude: Double,
+        locationVerified: Bool
+    ) async throws -> AttendanceDecisionResult {
+        throw StubSessionError.unsupported(action: "GPS 출석 요청")
+    }
+
+    func submitExcuse(
+        scheduleId: String,
+        excuseReason: String,
+        isVerified: Bool,
+        latitude: Double,
+        longitude: Double
+    ) async throws -> AttendanceDecisionResult {
+        throw StubSessionError.unsupported(action: "사유 결석/지각 제출")
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubMemberRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubMemberRepository.swift
@@ -1,0 +1,110 @@
+//
+//  StubMemberRepository.swift
+//  UMCApp
+//
+//  Created by jaewon Lee on 8/4/26.
+//
+
+#if DEBUG
+import ActivityDomain
+import CoreDomain
+import UMCFoundation
+
+/// stub 세션에서 멤버 관리 화면을 서버 없이 표시하는 Repository.
+///
+/// 목록·검색·상세 조회는 픽스처를 반환한다. 상벌점 부여/삭제는 실제 요청으로 넘어가지
+/// 않도록 미지원 에러를 던진다.
+struct StubMemberRepository: MemberRepositoryProtocol {
+
+    // MARK: - 멤버 목록
+
+    func fetchMembers() async throws -> [MemberManagementItem] {
+        StubSessionFixtures.members
+    }
+
+    func fetchMembersPage(page: Int) async throws -> MemberPage {
+        guard page == 0 else {
+            return MemberPage(members: [], hasNext: false, currentPage: page)
+        }
+        return MemberPage(members: StubSessionFixtures.members, hasNext: false, currentPage: 0)
+    }
+
+    // MARK: - 챌린저 검색
+
+    func searchChallengers(
+        keyword: String?,
+        cursor: Int?,
+        size: Int
+    ) async throws -> ChallengerSearchPage {
+        let candidates = StubSessionFixtures.members.map { member in
+            ChallengerInfo(
+                memberId: member.memberID ?? "",
+                challengerId: member.challengerID,
+                gen: member.generation,
+                name: member.name,
+                nickname: member.nickname,
+                schoolName: member.school,
+                profileImage: member.profile,
+                part: member.part
+            )
+        }
+        guard let keyword, !keyword.isEmpty else {
+            return ChallengerSearchPage(challengers: candidates, hasNext: false, nextCursor: nil)
+        }
+        let filtered = candidates.filter {
+            $0.name.localizedCaseInsensitiveContains(keyword)
+                || $0.nickname.localizedCaseInsensitiveContains(keyword)
+        }
+        return ChallengerSearchPage(challengers: filtered, hasNext: false, nextCursor: nil)
+    }
+
+    // MARK: - 상벌점 부여 / 삭제
+
+    func grantPoint(
+        challengerId: String,
+        pointType: ChallengerPointType,
+        pointValue: Int,
+        description: String
+    ) async throws {
+        throw StubSessionError.unsupported(action: "상벌점 부여")
+    }
+
+    func deletePoint(challengerPointId: String) async throws {
+        throw StubSessionError.unsupported(action: "상벌점 삭제")
+    }
+
+    func fetchPointHistory(
+        challengerId: String
+    ) async throws -> [OperatorMemberPenaltyHistory] {
+        member(challengerId: challengerId)?.penaltyHistory ?? []
+    }
+
+    // MARK: - 멤버 상세
+
+    func fetchAllGenerations(memberId: String) async throws -> String {
+        member(memberId: memberId)?.generation ?? "12기"
+    }
+
+    func fetchGenerationPointSummaries(
+        memberId: String
+    ) async throws -> [GenerationPointSummary] {
+        member(memberId: memberId)?.generationPoints ?? []
+    }
+
+    func fetchAttendanceRecords(
+        memberId: String
+    ) async throws -> [MemberAttendanceRecord] {
+        member(memberId: memberId)?.attendanceRecords ?? []
+    }
+
+    // MARK: - Private Function
+
+    private func member(memberId: String) -> MemberManagementItem? {
+        StubSessionFixtures.members.first { $0.memberID == memberId }
+    }
+
+    private func member(challengerId: String) -> MemberManagementItem? {
+        StubSessionFixtures.members.first { $0.challengerID == challengerId }
+    }
+}
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubSessionFixtures.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubSessionFixtures.swift
@@ -44,7 +44,7 @@ enum StubSessionFixtures {
                 challengerId: "100",
                 gisu: "12",
                 gisuId: "10",
-                roleType: .challenger,
+                roleType: .schoolPresident,
                 organizationType: .school,
                 organizationId: "3",
                 responsiblePart: "IOS"
@@ -160,6 +160,164 @@ enum StubSessionFixtures {
             weekNo: "5",
             title: "재사용 가능한 컴포넌트"
         )
+    ]
+
+    /// 운영진 스터디 그룹 관리 화면 픽스처. 멘토 1명 + 스터디원을 둔 그룹 2개.
+    static let studyGroups: [StudyGroupInfo] = [
+        StudyGroupInfo(
+            serverID: "601",
+            name: "iOS 심화 스터디",
+            part: .front(type: .ios),
+            createdDate: Date(timeIntervalSinceNow: -86_400 * 14),
+            mentors: [
+                StudyGroupMember(
+                    serverID: "201",
+                    challengerID: "301",
+                    memberID: "201",
+                    name: "이파트",
+                    nickname: "스위프트",
+                    university: "한성대학교",
+                    role: .leader,
+                    bestWorkbookPoint: 3
+                )
+            ],
+            members: [
+                StudyGroupMember(
+                    serverID: "211",
+                    challengerID: "311",
+                    memberID: "211",
+                    name: "김스위",
+                    nickname: "옵셔널",
+                    university: "한성대학교",
+                    role: .member,
+                    bestWorkbookPoint: 2
+                ),
+                StudyGroupMember(
+                    serverID: "212",
+                    challengerID: "312",
+                    memberID: "212",
+                    name: "윤클로",
+                    nickname: "클로저",
+                    university: "한성대학교",
+                    role: .member,
+                    bestWorkbookPoint: 1
+                ),
+            ]
+        ),
+        StudyGroupInfo(
+            serverID: "602",
+            name: "Android 기초 스터디",
+            part: .front(type: .android),
+            createdDate: Date(timeIntervalSinceNow: -86_400 * 7),
+            mentors: [
+                StudyGroupMember(
+                    serverID: "202",
+                    challengerID: "302",
+                    memberID: "202",
+                    name: "박안드",
+                    nickname: "코틀린",
+                    university: "한성대학교",
+                    role: .leader,
+                    bestWorkbookPoint: 2
+                )
+            ],
+            members: [
+                StudyGroupMember(
+                    serverID: "221",
+                    challengerID: "321",
+                    memberID: "221",
+                    name: "오코루",
+                    nickname: "코루틴",
+                    university: "한성대학교",
+                    role: .member,
+                    bestWorkbookPoint: 0
+                )
+            ]
+        ),
+    ]
+
+    /// 스터디원 제출 현황 픽스처. `weeklyCurriculumOptions` 와 같은 주차 식별자를 공유한다.
+    static let studyMemberSubmissions: [StudyMemberSubmission] = [
+        StudyMemberSubmission(
+            studyGroupMemberId: "211",
+            memberId: "211",
+            memberName: "김스위",
+            nickname: "옵셔널",
+            schoolName: "한성대학교",
+            studyGroupId: "601",
+            studyGroupName: "iOS 심화 스터디",
+            part: .front(type: .ios),
+            partLabel: "iOS",
+            weeks: [
+                WeeklySubmission(
+                    weekNo: "1",
+                    weeklyCurriculumId: "1001",
+                    challengerWorkbookId: "5001",
+                    status: .pass,
+                    isBest: true
+                ),
+                WeeklySubmission(
+                    weekNo: "2",
+                    weeklyCurriculumId: "1002",
+                    challengerWorkbookId: "5002",
+                    status: .pass
+                ),
+                WeeklySubmission(
+                    weekNo: "3",
+                    weeklyCurriculumId: "1003",
+                    status: .notSubmitted
+                ),
+            ]
+        ),
+        StudyMemberSubmission(
+            studyGroupMemberId: "212",
+            memberId: "212",
+            memberName: "윤클로",
+            nickname: "클로저",
+            schoolName: "한성대학교",
+            studyGroupId: "601",
+            studyGroupName: "iOS 심화 스터디",
+            part: .front(type: .ios),
+            partLabel: "iOS",
+            weeks: [
+                WeeklySubmission(
+                    weekNo: "1",
+                    weeklyCurriculumId: "1001",
+                    challengerWorkbookId: "5003",
+                    status: .pass
+                ),
+                WeeklySubmission(
+                    weekNo: "2",
+                    weeklyCurriculumId: "1002",
+                    challengerWorkbookId: "5004",
+                    status: .inProgress
+                ),
+            ]
+        ),
+        StudyMemberSubmission(
+            studyGroupMemberId: "221",
+            memberId: "221",
+            memberName: "오코루",
+            nickname: "코루틴",
+            schoolName: "한성대학교",
+            studyGroupId: "602",
+            studyGroupName: "Android 기초 스터디",
+            part: .front(type: .android),
+            partLabel: "Android",
+            weeks: [
+                WeeklySubmission(
+                    weekNo: "1",
+                    weeklyCurriculumId: "1001",
+                    challengerWorkbookId: "5005",
+                    status: .fail
+                ),
+                WeeklySubmission(
+                    weekNo: "2",
+                    weeklyCurriculumId: "1002",
+                    status: .notSubmitted
+                ),
+            ]
+        ),
     ]
 
     // MARK: - Notice
@@ -391,6 +549,348 @@ enum StubSessionFixtures {
         }
 
         return result
+    }
+
+    // MARK: - Member
+
+    /// 멤버 관리 화면 픽스처 — 파트별 그룹핑 확인용으로 6개 파트를 모두 포함한다.
+    static let members: [MemberManagementItem] = [
+        MemberManagementItem(
+            memberID: "201",
+            challengerID: "301",
+            profile: nil,
+            name: "이파트",
+            nickname: "스위프트",
+            generation: "12기",
+            school: "한성대학교",
+            position: "iOS 파트장",
+            part: .front(type: .ios),
+            penalty: 0,
+            rewardPoints: 6,
+            badge: true,
+            managementTeam: .schoolPartLeader,
+            attendanceRecords: [
+                MemberAttendanceRecord(
+                    sessionTitle: "iOS 파트 정기 스터디",
+                    week: 3,
+                    status: .present
+                ),
+                MemberAttendanceRecord(
+                    sessionTitle: "중앙 연합 세미나",
+                    week: 0,
+                    status: .late
+                ),
+            ],
+            penaltyHistory: [
+                OperatorMemberPenaltyHistory(
+                    challengerPointId: "401",
+                    date: Date(timeIntervalSinceNow: -86_400 * 5),
+                    reason: "우수 워크북",
+                    penaltyScore: 2,
+                    pointType: .bestWorkbook
+                )
+            ],
+            generationPoints: [GenerationPointSummary(gisu: 12, reward: 6, penalty: 0)]
+        ),
+        MemberManagementItem(
+            memberID: "202",
+            challengerID: "302",
+            profile: nil,
+            name: "박안드",
+            nickname: "코틀린",
+            generation: "12기",
+            school: "한성대학교",
+            position: "Android 파트원",
+            part: .front(type: .android),
+            penalty: 2,
+            rewardPoints: 1,
+            badge: false,
+            managementTeam: .challenger,
+            attendanceRecords: [],
+            penaltyHistory: [
+                OperatorMemberPenaltyHistory(
+                    challengerPointId: "402",
+                    date: Date(timeIntervalSinceNow: -86_400 * 8),
+                    reason: "스터디 지각",
+                    penaltyScore: 2,
+                    pointType: .studyLate
+                )
+            ],
+            generationPoints: [GenerationPointSummary(gisu: 12, reward: 1, penalty: 2)]
+        ),
+        MemberManagementItem(
+            memberID: "203",
+            challengerID: "303",
+            profile: nil,
+            name: "최웹",
+            nickname: "리액트",
+            generation: "11기",
+            school: "한성대학교",
+            position: "Web 파트원",
+            part: .front(type: .web),
+            penalty: 0,
+            rewardPoints: 2,
+            badge: false,
+            managementTeam: .challenger,
+            attendanceRecords: [],
+            penaltyHistory: []
+        ),
+        MemberManagementItem(
+            memberID: "204",
+            challengerID: "304",
+            profile: nil,
+            name: "정서버",
+            nickname: "스프링",
+            generation: "12기",
+            school: "한성대학교",
+            position: "Server 파트원",
+            part: .server(type: .spring),
+            penalty: 4,
+            rewardPoints: 0,
+            badge: false,
+            managementTeam: .challenger,
+            attendanceRecords: [],
+            penaltyHistory: [
+                OperatorMemberPenaltyHistory(
+                    challengerPointId: "403",
+                    date: Date(timeIntervalSinceNow: -86_400 * 3),
+                    reason: "워크북 미제출",
+                    penaltyScore: 4,
+                    pointType: .noWorkbookMission
+                )
+            ]
+        ),
+        MemberManagementItem(
+            memberID: "205",
+            challengerID: "305",
+            profile: nil,
+            name: "한디자인",
+            nickname: "피그마",
+            generation: "12기",
+            school: "한성대학교",
+            position: "Designer",
+            part: .design,
+            penalty: 0,
+            rewardPoints: 3,
+            badge: false,
+            managementTeam: .challenger,
+            attendanceRecords: [],
+            penaltyHistory: []
+        ),
+        MemberManagementItem(
+            memberID: "206",
+            challengerID: "306",
+            profile: nil,
+            name: "조기획",
+            nickname: "노션",
+            generation: "11기",
+            school: "한성대학교",
+            position: "PM",
+            part: .pm,
+            penalty: 0,
+            rewardPoints: 0,
+            badge: false,
+            managementTeam: .schoolVicePresident,
+            attendanceRecords: [],
+            penaltyHistory: []
+        ),
+    ]
+
+    // MARK: - Attendance (Operator)
+
+    /// 운영진 출석 관리 화면 픽스처. 오늘 기준 상대 일자라 언제 열어도 최근 데이터로 보인다.
+    static func attendanceSchedules() -> [ScheduleAttendanceInfo] {
+        let calendar = Calendar.kstGregorian
+        let now = Date.now
+
+        func at(_ dayOffset: Int, hour: Int, minute: Int = 0) -> Date {
+            let day = calendar.date(byAdding: .day, value: dayOffset, to: now) ?? now
+            return calendar.date(bySettingHour: hour, minute: minute, second: 0, of: day) ?? day
+        }
+
+        let ongoing = ScheduleAttendanceInfo(
+            scheduleId: "7001",
+            name: "iOS 파트 정기 스터디",
+            description: "stub 세션 출석 픽스처입니다.",
+            startsAt: at(0, hour: 19),
+            endsAt: at(0, hour: 21),
+            location: ScheduleLocation(
+                latitude: 37.5665,
+                longitude: 126.9780,
+                locationName: "한성대학교 상상관"
+            ),
+            isOnline: false,
+            authorMemberId: "201",
+            attendancePolicy: ScheduleAttendancePolicy(
+                checkInStartAt: at(0, hour: 18, minute: 30),
+                onTimeEndAt: at(0, hour: 19, minute: 10),
+                lateEndAt: at(0, hour: 19, minute: 30)
+            ),
+            tags: ["스터디"],
+            participants: [
+                ParticipantAttendance(
+                    memberId: "201",
+                    name: "이파트",
+                    nickname: "스위프트",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .present,
+                    isLocationVerified: true,
+                    excuseReason: nil
+                ),
+                ParticipantAttendance(
+                    memberId: "211",
+                    name: "김스위",
+                    nickname: "옵셔널",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .presentPending,
+                    isLocationVerified: true,
+                    excuseReason: nil
+                ),
+                ParticipantAttendance(
+                    memberId: "212",
+                    name: "윤클로",
+                    nickname: "클로저",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .latePending,
+                    isLocationVerified: true,
+                    excuseReason: nil
+                ),
+                ParticipantAttendance(
+                    memberId: "202",
+                    name: "박안드",
+                    nickname: "코틀린",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .excusedPending,
+                    isLocationVerified: false,
+                    excuseReason: "팀 프로젝트 마감과 겹쳐 이번 세션은 온라인으로 대체 참여합니다."
+                ),
+                ParticipantAttendance(
+                    memberId: "203",
+                    name: "최웹",
+                    nickname: "리액트",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .absent,
+                    isLocationVerified: false,
+                    excuseReason: nil
+                ),
+            ]
+        )
+
+        let past = ScheduleAttendanceInfo(
+            scheduleId: "7002",
+            name: "중앙 연합 세미나",
+            description: "stub 세션 출석 픽스처입니다.",
+            startsAt: at(-3, hour: 14),
+            endsAt: at(-3, hour: 17),
+            location: nil,
+            isOnline: true,
+            authorMemberId: "201",
+            attendancePolicy: nil,
+            tags: ["세미나"],
+            participants: [
+                ParticipantAttendance(
+                    memberId: "201",
+                    name: "이파트",
+                    nickname: "스위프트",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .present,
+                    isLocationVerified: true,
+                    excuseReason: nil
+                ),
+                ParticipantAttendance(
+                    memberId: "204",
+                    name: "정서버",
+                    nickname: "스프링",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .late,
+                    isLocationVerified: true,
+                    excuseReason: nil
+                ),
+                ParticipantAttendance(
+                    memberId: "205",
+                    name: "한디자인",
+                    nickname: "피그마",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .excused,
+                    isLocationVerified: false,
+                    excuseReason: "학과 시험 일정과 겹쳐 불참합니다."
+                ),
+                ParticipantAttendance(
+                    memberId: "206",
+                    name: "조기획",
+                    nickname: "노션",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .absent,
+                    isLocationVerified: false,
+                    excuseReason: nil
+                ),
+            ]
+        )
+
+        let upcoming = ScheduleAttendanceInfo(
+            scheduleId: "7003",
+            name: "지부 네트워킹 데이",
+            description: "stub 세션 출석 픽스처입니다.",
+            startsAt: at(10, hour: 18),
+            endsAt: at(10, hour: 20),
+            location: ScheduleLocation(
+                latitude: 37.5665,
+                longitude: 126.9780,
+                locationName: "GACI 지부 세미나실"
+            ),
+            isOnline: false,
+            authorMemberId: "201",
+            attendancePolicy: ScheduleAttendancePolicy(
+                checkInStartAt: at(10, hour: 17, minute: 30),
+                onTimeEndAt: at(10, hour: 18, minute: 10),
+                lateEndAt: at(10, hour: 18, minute: 30)
+            ),
+            tags: ["네트워킹"],
+            participants: [
+                ParticipantAttendance(
+                    memberId: "202",
+                    name: "박안드",
+                    nickname: "코틀린",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .pending,
+                    isLocationVerified: false,
+                    excuseReason: nil
+                ),
+                ParticipantAttendance(
+                    memberId: "203",
+                    name: "최웹",
+                    nickname: "리액트",
+                    profileImageURL: "",
+                    schoolId: "3",
+                    schoolName: "한성대학교",
+                    attendanceStatus: .pending,
+                    isLocationVerified: false,
+                    excuseReason: nil
+                ),
+            ]
+        )
+
+        return [ongoing, past, upcoming]
     }
 
     // MARK: - Private Function

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubStudyRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubStudyRepository.swift
@@ -9,10 +9,11 @@
 import ActivityDomain
 import UMCFoundation
 
-/// stub 세션에서 챌린저 스터디 화면을 서버 없이 표시하는 Repository.
+/// stub 세션에서 스터디 화면(챌린저·운영진)을 서버 없이 표시하는 Repository.
 ///
-/// 커리큘럼 조회와 주차 선택지는 픽스처를 반환한다.
-/// 운영진 스터디 그룹 관리·변경 기능은 실제 요청으로 넘어가지 않도록 미지원 에러를 던진다.
+/// 커리큘럼·스터디 그룹·제출 현황 조회는 픽스처를 반환한다.
+/// 그룹 CRUD·멤버/멘토 변경 등 서버에 반영돼야 하는 쓰기 액션은 실제 요청으로 넘어가지
+/// 않도록 미지원 에러를 던진다.
 struct StubStudyRepository: StudyRepositoryProtocol {
 
     // MARK: - 커리큘럼 / 미션
@@ -28,18 +29,28 @@ struct StubStudyRepository: StudyRepositoryProtocol {
     // MARK: - 운영진 스터디 그룹 조회
 
     func fetchStudyGroupDetails() async throws -> [StudyGroupInfo] {
-        throw StubSessionError.unsupported(action: "스터디 그룹 목록 조회")
+        StubSessionFixtures.studyGroups
     }
 
     func fetchStudyGroupDetailsPage(
         cursor: String?,
         size: Int
     ) async throws -> StudyGroupDetailsPage {
-        throw StubSessionError.unsupported(action: "스터디 그룹 목록 조회")
+        StudyGroupDetailsPage(
+            content: StubSessionFixtures.studyGroups,
+            hasNext: false,
+            nextCursor: nil
+        )
     }
 
     func fetchStudyGroupDetail(groupId: String) async throws -> StudyGroupInfo {
-        throw StubSessionError.unsupported(action: "스터디 그룹 상세 조회")
+        guard
+            let group = StubSessionFixtures.studyGroups
+                .first(where: { $0.serverID == groupId })
+        else {
+            throw StubSessionError.unsupported(action: "스터디 그룹 상세 조회")
+        }
+        return group
     }
 
     func resolveChallengerId(
@@ -50,7 +61,9 @@ struct StubStudyRepository: StudyRepositoryProtocol {
     }
 
     func fetchStudyGroupNames() async throws -> [StudyGroupName] {
-        throw StubSessionError.unsupported(action: "스터디 그룹 이름 조회")
+        StubSessionFixtures.studyGroups.map {
+            StudyGroupName(groupId: $0.serverID, name: $0.name)
+        }
     }
 
     // MARK: - 스터디원 제출 현황
@@ -61,7 +74,31 @@ struct StubStudyRepository: StudyRepositoryProtocol {
         cursor: String?,
         size: Int
     ) async throws -> StudyMemberSubmissionPage {
-        throw StubSessionError.unsupported(action: "스터디원 제출 현황 조회")
+        var rows = StubSessionFixtures.studyMemberSubmissions
+        if let studyGroupId {
+            rows = rows.filter { $0.studyGroupId == studyGroupId }
+        }
+        if !weekNos.isEmpty {
+            let weekSet = Set(weekNos)
+            rows = rows.compactMap { row in
+                let matched = row.weeks.filter { weekSet.contains($0.weekNo) }
+                guard !matched.isEmpty else { return nil }
+                return StudyMemberSubmission(
+                    studyGroupMemberId: row.studyGroupMemberId,
+                    memberId: row.memberId,
+                    memberName: row.memberName,
+                    nickname: row.nickname,
+                    schoolName: row.schoolName,
+                    profileImageURL: row.profileImageURL,
+                    studyGroupId: row.studyGroupId,
+                    studyGroupName: row.studyGroupName,
+                    part: row.part,
+                    partLabel: row.partLabel,
+                    weeks: matched
+                )
+            }
+        }
+        return StudyMemberSubmissionPage(content: rows, hasNext: false, nextCursor: nil)
     }
 
     // MARK: - 운영진 스터디 그룹 CRUD


### PR DESCRIPTION
resolves #1068

## ✨ PR 유형

<!-- 어떤 변경 사항이 있나요?? -->

🛠️ [Chore]

## 📷 스크린샷 or 영상(UI 변경 시)
<!-- UI 관련 작업이라면 영상으로 올려주세요
그 외에는 스크린샷으로 올려도 무방합니다.
어떤 작업을 하였는지 시각적으로 바로 확인 가능하게 해주세요! -->

## 🛠️ 작업내용
<!-- [ 작업한 내용을 작성해주세요 ] -->

- `StubMemberRepository`(신규) — 구성원 관리(챌린저/운영진) read 목데이터
- `StubAttendanceRepository`(신규) — 출석 관리(운영진) read 목데이터, `ChallengerAttendanceRepositoryProtocol`·`OperatorAttendanceRepositoryProtocol` 동시 준수
- `StubStudyRepository` 확장 — 그룹 상세 조회·제출 현황 조회 지원
- `StubSessionFixtures` 확장 — 스터디 그룹, 구성원, 출석 일정 픽스처 추가
- `DIContainer+StubSession` — 신규 Repository 3종 DI 등록 추가
- 기존과 동일하게 `StubSessionMode.isEnabled` 단일 플래그로 전체 제어
- `make build` 성공 확인

## 📋 추후 진행 상황
<!-- [ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ] -->

## 📌 리뷰 포인트
<!-- [ 어떤 부분을 잘 체크해야하는지 작성해주세요 ] -->

- `StubMemberRepository.swift`, `StubAttendanceRepository.swift`(신규) — Repository Protocol 계약 준수 확인 필요
- `DIContainer+StubSession.swift` — 의존성 주입 등록 확인 필요
- `StubSessionFixtures.swift` — 픽스처 데이터 정합성 확인 필요



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)