### PR TITLE
🐛 [Fix] 출석 화면 디자인 토큰 준수 — 상태 색 매핑 Core 단일화

### DIFF
--- a/UMCApp/Core/UIComponents/Sources/Badge/AttendanceBadgeStatus.swift
+++ b/UMCApp/Core/UIComponents/Sources/Badge/AttendanceBadgeStatus.swift
@@ -91,4 +91,15 @@ public enum AttendanceBadgeStatus: String, CaseIterable, Equatable, Hashable, Se
             return .grey600
         }
     }
+
+    /// 배지/카드 배경에 채울 색상 (``tintColor`` 를 옅게 깐 값)
+    public var backgroundColor: Color {
+        tintColor.opacity(Constants.backgroundOpacity)
+    }
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let backgroundOpacity: Double = 0.18
+    }
 }

--- a/UMCApp/Core/UIComponents/Sources/Badge/AttendanceStatusBadge.swift
+++ b/UMCApp/Core/UIComponents/Sources/Badge/AttendanceStatusBadge.swift
@@ -20,7 +20,6 @@ public struct AttendanceStatusBadge: View, Equatable {
     // MARK: - Constants
 
     fileprivate enum Constants {
-        static let backgroundOpacity: Double = 0.18
         static let unknownIconSize: CGFloat = 11
     }
 
@@ -49,7 +48,7 @@ public struct AttendanceStatusBadge: View, Equatable {
         .padding(.horizontal, DefaultSpacing.spacing8)
         .padding(.vertical, DefaultSpacing.spacing4)
         .glassEffect(
-            .clear.tint(status.tintColor.opacity(Constants.backgroundOpacity)),
+            .clear.tint(status.backgroundColor),
             in: Capsule()
         )
         .accessibilityElement(children: .combine)

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/ParticipantAttendanceRow.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/ParticipantAttendanceRow.swift
@@ -97,9 +97,9 @@ struct ParticipantAttendanceRow: View, Equatable {
                     Image(systemName: "location.fill")
                         .font(.system(size: Constants.verifiedIconSize))
                     Text("GPS 인증")
-                        .appFont(.caption2, color: .green)
+                        .appFont(.caption2)
                 }
-                .foregroundStyle(.green)
+                .foregroundStyle(Color.green500)
             }
         }
     }

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/PendingApprovalSheet.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/PendingApprovalSheet.swift
@@ -171,7 +171,7 @@ struct PendingApprovalSheet: View {
         } label: {
             Label("승인", systemImage: "checkmark")
         }
-        .tint(.green)
+        .tint(Color.green500)
         .disabled(isProcessing)
 
         Button {
@@ -179,7 +179,7 @@ struct PendingApprovalSheet: View {
         } label: {
             Label("거절", systemImage: "xmark")
         }
-        .tint(.red)
+        .tint(Color.red500)
         .disabled(isProcessing)
 
         if let reason = participant.excuseReason, !reason.isEmpty {
@@ -188,7 +188,7 @@ struct PendingApprovalSheet: View {
             } label: {
                 Label("사유", systemImage: "text.bubble")
             }
-            .tint(.orange)
+            .tint(Color.orange500)
         }
     }
 

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
@@ -98,7 +98,7 @@ private struct MyAttendanceItemPresenter: View, Equatable {
             }
         }
         .padding(DefaultConstant.defaultListPadding)
-        .background(.white)
+        .background(Color.grey000)
         .contentShape(Rectangle())
         .onTapGesture {
             guard hasExpandableContent else { return }

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerSessionCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerSessionCard.swift
@@ -70,7 +70,7 @@ struct ChallengerSessionCard: View, Equatable {
                 corners: .concentric(minimum: DefaultConstant.concentricRadius),
                 isUniform: true
             )
-            .fill(.white)
+            .fill(Color.grey000)
             .glass()
         }
         .contentShape(Rectangle())

--- a/UMCApp/Features/Activity/Presentation/Sources/Extensions/AttendancePolicyDisplay.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Extensions/AttendancePolicyDisplay.swift
@@ -38,9 +38,9 @@ enum AttendancePolicyRole {
 
     var tintColor: Color {
         switch self {
-        case .checkIn: .green
-        case .onTime: .orange
-        case .late: .red
+        case .checkIn: .green500
+        case .onTime: .orange500
+        case .late: .red500
         }
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Extensions/AttendanceStatus+Color.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Extensions/AttendanceStatus+Color.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import ActivityDomain
+import CoreUIComponents
 
 /// `AttendanceStatus` 의 시각 표현 매핑.
 ///
@@ -16,17 +17,26 @@ public extension AttendanceStatus {
 
     /// 배지/버튼 배경 색상
     var backgroundColor: Color {
-        switch self {
-        case .beforeAttendance: return .gray.opacity(0.7)
-        case .pendingApproval:  return .yellow.opacity(0.7)
-        case .present:          return .green.opacity(0.7)
-        case .late:             return .yellow.opacity(0.7)
-        case .absent:           return .red.opacity(0.7)
-        }
+        badgeStatus.backgroundColor
     }
 
     /// 배지/버튼 폰트 색상
     var fontColor: Color {
-        .white
+        badgeStatus.foregroundColor
+    }
+}
+
+extension AttendanceStatus {
+
+    /// 공용 뱃지 색 매핑(``AttendanceBadgeStatus``)으로 변환한다. 색상만 사용한다.
+    /// `default` 를 두지 않아 도메인 케이스 추가 시 컴파일 단계에서 누락이 드러난다.
+    var badgeStatus: AttendanceBadgeStatus {
+        switch self {
+        case .beforeAttendance: return .pending
+        case .pendingApproval:  return .presentPending
+        case .present:          return .present
+        case .late:             return .late
+        case .absent:           return .absent
+        }
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Extensions/MyAttendanceItemStatus+Color.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Extensions/MyAttendanceItemStatus+Color.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import ActivityDomain
+import CoreUIComponents
 
 /// `MyAttendanceItemStatus` 의 시각 표현 매핑.
 ///
@@ -16,16 +17,25 @@ public extension MyAttendanceItemStatus {
 
     /// 배지/버튼 배경 색상
     var backgroundColor: Color {
-        switch self {
-        case .pendingApproval: return .yellow.opacity(0.7)
-        case .present:         return .green.opacity(0.7)
-        case .late:            return .yellow.opacity(0.7)
-        case .absent:          return .red.opacity(0.7)
-        }
+        badgeStatus.backgroundColor
     }
 
     /// 배지/버튼 폰트 색상
     var fontColor: Color {
-        .white
+        badgeStatus.foregroundColor
+    }
+}
+
+extension MyAttendanceItemStatus {
+
+    /// 공용 뱃지 색 매핑(``AttendanceBadgeStatus``)으로 변환한다. 색상만 사용한다.
+    /// `default` 를 두지 않아 도메인 케이스 추가 시 컴파일 단계에서 누락이 드러난다.
+    var badgeStatus: AttendanceBadgeStatus {
+        switch self {
+        case .pendingApproval: return .presentPending
+        case .present:         return .present
+        case .late:            return .late
+        case .absent:          return .absent
+        }
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -188,7 +188,7 @@ struct ChallengerAttendanceSessionView: View {
     private var emptySessionView: some View {
         emptyStateCard(
             systemImage: "checkmark.circle.fill",
-            tint: .green,
+            tint: .green500,
             title: "모든 세션 출석을 완료했어요",
             description: "지금은 출석할 수 있는 세션이 없어요.\n새로운 세션이 열리면 이곳에 표시됩니다."
         )
@@ -261,7 +261,7 @@ struct ChallengerAttendanceSessionView: View {
                 corners: .concentric(minimum: DefaultConstant.concentricRadius),
                 isUniform: true
             )
-            .fill(.white)
+            .fill(Color.grey000)
             .glass()
         }
     }

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceDetailView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceDetailView.swift
@@ -261,7 +261,7 @@ struct OperatorAttendanceDetailView: View {
             .padding(DefaultSpacing.spacing12)
             .frame(maxWidth: .infinity)
             .glassEffect(
-                .regular.tint(.orange.opacity(Constants.bannerTintOpacity)).interactive(),
+                .regular.tint(Color.orange500.opacity(Constants.bannerTintOpacity)).interactive(),
                 in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius))
             )
         }
@@ -402,7 +402,7 @@ struct OperatorAttendanceDetailView: View {
             } label: {
                 Label("승인", systemImage: "checkmark")
             }
-            .tint(.green)
+            .tint(Color.green500)
             .disabled(isProcessing)
 
             Button {
@@ -410,7 +410,7 @@ struct OperatorAttendanceDetailView: View {
             } label: {
                 Label("거절", systemImage: "xmark")
             }
-            .tint(.red)
+            .tint(Color.red500)
             .disabled(isProcessing)
 
             if let reason = participant.excuseReason, !reason.isEmpty {
@@ -419,7 +419,7 @@ struct OperatorAttendanceDetailView: View {
                 } label: {
                     Label("사유", systemImage: "text.bubble")
                 }
-                .tint(.orange)
+                .tint(Color.orange500)
             }
         }
     }


### PR DESCRIPTION
## 개요

이슈 #1036 의 완료 조건 중 **AC4(디자인 시스템 토큰 준수, 하드코딩 값 없음)** 를 충족시킵니다.

출석 화면 View 자체는 #1031(운영진 목록/상세)·#1050(챌린저)에서 이미 이식 완료되어
AC1·AC2·AC3·AC5 는 충족 상태였고, 남아 있던 컬러 하드코딩만 정리했습니다.

## 배경

출석 상태 → 색 매핑이 앱 안에 3벌 존재했습니다.

| 위치 | 상태 |
|---|---|
| `Core/UIComponents/Badge/AttendanceBadgeStatus` | 디자인 토큰 기반 (정답) |
| `ActivityPresentation/Extensions/AttendanceStatus+Color` | `.gray/.yellow/.green/.red` + `fontColor = .white` |
| `ActivityPresentation/Extensions/MyAttendanceItemStatus+Color` | 동일 |

AC5 가 뒤 두 익스텐션의 재사용을 명시하고 있어 **공개 API 는 그대로 두고 내부 구현만**
Core 의 토큰 매핑에 위임했습니다. 호출부는 한 줄도 바뀌지 않습니다.

## 변경 사항

- `AttendanceBadgeStatus` 에 `backgroundColor`(= `tintColor.opacity(0.18)`) 노출.
  `AttendanceStatusBadge` 가 갖고 있던 `backgroundOpacity` 상수는 제거하고 이를 사용
- `AttendanceStatus+Color` / `MyAttendanceItemStatus+Color` → `badgeStatus` 브리지로 위임.
  `ParticipantAttendanceStatus+UI` 의 기존 브리지 패턴을 그대로 따랐고, `default` 를 두지 않아
  도메인 케이스 추가 시 컴파일 단계에서 매핑 누락이 드러납니다
- `.white` 리터럴 3곳 → `.grey000` (light `#FFFFFF` / dark `#000000` 적응형)
- 시스템 컬러 → 팔레트 토큰
  - 스와이프 액션 tint 6곳 (`OperatorAttendanceDetailView`, `PendingApprovalSheet`)
  - 승인 대기 배너 glass tint (`OperatorAttendanceDetailView`)
  - `AttendancePolicyDisplay.tintColor` 3케이스
  - `ChallengerAttendanceSessionView` 빈 상태 tint
  - `ParticipantAttendanceRow` — 부모/자식 중복 색 지정 중 하나 제거

## 부수 효과

- **다크 모드**: `.white` 하드코딩 탓에 챌린저 세션 카드·나의 출석 카드가 다크에서
  흰 판으로 남아 `.grey900` 본문과 뒤집히던 문제 해소
- **대비**: 흰 글자 on `.yellow.opacity(0.7)` 조합(승인 대기·지각 배지)이 사라지고
  운영진 배지와 동일한 톤으로 통일

## 테스트

- `make build` (Debug / iPhone 17 Pro Simulator) — **BUILD SUCCEEDED**
- 로직 변경 없는 색상 매핑 전용 diff, `AppProduct/` 무변경

## 범위 밖 (별도 이슈 제안)

이번 PR 에 섞으면 리뷰가 흐려져 남겨둡니다.

- 운영진 모드 진입 스위치가 `#if DEBUG` 하나뿐 (`ActivityView.swift`) — 탭바 하단
  액세서리 이식 전이라 Release 에서 운영진 출석 화면에 도달할 수 없음
- `ActivityDestination.attendanceDetail` 데드코드 (생산자 0곳)
- `ChallengerAttendanceViewModel.myHistory` — 진입마다 조회하지만 읽는 View 없음
- `.font(.system(size:))` 11곳 Dynamic Type 미대응 / 터치 타깃 44pt 미달 4곳
- 챌린저 카드의 `.glass()` 는 Liquid Glass 가 아닌 drop shadow — 운영진 화면과 표면 언어 불일치

Closes #1036
