### PR TITLE
✨ [Feature] 알림 보관함(NoticeAlarmView) 실내용 이식 — NoticeHistoryData · NoticeAlarmCard

### DIFF
--- a/UMCApp/Features/Home/Domain/Sources/Models/NoticeHistory/NoticeAlarmType.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/NoticeHistory/NoticeAlarmType.swift
@@ -1,0 +1,23 @@
+//
+//  NoticeAlarmType.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 1/20/26.
+//
+
+import Foundation
+
+/// 알림 상태 타입 (성공, 정보, 경고, 에러)
+///
+/// 알림 보관함에서 알림의 성격을 구분하는 데 사용합니다.
+/// 시각 매핑(SF Symbol, Color)은 `HomePresentation`의 extension에서 제공합니다.
+public enum NoticeAlarmType: String, Codable, Sendable {
+    /// 성공 상태
+    case success
+    /// 정보 상태
+    case info
+    /// 경고 상태
+    case warning
+    /// 에러 상태
+    case error
+}

--- a/UMCApp/Features/Home/Domain/Sources/Models/NoticeHistory/NoticeHistoryData.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/NoticeHistory/NoticeHistoryData.swift
@@ -1,0 +1,48 @@
+//
+//  NoticeHistoryData.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 1/20/26.
+//
+
+import Foundation
+import SwiftData
+
+/// 알림 히스토리 로컬 저장 모델 (SwiftData)
+///
+/// 사용자의 알림 내역을 로컬 데이터베이스에 저장하고 관리합니다.
+/// `NoticeAlarmType`을 포함해 알림의 성격(정보, 경고 등)을 구분합니다.
+@Model
+public final class NoticeHistoryData {
+
+    // MARK: - Property
+
+    public var id: UUID = UUID()
+    public var title: String = ""
+    public var content: String = ""
+    /// 알림 타입 rawValue 저장값
+    public var iconRaw: String = NoticeAlarmType.info.rawValue
+    public var createdAt: Date = Date()
+
+    /// 알림 타입. SwiftData 저장은 `iconRaw`(String)로 하고 앱에서는 enum으로 접근합니다.
+    public var icon: NoticeAlarmType {
+        get { NoticeAlarmType(rawValue: iconRaw) ?? .info }
+        set { iconRaw = newValue.rawValue }
+    }
+
+    // MARK: - Init
+
+    public init(
+        id: UUID = .init(),
+        title: String,
+        content: String,
+        icon: NoticeAlarmType,
+        createdAt: Date
+    ) {
+        self.id = id
+        self.title = title
+        self.content = content
+        self.iconRaw = icon.rawValue
+        self.createdAt = createdAt
+    }
+}

--- a/UMCApp/Features/Home/Domain/Tests/Models/NoticeHistoryDataTests.swift
+++ b/UMCApp/Features/Home/Domain/Tests/Models/NoticeHistoryDataTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import HomeDomain
+
+@Suite("NoticeHistoryData — icon rawValue 브리징 검증")
+struct NoticeHistoryDataTests {
+
+    @Test("init에 넘긴 타입이 iconRaw로 저장되고 icon으로 그대로 복원된다")
+    func iconRoundTripsThroughRawValue() {
+        for expected in [NoticeAlarmType.success, .info, .warning, .error] {
+            let notice = NoticeHistoryData(
+                title: "제목",
+                content: "내용",
+                icon: expected,
+                createdAt: .init(timeIntervalSince1970: 0)
+            )
+
+            #expect(notice.iconRaw == expected.rawValue)
+            #expect(notice.icon == expected)
+        }
+    }
+
+    @Test("icon setter가 iconRaw를 갱신한다")
+    func iconSetterUpdatesRawValue() {
+        let notice = NoticeHistoryData(
+            title: "제목",
+            content: "내용",
+            icon: .info,
+            createdAt: .init(timeIntervalSince1970: 0)
+        )
+
+        notice.icon = .error
+
+        #expect(notice.iconRaw == NoticeAlarmType.error.rawValue)
+        #expect(notice.icon == .error)
+    }
+
+    @Test("알 수 없는 iconRaw는 info로 fallback한다")
+    func unknownRawValueFallsBackToInfo() {
+        let notice = NoticeHistoryData(
+            title: "제목",
+            content: "내용",
+            icon: .warning,
+            createdAt: .init(timeIntervalSince1970: 0)
+        )
+
+        notice.iconRaw = "존재하지_않는_타입"
+
+        #expect(notice.icon == .info)
+    }
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/NoticeAlarmCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/NoticeAlarmCard.swift
@@ -1,0 +1,113 @@
+//
+//  NoticeAlarmCard.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 1/20/26.
+//
+
+import CoreDesignSystem
+import HomeDomain
+import SwiftUI
+import UMCFoundation
+
+/// 알림 보관함 행 카드 — 알림 타입별 아이콘/색상과 제목·내용·상대 시간을 표시한다.
+struct NoticeAlarmCard: View {
+
+    // MARK: - Property
+
+    let notice: NoticeHistoryData
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let iconSize: CGFloat = 24
+        static let iconPadding: CGFloat = 8
+        static let iconBackgroundOpacity: CGFloat = 0.2
+        static let contentLineLimit: Int = 2
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(alignment: .top, spacing: DefaultSpacing.spacing16) {
+            icon
+            info
+        }
+    }
+
+    // MARK: - Component
+
+    private var icon: some View {
+        Image(systemName: notice.icon.image)
+            .renderingMode(.template)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: Constants.iconSize, height: Constants.iconSize)
+            .fontWeight(.semibold)
+            .foregroundStyle(notice.icon.color)
+            .padding(Constants.iconPadding)
+            .background(notice.icon.color.opacity(Constants.iconBackgroundOpacity), in: .circle)
+            .glassEffect(.clear, in: .circle)
+    }
+
+    private var info: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            titleRow
+
+            Text(notice.content)
+                .appFont(.subheadline, color: .grey600)
+                .multilineTextAlignment(.leading)
+                .lineLimit(Constants.contentLineLimit)
+        }
+    }
+
+    private var titleRow: some View {
+        HStack {
+            Text(notice.title)
+                .appFont(.callout, weight: .semibold, color: .grey900)
+
+            Spacer()
+
+            Text(notice.createdAt.timeAgoText)
+                .appFont(.footnote, color: .grey500)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview(traits: .sizeThatFitsLayout) {
+    VStack(spacing: DefaultSpacing.spacing16) {
+        NoticeAlarmCard(notice: NoticeHistoryData(
+            title: "신입 모집 안내",
+            content: "UMC 7기 신입 회원을 모집합니다. 많은 지원 부탁드립니다!",
+            icon: .info,
+            createdAt: Date(timeIntervalSinceNow: -3600)
+        ))
+
+        NoticeAlarmCard(notice: NoticeHistoryData(
+            title: "회비 납부 완료",
+            content: "1월 회비가 정상적으로 납부되었습니다.",
+            icon: .success,
+            createdAt: Date(timeIntervalSinceNow: -86400)
+        ))
+
+        NoticeAlarmCard(notice: NoticeHistoryData(
+            title: "지각 경고",
+            content: "이번 주 세미나에 10분 지각하셨습니다.",
+            icon: .warning,
+            createdAt: Date(timeIntervalSinceNow: -604800)
+        ))
+
+        NoticeAlarmCard(notice: NoticeHistoryData(
+            title: "출석 미달",
+            content: "출석률이 80% 미만입니다. 주의해주세요.",
+            icon: .error,
+            createdAt: Date(timeIntervalSinceNow: -2592000)
+        ))
+    }
+    .padding()
+    .modelContainer(for: [NoticeHistoryData.self], inMemory: true)
+}
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Extensions/NoticeAlarmType+Visual.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Extensions/NoticeAlarmType+Visual.swift
@@ -1,0 +1,37 @@
+//
+//  NoticeAlarmType+Visual.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 1/20/26.
+//
+
+import CoreDesignSystem
+import HomeDomain
+import SwiftUI
+
+/// `NoticeAlarmType` 에 대한 시각 표현(SF Symbol, 상태 색상) 매핑.
+///
+/// raw 값 정의는 `HomeDomain` 의 enum 에 위치하고,
+/// SwiftUI 의존이 필요한 시각 토큰만 본 모듈에 분리합니다.
+extension NoticeAlarmType {
+
+    /// 상태별 시스템 심볼 이미지 이름
+    var image: String {
+        switch self {
+        case .success: return "checkmark.circle"
+        case .info:    return "info.circle"
+        case .warning: return "exclamationmark.circle"
+        case .error:   return "xmark.circle"
+        }
+    }
+
+    /// 상태별 색상 토큰
+    var color: Color {
+        switch self {
+        case .success: return .green500
+        case .info:    return .indigo500
+        case .warning: return .yellow500
+        case .error:   return .red500
+        }
+    }
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Views/NoticeAlarmView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/NoticeAlarmView.swift
@@ -5,16 +5,21 @@
 //  Created by JEONG on 7/30/26.
 //
 
+import CoreDesignSystem
 import CoreUIComponents
+import HomeDomain
+import SwiftData
 import SwiftUI
 
-/// 알림 보관함 화면.
-///
-/// - Important: 아직 빈 상태만 표시하는 스텁이다. 실제 알림 내역은 SwiftData 모델
-///   `NoticeHistoryData`와 `NoticeAlarmCard`에 의존하는데 둘 다 이식 전이므로, 이 슬라이스는
-///   홈 툴바 → 알림 보관함 라우팅만 복구한다. 두 타입이 이식되면 `@Query`로 최신순 목록과
-///   스와이프/전체 삭제 액션을 채운다.
+/// 알림 보관함 화면 — 로컬에 저장된 알림 내역을 최신순으로 보여준다.
 public struct NoticeAlarmView: View {
+
+    // MARK: - Property
+
+    @Environment(\.modelContext) private var modelContext
+
+    @Query(sort: \NoticeHistoryData.createdAt, order: .reverse)
+    private var notices: [NoticeHistoryData]
 
     // MARK: - Constants
 
@@ -22,6 +27,7 @@ public struct NoticeAlarmView: View {
         static let emptyTitle: String = "알림 내역이 없습니다."
         static let emptySystemImage: String = "bell.slash"
         static let emptyDescription: String = "새로운 소식이 도착하면 이곳에 표시됩니다."
+        static let deleteAllTitle: String = "전체 삭제"
     }
 
     // MARK: - Init
@@ -31,13 +37,62 @@ public struct NoticeAlarmView: View {
     // MARK: - Body
 
     public var body: some View {
+        Group {
+            if notices.isEmpty {
+                emptyView
+            } else {
+                noticeList
+            }
+        }
+        .umcDefaultBackground()
+        .navigation(naviTitle: NavigationTitle.Notice.alarmArchive, displayMode: .inline)
+        .toolbar {
+            if !notices.isEmpty {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(Constants.deleteAllTitle, role: .destructive, action: deleteAllNotices)
+                }
+            }
+        }
+    }
+
+    // MARK: - Component
+
+    private var emptyView: some View {
         ContentUnavailableView(
             Constants.emptyTitle,
             systemImage: Constants.emptySystemImage,
             description: Text(Constants.emptyDescription)
         )
-        .umcDefaultBackground()
-        .navigation(naviTitle: NavigationTitle.Notice.alarmArchive, displayMode: .inline)
+    }
+
+    private var noticeList: some View {
+        List {
+            ForEach(notices) { notice in
+                NoticeAlarmCard(notice: notice)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(DefaultConstant.defaultListPadding)
+            }
+            .onDelete(perform: deleteNotices)
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    // MARK: - Function
+
+    private func deleteNotices(at offsets: IndexSet) {
+        for index in offsets {
+            modelContext.delete(notices[index])
+        }
+        try? modelContext.save()
+    }
+
+    private func deleteAllNotices() {
+        for notice in notices {
+            modelContext.delete(notice)
+        }
+        try? modelContext.save()
     }
 }
 
@@ -46,7 +101,56 @@ public struct NoticeAlarmView: View {
 #if DEBUG
 #Preview {
     NavigationStack {
-        NoticeAlarmView()
+        NoticeAlarmPreviewSeedView()
     }
+    .modelContainer(for: [NoticeHistoryData.self], inMemory: true)
+}
+
+private struct NoticeAlarmPreviewSeedView: View {
+
+    @Environment(\.modelContext) private var modelContext
+
+    @Query(sort: \NoticeHistoryData.createdAt, order: .reverse)
+    private var notices: [NoticeHistoryData]
+
+    var body: some View {
+        NoticeAlarmView()
+            .task {
+                guard notices.isEmpty else { return }
+                seedDummyNotices(modelContext: modelContext)
+            }
+    }
+}
+
+private func seedDummyNotices(modelContext: ModelContext) {
+    let dummyNotices: [NoticeHistoryData] = [
+        NoticeHistoryData(
+            title: "중앙 해커톤 참여 확정",
+            content: "축하합니다! 해커톤 참가가 확정되었습니다.",
+            icon: .success,
+            createdAt: .now.addingTimeInterval(-60 * 5)
+        ),
+        NoticeHistoryData(
+            title: "정기 세션 불참 경고",
+            content: "무단 결석 1회가 누적되었습니다.",
+            icon: .warning,
+            createdAt: .now.addingTimeInterval(-60 * 30)
+        ),
+        NoticeHistoryData(
+            title: "운영진 면접 결과 안내",
+            content: "이번 기수 운영진 면접 결과를 확인해주세요.",
+            icon: .info,
+            createdAt: .now.addingTimeInterval(-60 * 60 * 2)
+        ),
+        NoticeHistoryData(
+            title: "출석 점검 필요",
+            content: "출석률이 기준 미만입니다. 다음 세션 출석이 필요합니다.",
+            icon: .error,
+            createdAt: .now.addingTimeInterval(-60 * 60 * 24)
+        )
+    ]
+
+    dummyNotices.forEach { modelContext.insert($0) }
+    try? modelContext.save()
 }
 #endif

--- a/UMCApp/Project.swift
+++ b/UMCApp/Project.swift
@@ -65,6 +65,7 @@ let project = Project(
                 .project(target: "ActivityDomain", path: .relativeToRoot("Features/Activity")),
                 .project(target: "ActivityPresentation", path: .relativeToRoot("Features/Activity")),
                 .project(target: "ActivityData", path: .relativeToRoot("Features/Activity")),
+                .project(target: "HomeDomain", path: .relativeToRoot("Features/Home")),
                 .project(target: "HomePresentation", path: .relativeToRoot("Features/Home")),
                 .project(target: "HomeData", path: .relativeToRoot("Features/Home")),
                 .project(target: "CommunityPresentation", path: .relativeToRoot("Features/Community")),

--- a/UMCApp/UMCApp/Sources/UMCAppApp.swift
+++ b/UMCApp/UMCApp/Sources/UMCAppApp.swift
@@ -9,6 +9,7 @@ import CoreDesignSystem
 import CoreDI
 import FirebaseCore
 import GoogleSignIn
+import HomeDomain
 import KakaoSDKAuth
 import KakaoSDKCommon
 import MaintenancePresentation
@@ -173,6 +174,7 @@ extension UMCAppApp {
         let schema = Schema([
             NoticeReadRecord.self,
             AITokenDailyUsageRecord.self,
+            NoticeHistoryData.self,
         ])
 
         do {


### PR DESCRIPTION
## ✨ PR 유형

기능 추가 (AppProduct → UMCApp 이관 잔여분 처리)

Closes #1035

## 📷 스크린샷 or 영상(UI 변경 시)

_알림 보관함 화면. 실기기 캡처는 푸시 파이프라인 이식 후 실데이터로 첨부 예정이며, 현재는 `#if DEBUG` 시드 프리뷰로 확인 가능합니다._

## 🛠️ 작업내용

#982에서 라우팅과 껍데기만 복원된 `NoticeAlarmView` 스텁을 실제 동작하는 알림 보관함으로 완성했습니다.

- **`NoticeAlarmType`** — raw enum(`String, Codable, Sendable`)을 `HomeDomain`에 추가.
  `image`/`color` 시각 매핑은 SwiftUI 의존이 있어 `HomePresentation`의 `NoticeAlarmType+Visual`로 분리했습니다.
  (기존 `ScheduleIconCategory` + `ScheduleIconCategory+Visual` 선례를 따랐고, `HomeDomain`의 SwiftUI import 0건 상태를 유지합니다.)
- **`NoticeHistoryData`** — SwiftData `@Model` 이식 후 `UMCAppApp.sharedModelContainer`의 `Schema`에 등록.
- **`NoticeAlarmCard`** — 컴포넌트 이식. 레거시가 쓰던 미존재 API/원색을 디자인 시스템 토큰으로 교정했습니다.
- **`NoticeAlarmView`** — 스텁 주석 제거, `@Query(sort: \.createdAt, order: .reverse)` 최신순 `List`로 교체.
  스와이프 삭제(`.onDelete`)와 전체 삭제 툴바 버튼(목록 비어있지 않을 때만 노출) 복원, 빈 상태 유지.
- **`UMCApp/Project.swift`** — 앱 진입점이 모델 타입을 참조하므로 앱 타겟에 `HomeDomain` 의존성 추가.
- **테스트** — `NoticeHistoryDataTests`로 `icon` ↔ `iconRaw` 왕복과 미지 rawValue의 `.info` 폴백을 검증.

### 레거시 대비 교정 사항

| 레거시(AppProduct) | UMCApp | 사유 |
|---|---|---|
| `.appFont(.calloutEmphasis, color: .black)` | `.appFont(.callout, weight: .semibold, color: .grey900)` | `AppFont`에 `calloutEmphasis` 없음. `RecentNoticeCard`와 동일하게 맞춤 |
| `.green` / `.blue` / `.yellow` / `.red` | `.green500` / `.indigo500` / `.yellow500` / `.red500` | 원색 대신 디자인 시스템 시맨틱 토큰 사용 |
| `Form` | `List` + `.scrollContentBackground(.hidden)` | `umcDefaultBackground()`와 합성 |

### 이번 PR에서 제외한 것

- **CoreML 알림 분류기**(`NoticeClassifier*`, `NoticeClassifierML.mlmodel`)와 이를 사용하는 `NoticeHistoryData`의 convenience init.
  레거시의 유일한 호출부가 `AppDelegate.saveNoticeHistory`인데 UMCApp에는 AppDelegate·푸시 수신 파이프라인이 아직 없어, 지금 이식하면 호출자 없는 죽은 코드가 됩니다.
- `GenerationMappingRecord` — 레거시 프리뷰의 `modelContainer`에서만 참조되던 타입이라 제외했습니다.

## 📋 추후 진행 상황

- **쓰기 측(푸시 수신 파이프라인) 이식** — `AppDelegate` + `UNUserNotificationCenterDelegate` + FCM 토큰 동기화.
  이게 들어와야 보관함에 실데이터가 쌓입니다. 현재는 읽기 측만 완성된 상태라 런타임에서는 빈 상태로 보입니다.
- 위 작업과 함께 CoreML 분류기(`NoticeClassifierML`)를 이식. `ScheduleClassifierRepository`의 `Bundle.module` 로딩 패턴을 그대로 따르면 됩니다.

## 📌 리뷰 포인트

- **`NoticeAlarmType` 배치** — Domain(raw) / Presentation(visual) 분리가 적절한지. `ScheduleIconCategory`는 Core에 있지만 이 타입은 Home 전용이라 Feature 모듈 안에 뒀습니다.
- **`UMCApp/Project.swift`의 `HomeDomain` 의존성 추가** — 앱 진입점에서 `Schema`에 모델 타입을 넣으려면 필요했는데, 다른 방식을 선호하신다면 알려주세요.
- **색상 토큰 매핑** — `info` → `indigo500` 선택. 레거시는 `.blue`였고 UMCApp에 `blue` 계열 시맨틱 토큰이 없어 `indigo500`으로 뒀습니다. 디자인팀 확인이 필요할 수 있습니다.
- **삭제 시 `try? modelContext.save()`** — 레거시 동작 그대로 유지했습니다. 실패를 무시하는데, 에러 핸들링 정책을 적용할지 판단 부탁드립니다.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
- [x] `make build` → **BUILD SUCCEEDED**
- [x] `xcodebuild test -scheme HomeDomain` → **TEST SUCCEEDED** (12 tests / 3 suites)
- [x] `AppProduct/` 무변경 (절대 규칙 #9)