### PR TITLE
♻️ [Refactor] 홈 일정 분류 후속 정리 3건 — 상태 degrade/pruning · 갱신 배칭 · 분기 테스트 (#986 #987 #988)

### DIFF
--- a/UMCApp/Features/Home/Domain/Tests/UseCases/ClassifyScheduleUseCaseTests.swift
+++ b/UMCApp/Features/Home/Domain/Tests/UseCases/ClassifyScheduleUseCaseTests.swift
@@ -48,6 +48,22 @@ struct ClassifyScheduleUseCaseTests {
         #expect(repository.classifyWithKeywordsCallCount == 1)
     }
 
+    @Test("모델 로드됐지만 ML 예측이 nil이면 키워드 분류 결과로 fallback한다")
+    func loadedModelWithNilMLResultFallsBackToKeywords() async {
+        let repository = MockScheduleClassifierRepository()
+        repository.isModelLoaded = true
+        repository.mlResult = nil
+        repository.keywordResult = .meeting
+        let useCase = ClassifyScheduleUseCase(repository: repository)
+
+        let result = await useCase.execute(title: "정기 회의")
+
+        #expect(result == .meeting)
+        #expect(repository.classifyWithMLCallCount == 1)
+        #expect(repository.classifyWithKeywordsCallCount == 1)
+        #expect(repository.cache["정기 회의"] == .meeting)
+    }
+
     @Test("분류 결과가 정규화된 캐시 키로 저장된다")
     func classificationResultIsCached() async {
         let repository = MockScheduleClassifierRepository()

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
@@ -28,7 +28,8 @@ public final class HomeViewModel {
     /// 실패 시 빈 딕셔너리로 degrade한다 (원본 AppProduct와 동일한 정책).
     public private(set) var scheduleByDates: [Date: [ScheduleDetailData]] = [:]
 
-    /// 일정 ID(``ScheduleDetailData/scheduleId``) → 분류된 카테고리. 분류가 끝난 일정만 채워지며,
+    /// 일정 ID(``ScheduleDetailData/scheduleId``) → 분류된 카테고리. 현재 로드된 일정만 담으며
+    /// (월 이동/조회 실패 시 ``scheduleByDates`` 와 동일하게 정리된다),
     /// 조회는 ``category(for:)`` 를 통해 기본값(``ScheduleIconCategory/general``)과 함께 사용한다.
     public private(set) var scheduleCategories: [String: ScheduleIconCategory] = [:]
 
@@ -109,7 +110,7 @@ public final class HomeViewModel {
             let startOfMonth = calendar.date(from: DateComponents(year: targetYear, month: targetMonth, day: 1)),
             let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth)
         else {
-            scheduleByDates = [:]
+            clearSchedules()
             return
         }
 
@@ -121,7 +122,7 @@ public final class HomeViewModel {
             )
             await classifySchedules(scheduleByDates.values.flatMap { $0 })
         } catch {
-            scheduleByDates = [:]
+            clearSchedules()
         }
     }
 
@@ -139,12 +140,26 @@ public final class HomeViewModel {
 
     /// 일정 제목을 분류해 ``scheduleCategories`` 를 갱신한다. 빈 제목이거나 분류가 실패해도
     /// UseCase가 `.general`을 반환하므로 별도 에러 처리는 필요 없다.
+    ///
+    /// 결과는 로컬 딕셔너리에 누적한 뒤 한 번만 할당한다. 뷰 무효화가 일정 수만큼 쪼개지는 것을
+    /// 막고, 현재 일정 집합으로 새로 구성하므로 이전 달 분류 결과가 함께 pruning된다.
     private func classifySchedules(_ schedules: [ScheduleDetailData]) async {
+        var categories: [String: ScheduleIconCategory] = [:]
+
         for schedule in schedules {
-            scheduleCategories[schedule.scheduleId] = await classifyScheduleUseCase.execute(
+            categories[schedule.scheduleId] = await classifyScheduleUseCase.execute(
                 title: schedule.name
             )
         }
+
+        scheduleCategories = categories
+    }
+
+    /// 일정 조회가 불가능하거나 실패했을 때의 degrade 처리. 캘린더는 흐름을 막지 않아야 하므로
+    /// 일정과 분류 결과를 함께 비운다 (UseCase 레이어의 분류 캐시는 유지된다).
+    private func clearSchedules() {
+        scheduleByDates = [:]
+        scheduleCategories = [:]
     }
 
     /// 최신 기수의 최근 공지 5건을 조회한다. 소속 기수가 없으면 빈 목록으로 처리한다.

--- a/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
+++ b/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
@@ -116,15 +116,7 @@ struct HomeViewModelTests {
 
     @Test("fetchSchedules() 성공 시 일정 제목을 분류해 scheduleCategories를 채운다")
     func fetchSchedulesClassifiesLoadedSchedules() async {
-        let schedule = ScheduleDetailData(
-            scheduleId: "1",
-            name: "알고리즘 스터디",
-            description: "",
-            tags: [],
-            startsAt: .now,
-            endsAt: .now.addingTimeInterval(3600),
-            isParticipant: true
-        )
+        let schedule = makeSchedule(scheduleId: "1", name: "알고리즘 스터디")
         let fetchSchedulesUseCase = MockFetchSchedulesUseCase(result: [.now: [schedule]])
         let classifyScheduleUseCase = MockClassifyScheduleUseCase()
         classifyScheduleUseCase.resultsByTitle["알고리즘 스터디"] = .study
@@ -137,6 +129,48 @@ struct HomeViewModelTests {
 
         #expect(viewModel.category(for: "1") == .study)
         #expect(classifyScheduleUseCase.classifiedTitles == ["알고리즘 스터디"])
+    }
+
+    @Test("fetchSchedules() 실패 시 일정과 분류 결과를 함께 비운다")
+    func fetchSchedulesFailureClearsCategories() async {
+        let fetchSchedulesUseCase = MockFetchSchedulesUseCase(
+            result: [.now: [makeSchedule(scheduleId: "1", name: "알고리즘 스터디")]]
+        )
+        let classifyScheduleUseCase = MockClassifyScheduleUseCase()
+        classifyScheduleUseCase.resultsByTitle["알고리즘 스터디"] = .study
+        let viewModel = makeViewModel(
+            fetchSchedulesUseCase: fetchSchedulesUseCase,
+            classifyScheduleUseCase: classifyScheduleUseCase
+        )
+        await viewModel.fetchSchedules()
+
+        fetchSchedulesUseCase.error = DummyError()
+        await viewModel.fetchSchedules()
+
+        #expect(viewModel.scheduleByDates.isEmpty)
+        #expect(viewModel.scheduleCategories.isEmpty)
+        #expect(viewModel.category(for: "1") == .general)
+    }
+
+    @Test("월 이동으로 일정이 갱신되면 이전 달 분류 결과를 pruning한다")
+    func scheduleCategoriesArePrunedOnMonthChange() async {
+        let fetchSchedulesUseCase = MockFetchSchedulesUseCase(
+            result: [.now: [makeSchedule(scheduleId: "1", name: "알고리즘 스터디")]]
+        )
+        let classifyScheduleUseCase = MockClassifyScheduleUseCase()
+        classifyScheduleUseCase.resultsByTitle["알고리즘 스터디"] = .study
+        classifyScheduleUseCase.resultsByTitle["정기 회의"] = .meeting
+        let viewModel = makeViewModel(
+            fetchSchedulesUseCase: fetchSchedulesUseCase,
+            classifyScheduleUseCase: classifyScheduleUseCase
+        )
+        await viewModel.fetchSchedules(year: 2026, month: 7)
+
+        fetchSchedulesUseCase.result = [.now: [makeSchedule(scheduleId: "2", name: "정기 회의")]]
+        await viewModel.fetchSchedules(year: 2026, month: 8)
+
+        #expect(viewModel.scheduleCategories == ["2": .meeting])
+        #expect(viewModel.category(for: "1") == .general)
     }
 
     @Test("fetchProfile(forceRefresh: true)는 UseCase에 forceRefresh를 그대로 전달한다")
@@ -185,6 +219,18 @@ private func makeViewModel(
     return HomeViewModel(container: container)
 }
 
+private func makeSchedule(scheduleId: String, name: String) -> ScheduleDetailData {
+    ScheduleDetailData(
+        scheduleId: scheduleId,
+        name: name,
+        description: "",
+        tags: [],
+        startsAt: .now,
+        endsAt: .now.addingTimeInterval(3600),
+        isParticipant: true
+    )
+}
+
 private func makeProfile(generationNumbers: [String]) -> HomeProfileResult {
     HomeProfileResult(
         memberId: "1",
@@ -227,12 +273,19 @@ private final class MockFetchRecentNoticesUseCase: FetchRecentNoticesUseCaseProt
     }
 }
 
-/// 프로필 로딩 상태 전이 테스트는 일정 조회 결과와 무관하므로 빈 결과만 반환한다.
-private struct MockFetchSchedulesUseCase: FetchSchedulesUseCaseProtocol, Sendable {
-    var result: [Date: [ScheduleDetailData]] = [:]
+/// 프로필 로딩 상태 전이 테스트는 일정 조회 결과와 무관하므로 기본값은 빈 결과다.
+/// 월 이동/조회 실패 시나리오를 위해 호출 사이에 `result`/`error`를 바꿀 수 있다.
+private final class MockFetchSchedulesUseCase: FetchSchedulesUseCaseProtocol, @unchecked Sendable {
+    var result: [Date: [ScheduleDetailData]]
+    var error: Error?
+
+    init(result: [Date: [ScheduleDetailData]] = [:]) {
+        self.result = result
+    }
 
     func execute(from: Date, to: Date, isAttendanceRequired: Bool) async throws -> [Date: [ScheduleDetailData]] {
-        result
+        if let error { throw error }
+        return result
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor + ✅ Test — PR #984(ScheduleClassifier 이식)에서 defer된 후속 정리 3건입니다.
세 이슈 모두 `HomeViewModel.classifySchedules(_:)`와 그 테스트를 건드려 하나의 PR로 묶었습니다. UI 변경 없음.

| 이슈 | 내용 |
|------|------|
| #986 | `scheduleCategories` 생명주기를 `scheduleByDates`와 일치 |
| #987 | 분류 결과 1회 할당으로 뷰 무효화 배칭 |
| #988 | 키워드 fallback 분기 명시 테스트 |

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 — ViewModel 내부 상태 관리 리팩터링입니다.

## 🛠️ 작업내용

### #986 — 상태 degrade / 월 이동 pruning

- `clearSchedules()` 추가. 월 계산 불가·조회 실패 시 `scheduleByDates`만 비우던 것을 `scheduleCategories`까지 함께 비웁니다.
- 두 상태의 생명주기가 어긋나 있어, 실패 후에도 이전 달 분류 결과가 남아 있었습니다.
- UseCase 레이어의 UserDefaults 분류 캐시는 건드리지 않습니다 — ViewModel 상태만 정리합니다.

### #987 — 분류 결과 1회 할당

- 일정별 `await` 결과를 로컬 딕셔너리에 누적한 뒤, 루프 종료 후 `scheduleCategories`에 1회 할당합니다 (뷰 무효화 N회 → 1회).
- 로컬 딕셔너리를 **현재 일정 집합 기준**으로 새로 구성하므로, #986의 pruning이 같은 변경으로 함께 해결됩니다 (세션 내 무한 성장 제거).
- UseCase 호출 횟수는 기존과 동일합니다 — 분류 재사용은 UseCase 캐시가 담당합니다.

### #988 — 키워드 fallback 분기 테스트

- `isModelLoaded == true` + `classifyWithML(title:)` → `nil` ⇒ 키워드 분류 결과 반환 시나리오를 명시적으로 검증합니다.
- ML 1회 호출 후 키워드 결과가 정규화 캐시 키로 저장되는지도 함께 확인합니다.
- `MockScheduleClassifierRepository`가 이미 `mlResult: ScheduleIconCategory?`로 해당 구성을 지원해 Mock 변경은 없습니다.

### 테스트

- `HomeViewModelTests`: 실패 시 degrade / 월 이동 pruning 검증 2건 추가. 호출 사이 결과·에러 교체가 가능하도록 `MockFetchSchedulesUseCase`를 class로 전환하고, 일정 생성 헬퍼(`makeSchedule`)로 중복을 정리했습니다.
- `ClassifyScheduleUseCaseTests`: 분기 명시 테스트 1건 추가.
- 결과: `HomePresentation` 16 / `HomeDomain` 19 / `UMCApp` 14 — **TEST SUCCEEDED**.

## 📋 추후 진행 상황

- UseCase 레이어의 UserDefaults 분류 캐시는 이번 범위 밖입니다. 캐시 크기 상한·만료 정책이 필요해지면 별도 이슈로 다룹니다.
- `classifySchedules(_:)`는 순차 `await`를 유지했습니다. 일정 수가 많아져 체감 지연이 생기면 그때 병렬화를 검토합니다.

## 📌 리뷰 포인트

- **`clearSchedules()` 호출 지점 2곳** (`HomeViewModel.swift`) — 월 계산 실패 경로와 `catch` 경로 모두에서 두 상태가 함께 비워지는지 확인 부탁드립니다.
- **1회 할당으로 바뀐 뒤의 pruning 의도** — 로컬 딕셔너리를 새로 만들어 통째로 갈아끼우는 방식이라, 이전 결과 유지가 필요한 케이스가 없는지 봐주세요. (`category(for:)`가 기본값 `.general`로 degrade합니다.)
- **`MockFetchSchedulesUseCase`의 struct → class 전환** — 호출 사이 결과 교체 목적입니다. 다른 테스트에 영향이 없는지 확인 부탁드립니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

Closes #986
Closes #987
Closes #988
