### PR TITLE
♻️ [Refactor] 일정 수정·삭제·강제 삭제 파이프라인 이식 (#1087)

### DIFF
--- a/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
+++ b/UMCApp/Core/Foundation/Sources/Error/Types/DomainError.swift
@@ -81,6 +81,11 @@ public enum DomainError: Error, LocalizedError, Equatable {
     /// 출석 사유 입력 필요
     case attendanceReasonRequired
 
+    // MARK: - 일정
+
+    /// 출석 기록이 있어 일반 삭제가 거부됨 (강제 삭제로 에스컬레이션 가능)
+    case scheduleHasAttendanceRecords
+
     // MARK: - 워크북/과제
 
     /// 제출 기한 초과
@@ -140,6 +145,8 @@ public enum DomainError: Error, LocalizedError, Equatable {
             return "출석 시간이 지났습니다."
         case .attendanceReasonRequired:
             return "출석 사유를 입력해주세요."
+        case .scheduleHasAttendanceRecords:
+            return "출석 기록이 있는 일정은 삭제할 수 없습니다. 최고 관리자에게 강제 삭제를 요청하세요."
         case .workbookDeadlinePassed:
             return "제출 기한이 지났습니다."
         case .workbookAlreadySubmitted:

--- a/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
+++ b/UMCApp/Features/Activity/Domain/Tests/UseCases/ChallengerAttendanceUseCaseTests.swift
@@ -186,8 +186,16 @@ private final class MockScheduleRepository: @unchecked Sendable, ScheduleReposit
         fatalError("createSchedule 은 ChallengerAttendanceUseCase 계약 밖입니다.")
     }
 
+    func updateSchedule(scheduleId: String, request: ScheduleUpdateRequest) async throws {
+        fatalError("updateSchedule 은 ChallengerAttendanceUseCase 계약 밖입니다.")
+    }
+
     func deleteSchedule(scheduleId: String) async throws {
         fatalError("deleteSchedule 은 ChallengerAttendanceUseCase 계약 밖입니다.")
+    }
+
+    func forceDeleteSchedule(scheduleId: String) async throws {
+        fatalError("forceDeleteSchedule 은 ChallengerAttendanceUseCase 계약 밖입니다.")
     }
 }
 

--- a/UMCApp/Features/Home/Data/Sources/DTOs/Request/ScheduleUpdateRequestDTO.swift
+++ b/UMCApp/Features/Home/Data/Sources/DTOs/Request/ScheduleUpdateRequestDTO.swift
@@ -1,0 +1,109 @@
+//
+//  ScheduleUpdateRequestDTO.swift
+//  HomeData
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+import HomeDomain
+import UMCFoundation
+
+/// 일정 수정 Request DTO (V2)
+///
+/// `PATCH /api/v2/schedules/{id}` 의 요청 본문을 인코딩한다. PATCH 의미상 값이 없는 필드는
+/// `encodeIfPresent` 로 본문에서 통째로 빠지므로, 서버는 해당 필드를 기존 값으로 유지한다.
+///
+/// - Note: 서버 request 계약이 참여자 식별자를 `Set<Long>` 으로 받으므로 생성 요청과 동일하게
+///   `participantMemberIds` 만 `Int` 로 직렬화한다 (절대 규칙 #2 는 응답 한정).
+struct ScheduleUpdateRequestDTO: Encodable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    let name: String?
+    let description: String?
+    /// 시작 일시 (UTC ISO8601 문자열로 인코딩)
+    let startsAt: Date?
+    /// 종료 일시 (UTC ISO8601 문자열로 인코딩)
+    let endsAt: Date?
+    let location: ScheduleLocationRequestDTO?
+    let participantMemberIds: [Int]?
+    let tags: [String]?
+    let attendancePolicy: ScheduleAttendancePolicyRequestDTO?
+    /// 비대면 여부. `nil` 이면 필드를 보내지 않아 서버가 현행 유지하고,
+    /// `true`/`false` 는 대면 ↔ 비대면 전환을 명시한다.
+    let isOnline: Bool?
+    /// 출석 필수 여부. `nil` 이면 필드를 보내지 않아 서버가 현행 유지하고,
+    /// `true`/`false` 는 출석 필수 ↔ 비필수 전환을 명시한다.
+    let isAttendanceRequired: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case description
+        case startsAt
+        case endsAt
+        case location
+        case participantMemberIds
+        case tags
+        case attendancePolicy
+        case isOnline
+        case isAttendanceRequired
+    }
+
+    // MARK: - Function
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encodeIfPresent(
+            startsAt.map(ServerDateTimeConverter.toUTCDateTimeString),
+            forKey: .startsAt
+        )
+        try container.encodeIfPresent(
+            endsAt.map(ServerDateTimeConverter.toUTCDateTimeString),
+            forKey: .endsAt
+        )
+        try container.encodeIfPresent(location, forKey: .location)
+        try container.encodeIfPresent(participantMemberIds, forKey: .participantMemberIds)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(attendancePolicy, forKey: .attendancePolicy)
+        try container.encodeIfPresent(isOnline, forKey: .isOnline)
+        try container.encodeIfPresent(isAttendanceRequired, forKey: .isAttendanceRequired)
+    }
+}
+
+// MARK: - Domain → DTO
+
+extension ScheduleUpdateRequestDTO {
+
+    /// 도메인 입력 모델을 요청 DTO 로 옮긴다.
+    ///
+    /// 참여자 식별자 중 정수로 해석되지 않는 값은 서버가 받을 수 없으므로 제외한다.
+    init(domain: ScheduleUpdateRequest) {
+        self.init(
+            name: domain.name,
+            description: domain.description,
+            startsAt: domain.startsAt,
+            endsAt: domain.endsAt,
+            location: domain.location.map {
+                ScheduleLocationRequestDTO(
+                    latitude: $0.latitude,
+                    longitude: $0.longitude,
+                    locationName: $0.locationName
+                )
+            },
+            participantMemberIds: domain.participantMemberIds?.compactMap(Int.init),
+            tags: domain.tags,
+            attendancePolicy: domain.attendancePolicy.map {
+                ScheduleAttendancePolicyRequestDTO(
+                    checkInStartAt: ServerDateTimeConverter.toUTCDateTimeString($0.checkInStartAt),
+                    onTimeEndAt: ServerDateTimeConverter.toUTCDateTimeString($0.onTimeEndAt),
+                    lateEndAt: ServerDateTimeConverter.toUTCDateTimeString($0.lateEndAt)
+                )
+            },
+            isOnline: domain.isOnline,
+            isAttendanceRequired: domain.isAttendanceRequired
+        )
+    }
+}

--- a/UMCApp/Features/Home/Data/Sources/Repositories/ScheduleRepository.swift
+++ b/UMCApp/Features/Home/Data/Sources/Repositories/ScheduleRepository.swift
@@ -110,12 +110,18 @@ public final class ScheduleRepository: ScheduleRepositoryProtocol, @unchecked Se
         return try apiResponse.unwrap().value
     }
 
-    /// 일정을 삭제한다.
+    /// 일정을 부분 수정한다. 전송할 필드 선별은 요청 DTO 의 인코딩이 담당한다.
     ///
     /// 성공 응답 본문이 비어 있을 수 있어(204 등) 그 경우는 성공으로 간주한다.
-    public func deleteSchedule(scheduleId: String) async throws {
+    public func updateSchedule(
+        scheduleId: String,
+        request: ScheduleUpdateRequest
+    ) async throws {
         let response = try await networkRequesting.request(
-            ScheduleV2Router.deleteSchedule(scheduleId: scheduleId)
+            ScheduleV2Router.patchSchedule(
+                scheduleId: scheduleId,
+                body: ScheduleUpdateRequestDTO(domain: request)
+            )
         )
 
         guard !response.data.isEmpty else { return }
@@ -128,10 +134,81 @@ public final class ScheduleRepository: ScheduleRepositoryProtocol, @unchecked Se
             try apiResponse.validateSuccess()
         } catch let decodingError as DecodingError {
             #if DEBUG
+            print("[ScheduleRepository] updateSchedule decodingError=\(decodingError)")
+            #endif
+            throw RepositoryError.decodingError(detail: "\(decodingError)")
+        }
+    }
+
+    /// 일정을 삭제한다.
+    ///
+    /// 성공 응답 본문이 비어 있을 수 있어(204 등) 그 경우는 성공으로 간주한다.
+    /// 출석 기록을 이유로 거부된 응답은 강제 삭제 안내가 가능하도록 도메인 에러로 승격한다.
+    public func deleteSchedule(scheduleId: String) async throws {
+        let response = try await networkRequesting.request(
+            ScheduleV2Router.deleteSchedule(scheduleId: scheduleId)
+        )
+
+        guard !response.data.isEmpty else { return }
+
+        let apiResponse: APIResponse<EmptyResult>
+        do {
+            apiResponse = try JSONDecoder().decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+        } catch let decodingError as DecodingError {
+            #if DEBUG
             print("[ScheduleRepository] deleteSchedule decodingError=\(decodingError)")
             #endif
             throw RepositoryError.decodingError(detail: "\(decodingError)")
         }
+
+        do {
+            try apiResponse.validateSuccess()
+        } catch let serverError as RepositoryError {
+            throw Self.mapDeleteError(serverError)
+        }
+    }
+
+    /// 출석 기록이 있는 일정을 강제 삭제한다. 권한 검증은 서버가 한다.
+    public func forceDeleteSchedule(scheduleId: String) async throws {
+        let response = try await networkRequesting.request(
+            ScheduleV2Router.forceDeleteSchedule(scheduleId: scheduleId)
+        )
+
+        guard !response.data.isEmpty else { return }
+
+        do {
+            let apiResponse = try JSONDecoder().decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let decodingError as DecodingError {
+            #if DEBUG
+            print("[ScheduleRepository] forceDeleteSchedule decodingError=\(decodingError)")
+            #endif
+            throw RepositoryError.decodingError(detail: "\(decodingError)")
+        }
+    }
+
+    /// 삭제 거부 응답 중 "출석 기록 존재" 케이스만 도메인 에러로 승격한다.
+    ///
+    /// 호출부가 강제 삭제로 에스컬레이션할지 판단하는 유일한 신호라 일반 서버 에러와 구분한다.
+    ///
+    /// ponytail: 서버가 이 거부에 전용 code 를 주지 않아 메시지 문자열 스니핑에 의존한다.
+    /// 서버 문구가 바뀌면 일반 서버 에러로 조용히 되돌아간다 — 전용 code(예: `SCHEDULE-00xx`)가
+    /// 생기면 code 우선 판정으로 교체하고 문자열은 fallback 으로 남긴다.
+    private static func mapDeleteError(_ error: RepositoryError) -> Error {
+        guard case .serverError(let code, let message) = error else { return error }
+
+        let combined = "\(code ?? "") \(message ?? "")"
+        let hasAttendanceRecords = combined.contains("출석 기록")
+            || combined.contains("출석 데이터")
+            || (combined.contains("출석") && combined.contains("삭제"))
+
+        return hasAttendanceRecords ? DomainError.scheduleHasAttendanceRecords : error
     }
 }
 

--- a/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
+++ b/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
@@ -29,8 +29,12 @@ enum ScheduleV2Router: BaseTargetType {
     case getScheduleDetail(scheduleId: String)
     /// 일정 생성
     case postSchedule(body: ScheduleCreateRequestDTO)
+    /// 일정 수정 (부분 갱신 — 본문에 실린 필드만 반영된다)
+    case patchSchedule(scheduleId: String, body: ScheduleUpdateRequestDTO)
     /// 일정 삭제 (스터디 일정 등록 2단계 실패 시 1단계 롤백 등)
     case deleteSchedule(scheduleId: String)
+    /// 일정 강제 삭제 (출석 기록이 있어 일반 삭제가 거부된 일정 — 서버가 권한을 검증한다)
+    case forceDeleteSchedule(scheduleId: String)
 
     // MARK: - Path
 
@@ -42,6 +46,10 @@ enum ScheduleV2Router: BaseTargetType {
             return "/api/v2/schedules"
         case .getScheduleDetail(let scheduleId), .deleteSchedule(let scheduleId):
             return "/api/v2/schedules/\(scheduleId)"
+        case .patchSchedule(let scheduleId, _):
+            return "/api/v2/schedules/\(scheduleId)"
+        case .forceDeleteSchedule(let scheduleId):
+            return "/api/v2/schedules/\(scheduleId)/force"
         }
     }
 
@@ -53,7 +61,9 @@ enum ScheduleV2Router: BaseTargetType {
             return .get
         case .postSchedule:
             return .post
-        case .deleteSchedule:
+        case .patchSchedule:
+            return .patch
+        case .deleteSchedule, .forceDeleteSchedule:
             return .delete
         }
     }
@@ -69,7 +79,9 @@ enum ScheduleV2Router: BaseTargetType {
             )
         case .postSchedule(let body):
             return .requestJSONEncodable(body)
-        case .getScheduleDetail, .deleteSchedule:
+        case .patchSchedule(_, let body):
+            return .requestJSONEncodable(body)
+        case .getScheduleDetail, .deleteSchedule, .forceDeleteSchedule:
             return .requestPlain
         }
     }

--- a/UMCApp/Features/Home/Data/Tests/ScheduleUpdatePipelineTests.swift
+++ b/UMCApp/Features/Home/Data/Tests/ScheduleUpdatePipelineTests.swift
@@ -1,0 +1,121 @@
+//
+//  ScheduleUpdatePipelineTests.swift
+//  HomeDataTests
+//
+//  Created by euijjang97 on 8/8/26.
+//
+//  PATCH 부분 전송 계약(설정하지 않은 필드는 본문에서 생략)과, 강제 삭제 에스컬레이션의 유일한
+//  신호인 "출석 기록 존재" 삭제 거부가 도메인 에러로 승격되는지 검증한다.
+//
+
+import Foundation
+import Testing
+import Moya
+import CoreNetwork
+import UMCFoundation
+import HomeDomain
+@testable import HomeData
+
+// MARK: - Test Double
+
+/// ``HomeNetworkRequesting`` 가짜 구현 (고정 본문 1회 응답).
+private struct StubScheduleNetwork: HomeNetworkRequesting {
+
+    let body: Data
+
+    func request<T: TargetType>(_ target: T) async throws -> Response {
+        Response(statusCode: 200, data: body)
+    }
+}
+
+@Suite("일정 수정/삭제 파이프라인")
+struct ScheduleUpdatePipelineTests {
+
+    // MARK: - PATCH 부분 전송
+
+    @Test("설정하지 않은 필드는 요청 본문에서 생략된다")
+    func omitsUnsetFields() throws {
+        let dto = ScheduleUpdateRequestDTO(domain: ScheduleUpdateRequest(name: "세미나"))
+
+        let body = try encodeToJSONObject(dto)
+
+        #expect(body.keys.sorted() == ["name"])
+    }
+
+    @Test("설정한 필드는 값과 함께 전송된다 (false 도 생략되지 않는다)")
+    func encodesSetFields() throws {
+        let startsAt = Date(timeIntervalSince1970: 1_770_000_000)
+        let dto = ScheduleUpdateRequestDTO(
+            domain: ScheduleUpdateRequest(
+                startsAt: startsAt,
+                participantMemberIds: ["7", "정수아님"],
+                isOnline: false,
+                isAttendanceRequired: false
+            )
+        )
+
+        let body = try encodeToJSONObject(dto)
+
+        #expect(
+            body["startsAt"] as? String == ServerDateTimeConverter.toUTCDateTimeString(startsAt)
+        )
+        #expect(body["participantMemberIds"] as? [Int] == [7])
+        #expect(body["isOnline"] as? Bool == false)
+        #expect(body["isAttendanceRequired"] as? Bool == false)
+        #expect(body["name"] == nil)
+    }
+
+    // MARK: - 삭제 거부 매핑
+
+    @Test("출석 기록으로 거부된 삭제는 도메인 에러로 승격된다")
+    func mapsAttendanceRecordRejection() async throws {
+        let repository = makeRepository(
+            responseBody: #"""
+            {
+                "success": false,
+                "code": "SCHEDULE-0011",
+                "message": "출석 기록이 있어 삭제할 수 없습니다.",
+                "result": null
+            }
+            """#
+        )
+
+        await #expect(throws: DomainError.scheduleHasAttendanceRecords) {
+            try await repository.deleteSchedule(scheduleId: "12")
+        }
+    }
+
+    @Test("그 밖의 삭제 실패는 서버 에러 그대로 전달된다")
+    func keepsUnrelatedServerError() async throws {
+        let repository = makeRepository(
+            responseBody: #"""
+            {
+                "success": false,
+                "code": "SCHEDULE-0009",
+                "message": "일정을 찾을 수 없습니다.",
+                "result": null
+            }
+            """#
+        )
+
+        await #expect(
+            throws: RepositoryError.serverError(
+                code: "SCHEDULE-0009",
+                message: "일정을 찾을 수 없습니다."
+            )
+        ) {
+            try await repository.deleteSchedule(scheduleId: "12")
+        }
+    }
+
+    // MARK: - Helper
+
+    private func makeRepository(responseBody: String) -> ScheduleRepository {
+        ScheduleRepository(networkRequesting: StubScheduleNetwork(body: Data(responseBody.utf8)))
+    }
+
+    private func encodeToJSONObject(_ value: some Encodable) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        return try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleRepositoryProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleRepositoryProtocol.swift
@@ -37,10 +37,24 @@ public protocol ScheduleRepositoryProtocol {
     /// - Returns: 생성된 일정 식별자 (서버 정수를 절대 규칙 #2 에 따라 `String` 으로 보존)
     func createSchedule(_ request: ScheduleCreationRequest) async throws -> String
 
+    /// 일정을 부분 수정한다.
+    ///
+    /// 요청 모델에서 값이 설정된 필드만 서버로 전송되므로, 화면이 바꾸지 않은 항목은
+    /// 다시 채워 보내지 않아도 기존 값이 유지된다.
+    func updateSchedule(scheduleId: String, request: ScheduleUpdateRequest) async throws
+
     /// 일정을 삭제한다.
     ///
     /// 스터디 일정 등록 2단계(그룹 연결)가 실패했을 때 1단계 일정을 되돌리는 용도로 쓴다.
     ///
-    /// - Note: 서버는 출석 기록이 있는 일정의 일반 삭제를 거부한다.
+    /// - Note: 서버는 출석 기록이 있는 일정의 일반 삭제를 거부한다. 이 경우
+    ///   `DomainError.scheduleHasAttendanceRecords` 로 던져지며, 강제 삭제로 넘어갈지
+    ///   판단하는 유일한 신호다.
     func deleteSchedule(scheduleId: String) async throws
+
+    /// 출석 기록이 있는 일정을 강제 삭제한다.
+    ///
+    /// 일반 삭제가 출석 기록을 이유로 거부됐을 때의 에스컬레이션 경로다.
+    /// 호출 권한(일정 기수의 최고 관리자)은 서버가 검증하고 그 외에는 403 으로 반려한다.
+    func forceDeleteSchedule(scheduleId: String) async throws
 }

--- a/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleUpdateRequest.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleUpdateRequest.swift
@@ -1,0 +1,62 @@
+//
+//  ScheduleUpdateRequest.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+
+/// 일정 수정 입력 모델
+///
+/// `PATCH /api/v2/schedules/{id}` 로 보낼 값을 도메인 어휘로 표현한다. 부분 수정이므로 모든
+/// 필드가 Optional 이고, `nil` 은 "변경하지 않음"을 뜻한다 (요청 본문에서 생략된다).
+///
+/// - Note: `participantMemberIds` 는 생성 입력과 마찬가지로 절대 규칙 #2 에 따라 `String` 으로
+///   다루며, 서버 request 계약(`Set<Long>`)에 맞춘 `Int` 변환은 Data 레이어가 수행한다.
+public struct ScheduleUpdateRequest: Equatable, Sendable {
+
+    // MARK: - Property
+
+    public let name: String?
+    public let description: String?
+    public let startsAt: Date?
+    public let endsAt: Date?
+    /// 장소 (`nil` = 변경 없음 — 비대면 전환은 `isOnline` 으로 표현한다)
+    public let location: ScheduleLocation?
+    /// 참여자 멤버 식별자 목록 (전체 교체)
+    public let participantMemberIds: [String]?
+    public let tags: [String]?
+    /// 출석 정책 (`nil` = 변경 없음 — 출석 비필수 전환은 `isAttendanceRequired` 로 표현한다)
+    public let attendancePolicy: ScheduleAttendancePolicy?
+    /// 비대면 여부. `nil` = 변경 없음, `true`/`false` = 명시적 전환
+    public let isOnline: Bool?
+    /// 출석 필수 여부. `nil` = 변경 없음, `true`/`false` = 명시적 전환
+    public let isAttendanceRequired: Bool?
+
+    // MARK: - Init
+
+    public init(
+        name: String? = nil,
+        description: String? = nil,
+        startsAt: Date? = nil,
+        endsAt: Date? = nil,
+        location: ScheduleLocation? = nil,
+        participantMemberIds: [String]? = nil,
+        tags: [String]? = nil,
+        attendancePolicy: ScheduleAttendancePolicy? = nil,
+        isOnline: Bool? = nil,
+        isAttendanceRequired: Bool? = nil
+    ) {
+        self.name = name
+        self.description = description
+        self.startsAt = startsAt
+        self.endsAt = endsAt
+        self.location = location
+        self.participantMemberIds = participantMemberIds
+        self.tags = tags
+        self.attendancePolicy = attendancePolicy
+        self.isOnline = isOnline
+        self.isAttendanceRequired = isAttendanceRequired
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/DeleteScheduleUseCaseProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/DeleteScheduleUseCaseProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  DeleteScheduleUseCaseProtocol.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+
+/// 일정 삭제 UseCase 인터페이스
+///
+/// 출석 기록이 있는 일정은 서버가 거부하고 `DomainError.scheduleHasAttendanceRecords` 로
+/// 전달되므로, 호출부는 그 신호를 받아 강제 삭제로 넘어갈지 결정한다.
+public protocol DeleteScheduleUseCaseProtocol {
+
+    /// - Parameter scheduleId: 삭제할 일정 식별자
+    func execute(scheduleId: String) async throws
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/ForceDeleteScheduleUseCaseProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/ForceDeleteScheduleUseCaseProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  ForceDeleteScheduleUseCaseProtocol.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+
+/// 일정 강제 삭제 UseCase 인터페이스
+///
+/// 일반 삭제가 출석 기록을 이유로 거부됐을 때의 에스컬레이션 경로다.
+public protocol ForceDeleteScheduleUseCaseProtocol {
+
+    /// - Parameter scheduleId: 강제 삭제할 일정 식별자
+    func execute(scheduleId: String) async throws
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/DeleteScheduleUseCase.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/DeleteScheduleUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  DeleteScheduleUseCase.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+
+/// 일정 삭제 UseCase 구현체
+public final class DeleteScheduleUseCase: DeleteScheduleUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: ScheduleRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: ScheduleRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(scheduleId: String) async throws {
+        try await repository.deleteSchedule(scheduleId: scheduleId)
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/ForceDeleteScheduleUseCase.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/ForceDeleteScheduleUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  ForceDeleteScheduleUseCase.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+
+/// 일정 강제 삭제 UseCase 구현체
+public final class ForceDeleteScheduleUseCase: ForceDeleteScheduleUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: ScheduleRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: ScheduleRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(scheduleId: String) async throws {
+        try await repository.forceDeleteSchedule(scheduleId: scheduleId)
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/UpdateScheduleUseCase.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/UpdateScheduleUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  UpdateScheduleUseCase.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+
+/// 일정 부분 수정 UseCase 구현체
+public final class UpdateScheduleUseCase: UpdateScheduleUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: ScheduleRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: ScheduleRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(scheduleId: String, request: ScheduleUpdateRequest) async throws {
+        try await repository.updateSchedule(scheduleId: scheduleId, request: request)
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/UpdateScheduleUseCaseProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/UpdateScheduleUseCaseProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  UpdateScheduleUseCaseProtocol.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+
+/// 일정 부분 수정 UseCase 인터페이스
+public protocol UpdateScheduleUseCaseProtocol {
+
+    /// - Parameters:
+    ///   - scheduleId: 수정할 일정 식별자
+    ///   - request: 값이 설정된 필드만 서버로 전송되는 부분 수정 입력
+    func execute(scheduleId: String, request: ScheduleUpdateRequest) async throws
+}

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift
@@ -14,7 +14,8 @@ import UMCFoundation
 
 /// 일정 상세 화면 ViewModel
 ///
-/// 조회는 읽기 전용이다. 수정/삭제는 대상 화면과 권한 판정이 아직 이식되지 않아 다루지 않는다.
+/// 조회 실패는 화면 내 `Loadable` 로, 삭제·강제 삭제 실패는 흐름을 끊는 `ErrorHandler` 로 나눠 처리한다.
+/// 수정은 편집 화면이 아직 이식되지 않아 권한만 계산해 두고 진입점을 노출하지 않는다.
 @Observable
 @MainActor
 final class ScheduleDetailViewModel {
@@ -23,11 +24,31 @@ final class ScheduleDetailViewModel {
 
     private(set) var data: Loadable<ScheduleDetailData> = .idle
 
+    var alertPrompt: AlertPrompt?
+
+    /// - TODO: (#1091) 일정 편집 화면 이식 후 수정 진입점 연결
+    private(set) var canEditSchedule: Bool = false
+
+    private(set) var canDeleteSchedule: Bool = false
+    private(set) var canForceDeleteSchedule: Bool = false
+    private(set) var isDeleting: Bool = false
+    private(set) var isDeleted: Bool = false
+
     private let scheduleId: String
     private let fetchScheduleDetailUseCase: FetchScheduleDetailUseCaseProtocol
+    private let deleteScheduleUseCase: DeleteScheduleUseCaseProtocol
+    private let forceDeleteScheduleUseCase: ForceDeleteScheduleUseCaseProtocol
+    private let authorizationUseCase: AuthorizationUseCaseProtocol
     private let userSession: UserSessionManager
+    private let errorHandler: ErrorHandler
 
     // MARK: - Computed Property
+
+    /// 이미 시작된 일정인지 여부. 시작된 일정은 서버가 수정을 거부한다.
+    var isScheduleStarted: Bool {
+        guard let schedule = data.value else { return false }
+        return Date() >= schedule.startsAt
+    }
 
     /// 출석 현황 화면으로 진입할 수 있는지 여부.
     ///
@@ -48,9 +69,13 @@ final class ScheduleDetailViewModel {
 
     // MARK: - Init
 
-    init(container: DIContainer, scheduleId: String) {
+    init(container: DIContainer, scheduleId: String, errorHandler: ErrorHandler) {
         self.scheduleId = scheduleId
+        self.errorHandler = errorHandler
         fetchScheduleDetailUseCase = container.resolve(FetchScheduleDetailUseCaseProtocol.self)
+        deleteScheduleUseCase = container.resolve(DeleteScheduleUseCaseProtocol.self)
+        forceDeleteScheduleUseCase = container.resolve(ForceDeleteScheduleUseCaseProtocol.self)
+        authorizationUseCase = container.resolve(AuthorizationUseCaseProtocol.self)
         userSession = container.resolve(UserSessionManager.self)
     }
 
@@ -90,7 +115,103 @@ final class ScheduleDetailViewModel {
         mapItem.openInMaps()
     }
 
+    /// 일정 리소스 권한을 조회한다.
+    ///
+    /// 조회에 실패하면 권한을 전부 닫는다. 상세 응답에는 권한 필드가 없어 대체할 근거가 없고,
+    /// 열어 두면 서버가 거부할 액션을 노출하게 된다.
+    func fetchSchedulePermission() async {
+        do {
+            let permission = try await authorizationUseCase.getResourcePermission(
+                resourceType: .schedule,
+                resourceId: scheduleId
+            )
+            canEditSchedule = permission.hasAny([.edit, .write, .manage])
+            canDeleteSchedule = permission.hasAny([.delete, .manage])
+            canForceDeleteSchedule = permission.hasAny([.forceDelete, .manage])
+        } catch {
+            canEditSchedule = false
+            canDeleteSchedule = false
+            canForceDeleteSchedule = false
+        }
+    }
+
+    /// 삭제 확인 다이얼로그를 띄운다.
+    func showDeleteConfirmation() {
+        alertPrompt = AlertPrompt(
+            title: "일정 삭제",
+            message: "일정을 삭제하겠습니까?",
+            positiveBtnTitle: "삭제",
+            positiveBtnAction: { [weak self] in
+                Task { @MainActor in await self?.deleteSchedule() }
+            },
+            negativeBtnTitle: "취소",
+            negativeBtnAction: {},
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    /// 일정을 삭제한다.
+    ///
+    /// 서버가 출석 기록을 이유로 거부했고 강제 삭제 권한까지 있을 때만 2차 확인으로 넘긴다.
+    /// 권한이 없으면 강제 삭제를 제안해 봐야 서버가 다시 거부하므로 일반 에러 경로를 탄다.
+    func deleteSchedule() async {
+        guard !isDeleting else { return }
+        isDeleting = true
+        defer { isDeleting = false }
+
+        do {
+            try await deleteScheduleUseCase.execute(scheduleId: scheduleId)
+            isDeleted = true
+        } catch DomainError.scheduleHasAttendanceRecords where canForceDeleteSchedule {
+            showForceDeleteConfirmation()
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Home",
+                    action: "deleteSchedule",
+                    retryAction: { [weak self] in await self?.deleteSchedule() }
+                )
+            )
+        }
+    }
+
     // MARK: - Private Function
+
+    private func showForceDeleteConfirmation() {
+        alertPrompt = AlertPrompt(
+            title: "출석 기록 포함 일정 강제 삭제",
+            message:
+                "이 일정에는 이미 출석 기록이 있습니다.\n강제 삭제하면 출석 데이터까지 함께 삭제되며, 되돌릴 수 없습니다.",
+            positiveBtnTitle: "강제 삭제",
+            positiveBtnAction: { [weak self] in
+                Task { @MainActor in await self?.forceDeleteSchedule() }
+            },
+            negativeBtnTitle: "취소",
+            negativeBtnAction: {},
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    private func forceDeleteSchedule() async {
+        guard !isDeleting else { return }
+        isDeleting = true
+        defer { isDeleting = false }
+
+        do {
+            try await forceDeleteScheduleUseCase.execute(scheduleId: scheduleId)
+            isDeleted = true
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(
+                    feature: "Home",
+                    action: "forceDeleteSchedule",
+                    retryAction: { [weak self] in await self?.forceDeleteSchedule() }
+                )
+            )
+        }
+    }
 
     private func displayText(for status: ScheduleAttendanceStatus) -> String {
         switch status {

--- a/UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift
@@ -15,8 +15,8 @@ import UMCFoundation
 
 /// 일정 상세 화면.
 ///
-/// 읽기 전용이다. 일정 수정/삭제·강제 삭제는 대상 화면과 권한 판정 UseCase 가 아직 이식되지
-/// 않아 이번 범위에서 제외했고, 장소는 역지오코딩 없이 좌표 그대로 Apple Maps 로 넘긴다.
+/// 장소는 역지오코딩 없이 좌표 그대로 Apple Maps 로 넘긴다. 수정 진입점은 편집 화면이 아직
+/// 이식되지 않아(#1091) 툴바에 노출하지 않고, 삭제·강제 삭제만 권한에 따라 연다.
 ///
 /// 출석 진입은 활동 모드로 갈린다. Admin 모드면 출석 현황 화면으로 이동하는 버튼을, 그 외에는
 /// 내 출석 상태를 read-only 로 보여 준다. 출석 비필수 일정은 두 경우 모두 표시하지 않는다.
@@ -24,6 +24,7 @@ public struct ScheduleDetailView: View {
 
     // MARK: - Property
 
+    @Environment(\.dismiss) private var dismiss
     @State private var viewModel: ScheduleDetailViewModel
     private let onAttendanceStatusTapped: () -> Void
 
@@ -35,6 +36,8 @@ public struct ScheduleDetailView: View {
         static let attendanceTitle: String = "출석"
         static let attendanceStatusButtonTitle: String = "출석 현황"
         static let myAttendanceStatusTitle: String = "내 출석 상태"
+        static let deleteActionTitle: String = "삭제하기"
+        static let deleteIcon: String = "trash"
         static let failedTitle: String = "일정을 불러오지 못했어요"
         static let failedSystemImage: String = "exclamationmark.triangle"
     }
@@ -43,17 +46,23 @@ public struct ScheduleDetailView: View {
 
     /// - Parameters:
     ///   - container: UseCase·세션을 resolve할 DI 컨테이너
+    ///   - errorHandler: 삭제·강제 삭제 실패를 전역 Alert 로 올릴 핸들러
     ///   - scheduleId: 조회할 일정 식별자
     ///   - onAttendanceStatusTapped: 출석 현황 버튼 탭 시 화면 이동을 위임하는 콜백
     ///
-    /// - Note: 이 화면의 실패는 모두 인라인(`Loadable`)으로 표시하므로 `ErrorHandler` 를 받지 않는다.
+    /// - Note: 조회 실패는 인라인(`Loadable`)으로 남고, 흐름을 끊는 삭제 실패만 `ErrorHandler` 로 간다.
     public init(
         container: DIContainer,
+        errorHandler: ErrorHandler,
         scheduleId: String,
         onAttendanceStatusTapped: @escaping () -> Void
     ) {
         _viewModel = State(
-            initialValue: ScheduleDetailViewModel(container: container, scheduleId: scheduleId)
+            initialValue: ScheduleDetailViewModel(
+                container: container,
+                scheduleId: scheduleId,
+                errorHandler: errorHandler
+            )
         )
         self.onAttendanceStatusTapped = onAttendanceStatusTapped
     }
@@ -67,9 +76,42 @@ public struct ScheduleDetailView: View {
                 naviTitle: NavigationTitle.Activity.scheduleDetail,
                 displayMode: .inline
             )
-            .task {
-                await viewModel.load()
+            .toolbar { toolbarContent }
+            .alertPrompt(item: $viewModel.alertPrompt)
+            .onChange(of: viewModel.isDeleted) { _, isDeleted in
+                if isDeleted { dismiss() }
             }
+            .task {
+                async let detail: Void = viewModel.load()
+                async let permission: Void = viewModel.fetchSchedulePermission()
+                await detail
+                await permission
+            }
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        if !toolbarActions.isEmpty {
+            ToolBarCollection.ToolbarTrailingMenu(actions: toolbarActions)
+        }
+    }
+
+    /// 삭제 중에는 액션을 비워 중복 요청을 막는다.
+    private var toolbarActions: [ToolBarCollection.ToolbarTrailingMenu.ActionItem] {
+        guard viewModel.data.value != nil,
+              viewModel.canDeleteSchedule,
+              !viewModel.isDeleting else { return [] }
+
+        return [
+            .init(
+                title: Constants.deleteActionTitle,
+                icon: Constants.deleteIcon,
+                role: .destructive,
+                action: viewModel.showDeleteConfirmation
+            )
+        ]
     }
 
     // MARK: - Content
@@ -318,15 +360,40 @@ private struct PreviewFetchScheduleDetailUseCase: FetchScheduleDetailUseCaseProt
     }
 }
 
+/// 삭제 액션을 노출하기 위한 프리뷰 전용 권한 스텁 (절대규칙 #5)
+private struct PreviewAuthorizationUseCase: AuthorizationUseCaseProtocol {
+    func getResourcePermission(
+        resourceType: AuthorizationResourceType,
+        resourceId: String
+    ) async throws -> ResourcePermission {
+        ResourcePermission(
+            resourceType: resourceType,
+            resourceId: resourceId,
+            grantedPermissions: [.delete]
+        )
+    }
+}
+
+private struct PreviewDeleteScheduleUseCase: DeleteScheduleUseCaseProtocol,
+                                             ForceDeleteScheduleUseCaseProtocol {
+    func execute(scheduleId: String) async throws {}
+}
+
 #Preview {
     let container = DIContainer()
     container.register(FetchScheduleDetailUseCaseProtocol.self) {
         PreviewFetchScheduleDetailUseCase()
     }
+    container.register(DeleteScheduleUseCaseProtocol.self) { PreviewDeleteScheduleUseCase() }
+    container.register(ForceDeleteScheduleUseCaseProtocol.self) {
+        PreviewDeleteScheduleUseCase()
+    }
+    container.register(AuthorizationUseCaseProtocol.self) { PreviewAuthorizationUseCase() }
     container.register(UserSessionManager.self) { UserSessionManager() }
     return NavigationStack {
         ScheduleDetailView(
             container: container,
+            errorHandler: ErrorHandler(),
             scheduleId: "1",
             onAttendanceStatusTapped: {}
         )

--- a/UMCApp/Features/Home/Presentation/Tests/ScheduleDetailViewModelTests.swift
+++ b/UMCApp/Features/Home/Presentation/Tests/ScheduleDetailViewModelTests.swift
@@ -45,19 +45,123 @@ struct ScheduleDetailViewModelTests {
     }
 }
 
+@MainActor
+@Suite("ScheduleDetailViewModel — 권한 판정과 삭제 에스컬레이션")
+struct ScheduleDetailPermissionTests {
+
+    @Test("edit/write/manage 는 수정, delete/manage 는 삭제, forceDelete/manage 는 강제 삭제를 연다")
+    func permissionsMapToActions() async {
+        let viewModel = makeViewModel(permissions: [.edit, .delete])
+
+        await viewModel.fetchSchedulePermission()
+
+        #expect(viewModel.canEditSchedule)
+        #expect(viewModel.canDeleteSchedule)
+        #expect(viewModel.canForceDeleteSchedule == false)
+    }
+
+    @Test("manage 단독으로도 수정·삭제·강제 삭제가 모두 열린다")
+    func managePermissionOpensEverything() async {
+        let viewModel = makeViewModel(permissions: [.manage])
+
+        await viewModel.fetchSchedulePermission()
+
+        #expect(viewModel.canEditSchedule)
+        #expect(viewModel.canDeleteSchedule)
+        #expect(viewModel.canForceDeleteSchedule)
+    }
+
+    @Test("read 권한만 있으면 어떤 액션도 열리지 않는다")
+    func readOnlyPermissionOpensNothing() async {
+        let viewModel = makeViewModel(permissions: [.read])
+
+        await viewModel.fetchSchedulePermission()
+
+        #expect(viewModel.canEditSchedule == false)
+        #expect(viewModel.canDeleteSchedule == false)
+        #expect(viewModel.canForceDeleteSchedule == false)
+    }
+
+    @Test("권한 조회가 실패하면 전부 닫는다")
+    func permissionFailureClosesEverything() async {
+        let viewModel = makeViewModel(permissions: [.manage], permissionFails: true)
+
+        await viewModel.fetchSchedulePermission()
+
+        #expect(viewModel.canEditSchedule == false)
+        #expect(viewModel.canDeleteSchedule == false)
+        #expect(viewModel.canForceDeleteSchedule == false)
+    }
+
+    @Test("출석 기록 때문에 삭제가 거부되고 강제 삭제 권한이 있으면 2차 확인을 띄운다")
+    func attendanceRecordsEscalateToForceDelete() async {
+        let viewModel = makeViewModel(
+            permissions: [.manage],
+            deleteError: DomainError.scheduleHasAttendanceRecords
+        )
+        await viewModel.fetchSchedulePermission()
+
+        await viewModel.deleteSchedule()
+
+        #expect(viewModel.alertPrompt?.title == "출석 기록 포함 일정 강제 삭제")
+        #expect(viewModel.isDeleted == false)
+    }
+
+    @Test("강제 삭제 권한이 없으면 같은 거부에도 2차 확인을 띄우지 않는다")
+    func attendanceRecordsWithoutForceDeleteShowsNoPrompt() async {
+        let viewModel = makeViewModel(
+            permissions: [.delete],
+            deleteError: DomainError.scheduleHasAttendanceRecords
+        )
+        await viewModel.fetchSchedulePermission()
+
+        await viewModel.deleteSchedule()
+
+        #expect(viewModel.alertPrompt == nil)
+        #expect(viewModel.isDeleted == false)
+    }
+
+    @Test("삭제에 성공하면 화면을 닫도록 isDeleted 를 세운다")
+    func successfulDeleteMarksDeleted() async {
+        let viewModel = makeViewModel(permissions: [.delete])
+        await viewModel.fetchSchedulePermission()
+
+        await viewModel.deleteSchedule()
+
+        #expect(viewModel.isDeleted)
+        #expect(viewModel.alertPrompt == nil)
+    }
+}
+
 // MARK: - Helpers
 
 @MainActor
 private func makeViewModel(
-    hasAttendancePolicy: Bool,
-    isAdminMode: Bool
+    hasAttendancePolicy: Bool = false,
+    isAdminMode: Bool = false,
+    permissions: Set<AuthorizationPermissionType> = [],
+    permissionFails: Bool = false,
+    deleteError: Error? = nil
 ) -> ScheduleDetailViewModel {
     let container = DIContainer()
     container.register(FetchScheduleDetailUseCaseProtocol.self) {
         StubFetchScheduleDetailUseCase(hasAttendancePolicy: hasAttendancePolicy)
     }
+    container.register(AuthorizationUseCaseProtocol.self) {
+        StubAuthorizationUseCase(permissions: permissions, shouldFail: permissionFails)
+    }
+    container.register(DeleteScheduleUseCaseProtocol.self) {
+        StubDeleteScheduleUseCase(error: deleteError)
+    }
+    container.register(ForceDeleteScheduleUseCaseProtocol.self) {
+        StubForceDeleteScheduleUseCase()
+    }
     container.register(UserSessionManager.self) { makeSession(isAdminMode: isAdminMode) }
-    return ScheduleDetailViewModel(container: container, scheduleId: "1")
+    return ScheduleDetailViewModel(
+        container: container,
+        scheduleId: "1",
+        errorHandler: ErrorHandler()
+    )
 }
 
 /// Admin 모드는 토글 가능 역할일 때만 켜지므로, 역할부터 맞춘 뒤 토글한다.
@@ -94,4 +198,35 @@ private struct StubFetchScheduleDetailUseCase: FetchScheduleDetailUseCaseProtoco
                 : nil
         )
     }
+}
+
+private struct StubAuthorizationUseCase: AuthorizationUseCaseProtocol {
+
+    let permissions: Set<AuthorizationPermissionType>
+    let shouldFail: Bool
+
+    func getResourcePermission(
+        resourceType: AuthorizationResourceType,
+        resourceId: String
+    ) async throws -> ResourcePermission {
+        if shouldFail { throw DomainError.custom(message: "권한 조회 실패") }
+        return ResourcePermission(
+            resourceType: resourceType,
+            resourceId: resourceId,
+            grantedPermissions: permissions
+        )
+    }
+}
+
+private struct StubDeleteScheduleUseCase: DeleteScheduleUseCaseProtocol {
+
+    let error: Error?
+
+    func execute(scheduleId: String) async throws {
+        if let error { throw error }
+    }
+}
+
+private struct StubForceDeleteScheduleUseCase: ForceDeleteScheduleUseCaseProtocol {
+    func execute(scheduleId: String) async throws {}
 }

--- a/UMCApp/UMCApp/Sources/DIContainer+Home.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Home.swift
@@ -40,6 +40,15 @@ extension DIContainer {
         register(FetchScheduleDetailUseCaseProtocol.self) {
             FetchScheduleDetailUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
         }
+        register(UpdateScheduleUseCaseProtocol.self) {
+            UpdateScheduleUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
+        }
+        register(DeleteScheduleUseCaseProtocol.self) {
+            DeleteScheduleUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
+        }
+        register(ForceDeleteScheduleUseCaseProtocol.self) {
+            ForceDeleteScheduleUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
+        }
         register(RegisterFCMTokenUseCaseProtocol.self) {
             RegisterFCMTokenUseCase(repository: self.resolve(HomeRepositoryProtocol.self))
         }

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubScheduleRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubScheduleRepository.swift
@@ -56,7 +56,13 @@ struct StubScheduleRepository: ScheduleRepositoryProtocol {
         StubSessionFixtures.createdScheduleId
     }
 
+    /// 저장소가 없으므로 수정은 no-op 이다 (화면 흐름만 통과시킨다).
+    func updateSchedule(scheduleId: String, request: ScheduleUpdateRequest) async throws {}
+
     /// 저장소가 없으므로 삭제는 no-op 이다 (호출부의 롤백 흐름만 통과시킨다).
     func deleteSchedule(scheduleId: String) async throws {}
+
+    /// 강제 삭제도 같은 이유로 no-op 이다.
+    func forceDeleteSchedule(scheduleId: String) async throws {}
 }
 #endif

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
@@ -58,6 +58,7 @@ private extension NavigationRoutingView {
         case .scheduleDetail(let scheduleId):
             ScheduleDetailView(
                 container: di,
+                errorHandler: errorHandler,
                 scheduleId: scheduleId,
                 onAttendanceStatusTapped: {
                     // 출석 현황은 Activity 탭이 소유한 목적지라, 탭을 옮긴 뒤 그 탭 스택에 쌓는다.


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 이슈 #1087 (일정 수정·삭제·강제 삭제 파이프라인 이식).

> 선행 의존이던 #1086(Authorization Core 이관)은 #1101 로 develop 에 먼저 머지됐습니다.
> 이 브랜치는 그 위로 리베이스했고, develop 의 `AuthorizationUseCaseProtocol` /
> `ResourcePermission` 을 그대로 사용합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 일정 상세 툴바에 삭제 진입점이 추가되고, 삭제/강제 삭제 확인 다이얼로그가 뜹니다.
     시뮬레이터 영상 첨부 예정 -->

## 🛠️ 작업내용

### Data
- `ScheduleV2Router` — `patchSchedule`(`PATCH /api/v2/schedules/{id}`),
  `forceDeleteSchedule`(`DELETE /api/v2/schedules/{id}/force`)
- `ScheduleUpdateRequestDTO` — 전 필드 Optional + 수기 `encode(to:)`/`encodeIfPresent` 로
  **진짜 PATCH 시맨틱** 보장 (화면이 안 건드린 필드는 본문에서 제외, `false` 는 제외되지 않음)
- `ScheduleRepository.updateSchedule` 에 **204 빈 본문 가드 추가** —
  레거시엔 없어서 정상 응답이 디코딩 에러로 떨어졌습니다.
- 출석 기록으로 인한 삭제 거부를 `DomainError.scheduleHasAttendanceRecords` 로 승격 →
  강제 삭제 에스컬레이션의 유일한 신호

### Domain
- `ScheduleRepositoryProtocol` 에 `updateSchedule` / `forceDeleteSchedule` 추가
- `ScheduleUpdateRequest` 도메인 모델 (전 필드 Optional)
- `UpdateScheduleUseCase` / `DeleteScheduleUseCase` / `ForceDeleteScheduleUseCase` + DI 등록

### Presentation
- 일정 상세 툴바에 삭제 진입점 복원
- `.alertPrompt(item:)` 로 삭제·강제 삭제 확인 다이얼로그 결선 (문구는 레거시 그대로)
- 삭제 성공 시 `dismiss()`
- `.schedule` 리소스 권한으로 `canEditSchedule` / `canDeleteSchedule` / `canForceDeleteSchedule` 분기

### 테스트
- `ScheduleUpdatePipelineTests` 5건 (HomeData)
- `ScheduleDetailViewModelTests` 권한·에스컬레이션 스위트 7건 (HomePresentation)

## 📋 추후 진행 상황

- **수정(연필) 진입점은 의도적으로 미포함**입니다. UMCApp에는 일정 편집 화면이 아직 없어서
  버튼을 달아도 이동할 목적지가 없습니다. 레거시 `ScheduleRegistrationView`(약 700줄 VM —
  capabilities·참여자 페이징·AI 분류·지도 피커) 이식은 **#1091** 범위입니다.
  데이터·도메인·권한 계층은 이번 PR에서 모두 준비돼 있으므로 #1091 은 화면만 붙이면 됩니다.
  (`canEditSchedule` 도 이미 계산되고 있고, 연결 지점에 `TODO: (#1091)` 로 표시해뒀습니다.)

## 📌 리뷰 포인트

- `UMCApp/Features/Home/Data/Sources/Repositories/ScheduleRepository.swift`
  — `mapDeleteError`. 서버가 "출석 기록 때문에 못 지운다"에 전용 code 를 주지 않아
  **메시지 문자열 스니핑**에 의존합니다(`ponytail:` 주석으로 표시). 전용 에러 코드를 받을 수 있으면
  그쪽이 맞습니다.
- `UMCApp/Features/Home/Data/Sources/DTOs/Request/ScheduleUpdateRequestDTO.swift`
  — `encodeIfPresent` 기반 부분 갱신. `participantMemberIds` 의 String→Int 변환은 DTO 경계에서만
  일어납니다(절대 규칙 #2 유지).
- `UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift`
  — `deleteSchedule()` 의 `catch DomainError.scheduleHasAttendanceRecords where canForceDeleteSchedule`
  분기. 강제 삭제 권한이 없으면 일반 에러 경로로 떨어집니다.
- `UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift`
  — `.task` 에서 상세 로드와 권한 조회를 `async let` 으로 병렬 실행.

### 검증
- `origin/develop`(dba14433, #1101 머지 이후) 위로 리베이스 완료 — 충돌 없음
- `make build` 성공
- 모듈 스킴 테스트 HomeData / HomePresentation / ActivityDomain 전부 통과
- ⚠️ `make test`(앱 타겟)는 로컬에 `UMCApp/Secrets/Secrets.xcconfig` 가 없어
  `KAKAO_KEY not found in Info.plist` 로 런처가 죽습니다. 이번 변경과 무관한 로컬 환경 이슈입니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
