### PR TITLE
♻️ [Refactor] 로그인 직후 FCM 토큰 동기화 트리거 추가 (#1008)

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Extensions/Notification+Names.swift
+++ b/UMCApp/Core/Foundation/Sources/Extensions/Notification+Names.swift
@@ -26,6 +26,12 @@ public extension Notification.Name {
     /// 이 알림을 받으면 승인 대기 안내 화면으로 이동해야 합니다.
     static let navigateToPendingApproval = Notification.Name("navigateToPendingApproval")
 
+    /// 멤버 프로필이 로컬 저장소에 동기화되었을 때 발송되는 알림.
+    ///
+    /// `AppDelegate`가 수신해 FCM 토큰을 재동기화합니다. 앱 실행 직후에는 `memberId`가 없어
+    /// 토큰 등록이 건너뛰어지므로, 같은 세션에서 로그인한 사용자를 위한 재시도 트리거입니다.
+    static let memberProfileUpdated = Notification.Name("memberProfileUpdated")
+
     // MARK: - Domain Updates
 
     /// 출석 승인/반려 상태 변경 알림.

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/SyncProfileStorageUseCase.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/SyncProfileStorageUseCase.swift
@@ -62,6 +62,10 @@ public final class SyncProfileStorageUseCase: SyncProfileStorageUseCaseProtocol 
         userDefaults.set(profile.isApproved, forKey: AppStorageKey.canAutoLogin)
 
         userSessionManager.updateRole(resolvedRole, allRoles: profile.roles.map(\.roleType))
+
+        // 로그인 진입점 4곳이 모두 이 UseCase를 거치므로, memberId 확보 시점의 FCM 토큰
+        // 재동기화 트리거는 여기 한 곳에서만 발송한다.
+        NotificationCenter.default.post(name: .memberProfileUpdated, object: nil)
     }
 
     // MARK: - Private Function

--- a/UMCApp/Features/Auth/Domain/Tests/UseCases/SyncProfileStorageUseCaseTests.swift
+++ b/UMCApp/Features/Auth/Domain/Tests/UseCases/SyncProfileStorageUseCaseTests.swift
@@ -275,6 +275,31 @@ struct SyncProfileStorageUseCaseTests {
         #expect(userSessionManager.allRoles == [.chapterPresident, .schoolPartLeader])
     }
 
+    @Test("프로필 동기화를 마치면 FCM 토큰 재동기화용 memberProfileUpdated를 발송한다")
+    func postsMemberProfileUpdatedAfterSync() async {
+        let userDefaults = makeIsolatedUserDefaults()
+        let useCase = SyncProfileStorageUseCase(
+            userSessionManager: UserSessionManager(),
+            userDefaults: userDefaults
+        )
+        let profile = Profile(memberId: "42", name: "A", nickname: "a", generations: ["11"])
+
+        // 병렬 실행되는 다른 테스트의 `execute`도 같은 알림을 발송하므로 최소 1회로 확인한다.
+        await confirmation("memberProfileUpdated 발송", expectedCount: 1...) { posted in
+            let observer = NotificationCenter.default.addObserver(
+                forName: .memberProfileUpdated,
+                object: nil,
+                queue: nil
+            ) { _ in posted() }
+            defer { NotificationCenter.default.removeObserver(observer) }
+
+            useCase.execute(profile: profile)
+        }
+
+        // 구독자(AppDelegate)가 토큰을 등록하려면 발송 시점에 memberId가 기록돼 있어야 한다.
+        #expect(userDefaults.string(forKey: AppStorageKey.memberId) == "42")
+    }
+
     @Test("역할이 없는 프로필은 UserSessionManager의 allRoles를 challenger 하나로 채운다")
     func fillsAllRolesWithChallengerWhenProfileHasNoRoles() {
         let userSessionManager = UserSessionManager()

--- a/UMCApp/UMCApp/Sources/AppDelegate.swift
+++ b/UMCApp/UMCApp/Sources/AppDelegate.swift
@@ -60,6 +60,12 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         Messaging.messaging().delegate = self
         UNUserNotificationCenter.current().delegate = self
         registerRemoteNotificationsIfAuthorized()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(memberProfileDidUpdate),
+            name: .memberProfileUpdated,
+            object: nil
+        )
         return true
     }
 
@@ -132,6 +138,17 @@ extension Notification.Name {
 // MARK: - Private Function
 
 private extension AppDelegate {
+
+    /// 로그인/가입 직후 프로필이 저장되면 FCM 토큰을 다시 동기화한다.
+    ///
+    /// 앱 실행 시점에는 `memberId`가 없어 ``syncFCMTokenIfPossible(trigger:)``가 조기 반환하고,
+    /// 같은 세션 안에서 로그인해도 `applicationDidBecomeActive`는 다시 호출되지 않는다.
+    @objc
+    func memberProfileDidUpdate() {
+        Task { @MainActor in
+            await syncFCMTokenIfPossible(trigger: "memberProfileUpdated")
+        }
+    }
 
     /// FCM 토큰을 서버에 동기화한다.
     ///


### PR DESCRIPTION
## ✨ PR 유형

♻️ Refactor — 이슈 #1008(FCM 푸시 `AppProduct/` → `UMCApp/` 이관)의 **마지막 남은 갭 1건**을 처리합니다.

6개 완료 조건 중 5건은 #1079 에서 이미 처리됐고, 이 PR 은 남은 1건(로그인 직후 토큰 동기화 트리거)만 다룹니다.

| # | 조건 | 상태 | 근거 위치 |
|---|------|------|----------|
| 1 | FirebaseMessaging 의존성 + APNs ↔ FCM 토큰 매핑 | ✅ #1079 | `UMCApp/Project.swift:83-84`, `AppDelegate.swift:60,76` |
| 2 | 알림 권한 요청 | ✅ #1079 | `AppDelegate.swift:202-224` |
| 3 | 포그라운드/백그라운드 수신 델리게이트 | ✅ #1079 | `AppDelegate.swift:86-102` |
| 4 | Push capability / Background Modes / entitlements | ✅ #1079 | `UMCApp.entitlements`, `Secrets/Shared.xcconfig:25-26`, `Project.swift:49-50` |
| 5 | **로그인·가입 직후 FCM 토큰 동기화 트리거** | 🔧 **이번 PR** | 아래 작업내용 |
| 6 | The Ping 딥링크 | ⛔️ 범위 밖 | AppProduct 에도 없던 기능 (아래 "추후 진행 상황") |

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 — 앱 생명주기·유즈케이스 계층만 수정했습니다. (View 파일 변경 0건)

## 🛠️ 작업내용

### 문제

앱 최초 실행 시 `configure` 시점에는 `memberId == 0` 이라 `syncFCMTokenIfPossible` 이 조기 반환합니다.
이후 사용자가 **같은 세션 안에서** 로그인하면 `SyncProfileStorageUseCase` 가 `memberId` 를 기록하지만
**재동기화를 호출하는 주체가 없고**, `applicationDidBecomeActive` 는 이미 active 상태라 다시 불리지 않습니다.

→ **신규 가입자·최초 로그인 사용자는 첫 세션 내내 서버에 FCM 토큰이 등록되지 않아 푸시를 받지 못합니다.**

AppProduct 는 `.memberProfileUpdated` NotificationCenter 옵저버로 이 구멍을 막고 있었으나, UMCApp 에는 해당 알림 자체가 이관되지 않았습니다.

### 변경

| 파일 | 내용 |
|------|------|
| `Notification+Names.swift` | `.memberProfileUpdated` 를 **UMCFoundation 에 선언** — 기존 `.fcmTokenReceived` 는 App 타깃 로컬 선언이라 Auth 모듈에서 보이지 않음 |
| `SyncProfileStorageUseCase.execute` | 프로필 저장 완료 후 알림 **1회** 발송 |
| `AppDelegate` | 해당 알림 구독 → `syncFCMTokenIfPossible(trigger: "memberProfileUpdated")` |

신규 타입·프로토콜 없이 기존 NotificationCenter 배선만 이어 붙였습니다. 순 +52줄(테스트 25줄 포함).

### 진입점별 개별 호출을 넣지 않은 이유

`SyncProfileStorageUseCase.execute` **한 곳이 로그인 경로 전체의 choke point** 입니다. 4개 진입점에 각각 호출을 심는 대신 여기 한 곳만 건드렸습니다.

| 진입점 | 위치 |
|--------|------|
| 소셜 로그인 | `LoginViewModel.swift:210` |
| 이메일 로그인 | `EmailLoginViewModel.swift:141` |
| 미인증 UMC 재등록 | `FailedVerificationUMCViewModel.swift:182` |
| 자동 로그인 | `CheckAuthStatusUseCase.swift:60` |

## 📋 추후 진행 상황

- **The Ping 딥링크**(푸시 탭 → 공지 상세 이동)는 AppProduct 에도 구현되어 있지 않아 이관 대상이 아닙니다. 이식이 아니라 **신규 기능**이므로 별도 이슈로 분리하는 것을 권장합니다. (#1008 완료 조건 6번)

## 📌 리뷰 포인트

**1. 토큰 중복 업로드가 없는지** — `syncFCMTokenIfPossible` 의 `uploadedFCMToken` / `uploadedFCMMemberId` 가드(`AppDelegate.swift:154-156`)가 동일 `(memberId, token)` 조합의 재업로드를 이미 차단합니다. 트리거가 늘어나도 중복 등록은 발생하지 않는다는 판단인데, 이 가드가 유일한 방어선이라 확인 부탁드립니다.

**2. 알림 선언 위치** — `.memberProfileUpdated` 를 App 타깃이 아닌 **UMCFoundation** 에 둔 이유는 발송자(Auth Domain)와 수신자(App 타깃)가 서로 다른 모듈이기 때문입니다. 기존 `.fcmTokenReceived` 가 App 로컬 선언이라 Auth 에서 참조 불가했던 것과 같은 이유입니다.

**3. 테스트의 `expectedCount: 1...`** — 동일 스위트의 다른 테스트가 병렬 실행 중 같은 알림을 발송할 수 있어 정확히 1회가 아닌 "1회 이상"으로 확인합니다. 더 엄격한 격리 방식이 낫다면 알려주세요.

## ✅ 테스트

`SyncProfileStorageUseCaseTests` 에 알림 발송 검증 테스트 추가 (Swift Testing).

```
AuthDomain : Test run with 51 tests in 14 suites passed  ** TEST SUCCEEDED **
UMCApp     : Test run with 14 tests in 2 suites passed   ** TEST SUCCEEDED **
```

`AppProduct/` 변경 0건 (v2.2.0 동결 준수).

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

Closes #1008
