### PR TITLE
✅ [Test] ResourcePermission 매핑 분리 및 권한 응답 테스트 6건 추가 (#1086)

### DIFF
--- a/UMCApp/Core/Network/Sources/Authorization/AuthorizationRepository.swift
+++ b/UMCApp/Core/Network/Sources/Authorization/AuthorizationRepository.swift
@@ -43,25 +43,7 @@ public final class AuthorizationRepository: AuthorizationRepositoryProtocol, @un
             APIResponse<ResourcePermissionResponseDTO>.self,
             from: response.data
         )
-        let dto = try apiResponse.unwrap()
 
-        guard let mappedResourceType = AuthorizationResourceType(rawValue: dto.resourceType) else {
-            throw RepositoryError.decodingError(
-                detail: "Unknown resourceType: \(dto.resourceType)"
-            )
-        }
-
-        let granted = Set(
-            dto.permissions.compactMap { item -> AuthorizationPermissionType? in
-                guard item.hasPermission else { return nil }
-                return AuthorizationPermissionType(rawValue: item.permissionType)
-            }
-        )
-
-        return ResourcePermission(
-            resourceType: mappedResourceType,
-            resourceId: dto.resourceId,
-            grantedPermissions: granted
-        )
+        return try apiResponse.unwrap().toDomain()
     }
 }

--- a/UMCApp/Core/Network/Sources/Authorization/ResourcePermissionResponseDTO+Mapping.swift
+++ b/UMCApp/Core/Network/Sources/Authorization/ResourcePermissionResponseDTO+Mapping.swift
@@ -1,0 +1,46 @@
+//
+//  ResourcePermissionResponseDTO+Mapping.swift
+//  CoreNetwork
+//
+//  Created by euijjang97 on 8/8/26.
+//
+//  `ResourcePermissionResponseDTO` → 도메인 모델 매핑.
+//  `AuthorizationRepository` 안에 인라인돼 있던 변환을 `MemberProfileResponseDTO+Mapping` 과
+//  같은 위치로 옮겨, 네트워크 스텁 없이 매핑 규칙만 단위 테스트할 수 있게 한다.
+//
+
+import CoreDomain
+import Foundation
+import UMCFoundation
+
+// MARK: - toDomain
+
+extension ResourcePermissionResponseDTO {
+
+    /// DTO → `ResourcePermission` 도메인 모델 변환.
+    ///
+    /// - 허용되지 않은 권한(`hasPermission == false`)은 결과에서 제외한다.
+    /// - 앱이 모르는 `permissionType` 은 조용히 버린다. 서버가 권한 종류를 추가해도
+    ///   기존 클라이언트가 권한 조회 전체를 실패시키지 않게 하기 위함이다.
+    /// - 반면 `resourceType` 은 무엇에 대한 권한인지를 규정하므로 모르는 값이면 실패시킨다.
+    ///
+    /// - Throws: 앱이 모르는 `resourceType` 일 때 `RepositoryError.decodingError`
+    public func toDomain() throws -> ResourcePermission {
+        guard let mappedResourceType = AuthorizationResourceType(rawValue: resourceType) else {
+            throw RepositoryError.decodingError(detail: "Unknown resourceType: \(resourceType)")
+        }
+
+        let granted = Set(
+            permissions.compactMap { item -> AuthorizationPermissionType? in
+                guard item.hasPermission else { return nil }
+                return AuthorizationPermissionType(rawValue: item.permissionType)
+            }
+        )
+
+        return ResourcePermission(
+            resourceType: mappedResourceType,
+            resourceId: resourceId,
+            grantedPermissions: granted
+        )
+    }
+}

--- a/UMCApp/Core/Network/Tests/Authorization/ResourcePermissionMappingTests.swift
+++ b/UMCApp/Core/Network/Tests/Authorization/ResourcePermissionMappingTests.swift
@@ -1,0 +1,113 @@
+//
+//  ResourcePermissionMappingTests.swift
+//  CoreNetworkTests
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import CoreDomain
+import Foundation
+import Testing
+import UMCFoundation
+@testable import CoreNetwork
+
+@Suite("ResourcePermission — 권한 응답 디코딩/도메인 매핑")
+struct ResourcePermissionMappingTests {
+
+    // MARK: - Fixtures
+
+    private static func decodeDTO(
+        resourceType: String = "NOTICE",
+        resourceId: Any = 42,
+        permissions: [[String: Any]]? = []
+    ) throws -> ResourcePermissionResponseDTO {
+        var json: [String: Any] = [
+            "resourceType": resourceType,
+            "resourceId": resourceId,
+        ]
+        if let permissions {
+            json["permissions"] = permissions
+        }
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(ResourcePermissionResponseDTO.self, from: data)
+    }
+
+    // MARK: - Mapping
+
+    @Test("허용된 권한만 매핑하고 숫자 resourceId는 String으로 흡수한다")
+    func mapsGrantedPermissionsAndFlexibleResourceId() throws {
+        let dto = try Self.decodeDTO(permissions: [
+            ["permissionType": "EDIT", "hasPermission": true],
+            ["permissionType": "DELETE", "hasPermission": false],
+            ["permissionType": "MANAGE", "hasPermission": true],
+        ])
+
+        let permission = try dto.toDomain()
+
+        #expect(permission.resourceType == .notice)
+        #expect(permission.resourceId == "42")
+        #expect(permission.grantedPermissions == [.edit, .manage])
+        #expect(permission.has(.delete) == false)
+    }
+
+    @Test("알 수 없는 permissionType은 조용히 무시한다")
+    func ignoresUnknownPermissionType() throws {
+        let dto = try Self.decodeDTO(resourceId: "7", permissions: [
+            ["permissionType": "TELEPORT", "hasPermission": true],
+            ["permissionType": "READ", "hasPermission": true],
+        ])
+
+        let permission = try dto.toDomain()
+
+        #expect(permission.grantedPermissions == [.read])
+    }
+
+    @Test("알 수 없는 resourceType은 디코딩 에러로 실패한다")
+    func throwsOnUnknownResourceType() throws {
+        let dto = try Self.decodeDTO(resourceType: "GALAXY", permissions: [])
+
+        #expect(throws: RepositoryError.self) {
+            try dto.toDomain()
+        }
+    }
+
+    // MARK: - Decoding Leniency
+
+    @Test("permissions 키가 없으면 권한 없음으로 디코딩한다")
+    func treatsMissingPermissionsAsEmpty() throws {
+        let dto = try Self.decodeDTO(resourceType: "SCHEDULE", permissions: nil)
+
+        let permission = try dto.toDomain()
+
+        #expect(permission.resourceType == .schedule)
+        #expect(permission.grantedPermissions.isEmpty)
+    }
+
+    @Test("hasPermission이 문자열·숫자로 와도 Bool로 흡수하고 누락은 false로 본다")
+    func absorbsFlexibleHasPermission() throws {
+        let dto = try Self.decodeDTO(resourceType: "SCHEDULE", permissions: [
+            ["permissionType": "READ", "hasPermission": "true"],
+            ["permissionType": "EDIT", "hasPermission": 1],
+            ["permissionType": "DELETE", "hasPermission": 0],
+            ["permissionType": "FORCE_DELETE"],
+        ])
+
+        let permission = try dto.toDomain()
+
+        #expect(permission.grantedPermissions == [.read, .edit])
+    }
+
+    // MARK: - hasAny
+
+    @Test("hasAny는 전달한 권한 중 하나라도 보유하면 true다")
+    func hasAnyMatchesSinglePermission() {
+        let permission = ResourcePermission(
+            resourceType: .notice,
+            resourceId: "42",
+            grantedPermissions: [.manage]
+        )
+
+        #expect(permission.hasAny([.write, .edit, .manage]))
+        #expect(permission.hasAny([.approve, .check]) == false)
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

Test + Refactor — #1086(#1101 로 머지)에서 이식된 Authorization 리소스 권한 계층에
**테스트가 한 건도 없어** 매핑 규칙을 검증 가능한 형태로 분리하고 커버리지를 채웁니다.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음.

## 🛠️ 작업내용

- `AuthorizationRepository.getResourcePermission` 안에 인라인돼 있던 DTO → 도메인 변환을
  `ResourcePermissionResponseDTO+Mapping.swift` 의 `toDomain()` 으로 분리
  - 기존 `MemberProfileResponseDTO+Mapping.swift` 와 동일한 배치·네이밍
  - 매핑이 Repository 안에 있으면 검증하려고 `MoyaNetworkAdapter` 를 스터빙해야 해서,
    매핑 규칙 하나 확인하는 데 네트워크 하네스가 통째로 필요했습니다
- `AuthorizationRepository` 는 `try apiResponse.unwrap().toDomain()` 한 줄로 축소
  — **동작 변경 없음**, 코드 이동입니다
- 매핑 테스트 6건 추가 (`ResourcePermissionMappingTests`)
  1. 허용된 권한만 매핑하고 숫자 `resourceId` 를 String 으로 흡수
  2. 앱이 모르는 `permissionType` 은 조용히 무시 (서버가 권한 종류를 추가해도 조회 전체가 실패하지 않음)
  3. 앱이 모르는 `resourceType` 은 `RepositoryError` 로 실패
  4. `permissions` 키 누락 → 권한 없음
  5. `hasPermission` 이 `"true"` / `1` / `0` / 누락으로 와도 Bool 로 흡수
  6. `hasAny` 동작

## 📋 추후 진행 상황

- `AuthorizationRouter` / `ResourcePermissionQuery` 의 쿼리 직렬화까지 검증하려면
  `StubURLProtocol` 기반 통합 테스트가 필요합니다. 이번 PR 범위 밖으로 뒀습니다.

## 📌 리뷰 포인트

- `UMCApp/Core/Network/Sources/Authorization/ResourcePermissionResponseDTO+Mapping.swift`
  — **모르는 값에 대한 비대칭 정책**이 의도대로인지 봐주세요.
    `permissionType` 은 무시(전방 호환), `resourceType` 은 실패(무엇에 대한 권한인지가 깨지므로).
    #1101 에서 이미 그렇게 구현돼 있던 걸 그대로 옮기고 주석으로 근거만 남겼습니다.
- `UMCApp/Core/Network/Sources/Authorization/AuthorizationRepository.swift`
  — 코드 이동 외에 동작이 바뀐 곳이 없는지 확인 부탁드립니다.

### 검증
- `make build` 성공
- `CoreNetwork` 스킴 테스트 통과 (신규 스위트 `ResourcePermission — 권한 응답 디코딩/도메인 매핑` 포함)
  - `KeychainTokenStoreTests` 의 `-34018` 은 시뮬레이터 Keychain 엔타이틀먼트 문제로
    기존부터 known issue 로 기록되던 항목입니다. 이번 변경과 무관합니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
