### PR TITLE
♻️ [Refactor] Notice DI 등록 3건 누락 보완 — NoticeRead·NoticeEditorTarget 결선 (#1084)

### DIFF
--- a/UMCApp/Core/DI/Sources/DIContainer.swift
+++ b/UMCApp/Core/DI/Sources/DIContainer.swift
@@ -169,7 +169,12 @@ extension DIContainer {
         modelContext: ModelContext
     ) -> DIContainer {
         let container = DIContainer()
-        
+
+        // MARK: - SwiftData
+        container.register(ModelContext.self) {
+            modelContext
+        }
+
         // MARK: - Token Store (NetworkClient보다 먼저 등록)
         container.register(TokenStore.self) {
             KeychainTokenStore()

--- a/UMCApp/UMCApp/Sources/DIContainer+Notice.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Notice.swift
@@ -9,9 +9,12 @@ import CoreDI
 import CoreNetwork
 import NoticeDomain
 import NoticeData
+import SwiftData
 import UMCFoundation
 
 extension DIContainer {
+    /// `ModelContext` 는 ``DIContainer/configured(modelContext:)`` 가 등록한 공유 인프라이므로
+    /// `MoyaNetworkAdapter` 와 같이 `resolve` 로만 재사용한다.
     func registerNoticeDependencies() {
         register(StorageRepositoryProtocol.self) {
             StorageRepository(adapter: self.resolve(MoyaNetworkAdapter.self))
@@ -19,10 +22,21 @@ extension DIContainer {
         register(NoticeRepositoryProtocol.self) {
             NoticeRepository(adapter: self.resolve(MoyaNetworkAdapter.self))
         }
+        register(NoticeReadRepositoryProtocol.self) {
+            NoticeReadRepository(modelContext: self.resolve(ModelContext.self))
+        }
         register(NoticeUseCaseProtocol.self) {
             NoticeUseCase(
                 repository: self.resolve(NoticeRepositoryProtocol.self),
                 storageRepository: self.resolve(StorageRepositoryProtocol.self)
+            )
+        }
+        register(NoticeEditorTargetRepositoryProtocol.self) {
+            NoticeEditorTargetRepository(adapter: self.resolve(MoyaNetworkAdapter.self))
+        }
+        register(NoticeEditorTargetUseCaseProtocol.self) {
+            NoticeEditorTargetUseCase(
+                repository: self.resolve(NoticeEditorTargetRepositoryProtocol.self)
             )
         }
     }


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 이관 완료된 Notice Repository/UseCase 가 DIContainer 에 등록되지 않아 `resolve` 시 `fatalError` 로 이어지던 미결선 3건을 보완합니다. (closes #1084)

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (DI 결선 전용).

## 🛠️ 작업내용

- `DIContainer+Notice.registerNoticeDependencies()` 에 등록 3건 추가
  - `NoticeReadRepositoryProtocol` → `NoticeReadRepository(modelContext:)` (읽음 처리 · The Ping)
  - `NoticeEditorTargetRepositoryProtocol` → `NoticeEditorTargetRepository(adapter:)` (지부/학교 타겟 조회)
  - `NoticeEditorTargetUseCaseProtocol` → `NoticeEditorTargetUseCase(repository:)`
- `DIContainer.configured(modelContext:)` 에서 `ModelContext` 를 공유 인프라로 등록
  - 기존에 `modelContext` 파라미터를 받고도 body 에서 한 번도 사용하지 않던 死 파라미터였습니다. Notice 등록이 별도 확장 파일로 분리되면서 레거시의 클로저 캡처 경로가 끊긴 상태였습니다.
  - `MoyaNetworkAdapter` 와 동일한 \"공유 인프라는 `configured` 에서 등록하고 feature 확장은 `resolve` 로만 재사용한다\" 패턴을 그대로 따랐습니다.

## 📋 추후 진행 상황

**이 PR 만으로는 `NoticeViewModel.init` 이 아직 크래시합니다.** resolve 순서가 `NoticeUseCase`(:99) → **`ChallengerGenRepositoryProtocol`(:100)** → `NoticeRead`(:101) → `EditorTarget`(:102) 인데, `ChallengerGenRepository` 구현체가 UMCApp 으로 **아직 이관되지 않았습니다** (`AppProduct/AppProduct/Features/Home/Data/Repository/ChallengerGenRepository.swift` 에만 존재). 등록만으로는 해결 불가하며 이관이 선행돼야 합니다.

현재 Notice 탭은 플레이스홀더(`RootTabView.swift:108-109`)라 `NoticeViewModel` 이 생성되지 않아 크래시는 잠복 상태이지만, #1027 Notice 탭 실연결 전에 아래 후속 작업이 필요합니다.

- [ ] `ChallengerGenRepository` UMCApp 이관 + DI 등록 (#1027 선행)
- [ ] `AuthorizationUseCaseProtocol` — Presentation 로컬 스텁(`Sources/Stubs/AuthorizationStubs.swift:22`)만 있고 구현체·등록 없음 (`NoticeDetailViewModel.swift:32`)
- [ ] `ChallengerGenRepositoryProtocol` 이 `Features/Home/Domain` · `Features/Notice/Domain` 에 동일 사본 2개로 존재 — `ScheduleRepositoryProtocol` 처럼 canonical 일원화 검토

## 📌 리뷰 포인트

- `UMCApp/UMCApp/Sources/DIContainer+Notice.swift` — 등록 3건의 의존성 조립 순서 및 `NoticeEditorTargetUseCase(repository:)` 시그니처 일치 여부
- `UMCApp/Core/DI/Sources/DIContainer.swift:172-176` — `ModelContext` 를 컨테이너 공유 인프라로 등록하는 방식이 적절한지. 대안은 `registerNoticeDependencies(modelContext:)` 로 시그니처를 바꾸는 것이었으나, `configured` 의 파라미터를 계속 죽은 채로 두고 호출부(`UMCAppApp.swift:49`)까지 건드려야 해서 택하지 않았습니다.

## 🧪 검증

- `make build` → **BUILD SUCCEEDED** (신규 경고 없음)
- `make test` 는 변경 전후 동일하게 실패합니다 (테스트 호스트 앱 부팅 크래시). `git stash` 로 클린 트리에서 재현 확인했으며 이번 변경과 무관한 기존 문제입니다.
- `AppProduct/` 변경 없음 (절대 규칙 #9 준수)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)