### PR TITLE
♻️ [Refactor] 출석 화면 후속 정리 4건 — 라우터 일원화 · 미사용 조회 제거 · 접근성 · 표면 통일 (#1074 #1075 #1076 #1077)

### DIFF
--- a/UMCApp/Core/DesignSystem/Sources/Layout/DefaultConstant.swift
+++ b/UMCApp/Core/DesignSystem/Sources/Layout/DefaultConstant.swift
@@ -16,6 +16,9 @@ public enum DefaultConstant {
     public static let cornerRadius: CGFloat = 24
     public static let iconPadding: CGFloat = 8
 
+    /// 탭 가능한 요소의 최소 히트 영역 (Apple HIG 기준값).
+    public static let minimumTouchTarget: CGFloat = 44
+
     public static let defaultSafeHorizon: CGFloat = 16
     public static let defaultSafeTop: CGFloat = 20
     public static let defaultSafeBottom: CGFloat = 56

--- a/UMCApp/Core/Foundation/Sources/Extensions/Notification+Names.swift
+++ b/UMCApp/Core/Foundation/Sources/Extensions/Notification+Names.swift
@@ -31,7 +31,7 @@ public extension Notification.Name {
     /// 출석 승인/반려 상태 변경 알림.
     ///
     /// 운영진이 출석을 승인/반려하면 발송됩니다.
-    /// 챌린저 ViewModel이 수신하여 `myHistory`를 갱신합니다.
+    /// Activity 탭 ViewModel이 수신하여 세션 목록을 서버 상태로 다시 맞춥니다.
     static let attendanceStatusChanged = Notification.Name("attendanceStatusChanged")
 
     /// 기수 매핑 정보가 갱신되었을 때 발송되는 알림.

--- a/UMCApp/Core/UIComponents/Sources/PlaceSelectView/MapPlacePickerSubviews.swift
+++ b/UMCApp/Core/UIComponents/Sources/PlaceSelectView/MapPlacePickerSubviews.swift
@@ -38,7 +38,7 @@ struct MapPickerCurrentLocationIcon: View {
 
 /// 선택 상태, 로딩 상태, 확정 버튼을 조합한 하단 카드
 ///
-/// 레거시는 불투명 흰색 배경 위에 그림자만 얹은 가짜 글래스(`.glass()`)를 사용했지만,
+/// 레거시는 불투명 흰색 배경 위에 그림자만 얹은 가짜 글래스(`.cardShadow()`)를 사용했지만,
 /// 이 뷰는 `ScheduleCard` 등 기존 UMCApp 카드 선례와 동일하게 별도 배경 fill 없이
 /// 진짜 Liquid Glass(`.glassEffect(.regular, in:)`)만 적용한다.
 struct MapPickerSelectionCardView: View {

--- a/UMCApp/Core/UIComponents/Sources/Utilities/ShadowReuse.swift
+++ b/UMCApp/Core/UIComponents/Sources/Utilities/ShadowReuse.swift
@@ -19,8 +19,10 @@ public struct Shadow1: ViewModifier {
     }
 }
 
-/// glass modifier
-public struct Glass: ViewModifier {
+/// 카드 표면용 drop shadow 2단.
+///
+/// 이름과 달리 Liquid Glass(`.glassEffect`)가 아니라 불투명 배경 위에 얹는 그림자다.
+public struct CardShadow: ViewModifier {
     public func body(content: Content) -> some View {
         content
             .shadow(color: .black.opacity(0.03), radius: 4, x: 0, y: 8)
@@ -40,8 +42,8 @@ extension View {
         self.modifier(Shadow1())
     }
     
-    public func glass() -> some View {
-        self.modifier(Glass())
+    public func cardShadow() -> some View {
+        self.modifier(CardShadow())
     }
     
     public func blurShadow() -> some View {

--- a/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ActivityFeatureView.swift
@@ -11,9 +11,10 @@ import UMCFoundation
 
 /// Activity 탭의 루트.
 ///
-/// 탭 스택 자체는 상위 `RootTabView` 가 제공하므로 여기서 `NavigationStack` 을 만들지 않고,
-/// 이 탭이 다루는 목적지(``ActivityDestination``)의 렌더 분기만 등록한다. 라우팅을 App 이
-/// 아니라 이 모듈이 맡기 때문에 목적지 화면들을 `public` 으로 열지 않아도 된다.
+/// 탭 스택 자체는 상위 `RootTabView` 가 제공하므로 여기서 `NavigationStack` 을 만들지 않는다.
+/// 이 탭이 다루는 목적지(``ActivityDestination``)의 등록은 탭 루트 ``ActivityView`` 가 맡는다 —
+/// 목적지가 탭 루트 소유의 공유 ViewModel 을 캡처해야 해서 같은 body 안에 있어야 한다.
+/// 라우팅을 App 이 아니라 이 모듈이 맡기 때문에 목적지 화면들을 `public` 으로 열지 않아도 된다.
 ///
 /// 모듈 밖에는 이 타입만 노출하고, 모드×섹션 분기와 자식 조립은 내부 ``ActivityView`` 가
 /// 맡는다. 의존은 앱 루트가 환경에 심어 둔 DI 컨테이너와 전역 에러 처리기에서 받는다.
@@ -32,8 +33,5 @@ public struct ActivityFeatureView: View {
 
     public var body: some View {
         ActivityView(container: di, errorHandler: errorHandler)
-            .navigationDestination(for: ActivityDestination.self) { destination in
-                ActivityRoutingView(destination: destination)
-            }
     }
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/AttendanceMetaLabel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/AttendanceMetaLabel.swift
@@ -31,15 +31,9 @@ struct AttendanceMetaLabel<Content: View>: View {
     var body: some View {
         HStack(spacing: DefaultSpacing.spacing8) {
             Image(systemName: systemImage)
-                .font(.system(size: Constants.iconSize))
+                .font(.app(.caption1))
                 .foregroundStyle(Color.grey500)
             content()
         }
     }
-}
-
-// MARK: - Constants
-
-private enum Constants {
-    static let iconSize: CGFloat = 12
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/AttendanceScheduleRow.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/AttendanceScheduleRow.swift
@@ -32,10 +32,7 @@ struct AttendanceScheduleRow: View {
     }
 
     /// 진행중 카드만 은은한 indigo 틴트로 강조.
-    ///
-    /// (`Glass` 는 로컬 그림자 모디파이어와 이름이 겹칠 수 있어 SwiftUI 글래스 타입을
-    ///  명시적으로 한정한다.)
-    private var cardGlass: SwiftUICore.Glass {
+    private var cardGlass: Glass {
         switch status {
         case .inProgress:
             return .regular

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/ParticipantAttendanceRow.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/ParticipantAttendanceRow.swift
@@ -95,7 +95,7 @@ struct ParticipantAttendanceRow: View, Equatable {
             if participant.isLocationVerified {
                 HStack(spacing: Constants.verifiedIconSpacing) {
                     Image(systemName: "location.fill")
-                        .font(.system(size: Constants.verifiedIconSize))
+                        .font(.app(.caption2))
                     Text("GPS 인증")
                         .appFont(.caption2)
                 }
@@ -110,6 +110,5 @@ struct ParticipantAttendanceRow: View, Equatable {
 private enum Constants {
     static let avatarSize: CGFloat = 40
     static let reasonLineLimit: Int = 2
-    static let verifiedIconSize: CGFloat = 10
     static let verifiedIconSpacing: CGFloat = 2
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/PendingApprovalSheet.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Attendance/PendingApprovalSheet.swift
@@ -155,8 +155,13 @@ struct PendingApprovalSheet: View {
         } label: {
             Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                 .contentTransition(.symbolEffect(.replace))
-                .font(.system(size: Constants.selectionIconSize))
+                .font(.app(.title2))
                 .foregroundStyle(isSelected ? Color.indigo500 : Color.grey400)
+                .frame(
+                    minWidth: DefaultConstant.minimumTouchTarget,
+                    minHeight: DefaultConstant.minimumTouchTarget
+                )
+                .contentShape(.rect)
         }
         .buttonStyle(.plain)
         .transition(.scale.combined(with: .opacity))
@@ -270,6 +275,5 @@ struct PendingApprovalSheet: View {
 // MARK: - Constants
 
 private enum Constants {
-    static let selectionIconSize: CGFloat = 22
     static let selectionAnimationDuration: TimeInterval = 0.2
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceView.swift
@@ -182,7 +182,6 @@ struct ChallengerAttendanceView: View, Equatable {
     /// 출석 정책 3개 시각 팝오버 콘텐츠
     ///
     /// 시트 대신 ⓘ 버튼에 앵커된 말풍선으로 정책만 간편하게 확인합니다.
-    /// 첫 마운트 직후 정책이 비어 있으면 배경 갱신으로 채웁니다.
     @ViewBuilder
     private var policyPopoverContent: some View {
         if let policy = attendanceViewModel.attendancePolicy(for: session.info.sessionId) {
@@ -198,14 +197,11 @@ struct ChallengerAttendanceView: View, Equatable {
             }
             .padding(DefaultSpacing.spacing16)
         } else {
-            // 갱신을 요청하되 "불러오는 중" 이라고 단정하지 않는다. 일정 조회가 결선되기
-            // 전까지 refreshAvailableSchedules() 는 no-op 이라 기다려도 채워지지 않는다.
+            // 일정 페이로드에는 출석 정책이 붙은 일정만 실리므로(UseCase 필터), 여기 도달하면
+            // 기다려도 채워지지 않는다. "불러오는 중" 대신 사실을 그대로 안내한다.
             Text("등록된 출석 정책이 없어요")
                 .appFont(.footnote, color: .grey500)
                 .padding(DefaultSpacing.spacing16)
-                .task {
-                    await attendanceViewModel.refreshAvailableSchedules()
-                }
         }
     }
 

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerAttendanceView.swift
@@ -170,8 +170,14 @@ struct ChallengerAttendanceView: View, Equatable {
                 .font(.title3)
                 .foregroundStyle(Color.grey700)
                 .padding(DefaultSpacing.spacing8)
+                // 글래스 원의 시각 크기는 유지한 채, 그 바깥으로 히트 영역만 넓힌다.
+                .glassEffect(.regular.interactive(), in: .circle)
+                .frame(
+                    minWidth: DefaultConstant.minimumTouchTarget,
+                    minHeight: DefaultConstant.minimumTouchTarget
+                )
+                .contentShape(.rect)
         }
-        .glassEffect(.regular.interactive(), in: .circle)
         .accessibilityLabel("출석 정책 보기")
         .popover(isPresented: $showPolicyPopover) {
             policyPopoverContent
@@ -334,6 +340,11 @@ struct ChallengerAttendanceView: View, Equatable {
             Text("위치 인증이 안 되나요? 사유 제출하기")
                 .appFont(.caption1, color: .grey500)
                 .underline()
+                .frame(
+                    minWidth: DefaultConstant.minimumTouchTarget,
+                    minHeight: DefaultConstant.minimumTouchTarget
+                )
+                .contentShape(.rect)
         }
         .buttonStyle(.plain)
         .disabled(!canOpenReasonSheet)

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
@@ -68,9 +68,7 @@ private struct MyAttendanceItemPresenter: View, Equatable {
     fileprivate enum Constants {
         static let cardSpacing: CGFloat = 12
         static let contentSectionSpacing: CGFloat = 4
-        static let statusRadius: CGFloat = 8
         static let infoIconSpacing: CGFloat = 4
-        static let policyCornerRadius: CGFloat = 12
         static let policyColumnSpacing: CGFloat = 2
         static let policyTextScaleFactor: CGFloat = 0.8
         static let titleLineLimit: Int = 2
@@ -167,15 +165,8 @@ private struct MyAttendanceItemPresenter: View, Equatable {
         Text(model.status.text)
             .appFont(.caption1, weight: .semibold, color: model.status.fontColor)
             .padding(DefaultConstant.badgePadding)
-            .background(
-                model.status.backgroundColor,
-                in: RoundedRectangle(cornerRadius: Constants.statusRadius)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
-            .glassEffect(
-                .clear,
-                in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
-            )
+            .background(model.status.backgroundColor, in: Capsule())
+            .glassEffect(.clear, in: Capsule())
     }
 
     // MARK: - Expanded Section
@@ -227,7 +218,10 @@ private struct MyAttendanceItemPresenter: View, Equatable {
         .frame(maxWidth: .infinity)
         .background(
             Color.grey100,
-            in: RoundedRectangle(cornerRadius: Constants.policyCornerRadius)
+            in: ConcentricRectangle(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
         )
     }
 

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceCard.swift
@@ -84,6 +84,19 @@ private struct MyAttendanceItemPresenter: View, Equatable {
     // MARK: - Body
 
     var body: some View {
+        // 펼칠 내용이 없는 카드는 탭해도 아무 일이 없으므로 VoiceOver 에도 버튼으로
+        // 안내하지 않는다.
+        if hasExpandableContent {
+            Button(action: onTap) { card }
+                .buttonStyle(.plain)
+                .accessibilityValue(isExpanded ? "펼침" : "접힘")
+                .accessibilityHint(isExpanded ? "탭하면 접습니다" : "탭하면 출석 정보를 펼칩니다")
+        } else {
+            card
+        }
+    }
+
+    private var card: some View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
             header
 
@@ -100,10 +113,6 @@ private struct MyAttendanceItemPresenter: View, Equatable {
         .padding(DefaultConstant.defaultListPadding)
         .background(Color.grey000)
         .contentShape(Rectangle())
-        .onTapGesture {
-            guard hasExpandableContent else { return }
-            onTap()
-        }
     }
 
     // MARK: - Header

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceStatusView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerMyAttendanceStatusView.swift
@@ -71,7 +71,7 @@ struct ChallengerMyAttendanceStatusView: View {
             corners: .concentric(minimum: DefaultConstant.concentricRadius),
             isUniform: true
         ))
-        .glass()
+        .cardShadow()
     }
 }
 

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerPendingApprovalView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerPendingApprovalView.swift
@@ -16,7 +16,6 @@ struct ChallengerPendingApprovalView: View {
     // MARK: - Constants
 
     fileprivate enum Constants {
-        static let iconSize: CGFloat = 32
         static let horizontalPadding: CGFloat = 24
         static let verticalPadding: CGFloat = 28
         static let backgroundOpacity: CGFloat = 0.1
@@ -24,6 +23,8 @@ struct ChallengerPendingApprovalView: View {
     }
 
     // MARK: - Property
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var isRotating = false
 
@@ -51,17 +52,27 @@ struct ChallengerPendingApprovalView: View {
 
     private var iconView: some View {
         Image(systemName: "arrow.trianglehead.2.counterclockwise")
-            .font(.system(size: Constants.iconSize))
+            .font(.app(.largeTitle))
             .foregroundStyle(Color.yellow500)
             .rotationEffect(.degrees(isRotating ? 360 : 0))
-            .task {
-                withAnimation(
-                    .linear(duration: Constants.rotationDuration)
-                        .repeatForever(autoreverses: false)
-                ) {
-                    isRotating = true
-                }
-            }
+            .task(id: reduceMotion) { updateRotation() }
+    }
+
+    // MARK: - Function
+
+    /// "동작 줄이기"가 켜져 있으면 무한 회전을 멈춘다(아이콘 자체는 정지 상태로 계속 표시).
+    private func updateRotation() {
+        guard !reduceMotion else {
+            withAnimation(.linear(duration: .zero)) { isRotating = false }
+            return
+        }
+
+        withAnimation(
+            .linear(duration: Constants.rotationDuration)
+                .repeatForever(autoreverses: false)
+        ) {
+            isRotating = true
+        }
     }
 
     private var titleText: some View {

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerSessionCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerSessionCard.swift
@@ -72,7 +72,7 @@ struct ChallengerSessionCard: View, Equatable {
                     isUniform: true
                 )
                 .fill(Color.grey000)
-                .glass()
+                .cardShadow()
             }
             .contentShape(Rectangle())
         }
@@ -119,12 +119,8 @@ struct ChallengerSessionCard: View, Equatable {
                 color: session.attendanceStatus.fontColor
             )
             .padding(DefaultConstant.badgePadding)
-            .background(session.attendanceStatus.backgroundColor)
-            .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius))
-            .glassEffect(
-                .clear,
-                in: RoundedRectangle(cornerRadius: DefaultConstant.cornerRadius)
-            )
+            .background(session.attendanceStatus.backgroundColor, in: Capsule())
+            .glassEffect(.clear, in: Capsule())
     }
 }
 

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerSessionCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Attendance/ChallengerSessionCard.swift
@@ -54,29 +54,31 @@ struct ChallengerSessionCard: View, Equatable {
     // MARK: - Body
 
     var body: some View {
-        HStack(spacing: DefaultSpacing.spacing16) {
-            CardIconImage(
-                image: info.category.symbol,
-                color: info.category.color,
-                isLoading: .constant(false)
-            )
-            contentSection
-                .frame(maxWidth: .infinity, alignment: .leading)
-            statusSection
+        Button(action: onTap) {
+            HStack(spacing: DefaultSpacing.spacing16) {
+                CardIconImage(
+                    image: info.category.symbol,
+                    color: info.category.color,
+                    isLoading: .constant(false)
+                )
+                contentSection
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                statusSection
+            }
+            .padding(DefaultConstant.defaultListPadding)
+            .background {
+                ConcentricRectangle(
+                    corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                    isUniform: true
+                )
+                .fill(Color.grey000)
+                .glass()
+            }
+            .contentShape(Rectangle())
         }
-        .padding(DefaultConstant.defaultListPadding)
-        .background {
-            ConcentricRectangle(
-                corners: .concentric(minimum: DefaultConstant.concentricRadius),
-                isUniform: true
-            )
-            .fill(Color.grey000)
-            .glass()
-        }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            onTap()
-        }
+        .buttonStyle(.plain)
+        .accessibilityValue(isExpanded ? "펼침" : "접힘")
+        .accessibilityHint(isExpanded ? "탭하면 접습니다" : "탭하면 출석 정보를 펼칩니다")
     }
 
     // MARK: - View Components

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Curriculum/ChallengerCurriculumProgressCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Curriculum/ChallengerCurriculumProgressCard.swift
@@ -63,7 +63,7 @@ struct ChallengerCurriculumProgressCard: View, Equatable {
                 isUniform: true
             )
             .fill(Color.white)
-            .glass()
+            .cardShadow()
         }
     }
 

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Mission/ChallengerMissionCard.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Mission/ChallengerMissionCard.swift
@@ -86,7 +86,7 @@ fileprivate struct ChallengerMissionCardPresenter: View, Equatable {
                 isUniform: true
             )
             .fill(Color.white)
-            .glass()
+            .cardShadow()
         }
         .animation(
             .easeInOut(duration: DefaultConstant.animationTime),

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Mission/ChallengerMissionCardContent.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/Mission/ChallengerMissionCardContent.swift
@@ -95,7 +95,7 @@ struct ChallengerMissionCardContent: View, Equatable {
     ZStack {
         Color.grey100.ignoresSafeArea().frame(height: 400)
         ChallengerMissionCardContent(model: MissionPreviewData.singleMission)
-            .glass()
+            .cardShadow()
     }
 }
 

--- a/UMCApp/Features/Activity/Presentation/Sources/Navigation/ActivityDestination.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Navigation/ActivityDestination.swift
@@ -31,7 +31,9 @@ public enum ActivityDestination: Hashable, Sendable {
 
     /// 운영진의 단일 일정 출석 현황 화면.
     ///
-    /// 목적지 화면(`OperatorAttendanceDetailView`)은 연결되어 있다. 다만 레거시에서 이 경로를
-    /// 만들던 진입점(출석 현황 목록의 행 탭)은 아직 이 경로를 쓰지 않아 생산자가 없다.
+    /// 생산자는 두 곳이다 — 운영진 출석 목록의 행/승인 대기 배너 탭, 그리고 홈의 일정 상세
+    /// "출석 현황"(App `NavigationRoutingView`, 탭을 옮긴 뒤 이 목적지를 쌓는다).
+    /// 두 경로 모두 탭 루트가 소유한 하나의 `OperatorAttendanceViewModel` 로 착지하므로,
+    /// 상세의 승인/반려가 목록 배지에 그대로 반영된다.
     case attendanceDetail(scheduleId: String)
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Navigation/ActivityRoutingView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Navigation/ActivityRoutingView.swift
@@ -24,10 +24,17 @@ struct ActivityRoutingView: View {
 
     private let destination: ActivityDestination
 
+    /// 탭 루트가 소유한 출석 ViewModel. 목록을 거치지 않는 딥링크도 같은 인스턴스로 착지한다.
+    private let attendanceViewModel: OperatorAttendanceViewModel
+
     // MARK: - Init
 
-    init(destination: ActivityDestination) {
+    init(
+        destination: ActivityDestination,
+        attendanceViewModel: OperatorAttendanceViewModel
+    ) {
         self.destination = destination
+        self.attendanceViewModel = attendanceViewModel
     }
 
     // MARK: - Body
@@ -41,7 +48,10 @@ struct ActivityRoutingView: View {
             )
 
         case .attendanceDetail(let scheduleId):
-            OperatorAttendanceDetailRoute(scheduleId: scheduleId)
+            OperatorAttendanceDetailView(
+                viewModel: attendanceViewModel,
+                scheduleId: scheduleId
+            )
         }
     }
 }
@@ -90,49 +100,6 @@ private struct StudyScheduleRegistrationRoute: View {
                 studyRepository: di.resolve(StudyRepositoryProtocol.self),
                 registerScheduleUseCase: di.resolve(RegisterStudyScheduleUseCaseProtocol.self),
                 errorHandler: errorHandler
-            )
-        }
-    }
-}
-
-// MARK: - Operator Attendance Detail
-
-/// 운영진 출석 상세 화면의 조립 지점.
-///
-/// 목적지는 `scheduleId` 라는 값만 들고 오므로, 화면이 필요로 하는 ViewModel 은 여기서
-/// DI 로 만든다. 탭 재진입마다 새로 만들지 않도록 첫 등장 때 한 번만 생성한다.
-private struct OperatorAttendanceDetailRoute: View {
-
-    // MARK: - Property
-
-    @Environment(\.di) private var di
-    @Environment(ErrorHandler.self) private var errorHandler
-
-    @State private var viewModel: OperatorAttendanceViewModel?
-
-    private let scheduleId: String
-
-    // MARK: - Init
-
-    init(scheduleId: String) {
-        self.scheduleId = scheduleId
-    }
-
-    // MARK: - Body
-
-    var body: some View {
-        Group {
-            if let viewModel {
-                OperatorAttendanceDetailView(viewModel: viewModel, scheduleId: scheduleId)
-            } else {
-                ProgressView()
-            }
-        }
-        .task {
-            guard viewModel == nil else { return }
-            viewModel = OperatorAttendanceViewModel(
-                errorHandler: errorHandler,
-                useCase: di.resolve(OperatorAttendanceUseCaseProtocol.self)
             )
         }
     }

--- a/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/AttendancePreviewSupport.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/PreviewSupport/AttendancePreviewSupport.swift
@@ -37,10 +37,6 @@ final class PreviewChallengerAttendanceUseCase: ChallengerAttendanceUseCaseProto
         self.schedules = schedules
     }
 
-    /// 프리뷰가 미리 세팅한 것과 같은 목록을 돌려준다.
-    ///
-    /// 화면의 `.task` 가 `loadOnAppear()` 로 배경 갱신을 돌리므로, 여기서 빈 배열을 주면
-    /// 세팅해 둔 일정이 지워져 프리뷰가 비어 버린다.
     func fetchAvailableSchedules(now: Date) async throws -> [ScheduleDetailData] { schedules }
 
     func fetchMyHistory(now: Date) async throws -> [ScheduleDetailData] { [] }
@@ -250,17 +246,25 @@ enum AttendancePreviewData {
         timeWindow: AttendanceTimeWindow = .onTime,
         sessions: [Session] = []
     ) -> ChallengerAttendanceViewModel {
-        let schedules = sessions.map { schedule(for: $0, timeWindow: timeWindow) }
+        let payload = schedules(for: sessions, timeWindow: timeWindow)
         let viewModel = ChallengerAttendanceViewModel(
             errorHandler: ErrorHandler(),
             challengerAttendanceUseCase: PreviewChallengerAttendanceUseCase(
                 timeWindow: timeWindow,
-                schedules: schedules
+                schedules: payload
             )
         )
-        // 첫 렌더부터 일정이 보이도록 즉시 세팅한다 (`.task` 갱신도 같은 목록을 돌려준다).
-        viewModel.seedSchedulesForPreview(schedules)
+        viewModel.apply(schedules: payload)
         return viewModel
+    }
+
+    /// 세션 목록에 대응하는 프리뷰 일정 페이로드
+    @MainActor
+    static func schedules(
+        for sessions: [Session],
+        timeWindow: AttendanceTimeWindow = .onTime
+    ) -> [ScheduleDetailData] {
+        sessions.map { schedule(for: $0, timeWindow: timeWindow) }
     }
 
     /// 세션 하나에 대응하는 프리뷰 일정 페이로드
@@ -335,6 +339,7 @@ enum AttendancePreviewData {
             container: container,
             errorHandler: ErrorHandler(),
             sessions: sessions,
+            schedules: schedules(for: sessions),
             userId: userId,
             viewModel: viewModel(sessions: sessions)
         )

--- a/UMCApp/Features/Activity/Presentation/Sources/Support/PollingLoop.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Support/PollingLoop.swift
@@ -14,8 +14,8 @@ import Foundation
 /// `.task` 에서 호출하면 뷰 소멸 시 자동 취소됩니다.
 ///
 /// - 첫 refresh 는 한 주기 뒤에 실행됩니다. 진입 즉시 1회 갱신(refresh-first)이 필요하면
-///   루프 시작 전에 refresh 를 직접 1회 실행합니다(`ChallengerAttendanceViewModel` 방식) —
-///   순서 조합으로 표현하므로 별도 플래그 파라미터를 두지 않습니다.
+///   루프 시작 전에 refresh 를 직접 1회 실행합니다 — 순서 조합으로 표현하므로 별도 플래그
+///   파라미터를 두지 않습니다.
 /// - 대기 중 predicate 가 거짓으로 바뀌면 종료 전에 refresh 가 1회 더 실행될 수 있습니다.
 ///   호출부 refresh 는 배경 갱신(실패 무시·latest-wins)이어야 안전합니다.
 enum PollingLoop {

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ActivityViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ActivityViewModel.swift
@@ -16,6 +16,9 @@ import UMCFoundation
 /// 아니라 출석 가능 일정(`ChallengerAttendanceUseCaseProtocol.fetchAvailableSchedules()`)
 /// 에서 파생한다 — 레거시의 `FetchSessionsUseCase` 는 #994 가 일정 조회로 흡수했다.
 ///
+/// 같은 조회에서 나온 일정 원본(`schedules`)도 함께 소유해 자식 화면에 내려준다. 자식이
+/// 따로 조회하면 화면 진입 1회에 같은 엔드포인트로 요청이 두 번 나가기 때문이다.
+///
 /// DIP 를 지켜 UseCase Protocol 에만 의존하므로, 테스트는 Mock 만으로 완결된다.
 @MainActor
 @Observable
@@ -32,6 +35,22 @@ final class ActivityViewModel {
     private(set) var sessionsState: Loadable<[Session]> = .idle
     private(set) var userId: UserID?
 
+    /// 세션의 출석 정책·서버 상태 원본 (세션 목록과 같은 조회에서 나온다)
+    private(set) var schedules: [ScheduleDetailData] = []
+
+    /// 출석 상태 변경 알림 관찰 토큰
+    ///
+    /// UI 관찰 대상이 아닌 내부 구현 세부사항이라 `@ObservationIgnored` 로 추적에서 제외한다.
+    /// deinit(nonisolated)에서 해제해야 하므로 `nonisolated(unsafe)` — init 1회 설정 + deinit
+    /// 해제만이라 동시 접근이 없다.
+    @ObservationIgnored
+    private nonisolated(unsafe) var statusObserver: (any NSObjectProtocol)?
+
+    /// 폴링 간격
+    private enum PollingConfig {
+        static let intervalSeconds: Int = 30
+    }
+
     // MARK: - Init
 
     init(
@@ -42,6 +61,28 @@ final class ActivityViewModel {
         self.challengerAttendanceUseCase = challengerAttendanceUseCase
         self.fetchUserIdUseCase = fetchUserIdUseCase
         self.classifyScheduleUseCase = classifyScheduleUseCase
+        observeAttendanceStatusChange()
+    }
+
+    deinit {
+        if let observer = statusObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Notification
+
+    /// 운영진이 출석을 승인/반려하면 세션 상태를 서버 기준으로 다시 맞춘다.
+    private func observeAttendanceStatusChange() {
+        statusObserver = NotificationCenter.default.addObserver(
+            forName: .attendanceStatusChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.refreshSessions()
+            }
+        }
     }
 
     // MARK: - Action
@@ -71,8 +112,9 @@ final class ActivityViewModel {
         let previous = sessionsState
         sessionsState = .loading
         do {
-            let schedules = try await challengerAttendanceUseCase.fetchAvailableSchedules()
-            sessionsState = .loaded(await makeSessions(from: schedules))
+            let fresh = try await challengerAttendanceUseCase.fetchAvailableSchedules()
+            schedules = fresh
+            sessionsState = .loaded(await makeSessions(from: fresh))
         } catch {
             sessionsState = state(after: error, previous: previous)
         }
@@ -83,7 +125,7 @@ final class ActivityViewModel {
     /// 일정 멤버십(scheduleId 집합)이 그대로면 `sessionsState` 를 건드리지 않는다. `Session`
     /// 은 참조 타입이라 배열을 교체하면 제출 여부(`hasSubmitted`) 같은 로컬 상태가 새 인스턴스로
     /// 리셋되기 때문이다. 집합이 달라진 경우(일정 추가·삭제)에만 교체해 자식 `onChange` 를
-    /// 트리거한다. 개별 세션의 출석 상태 동기화는 자식 화면의 폴링이 담당한다.
+    /// 트리거하고, 그대로면 기존 인스턴스에 서버 출석 상태만 전파한다.
     func refreshSessions() async {
         guard !sessionsState.isLoading else { return }
         guard case .loaded(let current) = sessionsState else {
@@ -93,13 +135,42 @@ final class ActivityViewModel {
         }
 
         do {
-            let schedules = try await challengerAttendanceUseCase.fetchAvailableSchedules()
+            let fresh = try await challengerAttendanceUseCase.fetchAvailableSchedules()
+            schedules = fresh
             let currentIds = Set(current.map(\.id.value))
-            let freshIds = Set(schedules.map(\.scheduleId))
-            guard currentIds != freshIds else { return }
-            sessionsState = .loaded(await makeSessions(from: schedules))
+            let freshIds = Set(fresh.map(\.scheduleId))
+            guard currentIds != freshIds else {
+                syncSessionStates(current, with: fresh)
+                return
+            }
+            sessionsState = .loaded(await makeSessions(from: fresh))
         } catch {
             // 배경 갱신 실패는 화면을 막지 않는다 (취소 포함). 기존 목록을 유지한다.
+        }
+    }
+
+    // MARK: - Polling
+
+    /// 진행 중인 세션이 있는 동안 주기적으로 서버 상태를 갱신한다.
+    ///
+    /// `.task` 모디파이어에서 호출하면 뷰가 사라질 때 자동 취소된다. 루프 시작 전 1회 갱신은
+    /// 하지 않는다 — 진입 시 `load()` 가 방금 같은 엔드포인트를 조회했으므로 중복 요청이 된다.
+    func startPollingIfNeeded() async {
+        await PollingLoop.run(
+            intervalSeconds: PollingConfig.intervalSeconds,
+            while: { hasActiveSession },
+            refresh: { await refreshSessions() }
+        )
+    }
+
+    /// 진행 중인 세션이 하나라도 있는지 확인
+    private var hasActiveSession: Bool {
+        guard case .loaded(let sessions) = sessionsState else { return false }
+        return sessions.contains { session in
+            OperatorSessionStatus.from(
+                startTime: session.info.startTime,
+                endTime: session.info.endTime
+            ) == .inProgress
         }
     }
 
@@ -117,6 +188,31 @@ final class ActivityViewModel {
     }
 
     // MARK: - Function
+
+    /// 조회된 서버 출석 상태를 기존 `Session` 인스턴스에 전파한다.
+    ///
+    /// `ScheduleDetailData.scheduleId` 와 `Session.id` 를 맞춰 상태를 옮긴다.
+    ///
+    /// 서버가 `attendanceStatus` 를 안 내려준 일정(`nil`)은 건너뛴다. `nil` 은 "출석 전" 이라는
+    /// 판정이 아니라 정보 없음이므로, 이를 `.beforeAttendance` 로 치환하면 방금 제출해
+    /// 지각/승인 대기로 올라간 로컬 상태를 되돌려 버린다.
+    private func syncSessionStates(
+        _ sessions: [Session],
+        with schedules: [ScheduleDetailData]
+    ) {
+        guard let userId else { return }
+
+        let statusByScheduleId: [String: AttendanceStatus] = schedules.reduce(into: [:]) {
+            partialResult, schedule in
+            guard let status = schedule.attendanceStatus else { return }
+            partialResult[schedule.scheduleId] = AttendanceStatus(scheduleStatus: status)
+        }
+
+        for session in sessions {
+            guard let serverStatus = statusByScheduleId[session.id.value] else { continue }
+            session.updateStatusFromPolling(serverStatus, userId: userId)
+        }
+    }
 
     /// 일정 목록을 세션 목록으로 변환한다 (시작 시각 오름차순).
     ///

--- a/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/ViewModels/ChallengerAttendanceViewModel.swift
@@ -12,8 +12,11 @@ import UMCFoundation
 
 /// 챌린저(일반 참여자)의 출석 관련 상태 및 액션을 관리하는 ViewModel
 ///
-/// 출석 요청(GPS)·사유 제출·시간대 판정·지오펜스/권한 상태와 함께, 출석 가능 일정 목록과
-/// 내 출석 이력을 `ChallengerAttendanceUseCaseProtocol` 로 조회합니다.
+/// 출석 요청(GPS)·사유 제출·시간대 판정·지오펜스/권한 상태를 담당합니다.
+///
+/// 판정 근거가 되는 일정 페이로드는 직접 조회하지 않고, 상위(`ActivityViewModel`)가 소유한
+/// 것을 `apply(schedules:)` 로 전달받습니다 — 세션 목록과 같은 엔드포인트라 여기서 또 조회하면
+/// 화면 진입 1회에 같은 요청이 두 번 나갑니다.
 @MainActor
 @Observable
 final class ChallengerAttendanceViewModel {
@@ -23,30 +26,10 @@ final class ChallengerAttendanceViewModel {
     private let errorHandler: ErrorHandler
     private let challengerAttendanceUseCase: ChallengerAttendanceUseCaseProtocol
 
-    /// 출석 가능 일정 목록
-    private(set) var availableSchedules: Loadable<[ScheduleDetailData]> = .idle
-
-    /// 내 출석 이력
-    private(set) var myHistory: Loadable<[ScheduleDetailData]> = .idle
-
-    /// 출석 상태 변경 알림 관찰 토큰
+    /// 상위가 소유한 출석 가능 일정 페이로드
     ///
-    /// UI 관찰 대상이 아닌 내부 구현 세부사항이라 `@ObservationIgnored` 로 추적에서 제외합니다.
-    /// deinit(nonisolated)에서 해제해야 하므로 `nonisolated(unsafe)` — init 1회 설정 + deinit
-    /// 해제만이라 동시 접근이 없습니다.
-    @ObservationIgnored
-    private nonisolated(unsafe) var statusObserver: (any NSObjectProtocol)?
-
-    /// 폴링 대상 세션 (View에서 주입)
-    private var pollingSessions: [Session] = []
-
-    /// 폴링 시 Session 상태 업데이트용 userId
-    private var pollingUserId: UserID?
-
-    /// 폴링 설정
-    private enum PollingConfig {
-        static let intervalSeconds: Int = 30
-    }
+    /// 출석 버튼의 `scheduleId` 조회와 서버 정책 기반 시간대 판정에 씁니다.
+    private(set) var schedules: [ScheduleDetailData] = []
 
     // MARK: - Init
 
@@ -56,209 +39,25 @@ final class ChallengerAttendanceViewModel {
     ) {
         self.errorHandler = errorHandler
         self.challengerAttendanceUseCase = challengerAttendanceUseCase
-        observeAttendanceStatusChange()
     }
 
-    deinit {
-        if let observer = statusObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
+    // MARK: - 일정 페이로드
+
+    /// 상위가 조회한 일정 페이로드를 반영합니다.
+    func apply(schedules: [ScheduleDetailData]) {
+        self.schedules = schedules
     }
 
-    // MARK: - Notification
-
-    private func observeAttendanceStatusChange() {
-        statusObserver = NotificationCenter.default.addObserver(
-            forName: .attendanceStatusChanged,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                await self?.refreshMyHistory()
-            }
-        }
-    }
-
-    // MARK: - 세션 목록/이력 로딩
-
-    /// 화면 등장 시 로드 결정 메서드
+    /// SessionID → 일정 매핑
     ///
-    /// - `availableSchedules` 가 `.idle`(첫 마운트)이면 부모가 넘긴 sessions prop 이 즉시
-    ///   렌더되도록 `.loaded([])` 로 먼저 시드한 뒤 배경 갱신으로 페이로드를 채웁니다.
-    ///   페이로드는 출석 버튼의 `scheduleId` 조회와 서버 정책 기반 시간대 판정에 필요합니다.
-    /// - 재등장 시에는 두 목록 모두 로딩 스피너 없이 배경 갱신만 합니다.
-    func loadOnAppear() async {
-        if availableSchedules.isIdle {
-            availableSchedules = .loaded([])
-        }
-        await refreshAvailableSchedules()
-
-        guard !Task.isCancelled else { return }
-
-        if myHistory.isIdle {
-            // 첫 마운트: 자식 화면 고유 데이터라 정상 로딩 UI와 함께 조회
-            await fetchMyHistory()
-        } else {
-            await refreshMyHistory()
-        }
-    }
-
-    /// 출석 가능 일정 갱신 (로딩 상태 변경 없이)
-    ///
-    /// 세션 목록 변화(`onChange`)와 폴링에서도 호출하므로 internal 로 노출합니다.
-    func refreshAvailableSchedules() async {
-        guard !availableSchedules.isLoading else { return }
-        do {
-            let schedules = try await challengerAttendanceUseCase.fetchAvailableSchedules()
-            availableSchedules = .loaded(schedules)
-            syncSessionStates()
-        } catch {
-            // 배경 갱신 실패는 화면을 막지 않는다 (취소 포함). 기존 목록을 유지한다.
-        }
-    }
-
-    /// 출석 이력 배경 갱신 (로딩 상태 변경 없이)
-    private func refreshMyHistory() async {
-        guard !myHistory.isLoading else { return }
-        do {
-            let history = try await challengerAttendanceUseCase.fetchMyHistory()
-            myHistory = .loaded(history)
-        } catch {
-            // 배경 갱신 실패는 화면을 막지 않는다 (취소 포함). 기존 이력을 유지한다.
-        }
-    }
-
-    /// 출석 가능 일정 조회 (로딩 스피너 표시, `.failed` 재시도 버튼용)
-    func fetchAvailableSchedules() async {
-        guard !availableSchedules.isLoading else { return }
-        let previous = availableSchedules
-        availableSchedules = .loading
-        do {
-            let schedules = try await challengerAttendanceUseCase.fetchAvailableSchedules()
-            availableSchedules = .loaded(schedules)
-            syncSessionStates()
-        } catch {
-            availableSchedules = state(after: error, previous: previous)
-        }
-    }
-
-    /// 내 출석 이력 조회 (로딩 스피너 표시, `.failed` 재시도 버튼용)
-    func fetchMyHistory() async {
-        guard !myHistory.isLoading else { return }
-        let previous = myHistory
-        myHistory = .loading
-        do {
-            let history = try await challengerAttendanceUseCase.fetchMyHistory()
-            myHistory = .loaded(history)
-        } catch {
-            myHistory = state(after: error, previous: previous)
-        }
-    }
-
-    /// 앱 foreground 복귀 시 전체 갱신 (두 API 병렬 호출)
-    func refreshAfterForeground() async {
-        async let schedules: Void = refreshAvailableSchedules()
-        async let history: Void = refreshMyHistory()
-        _ = await (schedules, history)
-    }
-
-    /// SessionID → 일정 매핑 (available schedules 기반)
-    ///
-    /// 첫 마운트에는 `loadOnAppear()` 가 빈 배열로 시드하므로 `nil` 일 수 있습니다.
-    /// 호출 측은 `nil` 이면 `refreshAvailableSchedules()` 로 페이로드를 채웁니다.
+    /// 상위가 페이로드를 넘기기 전(첫 렌더 프레임)에는 `nil` 입니다.
     func schedule(for sessionId: SessionID) -> ScheduleDetailData? {
-        guard case .loaded(let schedules) = availableSchedules else { return nil }
-        return schedules.first { $0.scheduleId == sessionId.value }
+        schedules.first { $0.scheduleId == sessionId.value }
     }
 
-    /// SessionID → scheduleId 매핑 (available schedules 기반)
+    /// SessionID → scheduleId 매핑
     func scheduleId(for sessionId: SessionID) -> String? {
         schedule(for: sessionId)?.scheduleId
-    }
-
-    /// 조회된 서버 상태를 폴링 대상 Session 객체에 동기화
-    ///
-    /// `ScheduleDetailData.scheduleId` 와 `Session.id` 를 맞춰 상태를 전파합니다.
-    ///
-    /// 서버가 `attendanceStatus` 를 안 내려준 일정(`nil`)은 건너뜁니다. `nil` 은 "출석 전"
-    /// 이라는 판정이 아니라 정보 없음이므로, 이를 `.beforeAttendance` 로 치환하면 방금 제출해
-    /// 지각/승인 대기로 올라간 로컬 상태를 되돌려 버립니다.
-    private func syncSessionStates() {
-        guard case .loaded(let schedules) = availableSchedules,
-              let userId = pollingUserId else { return }
-
-        let statusByScheduleId: [String: AttendanceStatus] = schedules.reduce(into: [:]) {
-            partialResult, schedule in
-            guard let status = schedule.attendanceStatus else { return }
-            partialResult[schedule.scheduleId] = AttendanceStatus(scheduleStatus: status)
-        }
-
-        for session in pollingSessions {
-            guard let serverStatus = statusByScheduleId[session.id.value] else { continue }
-            session.updateStatusFromPolling(serverStatus, userId: userId)
-        }
-    }
-
-    /// 조회 실패 시 반영할 상태
-    ///
-    /// `.task` 라이프사이클 취소(빠른 화면 이탈·탭 전환)는 실패가 아니므로 `.failed` 로
-    /// 전이시키지 않고 이전 상태로 되돌립니다. 첫 마운트에서 취소되면 `.idle` 로 남아
-    /// 다음 등장 때 다시 조회합니다. 형제 ViewModel(Home/Notice/MyPage)의 취소 처리 관례와
-    /// 동일합니다.
-    private func state(
-        after error: Error,
-        previous: Loadable<[ScheduleDetailData]>
-    ) -> Loadable<[ScheduleDetailData]> {
-        guard !error.isCancellation else { return previous }
-        if let appError = error as? AppError { return .failed(appError) }
-        if let domainError = error as? DomainError { return .failed(.domain(domainError)) }
-        return .failed(.unknown(message: error.localizedDescription))
-    }
-
-    // MARK: - Polling
-
-    /// 폴링에 필요한 세션 및 userId를 설정합니다.
-    ///
-    /// View 초기화 시 한 번 호출합니다.
-    func configurePollingSessions(
-        _ sessions: [Session],
-        userId: UserID
-    ) {
-        self.pollingSessions = sessions
-        self.pollingUserId = userId
-    }
-
-    /// 세션 진행 중일 때 주기적으로 상태를 갱신합니다.
-    ///
-    /// 진행 중인 세션이 있으면 즉시 1회 갱신한 뒤 간격을 두고 반복하므로,
-    /// 화면 진입 직후 첫 갱신까지 대기 구간이 생기지 않습니다.
-    /// `.task` 모디파이어에서 호출하면 뷰 사라질 때 자동 취소됩니다.
-    /// 세션 시간 기반으로 진행 중 여부를 판단합니다.
-    func startPollingIfNeeded(sessions: [Session]) async {
-        // 공용 루프는 sleep-first 라, 문서화된 refresh-first 동작(진입 직후 대기 구간 없음)은
-        // 루프 시작 전 1회 갱신으로 표현한다.
-        guard !Task.isCancelled, hasActiveSession(in: sessions) else { return }
-        await refreshAvailableSchedules()
-        await refreshMyHistory()
-        await PollingLoop.run(
-            intervalSeconds: PollingConfig.intervalSeconds,
-            while: { hasActiveSession(in: sessions) },
-            refresh: {
-                await refreshAvailableSchedules()
-                await refreshMyHistory()
-            }
-        )
-    }
-
-    /// 진행 중인 세션이 하나라도 있는지 확인
-    private func hasActiveSession(in sessions: [Session]) -> Bool {
-        sessions.contains { session in
-            let status = OperatorSessionStatus.from(
-                startTime: session.info.startTime,
-                endTime: session.info.endTime
-            )
-            return status == .inProgress
-        }
     }
 
     // MARK: - Action
@@ -372,8 +171,8 @@ final class ChallengerAttendanceViewModel {
     /// 출석 버튼 위에 표시할 시간대별 안내 문구
     ///
     /// 출석 전(`beforeAttendance`) 상태에서만 문구를 반환합니다.
-    /// 정책 시각(available schedules)이 조회된 경우 마감 시각과 남은 시간을 함께 표시하고,
-    /// 아직 조회 전이면 시간대 설명만 표시합니다. 만료 시간대는 버튼 문구가 대신하므로 nil.
+    /// 정책 시각이 전달된 경우 마감 시각과 남은 시간을 함께 표시하고, 아직 전달 전이면
+    /// 시간대 설명만 표시합니다. 만료 시간대는 버튼 문구가 대신하므로 nil.
     func attendanceGuidanceText(for session: Session, at now: Date) -> String? {
         guard session.attendanceStatus == .beforeAttendance else { return nil }
 
@@ -439,7 +238,7 @@ final class ChallengerAttendanceViewModel {
         )
     }
 
-    /// 세션의 출석 정책 (`nil` = 아직 조회 전이거나 출석 비필수 일정)
+    /// 세션의 출석 정책 (`nil` = 아직 전달 전이거나 출석 비필수 일정)
     ///
     /// 시간대 판정과 같은 페이로드를 읽으므로, 화면이 보여주는 정책 시각과 실제 판정 기준이
     /// 어긋나지 않습니다. 정책 팝오버·출석 이력 카드가 표시용으로 사용합니다.
@@ -451,8 +250,8 @@ final class ChallengerAttendanceViewModel {
 
     /// 세션의 현재 출석 시간대
     ///
-    /// 서버 출석 정책(available schedules)이 조회된 경우 정책 시각을 기준으로 판정하고,
-    /// 아직 조회 전이면 UseCase 의 클라이언트 상수 기반 계산으로 폴백합니다.
+    /// 서버 출석 정책이 전달된 경우 정책 시각을 기준으로 판정하고,
+    /// 아직 전달 전이면 UseCase 의 클라이언트 상수 기반 계산으로 폴백합니다.
     /// 정책과 상수가 다를 때(예: 지각 마감이 시작+30분보다 늦은 일정) 서버 정책이 우선입니다.
     private func currentTimeWindow(
         for session: Session,
@@ -515,19 +314,3 @@ final class ChallengerAttendanceViewModel {
         await challengerAttendanceUseCase.stopGeofenceMonitoring()
     }
 }
-
-#if DEBUG
-
-extension ChallengerAttendanceViewModel {
-
-    /// 프리뷰 전용 — 네트워크 조회 없이 일정 페이로드를 적재합니다.
-    ///
-    /// 일정 ID·출석 정책은 모두 `availableSchedules` 에서 파생되므로, 프리뷰도 실제 조회가
-    /// 채우는 것과 같은 상태를 세팅해야 화면이 프로덕션과 같은 분기를 탑니다.
-    /// (별도 캐시를 두면 프리뷰만 통과하고 실제 화면은 비는 상태가 만들어집니다.)
-    func seedSchedulesForPreview(_ schedules: [ScheduleDetailData]) {
-        availableSchedules = .loaded(schedules)
-    }
-}
-
-#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/ActivityView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/ActivityView.swift
@@ -29,6 +29,7 @@ struct ActivityView: View {
 
     /// 탭 스택의 공유 경로. 자식 화면이 요청한 push 를 이 저장소로 넘긴다.
     @Environment(PathStore.self) private var pathStore
+    @Environment(\.scenePhase) private var scenePhase
 
     @State private var viewModel: ActivityViewModel
     @State private var selectedSection: ActivitySection?
@@ -186,8 +187,16 @@ struct ActivityView: View {
                     container: container,
                     errorHandler: errorHandler,
                     sessions: sessions,
+                    schedules: viewModel.schedules,
                     userId: userId
                 )
+                .task {
+                    await viewModel.startPollingIfNeeded()
+                }
+                .onChange(of: scenePhase) { _, phase in
+                    guard phase == .active else { return }
+                    Task { await viewModel.refreshSessions() }
+                }
             } else {
                 missingUserIdView
             }

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/ActivityView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/ActivityView.swift
@@ -34,6 +34,13 @@ struct ActivityView: View {
     @State private var viewModel: ActivityViewModel
     @State private var selectedSection: ActivitySection?
 
+    /// 출석 목록·상세가 공유하는 단일 ViewModel.
+    ///
+    /// 상세의 승인/반려가 목록 배지에 즉시 반영되려면 두 화면이 같은 인스턴스를 봐야 한다.
+    /// 딥링크(홈 → 일정 상세 → 출석 현황)는 목록을 거치지 않고 상세로 착지하므로, 소유자는
+    /// 목록이 아니라 두 진입점의 공통 조상인 탭 루트(이 화면)다.
+    @State private var attendanceViewModel: OperatorAttendanceViewModel
+
     private let container: DIContainer
     private let errorHandler: ErrorHandler
     private let userSession: UserSessionManager
@@ -59,6 +66,12 @@ struct ActivityView: View {
                 ),
                 fetchUserIdUseCase: container.resolve(FetchUserIdUseCaseProtocol.self),
                 classifyScheduleUseCase: container.resolve(ClassifyScheduleUseCaseProtocol.self)
+            )
+        )
+        _attendanceViewModel = State(
+            initialValue: OperatorAttendanceViewModel(
+                errorHandler: errorHandler,
+                useCase: container.resolve(OperatorAttendanceUseCaseProtocol.self)
             )
         )
     }
@@ -93,6 +106,14 @@ struct ActivityView: View {
             .navigationTitle(currentSection.title)
             .navigationBarTitleDisplayMode(.inline)
             .umcDefaultBackground()
+            .navigationDestination(
+                for: ActivityDestination.self
+            ) { [attendanceViewModel] destination in
+                ActivityRoutingView(
+                    destination: destination,
+                    attendanceViewModel: attendanceViewModel
+                )
+            }
             .toolbar {
                 ToolBarCollection.ToolBarCenterMenu(
                     items: availableSections,
@@ -140,8 +161,13 @@ struct ActivityView: View {
 
         case (.admin, .attendanceManage):
             OperatorAttendanceView(
-                errorHandler: errorHandler,
-                useCase: container.resolve(OperatorAttendanceUseCaseProtocol.self)
+                viewModel: attendanceViewModel,
+                onScheduleSelected: { scheduleId in
+                    pathStore.push(
+                        ActivityDestination.attendanceDetail(scheduleId: scheduleId),
+                        on: .activity
+                    )
+                }
             )
 
         case (.admin, .studyManage):

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -246,7 +246,7 @@ struct ChallengerAttendanceSessionView: View {
                 isUniform: true
             )
             .fill(Color.grey000)
-            .glass()
+            .cardShadow()
         }
     }
 

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -9,6 +9,7 @@ import ActivityDomain
 import CoreDesignSystem
 import CoreDI
 import CoreUIComponents
+import HomeDomain
 import SwiftUI
 import UMCFoundation
 
@@ -44,10 +45,10 @@ struct ChallengerAttendanceSessionView: View {
     @State private var attendanceViewModel: ChallengerAttendanceViewModel
     @State private var mapViewModelCache = MapViewModelCache()
     @State private var expandedSessionId: Session.ID?
-    @Environment(\.scenePhase) private var scenePhase
 
     private let errorHandler: ErrorHandler
     private let sessions: [Session]
+    private let schedules: [ScheduleDetailData]
     private let userId: UserID
 
     // MARK: - Init
@@ -56,17 +57,20 @@ struct ChallengerAttendanceSessionView: View {
     ///   - container: 출석 UseCase 를 resolve 할 DI 컨테이너
     ///   - errorHandler: 흐름 중단형 전역 에러 처리기
     ///   - sessions: 상위(일정 화면)가 소유한 세션 목록
+    ///   - schedules: 세션과 같은 조회에서 나온 일정 원본 (출석 정책·일정 ID 조회용)
     ///   - userId: 출석 주체
     ///   - viewModel: 프리뷰/테스트용 주입 지점 (기본값: container 로 생성)
     init(
         container: DIContainer,
         errorHandler: ErrorHandler,
         sessions: [Session],
+        schedules: [ScheduleDetailData],
         userId: UserID,
         viewModel: ChallengerAttendanceViewModel? = nil
     ) {
         self.errorHandler = errorHandler
         self.sessions = sessions
+        self.schedules = schedules
         self.userId = userId
         _attendanceViewModel = State(
             initialValue: viewModel ?? ChallengerAttendanceViewModel(
@@ -129,24 +133,8 @@ struct ChallengerAttendanceSessionView: View {
             DefaultConstant.defaultContentBottomMargins,
             for: .scrollContent
         )
-        .task {
-            // configurePollingSessions 는 반드시 loadOnAppear 보다 먼저 호출.
-            // 세션 상태 동기화가 pollingSessions 에 의존한다.
-            attendanceViewModel.configurePollingSessions(sessions, userId: userId)
-            await attendanceViewModel.loadOnAppear()
-        }
-        .task {
-            await attendanceViewModel.startPollingIfNeeded(sessions: sessions)
-        }
-        .onChange(of: sessions.map(\.id)) { _, _ in
-            // 상위가 세션 배열을 교체한 경우(일정 추가/삭제) 폴링 대상과 일정 정보를
-            // 최신 세션에 맞춰 재구성한다.
-            attendanceViewModel.configurePollingSessions(sessions, userId: userId)
-            Task { await attendanceViewModel.refreshAvailableSchedules() }
-        }
-        .onChange(of: scenePhase) { _, phase in
-            guard phase == .active else { return }
-            Task { await attendanceViewModel.refreshAfterForeground() }
+        .onChange(of: schedules, initial: true) { _, latest in
+            attendanceViewModel.apply(schedules: latest)
         }
         .onDisappear {
             Task { await attendanceViewModel.geofenceCleanup() }
@@ -160,9 +148,7 @@ struct ChallengerAttendanceSessionView: View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
             sectionHeader("출석 가능한 세션")
 
-            // TODO: Schedule 모듈 이식 후 일정 조회 로딩/실패 상태 분기 복원 - [26.08.02] 이재원
-            // — 세션 목록은 아직 상위 화면이 소유하고, ViewModel 의 availableSchedules
-            //   Loadable 은 Schedule 모듈과 함께 동결되어 있다. 재조회 UI 는 그때 붙인다.
+            // 조회 로딩·실패 UI 는 목록을 소유한 상위(`ActivityView`)가 그린다.
             if availableSessions.isEmpty {
                 emptySessionView
             } else {
@@ -201,10 +187,8 @@ struct ChallengerAttendanceSessionView: View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
             sectionHeader("나의 출석 현황")
 
-            // TODO: Schedule 모듈 이식 후 출석 이력 전용 조회로 교체 - [26.08.02] 이재원
-            // — 현재 이력은 상위가 넘긴 `sessions` 창에서 파생하므로, 그 창 밖의 과거
-            //   기록은 보이지 않는다(빈 상태 가이드가 뜰 수 있음). 레거시의 myHistory
-            //   API 는 ViewModel 의 Loadable 과 함께 동결되어 있다.
+            // 이력은 상위가 넘긴 `sessions` 창에서 파생하므로 그 창(출석 가능 일정 조회
+            // 구간) 밖의 과거 기록은 보이지 않는다 — 빈 상태 가이드가 뜰 수 있다.
             let items = attendanceHistoryItems
             if items.isEmpty {
                 emptyHistoryView

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Challenger/ChallengerAttendanceSessionView.swift
@@ -225,7 +225,7 @@ struct ChallengerAttendanceSessionView: View {
             // 빈 상태는 전환이 아니라 처음부터 표시되는 화면이므로
             // 전환 효과(symbolDrawOn)는 심볼이 그려지지 않아 정적 렌더로 표시합니다.
             Image(systemName: systemImage)
-                .font(.system(size: DefaultConstant.iconSize))
+                .font(.app(.largeTitle))
                 .foregroundStyle(tint)
 
             VStack(spacing: DefaultSpacing.spacing4) {

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceDetailView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceDetailView.swift
@@ -197,6 +197,14 @@ struct OperatorAttendanceDetailView: View {
                     } label: {
                         Label("위치 변경", systemImage: "map.fill")
                             .appFont(.caption1, color: .indigo500)
+                            // 라벨을 프레임 상단에 고정해 제목과의 정렬을 유지한 채
+                            // 히트 영역만 아래로 넓힌다.
+                            .frame(
+                                minWidth: DefaultConstant.minimumTouchTarget,
+                                minHeight: DefaultConstant.minimumTouchTarget,
+                                alignment: .top
+                            )
+                            .contentShape(.rect)
                     }
                     .buttonStyle(.plain)
                 }
@@ -246,7 +254,7 @@ struct OperatorAttendanceDetailView: View {
         } label: {
             HStack(spacing: DefaultSpacing.spacing8) {
                 Image(systemName: "clock.badge.exclamationmark")
-                    .font(.system(size: Constants.bannerIconSize, weight: .semibold))
+                    .font(.app(.subheadline, weight: .semibold))
                     .foregroundStyle(Color.orange600)
 
                 Text("승인 대기 \(count)건")
@@ -255,7 +263,7 @@ struct OperatorAttendanceDetailView: View {
                 Spacer()
 
                 Image(systemName: DefaultConstant.chevronForwardImage)
-                    .font(.system(size: Constants.chevronSize, weight: .semibold))
+                    .font(.app(.caption1, weight: .semibold))
                     .foregroundStyle(Color.orange400)
             }
             .padding(DefaultSpacing.spacing12)
@@ -307,7 +315,7 @@ struct OperatorAttendanceDetailView: View {
         VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
             HStack(spacing: DefaultSpacing.spacing4) {
                 Image(systemName: icon)
-                    .font(.system(size: Constants.statIconSize, weight: .semibold))
+                    .font(.app(.caption1, weight: .semibold))
                     .foregroundStyle(tint)
                 Text(label)
                     .appFont(.caption1, color: .grey500)
@@ -383,7 +391,7 @@ struct OperatorAttendanceDetailView: View {
     private var emptyParticipantView: some View {
         VStack(spacing: DefaultSpacing.spacing12) {
             Image(systemName: "person.2.slash")
-                .font(.system(size: Constants.emptyIconSize))
+                .font(.app(.title1))
                 .foregroundStyle(Color.grey400)
             Text("표시할 참여자가 없습니다")
                 .appFont(.subheadline, color: .grey500)
@@ -507,10 +515,6 @@ private struct LocationChangeTarget: Identifiable {
 // MARK: - Constants
 
 private enum Constants {
-    static let emptyIconSize: CGFloat = 28
-    static let bannerIconSize: CGFloat = 15
     static let bannerTintOpacity: Double = 0.16
-    static let chevronSize: CGFloat = 12
-    static let statIconSize: CGFloat = 12
     static let statValueMinimumScale: CGFloat = 0.8
 }

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceView.swift
@@ -297,7 +297,7 @@ struct OperatorAttendanceView: View {
         } label: {
             HStack(spacing: DefaultSpacing.spacing12) {
                 Image(systemName: "tray.and.arrow.down.fill")
-                    .font(.system(size: Constants.bannerIconSize))
+                    .font(.app(.body))
                     .foregroundStyle(Color.orange500)
 
                 Text("승인 대기 \(viewModel.totalPendingCount)건")
@@ -306,7 +306,7 @@ struct OperatorAttendanceView: View {
                 Spacer()
 
                 Image(systemName: DefaultConstant.chevronForwardImage)
-                    .font(.system(size: Constants.chevronSize, weight: .semibold))
+                    .font(.app(.footnote, weight: .semibold))
                     .foregroundStyle(Color.grey400)
             }
             .padding(DefaultSpacing.spacing16)
@@ -426,8 +426,6 @@ struct OperatorAttendanceView: View {
 
 private enum Constants {
     static let bannerAnimationDuration: TimeInterval = 0.2
-    static let bannerIconSize: CGFloat = 18
-    static let chevronSize: CGFloat = 13
     static let oneDayInSeconds: TimeInterval = 24 * 60 * 60
     static let permissionIconWidth: CGFloat = 32
     static let permissionRowSpacing: CGFloat = 2

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceView.swift
@@ -367,7 +367,10 @@ struct OperatorAttendanceView: View {
                 .padding(DefaultSpacing.spacing16)
                 .background(
                     .regularMaterial,
-                    in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius)
+                    in: ConcentricRectangle(
+                        corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                        isUniform: true
+                    )
                 )
 
                 Text(Constants.permissionGuideFooter)

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorAttendanceView.swift
@@ -15,48 +15,44 @@ import UMCFoundation
 
 /// 운영진 출석 관리 화면 (단일 통합 진입점)
 ///
-/// 출석 현황 목록을 루트로 두고, 행을 탭하면 같은 ViewModel 을 공유하는
-/// ``OperatorAttendanceDetailView`` 를 push 합니다. 상태·기간 필터는 우상단 툴바의 단일
-/// 메뉴로, 승인 대기 인박스는 상단 배너로 노출합니다.
+/// 출석 현황 목록을 루트로 두고, 행을 탭하면 상세 목적지 push 를 상위에 요청합니다. 상세와
+/// 같은 ViewModel 인스턴스를 공유하도록 소유는 탭 루트(``ActivityView``)가 맡습니다.
+/// 상태·기간 필터는 우상단 툴바의 단일 메뉴로, 승인 대기 인박스는 상단 배너로 노출합니다.
 ///
 /// - Important: 자체 `NavigationStack` 을 만들지 않습니다. 활동 탭의 스택 안에서 섹션 루트로
 ///   렌더되는 화면이라, 스택은 상위가 제공합니다(중첩 스택 방지).
 /// - Note: 위치 변경 시트는 공용 장소 선택기(`CoreUIComponents.PlaceSelectView`)를 그대로
 ///   사용합니다 — 별도 주입 seam 없이 시트 안에서 완결됩니다.
-public struct OperatorAttendanceView: View {
+struct OperatorAttendanceView: View {
 
     // MARK: - Property
 
     @Environment(\.scenePhase) private var scenePhase
 
-    @State private var viewModel: OperatorAttendanceViewModel
+    @Bindable private var viewModel: OperatorAttendanceViewModel
 
     /// "직접 입력" 기간 편집 시트 표시 플래그 (View 전용 일시 상태)
     @State private var isCustomDatePresented: Bool = false
 
-    /// push 된 상세 대상 일정 — `nil` 이면 목록만 표시한다.
-    @State private var pushedScheduleId: String?
+    /// 상세 화면 push 요청 — 목적지 등록을 소유한 탭 루트가 처리한다.
+    private let onScheduleSelected: (String) -> Void
 
     // MARK: - Init
 
     /// - Parameters:
-    ///   - errorHandler: 전역 에러 핸들러
-    ///   - useCase: 운영진 출석 UseCase
-    public init(
-        errorHandler: ErrorHandler,
-        useCase: OperatorAttendanceUseCaseProtocol
+    ///   - viewModel: 상세와 공유하는 출석 ViewModel (탭 루트 소유)
+    ///   - onScheduleSelected: 상세로 이동할 일정 식별자 전달
+    init(
+        viewModel: OperatorAttendanceViewModel,
+        onScheduleSelected: @escaping (String) -> Void
     ) {
-        _viewModel = State(
-            initialValue: OperatorAttendanceViewModel(
-                errorHandler: errorHandler,
-                useCase: useCase
-            )
-        )
+        self.viewModel = viewModel
+        self.onScheduleSelected = onScheduleSelected
     }
 
     // MARK: - Body
 
-    public var body: some View {
+    var body: some View {
         listStateContent
             .animation(
                 .easeInOut(duration: Constants.bannerAnimationDuration),
@@ -87,15 +83,14 @@ public struct OperatorAttendanceView: View {
                 customDateSheet
                     .presentationDragIndicator(.visible)
             }
-            .navigationDestination(item: $pushedScheduleId) { scheduleId in
-                OperatorAttendanceDetailView(
-                    viewModel: viewModel,
-                    scheduleId: scheduleId
-                )
-            }
             .task {
-                guard viewModel.listState.isIdle else { return }
-                await viewModel.fetchList()
+                // 탭 루트가 VM 을 소유해 섹션을 오갈 때 상태가 남는다. 최초 1회는 스피너 조회,
+                // 재진입은 기존 목록을 유지한 채 배경 갱신한다.
+                if viewModel.listState.isIdle {
+                    await viewModel.fetchList()
+                } else {
+                    await viewModel.refreshList()
+                }
             }
             .task(id: viewModel.listState.isComplete) {
                 await viewModel.startListPollingIfNeeded()
@@ -225,8 +220,6 @@ public struct OperatorAttendanceView: View {
     /// "직접 입력" 기간 편집 시트 — 시작/종료 날짜. 변경 즉시 재조회한다.
     @ViewBuilder
     private var customDateSheet: some View {
-        @Bindable var viewModel = viewModel
-
         NavigationStack {
             Form {
                 DatePicker(
@@ -300,7 +293,7 @@ public struct OperatorAttendanceView: View {
     private var pendingInboxBanner: some View {
         Button {
             guard let scheduleId = viewModel.firstPendingScheduleId else { return }
-            pushedScheduleId = scheduleId
+            onScheduleSelected(scheduleId)
         } label: {
             HStack(spacing: DefaultSpacing.spacing12) {
                 Image(systemName: "tray.and.arrow.down.fill")
@@ -417,7 +410,7 @@ public struct OperatorAttendanceView: View {
             LazyVStack(spacing: DefaultSpacing.spacing12) {
                 ForEach(infos) { info in
                     Button {
-                        pushedScheduleId = info.scheduleId
+                        onScheduleSelected(info.scheduleId)
                     } label: {
                         AttendanceScheduleRow(info: info)
                     }

--- a/UMCApp/Features/Activity/Presentation/Tests/ActivityViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/ActivityViewModelTests.swift
@@ -450,6 +450,106 @@ struct ActivityViewModelRefreshTests {
     }
 }
 
+// MARK: - 일정 페이로드 단일 소유
+
+@MainActor
+@Suite("ActivityViewModel — 일정 페이로드 단일 소유 (도메인 규칙)")
+struct ActivityViewModelScheduleOwnershipTests {
+
+    /// 회귀 박제 — 자식 화면(`ChallengerAttendanceViewModel`)이 같은 엔드포인트를 다시
+    /// 조회하면 화면 진입 1회에 요청이 2건 나간다. 페이로드는 여기서만 조회한다.
+    @Test("화면 진입 1회 = 일정 조회 요청 1건")
+    func screenEntryQueriesSchedulesOnce() async {
+        let attendance = MockRootAttendanceUseCase()
+        attendance.availableSchedulesResult = .success([makeSchedule(scheduleId: "S-1")])
+        let viewModel = makeViewModel(attendance: attendance)
+
+        await viewModel.load()
+
+        #expect(attendance.fetchAvailableSchedulesCallCount == 1)
+    }
+
+    @Test("조회한 일정 원본을 자식에게 내려줄 수 있게 보관한다")
+    func fetchedSchedulesAreRetained() async {
+        let attendance = MockRootAttendanceUseCase()
+        attendance.availableSchedulesResult = .success([
+            makeSchedule(scheduleId: "S-1"),
+            makeSchedule(scheduleId: "S-2"),
+        ])
+        let viewModel = makeViewModel(attendance: attendance)
+
+        await viewModel.fetchSessions()
+
+        #expect(viewModel.schedules.map(\.scheduleId) == ["S-1", "S-2"])
+    }
+
+    @Test("배경 갱신은 일정 집합이 그대로여도 원본을 최신으로 바꾼다")
+    func refreshUpdatesSchedulesWithoutMembershipChange() async {
+        let attendance = MockRootAttendanceUseCase()
+        attendance.availableSchedulesResult = .success([makeSchedule(scheduleId: "S-1")])
+        let viewModel = makeViewModel(attendance: attendance)
+        await viewModel.fetchSessions()
+
+        attendance.availableSchedulesResult = .success([
+            makeSchedule(scheduleId: "S-1", attendanceStatus: .present),
+        ])
+        await viewModel.refreshSessions()
+
+        #expect(viewModel.schedules.first?.attendanceStatus == .present)
+    }
+}
+
+// MARK: - 서버 출석 상태 동기화
+
+@MainActor
+@Suite("ActivityViewModel — 서버 출석 상태 동기화 (도메인 규칙)")
+struct ActivityViewModelStatusSyncTests {
+
+    /// 세션 목록을 적재한 뒤 다음 배경 갱신이 돌려줄 일정을 갈아끼운다.
+    @MainActor
+    private func makeLoadedViewModel(
+        attendance: MockRootAttendanceUseCase,
+        initial: [ScheduleDetailData],
+        next: [ScheduleDetailData]
+    ) async -> ActivityViewModel {
+        attendance.availableSchedulesResult = .success(initial)
+        let viewModel = makeViewModel(attendance: attendance)
+        await viewModel.load()
+        attendance.availableSchedulesResult = .success(next)
+        return viewModel
+    }
+
+    @Test("배경 갱신 — 서버 출석 상태를 기존 Session 인스턴스에 전파한다")
+    func refreshPropagatesServerStatus() async throws {
+        let attendance = MockRootAttendanceUseCase()
+        let viewModel = await makeLoadedViewModel(
+            attendance: attendance,
+            initial: [makeSchedule(scheduleId: "S-1")],
+            next: [makeSchedule(scheduleId: "S-1", attendanceStatus: .present)]
+        )
+        let session = try #require(try loadedSessions(viewModel).first)
+
+        await viewModel.refreshSessions()
+
+        #expect(session.attendanceStatus == .present)
+    }
+
+    @Test("배경 갱신 — 서버가 상태를 안 주면 로컬 상태를 덮어쓰지 않는다")
+    func refreshKeepsLocalStatusWhenServerOmitsIt() async throws {
+        let attendance = MockRootAttendanceUseCase()
+        let viewModel = await makeLoadedViewModel(
+            attendance: attendance,
+            initial: [makeSchedule(scheduleId: "S-1", attendanceStatus: .late)],
+            next: [makeSchedule(scheduleId: "S-1", attendanceStatus: nil)]
+        )
+        let session = try #require(try loadedSessions(viewModel).first)
+
+        await viewModel.refreshSessions()
+
+        #expect(session.attendanceStatus == .late)
+    }
+}
+
 // MARK: - 사용자 식별자
 
 @MainActor

--- a/UMCApp/Features/Activity/Presentation/Tests/ChallengerAttendanceViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/ChallengerAttendanceViewModelTests.swift
@@ -13,7 +13,7 @@ import UMCFoundation
 @testable import ActivityPresentation
 
 // Mock 과 이를 사용하는 헬퍼·스위트 전체를 하나의 가드 안에 둔다.
-// (`makeViewModel`/`seedSchedules` 는 Mock 을 파라미터 타입으로 직접 참조한다)
+// (`makeViewModel` 은 Mock 을 파라미터 타입으로 직접 참조한다)
 #if DEBUG
 
 // MARK: - Helpers
@@ -108,20 +108,6 @@ private func makeViewModel(
     )
 }
 
-/// 서버 정책이 실린 일정 목록을 실제 조회 경로로 적재한다.
-///
-/// 정책은 별도 캐시가 아니라 `availableSchedules` 페이로드에서 읽으므로, 시간대·안내 문구
-/// 테스트도 조회를 한 번 태워 상태를 만든다.
-@MainActor
-private func seedSchedules(
-    _ viewModel: ChallengerAttendanceViewModel,
-    useCase: MockChallengerAttendanceUseCase,
-    schedules: [ScheduleDetailData]
-) async {
-    useCase.availableSchedulesResult = .success(schedules)
-    await viewModel.fetchAvailableSchedules()
-}
-
 private struct DummyError: Error {}
 
 // MARK: - Mocks
@@ -144,17 +130,6 @@ private final class MockChallengerAttendanceUseCase: @unchecked Sendable,
 
     /// `isWithinAttendanceTime` 폴백 판정이 반환할 시간대
     var timeWindowToReturn: AttendanceTimeWindow = .onTime
-
-    var availableSchedulesResult: Result<[ScheduleDetailData], Error> = .success([])
-    var myHistoryResult: Result<[ScheduleDetailData], Error> = .success([])
-
-    /// `true` 면 일정 조회가 ``openAvailableSchedulesGate()`` 전까지 반환하지 않는다.
-    ///
-    /// 재진입 가드처럼 "요청이 진행 중인 순간" 을 관찰해야 하는 테스트에서 쓴다.
-    /// 대기를 `CheckedContinuation` 등록이 아니라 플래그 폴링으로 구현한 이유: 조회는
-    /// MainActor 밖(비격리 mock)에서 재개되므로, 등록 시점과 해제 시점이 다른 실행자에
-    /// 걸치면 아직 등록되지 않은 continuation 을 깨우려다 영영 멈춘다.
-    var gateAvailableSchedules: Bool = false
 
     // MARK: 호출 기록
 
@@ -180,6 +155,8 @@ private final class MockChallengerAttendanceUseCase: @unchecked Sendable,
 
     private(set) var isWithinAttendanceTimeCallCount: Int = 0
     private(set) var stopGeofenceMonitoringCallCount: Int = 0
+
+    /// 일정 조회 호출 기록 — SUT 가 조회 경로를 되살리지 않았는지 확인하는 용도.
     private(set) var fetchAvailableSchedulesCallCount: Int = 0
     private(set) var fetchMyHistoryCallCount: Int = 0
 
@@ -187,20 +164,12 @@ private final class MockChallengerAttendanceUseCase: @unchecked Sendable,
 
     func fetchAvailableSchedules(now: Date) async throws -> [ScheduleDetailData] {
         fetchAvailableSchedulesCallCount += 1
-        while gateAvailableSchedules {
-            await Task.yield()
-        }
-        return try availableSchedulesResult.get()
-    }
-
-    /// 게이트에 걸려 있던 일정 조회를 재개시킨다.
-    func openAvailableSchedulesGate() {
-        gateAvailableSchedules = false
+        return []
     }
 
     func fetchMyHistory(now: Date) async throws -> [ScheduleDetailData] {
         fetchMyHistoryCallCount += 1
-        return try myHistoryResult.get()
+        return []
     }
 
     func requestGPSAttendance(
@@ -516,11 +485,7 @@ struct ChallengerAttendanceViewModelTimeWindowTests {
         useCase.timeWindowToReturn = .expired  // 폴백이 쓰였다면 expired 가 나와야 함
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [makeScheduleDetail(policy: makePolicy())]
-        )
+        viewModel.apply(schedules: [makeScheduleDetail(policy: makePolicy())])
 
         let window = viewModel.timeWindow(for: session, now: fixedNow)
 
@@ -547,11 +512,7 @@ struct ChallengerAttendanceViewModelTimeWindowTests {
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
         // 정책: checkIn = fixedNow-600, onTimeEnd = fixedNow+600, lateEnd = fixedNow+1200
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [makeScheduleDetail(policy: makePolicy())]
-        )
+        viewModel.apply(schedules: [makeScheduleDetail(policy: makePolicy())])
 
         let window = viewModel.timeWindow(
             for: session,
@@ -569,11 +530,7 @@ struct ChallengerAttendanceViewModelTimeWindowTests {
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
         let policy = makePolicy()
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [makeScheduleDetail(policy: policy)]
-        )
+        viewModel.apply(schedules: [makeScheduleDetail(policy: policy)])
 
         #expect(viewModel.attendancePolicy(for: session.info.sessionId) == policy)
     }
@@ -588,16 +545,12 @@ struct ChallengerAttendanceViewModelTimeWindowTests {
 
     // MARK: - 서버 일정 ID 조회 (제출 경로)
 
-    @Test("조회된 일정의 서버 ID가 반환된다")
-    func scheduleIdReadsLoadedPayload() async {
+    @Test("전달된 일정의 서버 ID가 반환된다")
+    func scheduleIdReadsAppliedPayload() {
         let useCase = MockChallengerAttendanceUseCase()
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [makeScheduleDetail(scheduleId: "S-1")]
-        )
+        viewModel.apply(schedules: [makeScheduleDetail(scheduleId: "S-1")])
 
         #expect(viewModel.scheduleId(for: session.info.sessionId) == "S-1")
     }
@@ -605,8 +558,8 @@ struct ChallengerAttendanceViewModelTimeWindowTests {
     /// 회귀 박제 — 일정 ID가 없으면 출석·사유 제출이 서버에 도달할 수 없다.
     /// 화면은 이 nil 을 근거로 액션 버튼을 비활성화해, 사용자가 작성한 사유가
     /// 조용히 버려지지 않게 한다.
-    @Test("일정 ID 미조회 세션은 nil 을 반환한다")
-    func scheduleIdReturnsNilWhenNotFetched() {
+    @Test("일정 페이로드에 없는 세션은 nil 을 반환한다")
+    func scheduleIdReturnsNilWhenNotApplied() {
         let viewModel = makeViewModel(useCase: MockChallengerAttendanceUseCase())
         let session = makeSession()
 
@@ -664,17 +617,13 @@ struct ChallengerAttendanceViewModelGuidanceTests {
         let useCase = MockChallengerAttendanceUseCase()
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [
-                makeScheduleDetail(
-                    policy: makePolicy(
-                        onTimeEndAt: fixedNow.addingTimeInterval(420)  // 7분 뒤 마감
-                    )
+        viewModel.apply(schedules: [
+            makeScheduleDetail(
+                policy: makePolicy(
+                    onTimeEndAt: fixedNow.addingTimeInterval(420)  // 7분 뒤 마감
                 )
-            ]
-        )
+            )
+        ])
 
         let text = try #require(viewModel.attendanceGuidanceText(for: session, at: fixedNow))
 
@@ -687,18 +636,14 @@ struct ChallengerAttendanceViewModelGuidanceTests {
         let useCase = MockChallengerAttendanceUseCase()
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [
-                makeScheduleDetail(
-                    policy: makePolicy(
-                        onTimeEndAt: fixedNow.addingTimeInterval(-60),  // 정시 마감 지남
-                        lateEndAt: fixedNow.addingTimeInterval(720)     // 지각 마감 12분 뒤
-                    )
+        viewModel.apply(schedules: [
+            makeScheduleDetail(
+                policy: makePolicy(
+                    onTimeEndAt: fixedNow.addingTimeInterval(-60),  // 정시 마감 지남
+                    lateEndAt: fixedNow.addingTimeInterval(720)     // 지각 마감 12분 뒤
                 )
-            ]
-        )
+            )
+        ])
 
         let text = try #require(viewModel.attendanceGuidanceText(for: session, at: fixedNow))
 
@@ -711,17 +656,13 @@ struct ChallengerAttendanceViewModelGuidanceTests {
         let useCase = MockChallengerAttendanceUseCase()
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [
-                makeScheduleDetail(
-                    policy: makePolicy(
-                        checkInStartAt: fixedNow.addingTimeInterval(600)  // 10분 뒤 시작
-                    )
+        viewModel.apply(schedules: [
+            makeScheduleDetail(
+                policy: makePolicy(
+                    checkInStartAt: fixedNow.addingTimeInterval(600)  // 10분 뒤 시작
                 )
-            ]
-        )
+            )
+        ])
 
         let text = try #require(viewModel.attendanceGuidanceText(for: session, at: fixedNow))
 
@@ -742,17 +683,13 @@ struct ChallengerAttendanceViewModelGuidanceTests {
         let useCase = MockChallengerAttendanceUseCase()
         let viewModel = makeViewModel(useCase: useCase)
         let session = makeSession()
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [
-                makeScheduleDetail(
-                    policy: makePolicy(
-                        onTimeEndAt: fixedNow.addingTimeInterval(secondsLeft)
-                    )
+        viewModel.apply(schedules: [
+            makeScheduleDetail(
+                policy: makePolicy(
+                    onTimeEndAt: fixedNow.addingTimeInterval(secondsLeft)
                 )
-            ]
-        )
+            )
+        ])
 
         let text = try #require(viewModel.attendanceGuidanceText(for: session, at: fixedNow))
 
@@ -865,227 +802,52 @@ struct ChallengerAttendanceViewModelDelegationTests {
     }
 }
 
-// MARK: - 일정 목록/이력 로딩
+// MARK: - 일정 페이로드 반영
 
 @MainActor
-@Suite("ChallengerAttendanceViewModel — 일정 목록/이력 로딩 (도메인 규칙)")
-struct ChallengerAttendanceViewModelLoadingTests {
+@Suite("ChallengerAttendanceViewModel — 일정 페이로드 반영 (도메인 규칙)")
+struct ChallengerAttendanceViewModelScheduleTests {
 
-    @Test("첫 마운트 — 빈 배열 시드 후 배경 갱신으로 페이로드를 채운다")
-    func loadOnAppearSeedsThenRefreshes() async throws {
-        let useCase = MockChallengerAttendanceUseCase()
-        useCase.availableSchedulesResult = .success([makeScheduleDetail()])
-        useCase.myHistoryResult = .success([makeScheduleDetail(scheduleId: "H-1")])
-        let viewModel = makeViewModel(useCase: useCase)
-
-        await viewModel.loadOnAppear()
-
-        #expect(viewModel.availableSchedules.value?.map(\.scheduleId) == ["S-1"])
-        #expect(viewModel.myHistory.value?.map(\.scheduleId) == ["H-1"])
-    }
-
-    @Test("첫 마운트 — 이력은 로딩 UI 를 태우는 fetch 경로로 조회한다")
-    func loadOnAppearUsesFetchForFirstHistoryLoad() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        let viewModel = makeViewModel(useCase: useCase)
-
-        await viewModel.loadOnAppear()
-
-        #expect(useCase.fetchMyHistoryCallCount == 1)
-        #expect(viewModel.myHistory.value != nil)
-    }
-
-    @Test("재등장 — 두 목록 모두 배경 갱신만 하고 로딩 상태로 되돌리지 않는다")
-    func loadOnAppearRefreshesOnReappear() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        let viewModel = makeViewModel(useCase: useCase)
-        await viewModel.loadOnAppear()
-
-        useCase.availableSchedulesResult = .success([makeScheduleDetail(scheduleId: "S-2")])
-        useCase.myHistoryResult = .success([makeScheduleDetail(scheduleId: "H-2")])
-        await viewModel.loadOnAppear()
-
-        #expect(viewModel.availableSchedules.value?.map(\.scheduleId) == ["S-2"])
-        #expect(viewModel.myHistory.value?.map(\.scheduleId) == ["H-2"])
-        #expect(useCase.fetchAvailableSchedulesCallCount == 2)
-        #expect(useCase.fetchMyHistoryCallCount == 2)
-    }
-
-    @Test("fetch 실패 → .failed 로 재시도 UI 를 노출한다")
-    func fetchAvailableSchedulesFailsToFailedState() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        useCase.availableSchedulesResult = .failure(DummyError())
-        let viewModel = makeViewModel(useCase: useCase)
-
-        await viewModel.fetchAvailableSchedules()
-
-        #expect(viewModel.availableSchedules.error != nil)
-    }
-
-    @Test("이력 fetch 실패 → .failed 로 재시도 UI 를 노출한다")
-    func fetchMyHistoryFailsToFailedState() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        useCase.myHistoryResult = .failure(DummyError())
-        let viewModel = makeViewModel(useCase: useCase)
-
-        await viewModel.fetchMyHistory()
-
-        #expect(viewModel.myHistory.error != nil)
-    }
-
-    @Test("배경 갱신 실패 → 기존 목록을 유지하고 .failed 로 전이하지 않는다")
-    func refreshFailureKeepsPreviousSchedules() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        useCase.availableSchedulesResult = .success([makeScheduleDetail()])
-        let viewModel = makeViewModel(useCase: useCase)
-        await viewModel.fetchAvailableSchedules()
-
-        useCase.availableSchedulesResult = .failure(DummyError())
-        await viewModel.refreshAvailableSchedules()
-
-        #expect(viewModel.availableSchedules.value?.map(\.scheduleId) == ["S-1"])
-        #expect(viewModel.availableSchedules.error == nil)
-    }
-}
-
-// MARK: - 조회 취소 처리
-
-@MainActor
-@Suite("ChallengerAttendanceViewModel — 조회 취소 처리 (도메인 규칙)")
-struct ChallengerAttendanceViewModelCancellationTests {
-
-    @Test("첫 조회 취소 → .idle 로 남아 다음 등장 때 다시 조회한다")
-    func cancelledFirstFetchStaysIdle() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        useCase.availableSchedulesResult = .failure(CancellationError())
-        let viewModel = makeViewModel(useCase: useCase)
-
-        await viewModel.fetchAvailableSchedules()
-
-        #expect(viewModel.availableSchedules.isIdle)
-        #expect(viewModel.availableSchedules.error == nil)
-    }
-
-    @Test("적재 후 조회 취소 → 이전 목록으로 되돌리고 에러 카드를 띄우지 않는다")
-    func cancelledRefetchRestoresPreviousSchedules() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        useCase.availableSchedulesResult = .success([makeScheduleDetail()])
-        let viewModel = makeViewModel(useCase: useCase)
-        await viewModel.fetchAvailableSchedules()
-
-        useCase.availableSchedulesResult = .failure(CancellationError())
-        await viewModel.fetchAvailableSchedules()
-
-        #expect(viewModel.availableSchedules.value?.map(\.scheduleId) == ["S-1"])
-        #expect(viewModel.availableSchedules.error == nil)
-    }
-
-    @Test("이력 조회 취소 → .failed 로 전이하지 않는다")
-    func cancelledHistoryFetchDoesNotFail() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        useCase.myHistoryResult = .failure(CancellationError())
-        let viewModel = makeViewModel(useCase: useCase)
-
-        await viewModel.fetchMyHistory()
-
-        #expect(viewModel.myHistory.error == nil)
-        #expect(viewModel.myHistory.isIdle)
-    }
-
-    @Test("조회 진행 중 재호출 → 중복 요청을 보내지 않는다")
-    func concurrentFetchIsGuarded() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        useCase.gateAvailableSchedules = true
-        let viewModel = makeViewModel(useCase: useCase)
-
-        let first = Task { await viewModel.fetchAvailableSchedules() }
-        await drainUntil { useCase.fetchAvailableSchedulesCallCount == 1 }
-
-        // 진행 중인 요청이 아직 안 끝난 시점의 재호출은 무시돼야 한다.
-        await viewModel.fetchAvailableSchedules()
-        #expect(useCase.fetchAvailableSchedulesCallCount == 1)
-
-        useCase.openAvailableSchedulesGate()
-        await first.value
-        #expect(viewModel.availableSchedules.value != nil)
-    }
-}
-
-// MARK: - 일정 매핑 / 폴링 동기화
-
-@MainActor
-@Suite("ChallengerAttendanceViewModel — 일정 매핑·폴링 동기화 (도메인 규칙)")
-struct ChallengerAttendanceViewModelSyncTests {
-
-    @Test("조회 전 → 일정 매핑이 nil")
-    func scheduleLookupNilBeforeLoad() {
-        let useCase = MockChallengerAttendanceUseCase()
-        let viewModel = makeViewModel(useCase: useCase)
+    /// 회귀 박제 — 이 ViewModel 은 일정을 직접 조회하지 않는다. 조회를 되살리면 상위
+    /// (`ActivityViewModel`)와 같은 엔드포인트를 두 번 때리게 된다.
+    @Test("전달 전 → 일정 매핑이 nil")
+    func scheduleLookupNilBeforeApply() {
+        let viewModel = makeViewModel(useCase: MockChallengerAttendanceUseCase())
 
         #expect(viewModel.schedule(for: SessionID(value: "S-1")) == nil)
         #expect(viewModel.scheduleId(for: SessionID(value: "S-1")) == nil)
     }
 
-    @Test("조회 후 → SessionID 와 같은 scheduleId 를 돌려준다")
-    func scheduleLookupResolvesLoadedPayload() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        let viewModel = makeViewModel(useCase: useCase)
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [makeScheduleDetail(scheduleId: "S-1")]
-        )
+    @Test("전달 후 → SessionID 와 같은 scheduleId 를 돌려준다")
+    func scheduleLookupResolvesAppliedPayload() {
+        let viewModel = makeViewModel(useCase: MockChallengerAttendanceUseCase())
+
+        viewModel.apply(schedules: [makeScheduleDetail(scheduleId: "S-1")])
 
         #expect(viewModel.scheduleId(for: SessionID(value: "S-1")) == "S-1")
         #expect(viewModel.scheduleId(for: SessionID(value: "S-9")) == nil)
     }
 
-    @Test("폴링 동기화 — 서버 출석 상태를 Session 에 전파한다")
-    func syncPropagatesServerStatusToSession() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        let viewModel = makeViewModel(useCase: useCase)
-        let session = makeSession()
-        viewModel.configurePollingSessions([session], userId: UserID(value: "U-1"))
+    @Test("페이로드를 다시 전달하면 최신 목록으로 교체한다")
+    func applyReplacesPayload() {
+        let viewModel = makeViewModel(useCase: MockChallengerAttendanceUseCase())
 
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [makeScheduleDetail(attendanceStatus: .present)]
-        )
+        viewModel.apply(schedules: [makeScheduleDetail(scheduleId: "S-1")])
+        viewModel.apply(schedules: [makeScheduleDetail(scheduleId: "S-2")])
 
-        #expect(session.attendanceStatus == .present)
+        #expect(viewModel.schedules.map(\.scheduleId) == ["S-2"])
+        #expect(viewModel.scheduleId(for: SessionID(value: "S-1")) == nil)
     }
 
-    @Test("폴링 동기화 — 서버가 상태를 안 주면 로컬 상태를 덮어쓰지 않는다")
-    func syncKeepsSessionWhenServerStatusMissing() async {
+    @Test("페이로드를 반영해도 일정 조회 요청은 보내지 않는다")
+    func applyDoesNotQueryUseCase() {
         let useCase = MockChallengerAttendanceUseCase()
         let viewModel = makeViewModel(useCase: useCase)
-        let session = makeSession(initialAttendance: makeAttendance(status: .late))
-        viewModel.configurePollingSessions([session], userId: UserID(value: "U-1"))
 
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [makeScheduleDetail(attendanceStatus: nil)]
-        )
+        viewModel.apply(schedules: [makeScheduleDetail()])
 
-        #expect(session.attendanceStatus == .late)
-    }
-
-    @Test("폴링 동기화 — 목록에 없는 세션은 건드리지 않는다")
-    func syncIgnoresUnmatchedSession() async {
-        let useCase = MockChallengerAttendanceUseCase()
-        let viewModel = makeViewModel(useCase: useCase)
-        let session = makeSession(sessionId: "S-1")
-        viewModel.configurePollingSessions([session], userId: UserID(value: "U-1"))
-
-        await seedSchedules(
-            viewModel,
-            useCase: useCase,
-            schedules: [makeScheduleDetail(scheduleId: "S-9", attendanceStatus: .absent)]
-        )
-
-        #expect(session.attendanceStatus == .beforeAttendance)
+        #expect(useCase.fetchAvailableSchedulesCallCount == 0)
+        #expect(useCase.fetchMyHistoryCallCount == 0)
     }
 }
 

--- a/UMCApp/Features/Activity/Presentation/Tests/OperatorAttendanceViewModelTests.swift
+++ b/UMCApp/Features/Activity/Presentation/Tests/OperatorAttendanceViewModelTests.swift
@@ -1113,4 +1113,42 @@ struct OperatorAttendanceViewModelScheduleIdentityTests {
     }
 }
 
+// MARK: - 딥링크 착지 (목록 미로드 진입)
+
+@MainActor
+@Suite("OperatorAttendanceViewModel — 딥링크 착지 (목록 미로드 진입)")
+struct OperatorAttendanceViewModelDeepLinkTests {
+
+    @Test("목록 조회 없이 상세 선택 → 상세만 로드되고 listState 는 .idle 로 남는다")
+    func selectScheduleWithoutList() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        useCase.fetchDetailResult = makeScheduleInfo(scheduleId: "42", pendingCount: 1)
+        let viewModel = makeViewModel(useCase: useCase)
+
+        await viewModel.selectSchedule("42")
+
+        #expect(viewModel.detailState.value?.scheduleId == "42")
+        #expect(viewModel.listState.isIdle)
+        #expect(useCase.fetchListCalls.isEmpty)
+    }
+
+    @Test("목록 미로드 상태의 결정 → 상세만 갱신, 이후 목록 조회는 서버 값을 그대로 싣는다")
+    func decideWithoutListThenFetchList() async {
+        let useCase = MockOperatorAttendanceUseCase()
+        let pending = makeParticipant(memberId: "1", status: .presentPending)
+        let schedule = makeScheduleInfo(scheduleId: "42", participants: [pending])
+        useCase.fetchDetailResult = schedule
+        useCase.fetchListResult = [makeScheduleInfo(scheduleId: "42", pendingCount: 1)]
+        let viewModel = makeViewModel(useCase: useCase)
+        await viewModel.selectSchedule("42")
+
+        await viewModel.decideAttendance(participant: pending, isApproved: true)
+        // 딥링크 착지 후 뒤로 나가 목록이 처음 그려지는 순간
+        await viewModel.fetchList()
+
+        #expect(viewModel.detailState.value?.participants.first?.attendanceStatus == .present)
+        #expect(viewModel.listState.value?.first?.pendingCount == 1)
+    }
+}
+
 #endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeList/NoticeItem.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeList/NoticeItem.swift
@@ -74,7 +74,7 @@ private struct NoticeItemPresenter: View, Equatable {
         .background {
             ConcentricRectangle(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
                 .fill(.white)
-                .glass()
+                .cardShadow()
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor · 🐛 Fix — PR #1070(이슈 #1036 마무리) 리뷰에서 범위 밖으로 남긴 후속 정리 4건을 한 번에 처리합니다.

이슈별로 커밋을 분리했으니 **커밋 단위로 리뷰**하시면 편합니다.

| 커밋 | 이슈 |
|---|---|
| `ed95d95` | #1075 챌린저 출석 미사용 조회 경로 정리 |
| `d595da4` | #1074 출석 상세 진입 경로 라우터 일원화 |
| `98fbbc6` | #1076 출석 화면 접근성 4종 개선 |
| `e6d5838` | #1077 챌린저 출석 카드 표면 정리 |

## 📷 스크린샷 or 영상(UI 변경 시)

> ⚠️ **아직 첨부 못 했습니다. 머지 전 채워야 합니다.**
> 시뮬레이터 육안 확인이 필요한 항목이라 자동으로 캡처하지 못했습니다.

- [ ] #1076 — 글자 크기 **최대** 상태의 출석 화면 (운영진 목록/상세 · 챌린저)
- [ ] #1076 — VoiceOver 로터 캡처 (세션 카드 · 나의 출석 카드가 "버튼" + 펼침/접힘으로 안내되는지)
- [ ] #1076 — "동작 줄이기" ON 상태의 승인 대기 화면 (회전 정지)
- [ ] #1077 — 라이트/다크 Before-After (특히 아래 "리뷰 포인트" 1번의 정책 요약 모서리)
- [ ] 테스트 성공 스크린샷 + 커버리지 (CI 미적용 기간 한시 정책)

## 🛠️ 작업내용

### ♻️ #1075 — 챌린저 출석 미사용 조회 경로 정리 (`ed95d95`)

- `myHistory` · `fetchMyHistory()` · `refreshMyHistory()` 제거 — 화면의 "나의 출석 현황"은 상위가 넘긴 `sessions` prop 에서 파생되므로 조회 결과가 버려지고 있었습니다. **화면 진입 시 결과가 버려지는 네트워크 호출 0건.**
- 프로덕션 호출처가 없던 `fetchAvailableSchedules()` 제거 + `ChallengerAttendanceSessionView` 의 관련 TODO 해소
- **동일 엔드포인트 중복 조회 단일화** — 소유권을 상위 `ActivityViewModel` 로 승격하고 자식은 `apply(schedules:)` 로 받기만 합니다(`.onChange(of: schedules, initial: true)`). 폴링·상태 동기화·알림 관찰이 함께 올라가면서 자식의 `configurePollingSessions(_:userId:)` 주입 절차가 통째로 사라졌습니다. **진입 1회 = 요청 1건.**
- `ChallengerAttendanceView` 의 "일정 조회 미결선" 스테일 주석 정정 (실 API 는 이미 결선 상태)

> ⚠️ **이슈 본문에 없던 함정**: `.attendanceStatusChanged` 알림의 **유일한 소비자가 삭제 대상인 `refreshMyHistory()` 옵저버**였습니다. 이슈대로 지웠으면 승인/반려 반영 경로가 통째로 죽습니다. 옵저버를 `ActivityViewModel` 로 옮겨 `refreshSessions()` 로 재배선했고, `Notification+Names.swift` 문서도 실제 소비자로 정정했습니다.

### ♻️ #1074 — 출석 상세 진입 경로 라우터 일원화 (`d595da4`)

**결정: 유지** (이슈는 "폐기 검토"였으나 전제가 낡았습니다 — 아래 리뷰 포인트 2번)

- `OperatorAttendanceViewModel` 의 소유자를 목록 화면 → **Activity 탭 루트 `ActivityView`** 로 승격. 딥링크는 목록을 거치지 않고 상세로 착지하므로, VM 소유자는 두 진입점의 공통 조상이어야 같은 인스턴스를 공유할 수 있습니다.
- `.navigationDestination(for: ActivityDestination.self)` 등록을 `ActivityFeatureView` → `ActivityView` 로 이동 (목적지 클로저가 VM 을 캡처하려면 소유자와 같은 body 여야 함)
- 목록의 로컬 `pushedScheduleId` / `.navigationDestination(item:)` 삭제 → 행·배너 탭을 `pathStore.push(.attendanceDetail)` 로 일원화
- 새 VM 을 생성하던 `OperatorAttendanceDetailRoute` 삭제
- `ActivityDestination` **생산자 없는 케이스 0건** 확인 (`attendanceDetail`, `studyScheduleRegistration` 둘 다 생산자 있음)

신규 타입·프로토콜·환경 키 없이 처리했습니다. (`.environment` 주입 안은 "NavigationStack 안쪽 환경이 목적지까지 전파되는가"라는 SwiftUI 의미론에 런타임을 걸어야 해서 기각 — 클로저 캡처는 컴파일러가 보증합니다.)

### 🐛 #1076 — 출석 화면 접근성 4종 (`98fbbc6`)

- **Dynamic Type**: `.font(.system(size:))` 11곳을 텍스트 스타일 토큰(`.app(.caption1)` 등)으로 교체. `Font.app(size:)` 오버로드는 **쓰지 않았습니다** — 그것도 `relativeTo:` 가 없어 동일 결함입니다. 10곳은 크기가 정확히 일치, 2곳만 ±2pt.
- **터치 타깃**: `DefaultConstant.minimumTouchTarget = 44` 신설, 4곳에 `.frame(minWidth:minHeight:)` + `.contentShape(.rect)` 적용. 시각 크기 불변.
- **VoiceOver**: `ChallengerSessionCard` · `ChallengerMyAttendanceCard` 의 `.onTapGesture` → `Button` + `.buttonStyle(.plain)`. 펼침/접힘은 `.accessibilityValue` + `.accessibilityHint` 로 전달.
- **Reduce Motion**: `ChallengerPendingApprovalView` 무한 회전이 `accessibilityReduceMotion` 활성 시 정지 (`SymbolDrawOnModifier` 패턴 준용)

### ♻️ #1077 — 챌린저 출석 카드 표면 정리 (`e6d5838`)

**선행 결정: 챌린저 카드는 불투명 배경 유지 · Liquid Glass 전환 보류** (아래 리뷰 포인트 3번)

- `ShadowReuse.Glass` / `.glass()` → **`.cardShadow()` 개명** (drop shadow 2개일 뿐인데 이름 때문에 "글래스 적용됨"으로 오독됨). 호출부 7곳 / `ActivityPresentation`·`NoticePresentation` 2개 모듈. 잔존 참조 0건.
- 잔존 `RoundedRectangle` / `.rect(cornerRadius:)` → `ConcentricRectangle(corners: .concentric(minimum:))` 통일 (`GlassEffectContainer` 코너 상속 사유가 주석에 명시된 케이스는 제외)
- `ChallengerMyAttendanceCard` 이중 shape 정리 + 죽은 상수 `Constants.statusRadius` 제거
- 챌린저 상태 배지 2개를 Core 컴포넌트와 동일하게 `Capsule()` 로 통일

## 📋 추후 진행 상황

- **`.font(.system(size:))` 5곳이 출석 범위 밖에 남아 있습니다** — `MemberManagementCard`, `ChallengerMissionCardHeader`, `StudyGroupMemberChip`, `ActivityCompactMapView`, `ChallengerMemberDetailSheetView`. 동일한 Dynamic Type 결함이라 후속 티켓 후보입니다.
- 챌린저 카드의 Liquid Glass 전환 (#1077 첫 완료 조건) — 디자인팀 확인 후 별도 진행
- 배지 패딩 통일: Core 는 `.horizontal 8 / .vertical 4`, 챌린저는 `DefaultConstant.badgePadding`(8/16). 맞추면 배지가 실제로 작아지는 시각 변경이라 이번 범위에서 제외했습니다.

## 📌 리뷰 포인트

**1. `ChallengerMyAttendanceCard` 정책 요약 모서리가 눈에 띄게 둥글어집니다** — 고정 12 → `concentric(minimum: 40, isUniform: true)`. 이번 PR 에서 **유일하게 의도된 시각 변화**이며 #1077 이 명시적으로 요구한 통일입니다. 라이트/다크 캡처로 확인 부탁드립니다.

**2. #1074 의 이슈 전제가 낡았습니다** — 이슈는 `attendanceDetail` 을 "생산자 0곳 데드코드"로 봤지만, 이슈 작성 뒤 머지된 `5acce64a`(#1073)가 생산자를 추가했습니다: `NavigationRoutingView.swift` 의 일정 상세 → "출석 현황" 진입. **폐기하면 #1073 흐름이 끊깁니다.** 그래서 유지 + VM 공유 재설계로 갔습니다.

**3. VM 이 탭 수명이 되면서 생기는 회귀를 `.task` 분기로 막았습니다** — 기존엔 "섹션 재진입 = VM 재생성 = 재조회"였는데 그게 사라집니다. `OperatorAttendanceView.task` 의 `listState.isIdle ? fetchList() : refreshList()` 가 유일한 방어선이라 **여기를 지우면 조용한 stale 데이터 회귀**가 납니다.

**4. 히트 영역 확대는 레이아웃 공간을 실제로 차지합니다** — 승인 대기 시트의 선택 체크 원(22→44)은 선택 모드에서 행 콘텐츠를 우측으로 밀고, "사유 제출하기" 링크는 카드 하단이 늘어납니다. 글자·아이콘 크기 자체는 불변입니다. 허용 범위인지 봐주세요.

**5. ⓘ 버튼의 `.glassEffect` 를 Button 밖 → label 안으로 옮겼습니다** (시각 크기 36pt 유지 목적, 선례: `OperatorAttendanceDetailView.pendingBanner`). 확대된 8pt 여백을 탭하면 글래스 눌림 효과 없이 액션만 실행됩니다.

## ✅ 테스트

```
make test SCHEME=ActivityPresentation
✔ Test run with 295 tests in 61 suites passed
** TEST SUCCEEDED **
```

- `make build` — `CoreDesignSystem` / `CoreUIComponents` / `ActivityPresentation` / `NoticePresentation` / `UMCApp` 전부 `BUILD SUCCEEDED`
- #1074 는 **기존 `OperatorAttendanceViewModelTests` 무수정 통과**(VM 미변경, 소유 위치만 이동) + 딥링크 착지 경로 테스트 2건 신규 추가
- #1075 는 조회 경로 변경에 맞춰 테스트 갱신 + **동일 엔드포인트 호출 횟수 검증** 테스트 추가
- #1076 · #1077 은 테스트 파일 **무수정** 통과 (동작 불변의 근거)
- 전부 Swift Testing (`import Testing` / `@Test` / `#expect`), XCTest 미사용

`AppProduct/` 변경 0건 (v2.2.0 동결 준수). 순 −214줄.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

Closes #1074
Closes #1075
Closes #1076
Closes #1077
