### PR TITLE
✨ [Feature] 일정 상세 화면 이식 + 출석 현황 진입 흐름 연결

### DIFF
--- a/UMCApp/Core/Routing/Sources/PathStore.swift
+++ b/UMCApp/Core/Routing/Sources/PathStore.swift
@@ -35,6 +35,10 @@ public final class PathStore {
 
     // MARK: - Property
 
+    /// 현재 선택된 탭. `TabView(selection:)` 바인딩의 소스이자, 탭을 가로지르는 이동
+    /// (예: 홈의 일정 상세 → Activity 탭의 출석 현황)의 진입점이다.
+    public var selectedTab: NavigationTab = .home
+
     /// 탭별 경로. 값이 없는 탭은 루트(빈 경로)로 취급한다.
     private var paths: [NavigationTab: NavigationPath] = [:]
 

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
@@ -178,6 +178,10 @@ private final class MockScheduleRepository: @unchecked Sendable, ScheduleReposit
 
     // MARK: 계약 밖 메서드 (호출 시 실패 — 출석 UseCase 는 조회만 사용)
 
+    func fetchScheduleDetail(scheduleId: String) async throws -> ScheduleDetailData {
+        fatalError("fetchScheduleDetail 은 ChallengerAttendanceUseCase 계약 밖입니다.")
+    }
+
     func createSchedule(_ request: ScheduleCreationRequest) async throws -> String {
         fatalError("createSchedule 은 ChallengerAttendanceUseCase 계약 밖입니다.")
     }

--- a/UMCApp/Features/Home/Data/Sources/Repositories/ScheduleRepository.swift
+++ b/UMCApp/Features/Home/Data/Sources/Repositories/ScheduleRepository.swift
@@ -65,6 +65,26 @@ public final class ScheduleRepository: ScheduleRepositoryProtocol, @unchecked Se
         return Dictionary(grouping: schedules) { calendar.startOfDay(for: $0.startsAt) }
     }
 
+    /// 단일 일정 상세를 조회한다. 목록과 응답 스키마가 같아 같은 DTO/도메인 모델을 쓴다.
+    public func fetchScheduleDetail(scheduleId: String) async throws -> ScheduleDetailData {
+        let response = try await networkRequesting.request(
+            ScheduleV2Router.getScheduleDetail(scheduleId: scheduleId)
+        )
+
+        do {
+            let apiResponse = try JSONDecoder().decode(
+                APIResponse<ScheduleDetailDTO>.self,
+                from: response.data
+            )
+            return try apiResponse.unwrap().toDomain()
+        } catch let decodingError as DecodingError {
+            #if DEBUG
+            print("[ScheduleRepository] fetchScheduleDetail decodingError=\(decodingError)")
+            #endif
+            throw RepositoryError.decodingError(detail: "\(decodingError)")
+        }
+    }
+
     /// 일정을 생성하고 서버가 돌려준 식별자를 반환한다.
     ///
     /// 서버는 생성 결과로 일정 ID 스칼라 하나만 내려준다. 절대 규칙 #2 에 따라 정수를

--- a/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
+++ b/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
@@ -25,6 +25,8 @@ enum ScheduleV2Router: BaseTargetType {
 
     /// 내 일정 목록 조회 (기간 + 출석 필수 필터)
     case getMySchedules(query: MySchedulesQuery)
+    /// 단일 일정 상세 조회 (`deleteSchedule` 과 경로가 같고 method 로만 갈린다)
+    case getScheduleDetail(scheduleId: String)
     /// 일정 생성
     case postSchedule(body: ScheduleCreateRequestDTO)
     /// 일정 삭제 (스터디 일정 등록 2단계 실패 시 1단계 롤백 등)
@@ -38,7 +40,7 @@ enum ScheduleV2Router: BaseTargetType {
             return "/api/v2/schedules/me"
         case .postSchedule:
             return "/api/v2/schedules"
-        case .deleteSchedule(let scheduleId):
+        case .getScheduleDetail(let scheduleId), .deleteSchedule(let scheduleId):
             return "/api/v2/schedules/\(scheduleId)"
         }
     }
@@ -47,7 +49,7 @@ enum ScheduleV2Router: BaseTargetType {
 
     var method: Moya.Method {
         switch self {
-        case .getMySchedules:
+        case .getMySchedules, .getScheduleDetail:
             return .get
         case .postSchedule:
             return .post
@@ -67,7 +69,7 @@ enum ScheduleV2Router: BaseTargetType {
             )
         case .postSchedule(let body):
             return .requestJSONEncodable(body)
-        case .deleteSchedule:
+        case .getScheduleDetail, .deleteSchedule:
             return .requestPlain
         }
     }

--- a/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleRepositoryProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleRepositoryProtocol.swift
@@ -29,6 +29,9 @@ public protocol ScheduleRepositoryProtocol {
         isAttendanceRequired: Bool
     ) async throws -> [Date: [ScheduleDetailData]]
 
+    /// 단일 일정 상세 조회. 목록과 동일 스키마이므로 같은 도메인 모델을 돌려준다.
+    func fetchScheduleDetail(scheduleId: String) async throws -> ScheduleDetailData
+
     /// 일정을 생성하고 생성된 일정 식별자를 돌려준다.
     ///
     /// - Returns: 생성된 일정 식별자 (서버 정수를 절대 규칙 #2 에 따라 `String` 으로 보존)

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/FetchScheduleDetailUseCaseProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/FetchScheduleDetailUseCaseProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  FetchScheduleDetailUseCaseProtocol.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/6/26.
+//
+
+import Foundation
+
+/// 단일 일정 상세 조회 UseCase 인터페이스
+public protocol FetchScheduleDetailUseCaseProtocol {
+
+    /// - Parameter scheduleId: 조회할 일정 식별자
+    /// - Returns: 목록과 동일 스키마의 일정 상세 모델
+    func execute(scheduleId: String) async throws -> ScheduleDetailData
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchScheduleDetailUseCase.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchScheduleDetailUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  FetchScheduleDetailUseCase.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/6/26.
+//
+
+import Foundation
+
+/// 단일 일정 상세 조회 UseCase 구현체
+public final class FetchScheduleDetailUseCase: FetchScheduleDetailUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: ScheduleRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: ScheduleRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(scheduleId: String) async throws -> ScheduleDetailData {
+        try await repository.fetchScheduleDetail(scheduleId: scheduleId)
+    }
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/AttendancePolicyDisplaySection.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/AttendancePolicyDisplaySection.swift
@@ -1,0 +1,188 @@
+//
+//  AttendancePolicyDisplaySection.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 8/6/26.
+//
+
+import CoreDesignSystem
+import CoreUIComponents
+import HomeDomain
+import SwiftUI
+import UMCFoundation
+
+/// 일정 상세 화면에서 출석 정책 시각을 read-only 로 표시하는 섹션.
+///
+/// 출석 시작(`checkInStartAt`) → 출석 인정 마감(`onTimeEndAt`) → 지각 인정 마감(`lateEndAt`)
+/// 3개 임계값을 시간 흐름대로 가로 3분할 카드에 배치한다. 컬럼 너비가 항상 균등하므로 세 시각이
+/// 같거나 역전돼도 레이아웃이 깨지지 않는다.
+///
+/// 출석 비필수 일정은 정책 자체가 `nil` 이므로 노출 제어는 호출부가 맡는다.
+struct AttendancePolicyDisplaySection: View, Equatable {
+
+    // MARK: - Property
+
+    let policy: ScheduleAttendancePolicy
+
+    fileprivate enum Constants {
+        static let title: String = "출석 정책"
+        static let minimumScaleFactor: CGFloat = 0.8
+        static let iconBackgroundOpacity: CGFloat = 0.4
+        static let lineLimit: Int = 1
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.policy == rhs.policy
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text(Constants.title)
+                .appFont(.title2, weight: .semibold, color: .grey900)
+
+            policyCard
+        }
+    }
+
+    // MARK: - Card
+
+    private var policyCard: some View {
+        HStack(spacing: .zero) {
+            policyColumn(role: .checkIn, date: policy.checkInStartAt)
+
+            Divider()
+
+            policyColumn(role: .onTime, date: policy.onTimeEndAt)
+
+            Divider()
+
+            policyColumn(role: .late, date: policy.lateEndAt)
+        }
+        .frame(maxWidth: .infinity)
+        .glassEffect(
+            .regular,
+            in: .rect(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
+    }
+
+    // MARK: - Column
+
+    private func policyColumn(role: Role, date: Date) -> some View {
+        VStack(spacing: DefaultSpacing.spacing8) {
+            policyIcon(systemName: role.iconName, tintColor: role.tintColor)
+
+            VStack(spacing: DefaultSpacing.spacing4) {
+                Text(timeText(for: date))
+                    .appFont(.callout, weight: .semibold, color: .grey900)
+                    .lineLimit(Constants.lineLimit)
+                    .minimumScaleFactor(Constants.minimumScaleFactor)
+
+                Text(role.label)
+                    .appFont(.footnote, color: .grey500)
+                    .lineLimit(Constants.lineLimit)
+                    .minimumScaleFactor(Constants.minimumScaleFactor)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, DefaultSpacing.spacing16)
+        .padding(.horizontal, DefaultSpacing.spacing8)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel(for: role.label, date: date))
+    }
+
+    private func policyIcon(systemName: String, tintColor: Color) -> some View {
+        Image(systemName: systemName)
+            .foregroundStyle(tintColor)
+            .imageScale(.medium)
+            .padding(DefaultSpacing.spacing12)
+            .background(tintColor.opacity(Constants.iconBackgroundOpacity), in: .circle)
+    }
+
+    // MARK: - Role
+
+    /// 출석 정책 3개 임계값의 표시 메타데이터 (아이콘 / 라벨 / 색상 시맨틱).
+    ///
+    /// 색상은 green(출석 가능) → orange(출석 인정 마감) → red(지각 인정 마감) 순으로 시간 흐름의
+    /// 위험도를 표현한다.
+    private enum Role {
+        case checkIn
+        case onTime
+        case late
+
+        var iconName: String {
+            switch self {
+            case .checkIn: "door.right.hand.open"
+            case .onTime: "clock.badge.checkmark"
+            case .late: "xmark.circle"
+            }
+        }
+
+        /// 표시 라벨. 도메인(`lateEndAt`)과 용어를 통일한다.
+        var label: String {
+            switch self {
+            case .checkIn: "출석 시작"
+            case .onTime: "출석 인정 마감"
+            case .late: "지각 인정 마감"
+            }
+        }
+
+        var tintColor: Color {
+            switch self {
+            case .checkIn: .green
+            case .onTime: .orange
+            case .late: .red
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    /// 정책 시각을 KST 기준 표시 문자열로 변환한다.
+    ///
+    /// 기준점(`checkInStartAt`)과 같은 날이면 시각만, 자정을 넘는 정책처럼 다른 날이면 날짜까지
+    /// 함께 보여준다.
+    private func timeText(for date: Date) -> String {
+        if Calendar.kstGregorian.isDate(date, inSameDayAs: policy.checkInStartAt) {
+            return date.toHourMinutes()
+        }
+        return date.toMonthDayWeekDayWithTime()
+    }
+
+    /// VoiceOver 는 `"14:30"` 을 시각으로 읽어 주지 않아, 표시용과 별도로 문장형 시각을 만든다.
+    private func accessibilityLabel(for role: String, date: Date) -> String {
+        "\(role): \(Self.kstSpokenTimeFormatter.string(from: date))"
+    }
+
+    // MARK: - Formatter
+
+    private static let kstSpokenTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = .kst
+        formatter.dateFormat = "HH시 mm분"
+        return formatter
+    }()
+}
+
+// MARK: - Preview
+
+#Preview {
+    let now = Date()
+    ScrollView {
+        AttendancePolicyDisplaySection(
+            policy: ScheduleAttendancePolicy(
+                checkInStartAt: now.addingTimeInterval(-3600),
+                onTimeEndAt: now,
+                lateEndAt: now.addingTimeInterval(1800)
+            )
+        )
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+}

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift
@@ -1,0 +1,104 @@
+//
+//  ScheduleDetailViewModel.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 8/6/26.
+//
+
+import CoreDI
+import CoreDomain
+import Foundation
+import HomeDomain
+import MapKit
+import UMCFoundation
+
+/// 일정 상세 화면 ViewModel
+///
+/// 조회는 읽기 전용이다. 수정/삭제는 대상 화면과 권한 판정이 아직 이식되지 않아 다루지 않는다.
+@Observable
+@MainActor
+final class ScheduleDetailViewModel {
+
+    // MARK: - Property
+
+    private(set) var data: Loadable<ScheduleDetailData> = .idle
+
+    private let scheduleId: String
+    private let fetchScheduleDetailUseCase: FetchScheduleDetailUseCaseProtocol
+    private let userSession: UserSessionManager
+
+    // MARK: - Computed Property
+
+    /// 출석 현황 화면으로 진입할 수 있는지 여부.
+    ///
+    /// 출석 현황은 운영진 화면이므로 Admin 모드일 때만, 그리고 출석 정책이 붙은 일정에만 연다.
+    var canViewAttendanceStatus: Bool {
+        guard let schedule = data.value else { return false }
+        return userSession.currentActivityMode == .admin && schedule.requiresAttendanceApproval
+    }
+
+    /// 챌린저에게 보여줄 내 출석 상태 문구. 출석 비필수 일정이면 `nil`.
+    ///
+    /// ``ScheduleAttendanceStatus`` 의 표시 텍스트 매핑은 Presentation 책임이라 도메인이 아닌
+    /// 여기에 둔다. 정책이 있는데 서버가 상태를 내려주지 않았다면 아직 출석 전으로 간주한다.
+    var myAttendanceStatusText: String? {
+        guard let schedule = data.value, schedule.requiresAttendanceApproval else { return nil }
+        return displayText(for: schedule.attendanceStatus ?? .beforeAttendance)
+    }
+
+    // MARK: - Init
+
+    init(container: DIContainer, scheduleId: String) {
+        self.scheduleId = scheduleId
+        fetchScheduleDetailUseCase = container.resolve(FetchScheduleDetailUseCaseProtocol.self)
+        userSession = container.resolve(UserSessionManager.self)
+    }
+
+    // MARK: - Function
+
+    /// 일정 상세를 조회한다. 실패는 화면 내 인라인 상태로만 표시하고 흐름을 끊지 않는다.
+    func load() async {
+        if data.isLoading { return }
+
+        let previousData = data
+        data = .loading
+
+        do {
+            data = .loaded(try await fetchScheduleDetailUseCase.execute(scheduleId: scheduleId))
+        } catch is CancellationError {
+            data = previousData
+        } catch let error as RepositoryError {
+            data = .failed(.repository(error))
+        } catch let error as NetworkError {
+            data = .failed(.network(error))
+        } catch let error as AppError {
+            data = .failed(error)
+        } catch {
+            data = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    /// 일정 장소를 Apple Maps 에서 연다. 비대면 일정은 아무 것도 하지 않는다.
+    func openInMaps() {
+        guard let location = data.value?.location else { return }
+
+        let mapItem = MKMapItem(
+            location: CLLocation(latitude: location.latitude, longitude: location.longitude),
+            address: nil
+        )
+        mapItem.name = location.locationName
+        mapItem.openInMaps()
+    }
+
+    // MARK: - Private Function
+
+    private func displayText(for status: ScheduleAttendanceStatus) -> String {
+        switch status {
+        case .beforeAttendance: "출석 전"
+        case .pendingApproval: "승인 대기"
+        case .present: "출석"
+        case .late: "지각"
+        case .absent: "결석"
+        }
+    }
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift
@@ -1,0 +1,335 @@
+//
+//  ScheduleDetailView.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 8/6/26.
+//
+
+import CoreDesignSystem
+import CoreDI
+import CoreDomain
+import CoreUIComponents
+import HomeDomain
+import SwiftUI
+import UMCFoundation
+
+/// 일정 상세 화면.
+///
+/// 읽기 전용이다. 일정 수정/삭제·강제 삭제는 대상 화면과 권한 판정 UseCase 가 아직 이식되지
+/// 않아 이번 범위에서 제외했고, 장소는 역지오코딩 없이 좌표 그대로 Apple Maps 로 넘긴다.
+///
+/// 출석 진입은 활동 모드로 갈린다. Admin 모드면 출석 현황 화면으로 이동하는 버튼을, 그 외에는
+/// 내 출석 상태를 read-only 로 보여 준다. 출석 비필수 일정은 두 경우 모두 표시하지 않는다.
+public struct ScheduleDetailView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: ScheduleDetailViewModel
+    private let onAttendanceStatusTapped: () -> Void
+
+    // MARK: - Constants
+
+    fileprivate enum Constants {
+        static let loadingMessage: String = "일정 정보를 가져오는 중입니다."
+        static let detailTitle: String = "상세 안내"
+        static let attendanceTitle: String = "출석"
+        static let attendanceStatusButtonTitle: String = "출석 현황"
+        static let myAttendanceStatusTitle: String = "내 출석 상태"
+        static let failedTitle: String = "일정을 불러오지 못했어요"
+        static let failedSystemImage: String = "exclamationmark.triangle"
+    }
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - container: UseCase·세션을 resolve할 DI 컨테이너
+    ///   - scheduleId: 조회할 일정 식별자
+    ///   - onAttendanceStatusTapped: 출석 현황 버튼 탭 시 화면 이동을 위임하는 콜백
+    ///
+    /// - Note: 이 화면의 실패는 모두 인라인(`Loadable`)으로 표시하므로 `ErrorHandler` 를 받지 않는다.
+    public init(
+        container: DIContainer,
+        scheduleId: String,
+        onAttendanceStatusTapped: @escaping () -> Void
+    ) {
+        _viewModel = State(
+            initialValue: ScheduleDetailViewModel(container: container, scheduleId: scheduleId)
+        )
+        self.onAttendanceStatusTapped = onAttendanceStatusTapped
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        stateContent
+            .umcDefaultBackground()
+            .navigation(
+                naviTitle: NavigationTitle.Activity.scheduleDetail,
+                displayMode: .inline
+            )
+            .task {
+                await viewModel.load()
+            }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch viewModel.data {
+        case .idle, .loading:
+            Progress(message: Constants.loadingMessage, size: .regular)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .loaded(let data):
+            content(data)
+        case .failed(let error):
+            RetryContentUnavailableView(
+                title: Constants.failedTitle,
+                systemImage: Constants.failedSystemImage,
+                description: error.userMessage,
+                isRetrying: viewModel.data.isLoading,
+                retryAction: { await viewModel.load() }
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func content(_ data: ScheduleDetailData) -> some View {
+        ScrollView(.vertical) {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
+                topContent(data)
+
+                if let policy = data.attendancePolicy {
+                    AttendancePolicyDisplaySection(policy: policy)
+                        .equatable()
+                }
+
+                attendanceSection
+
+                detailDescription(data)
+            }
+        }
+        .contentMargins(.horizontal, DefaultConstant.defaultSafeHorizon, for: .scrollContent)
+        .contentMargins(.bottom, DefaultConstant.defaultContentBottomMargins, for: .scrollContent)
+    }
+
+    private func topContent(_ data: ScheduleDetailData) -> some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text(data.name)
+                .appFont(.title2, weight: .semibold, color: .grey900)
+
+            SchedulePlaceDateInfo(data: data, onMapLinkTapped: viewModel.openInMaps)
+                .equatable()
+        }
+    }
+
+    // MARK: - Attendance Section
+
+    @ViewBuilder
+    private var attendanceSection: some View {
+        if viewModel.canViewAttendanceStatus {
+            MainButton(Constants.attendanceStatusButtonTitle, action: onAttendanceStatusTapped)
+                .buttonSize(.large)
+                .buttonStyle(.glassProminent)
+        } else if let statusText = viewModel.myAttendanceStatusText {
+            myAttendanceStatus(statusText)
+        }
+    }
+
+    private func myAttendanceStatus(_ statusText: String) -> some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text(Constants.attendanceTitle)
+                .appFont(.title3, weight: .semibold, color: .grey900)
+
+            HStack {
+                Text(Constants.myAttendanceStatusTitle)
+                    .appFont(.callout, color: .grey600)
+
+                Spacer()
+
+                Text(statusText)
+                    .appFont(.callout, weight: .semibold, color: .grey900)
+            }
+            .padding(DefaultSpacing.spacing16)
+            .glassEffect(
+                .regular,
+                in: .rect(
+                    corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                    isUniform: true
+                )
+            )
+        }
+    }
+
+    private func detailDescription(_ data: ScheduleDetailData) -> some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text(Constants.detailTitle)
+                .appFont(.title3, weight: .semibold, color: .grey900)
+
+            Text(data.description)
+                .appFont(.callout, color: .grey600)
+                .multilineTextAlignment(.leading)
+        }
+    }
+}
+
+// MARK: - SchedulePlaceDateInfo
+
+/// 일정의 날짜/시간과 장소를 한 카드로 묶어 보여주는 컴포넌트.
+private struct SchedulePlaceDateInfo: View, Equatable {
+
+    // MARK: - Property
+
+    let data: ScheduleDetailData
+    let onMapLinkTapped: () -> Void
+
+    fileprivate enum Constants {
+        static let mapButtonTitle: String = "지도 보기"
+        static let offlineFallbackTitle: String = "비대면"
+        static let calendarImage: String = "calendar"
+        static let locationImage: String = "mappin.and.ellipse"
+        static let iconSize: CGFloat = 20
+        static let iconBackgroundOpacity: CGFloat = 0.4
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.data == rhs.data
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: .zero) {
+            dateTimeSection
+            Divider()
+            locationSection
+        }
+        .glassEffect(
+            .regular,
+            in: .rect(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
+    }
+
+    // MARK: - Section
+
+    private var dateTimeSection: some View {
+        infoSection(iconName: Constants.calendarImage, tintColor: .orange) {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                Text(dateText)
+                    .appFont(.callout, weight: .semibold, color: .grey900)
+
+                Text(timeText)
+                    .appFont(.subheadline, color: .grey600)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var locationSection: some View {
+        infoSection(iconName: Constants.locationImage, tintColor: .blue) {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing4) {
+                if let location = data.location {
+                    Text(location.locationName)
+                        .appFont(.callout, weight: .semibold, color: .grey900)
+
+                    Button(Constants.mapButtonTitle, action: onMapLinkTapped)
+                        .appFont(.footnote, color: .blue)
+                } else {
+                    Text(Constants.offlineFallbackTitle)
+                        .appFont(.callout, weight: .semibold, color: .grey900)
+                }
+            }
+        }
+    }
+
+    // MARK: - Component
+
+    private func infoSection<Content: View>(
+        iconName: String,
+        tintColor: Color,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        HStack(spacing: DefaultSpacing.spacing16) {
+            infoIcon(systemName: iconName, tintColor: tintColor)
+            content()
+            Spacer()
+        }
+        .padding(DefaultSpacing.spacing16)
+    }
+
+    private func infoIcon(systemName: String, tintColor: Color) -> some View {
+        Image(systemName: systemName)
+            .foregroundStyle(tintColor)
+            .font(.system(size: Constants.iconSize))
+            .padding()
+            .background(tintColor.opacity(Constants.iconBackgroundOpacity), in: .circle)
+            .glassEffect(.clear, in: .circle)
+    }
+
+    // MARK: - Function
+
+    /// 하루 안에서 끝나는 일정은 요일까지, 여러 날에 걸치면 시작~종료 날짜 범위를 보여준다.
+    private var dateText: String {
+        if Calendar.kstGregorian.isDate(data.startsAt, inSameDayAs: data.endsAt) {
+            return data.startsAt.toYearMonthDayWithWeekday()
+        }
+        return data.startsAt.dateRange(to: data.endsAt)
+    }
+
+    /// 서버가 종료 시각을 시작보다 앞서 내려주는 비정상 데이터에서는 범위 대신 시작 시각만 쓴다.
+    private var timeText: String {
+        guard data.startsAt <= data.endsAt else { return data.startsAt.toHourMinutes() }
+        return data.startsAt.timeRange(to: data.endsAt)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+/// 네트워크 없이 화면을 확인하기 위한 프리뷰 전용 UseCase (절대규칙 #5)
+private struct PreviewFetchScheduleDetailUseCase: FetchScheduleDetailUseCaseProtocol {
+    func execute(scheduleId: String) async throws -> ScheduleDetailData {
+        let startsAt = Date.now
+        return ScheduleDetailData(
+            scheduleId: scheduleId,
+            name: "iOS 파트 정기 스터디",
+            description: "워크북 6주차 발표와 코드 리뷰를 진행합니다.",
+            tags: ["스터디"],
+            startsAt: startsAt,
+            endsAt: startsAt.addingTimeInterval(7_200),
+            isParticipant: true,
+            location: ScheduleLocation(
+                latitude: 37.582_86,
+                longitude: 127.010_39,
+                locationName: "한성대학교 상상관"
+            ),
+            attendancePolicy: ScheduleAttendancePolicy(
+                checkInStartAt: startsAt.addingTimeInterval(-1_800),
+                onTimeEndAt: startsAt.addingTimeInterval(600),
+                lateEndAt: startsAt.addingTimeInterval(1_800)
+            ),
+            attendanceStatus: .present
+        )
+    }
+}
+
+#Preview {
+    let container = DIContainer()
+    container.register(FetchScheduleDetailUseCaseProtocol.self) {
+        PreviewFetchScheduleDetailUseCase()
+    }
+    container.register(UserSessionManager.self) { UserSessionManager() }
+    return NavigationStack {
+        ScheduleDetailView(
+            container: container,
+            scheduleId: "1",
+            onAttendanceStatusTapped: {}
+        )
+    }
+}
+#endif

--- a/UMCApp/Features/Home/Presentation/Tests/ScheduleDetailViewModelTests.swift
+++ b/UMCApp/Features/Home/Presentation/Tests/ScheduleDetailViewModelTests.swift
@@ -1,0 +1,97 @@
+//
+//  ScheduleDetailViewModelTests.swift
+//  HomePresentationTests
+//
+//  Created by euijjang97 on 8/6/26.
+//
+
+import CoreDI
+import CoreDomain
+import Foundation
+import HomeDomain
+import Testing
+import UMCFoundation
+@testable import HomePresentation
+
+@MainActor
+@Suite("ScheduleDetailViewModel — 출석 현황 진입 가능 여부")
+struct ScheduleDetailViewModelTests {
+
+    @Test("Admin 모드 + 출석 정책 있음 → 출석 현황 진입 가능")
+    func adminWithPolicyCanViewAttendanceStatus() async {
+        let viewModel = makeViewModel(hasAttendancePolicy: true, isAdminMode: true)
+
+        await viewModel.load()
+
+        #expect(viewModel.canViewAttendanceStatus)
+    }
+
+    @Test("Admin 모드 + 출석 정책 없음 → 진입 불가")
+    func adminWithoutPolicyCannotViewAttendanceStatus() async {
+        let viewModel = makeViewModel(hasAttendancePolicy: false, isAdminMode: true)
+
+        await viewModel.load()
+
+        #expect(viewModel.canViewAttendanceStatus == false)
+    }
+
+    @Test("Challenger 모드 + 출석 정책 있음 → 진입 불가")
+    func challengerWithPolicyCannotViewAttendanceStatus() async {
+        let viewModel = makeViewModel(hasAttendancePolicy: true, isAdminMode: false)
+
+        await viewModel.load()
+
+        #expect(viewModel.canViewAttendanceStatus == false)
+    }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeViewModel(
+    hasAttendancePolicy: Bool,
+    isAdminMode: Bool
+) -> ScheduleDetailViewModel {
+    let container = DIContainer()
+    container.register(FetchScheduleDetailUseCaseProtocol.self) {
+        StubFetchScheduleDetailUseCase(hasAttendancePolicy: hasAttendancePolicy)
+    }
+    container.register(UserSessionManager.self) { makeSession(isAdminMode: isAdminMode) }
+    return ScheduleDetailViewModel(container: container, scheduleId: "1")
+}
+
+/// Admin 모드는 토글 가능 역할일 때만 켜지므로, 역할부터 맞춘 뒤 토글한다.
+private func makeSession(isAdminMode: Bool) -> UserSessionManager {
+    let session = UserSessionManager()
+    guard isAdminMode else { return session }
+    session.updateRole(.schoolPresident)
+    session.toggleAdminMode()
+    return session
+}
+
+// MARK: - Stubs
+
+private struct StubFetchScheduleDetailUseCase: FetchScheduleDetailUseCaseProtocol {
+
+    let hasAttendancePolicy: Bool
+
+    func execute(scheduleId: String) async throws -> ScheduleDetailData {
+        let startsAt = Date.now
+        return ScheduleDetailData(
+            scheduleId: scheduleId,
+            name: "정기 세미나",
+            description: "",
+            tags: [],
+            startsAt: startsAt,
+            endsAt: startsAt.addingTimeInterval(3_600),
+            isParticipant: true,
+            attendancePolicy: hasAttendancePolicy
+                ? ScheduleAttendancePolicy(
+                    checkInStartAt: startsAt,
+                    onTimeEndAt: startsAt.addingTimeInterval(600),
+                    lateEndAt: startsAt.addingTimeInterval(1_800)
+                )
+                : nil
+        )
+    }
+}

--- a/UMCApp/Features/Home/Project.swift
+++ b/UMCApp/Features/Home/Project.swift
@@ -18,8 +18,12 @@ let project = featureProject(
     presentationExtraDependencies: [
         // 홈 진입 시 앱스토어 리뷰 요청(requestReview) 환경 값 사용.
         .sdk(name: "StoreKit", type: .framework),
+        // 일정 상세의 "지도 보기"가 MKMapItem.openInMaps()로 Apple Maps를 연다.
+        .sdk(name: "MapKit", type: .framework),
         .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
+        // 일정 상세의 출석 진입 분기가 전역 `UserSessionManager`의 활동 모드를 읽는다.
+        .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
         .project(target: "NoticeDomain", path: .relativeToRoot("Features/Notice")),
     ],
@@ -38,6 +42,7 @@ let project = featureProject(
     includesPresentationTests: true,
     presentationTestDependencies: [
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
+        .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
         .project(target: "NoticeDomain", path: .relativeToRoot("Features/Notice")),
         .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),

--- a/UMCApp/UMCApp/Sources/DIContainer+Home.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Home.swift
@@ -32,6 +32,9 @@ extension DIContainer {
         register(FetchSchedulesUseCaseProtocol.self) {
             FetchSchedulesUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
         }
+        register(FetchScheduleDetailUseCaseProtocol.self) {
+            FetchScheduleDetailUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
+        }
         register(ScheduleClassifierRepositoryProtocol.self) {
             ScheduleClassifierRepository()
         }

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubScheduleRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubScheduleRepository.swift
@@ -8,11 +8,17 @@
 #if DEBUG
 import Foundation
 import HomeDomain
+import UMCFoundation
 
 /// 카카오 로그인 서버 미등록 기간 한정 홈 일정 Repository stub (절대규칙 #5).
 ///
 /// 요청 기간 기준 상대 날짜로 픽스처를 생성하므로 달을 이동해도 일정이 표시된다.
 struct StubScheduleRepository: ScheduleRepositoryProtocol {
+
+    fileprivate enum Constants {
+        /// 상세 조회용 픽스처 생성 창 (60일). 가장 먼 픽스처(+23일)를 충분히 덮는다.
+        static let detailLookupWindow: TimeInterval = 60 * 60 * 24 * 60
+    }
 
     func fetchMySchedules(
         from: Date,
@@ -20,6 +26,29 @@ struct StubScheduleRepository: ScheduleRepositoryProtocol {
         isAttendanceRequired: Bool
     ) async throws -> [Date: [ScheduleDetailData]] {
         StubSessionFixtures.schedules(from: from, to: to)
+    }
+
+    /// 상세는 목록 픽스처에서 같은 식별자를 찾아 돌려준다.
+    ///
+    /// 픽스처가 요청 기간 기준 상대 날짜로 만들어지므로, 어느 달에서 진입하든 모든 후보가
+    /// 생성되도록 오늘부터 넉넉한 창을 잡는다.
+    func fetchScheduleDetail(scheduleId: String) async throws -> ScheduleDetailData {
+        let now = Date.now
+        let candidates = StubSessionFixtures.schedules(
+            from: now,
+            to: now.addingTimeInterval(Constants.detailLookupWindow)
+        )
+
+        guard let schedule = candidates.values
+            .flatMap({ $0 })
+            .first(where: { $0.scheduleId == scheduleId })
+        else {
+            throw RepositoryError.invalidResponse(
+                detail: "stub 세션에 없는 일정입니다 (scheduleId: \(scheduleId))"
+            )
+        }
+
+        return schedule
     }
 
     /// 서버 없이 화면을 보는 용도라 생성은 고정 식별자만 돌려준다.

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
@@ -5,7 +5,9 @@
 //  Created by euijjang97 on 7/8/26.
 //
 
+import ActivityPresentation
 import CoreDI
+import CoreRouting
 import HomePresentation
 import NoticePresentation
 import SwiftUI
@@ -21,6 +23,8 @@ struct NavigationRoutingView: View {
 
     @Environment(\.di) private var di
     @Environment(ErrorHandler.self) private var errorHandler
+    // `NoticePresentation` 이 같은 이름의 로컬 스텁을 아직 들고 있어 모듈을 명시한다.
+    @Environment(CoreRouting.PathStore.self) private var pathStore
     private let destination: NavigationDestination
 
     // MARK: - Init
@@ -49,9 +53,19 @@ private extension NavigationRoutingView {
         switch route {
         case .alarmHistory:
             NoticeAlarmView()
-        case .scheduleDetail:
-            // ScheduleDetailView는 Schedule 모듈 분리 이슈(#981)에서 이식된다.
-            Text("아직 지원하지 않는 화면입니다")
+        case .scheduleDetail(let scheduleId):
+            ScheduleDetailView(
+                container: di,
+                scheduleId: scheduleId,
+                onAttendanceStatusTapped: {
+                    // 출석 현황은 Activity 탭이 소유한 목적지라, 탭을 옮긴 뒤 그 탭 스택에 쌓는다.
+                    pathStore.selectedTab = .activity
+                    pathStore.push(
+                        ActivityDestination.attendanceDetail(scheduleId: scheduleId),
+                        on: .activity
+                    )
+                }
+            )
         }
     }
 }

--- a/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
+++ b/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
@@ -30,8 +30,6 @@ struct RootTabView: View {
 
     // MARK: - Property
 
-    @State private var selectedTab: NavigationTab = .home
-
     // `NoticePresentation` 이 같은 이름의 로컬 스텁(`NoticeNavigation.swift`)을 아직 들고 있어
     // 모듈을 명시한다. Notice 탭이 공유 경로로 옮겨오면 그 스텁과 함께 접두사도 사라진다.
     @State private var pathStore = CoreRouting.PathStore()
@@ -39,7 +37,7 @@ struct RootTabView: View {
     // MARK: - Body
 
     var body: some View {
-        TabView(selection: $selectedTab) {
+        TabView(selection: $pathStore.selectedTab) {
             ForEach(NavigationTab.allCases) { tab in
                 Tab(value: tab, role: tab.role) {
                     tabRootView(tab)


### PR DESCRIPTION
## ✨ PR 유형

기능 추가 (Feature) — #1034 일정 상세 화면 이식 + 출석 현황 진입 흐름 연결

## 📷 스크린샷 or 영상(UI 변경 시)

| 일정 상세 | 출석 현황 진입 (탭 교차) |
|---|---|
| 일정명 / 날짜·시간·장소 카드 / 출석 정책 3열 / 내 출석 상태 / 상세 안내 | Activity 탭으로 전환되며 `OperatorAttendanceDetailView` push |

> stub 세션 + 시뮬레이터(iPhone 17 Pro, iOS 26.5)로 두 화면 모두 렌더 확인했습니다.
> 스크린샷은 리뷰 시 코멘트로 첨부합니다.

## 🛠️ 작업내용

### Presentation (HomePresentation)
- `ScheduleDetailView` 이식 — 읽기 전용 상세 화면
  - 일정명 / 날짜·시간·장소 카드 / 출석 정책 / 출석 섹션 / 상세 안내
  - `Loadable` 분기: `Progress` · `RetryContentUnavailableView` · 콘텐츠
- `ScheduleDetailViewModel` 이식 — `@Observable` + `Loadable<ScheduleDetailData>`
  - `canViewAttendanceStatus`: 운영진 모드 × 출석 정책 있는 일정일 때만 `true`
  - `myAttendanceStatusText`: 챌린저에게 보여줄 내 출석 상태(read-only)
  - `openInMaps()`: 좌표를 Apple Maps 로 전달
- `AttendancePolicyDisplaySection` 이식 — 출석 시작 / 출석 인정 마감 / 지각 인정 마감 3열 카드

### 라우팅
- `NavigationRoutingView` 의 `.scheduleDetail` 스텁(`Text("아직 지원하지 않는 화면입니다")`)을 실화면으로 교체
- 일정 상세 → 출석 현황(**Activity 탭**) 진입 흐름 연결 (#982 AC2 잔여분)
  - `PathStore` 에 `selectedTab` 을 이관하고 `RootTabView` 가 이를 `TabView(selection:)` 으로 사용
  - 진입 시 탭을 `.activity` 로 옮긴 뒤 그 탭 스택에 `ActivityDestination.attendanceDetail` 을 push

### Domain / Data (HomeDomain, HomeData)
- `GET /api/v2/schedules/{id}` 추가 (`ScheduleV2Router.getScheduleDetail`) — `deleteSchedule` 과 path 를 공유하고 method 로만 분기
- `ScheduleRepositoryProtocol.fetchScheduleDetail(scheduleId:)` + `ScheduleRepository` 구현
- `FetchScheduleDetailUseCaseProtocol` / `FetchScheduleDetailUseCase` 추가, `DIContainer+Home` 등록
- 응답은 이미 이식돼 있던 `ScheduleDetailDTO` 재사용 — 정수 전 레이어 `String` 유지, custom `init(from:)` 그대로 (절대 규칙 #2/#3)

### 테스트 / 스텁
- `ScheduleDetailViewModelTests` — `canViewAttendanceStatus` 3케이스 (운영진×정책 / 운영진×정책없음 / 챌린저×정책)
- `StubScheduleRepository`, `MockScheduleRepository` 프로토콜 확장분 대응

## 📋 추후 진행 상황

이번 범위에서 **의도적으로 제외**한 항목입니다. 각각 별도 이슈가 필요합니다.

1. **일정 수정/삭제·강제 삭제 툴바** — 대상 화면(`ScheduleRegistrationView`)과 권한 판정(`AuthorizationUseCase` 실구현)이 아직 이식 전입니다. 권한 게이트 없이 파괴적 액션만 먼저 붙이는 건 부분 출하가 불가능해 제외했습니다.
2. **챌린저 "출석 체크" 진입** — `ChallengerAttendanceSessionView` 는 `[Session]` + `userId` + 카테고리 매핑을 요구해 `scheduleId` 만으로 도달할 수 없고, `ActivityView.selectedSection` 이 `private @State` 라 특정 섹션을 지정해 열 수도 없습니다. 레거시가 남긴 AC-Q1(cross-tab 라우팅 정책) 그 자체라 후속으로 분리합니다.
3. **장소 역지오코딩(도로명 주소)** — 좌표를 그대로 Apple Maps 로 넘기는 방식으로 대체했습니다.
4. **`NoticePresentation` 의 `PathStore` 로컬 스텁 제거** — Notice 탭 실연결 이슈에서 정리되면 `CoreRouting.` 모듈 한정 표기도 함께 사라집니다.

## 📌 리뷰 포인트

- **탭 교차 push 방식** (`NavigationRoutingView`): `ActivityDestination` 은 Activity Feature 소유이고 `.navigationDestination(for: ActivityDestination.self)` 등록도 `ActivityFeatureView` 가 갖고 있습니다. 그래서 Home 이 ActivityPresentation 을 직접 의존하는 대신 **탭을 옮긴 뒤 그 탭 스택에 push** 하는 방식을 골랐습니다(`RootTabView` 주석의 목적지 소유 정책 유지). **Activity 탭이 한 번도 렌더된 적 없는 콜드 상태**에서도 목적지가 해석되는지 시뮬레이터로 확인했습니다.
- **`selectedTab` 의 `PathStore` 이관**: 탭 선택이 라우팅 상태의 일부가 되면서 `RootTabView` 의 로컬 `@State` 를 제거했습니다. Feature 가 App 을 import 하지 않고도 탭을 옮길 수 있게 하려는 의도입니다.
- **운영진 판정 기준**: `UserSessionManager.currentActivityMode == .admin` 을 씁니다(`ActivityView` 와 동일 기준). `isParticipant` 는 조건에 넣지 않았는데, 운영진은 보통 해당 일정의 참여자가 아니기 때문입니다. 출석 마감 시각도 조건에서 뺐습니다 — 사후 승인이 주 용도라서입니다.
- **`getScheduleDetail` 과 `deleteSchedule` 의 path 공유**: 같은 URL 을 method 로만 구분합니다. 라우터 컨벤션상 이 묶음이 괜찮은지 봐주세요.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
- [x] `make build` / `make test` 통과 (HomeDomain 9 · HomeData 23 · HomePresentation 14 · ActivityDomain 218 · CoreRouting 6)
- [x] `AppProduct/` 무변경 (절대 규칙 #9)
