### PR TITLE
♻️ [Refactor] 로그인 화면 고객센터(카카오 문의 채널) 진입 경로 복원 (#1089)

### DIFF
--- a/UMCApp/Core/UIComponents/Sources/Auth/LoginActionStack.swift
+++ b/UMCApp/Core/UIComponents/Sources/Auth/LoginActionStack.swift
@@ -8,12 +8,9 @@
 import CoreDesignSystem
 import SwiftUI
 
-/// 로그인 액션 영역 — 카카오/Apple/Google 소셜 버튼 + UMC 계정(ID·PW) 진입.
+/// 로그인 액션 영역 — 카카오/Apple/Google 소셜 버튼 + UMC 계정(ID·PW) 진입 + 고객센터 푸터.
 ///
 /// 콜백 기반 dumb 컴포넌트라 여러 화면에서 재사용 가능하다.
-///
-/// - Note: 고객센터 문의 버튼은 이 컴포넌트의 스코프에 포함되지 않는다
-///   (카카오플러스 채널 연동은 별도 매니저 — 이 화면의 스코프 밖).
 public struct LoginActionStack: View {
 
     // MARK: - Property
@@ -23,6 +20,13 @@ public struct LoginActionStack: View {
     private let onAppleTap: () -> Void
     private let onGoogleTap: () -> Void
     private let onEmailTap: () -> Void
+    private let onSupportTap: () -> Void
+
+    private enum Constants {
+        static let supportInquiryPrompt: String = "로그인에 문제가 있으신가요?"
+        static let supportChannelLabel: String = "고객센터"
+        static let supportChannelSuffix: String = "로 문의해 주세요."
+    }
 
     // MARK: - Init
 
@@ -31,13 +35,15 @@ public struct LoginActionStack: View {
         onKakaoTap: @escaping () -> Void,
         onAppleTap: @escaping () -> Void,
         onGoogleTap: @escaping () -> Void,
-        onEmailTap: @escaping () -> Void
+        onEmailTap: @escaping () -> Void,
+        onSupportTap: @escaping () -> Void
     ) {
         self.isLoading = isLoading
         self.onKakaoTap = onKakaoTap
         self.onAppleTap = onAppleTap
         self.onGoogleTap = onGoogleTap
         self.onEmailTap = onEmailTap
+        self.onSupportTap = onSupportTap
     }
 
     // MARK: - Body
@@ -46,7 +52,10 @@ public struct LoginActionStack: View {
         VStack(spacing: DefaultSpacing.spacing32) {
             socialLoginSection
             Divider()
-            emailLoginButton
+            VStack(spacing: DefaultSpacing.spacing12) {
+                emailLoginButton
+                supportFooter
+            }
         }
     }
 
@@ -104,6 +113,28 @@ public struct LoginActionStack: View {
         .accessibilityLabel(Text("UMC 계정으로 로그인"))
         .accessibilityHint(Text("아이디와 비밀번호 입력 화면으로 이동합니다"))
     }
+
+    private var supportFooter: some View {
+        VStack(spacing: DefaultSpacing.spacing4) {
+            Text(Constants.supportInquiryPrompt)
+                .appFont(.footnote, color: .grey500)
+            HStack(spacing: .zero) {
+                Button(action: onSupportTap) {
+                    Text(Constants.supportChannelLabel)
+                        .foregroundStyle(.indigo)
+                        .appFont(.footnote, color: .grey500)
+                        .underline()
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text("고객센터로 문의하기"))
+                .accessibilityHint(Text("카카오톡 UMC 문의 채널을 엽니다"))
+
+                Text(Constants.supportChannelSuffix)
+                    .appFont(.footnote, color: .grey500)
+            }
+        }
+        .multilineTextAlignment(.center)
+    }
 }
 
 #if DEBUG
@@ -113,7 +144,8 @@ public struct LoginActionStack: View {
         onKakaoTap: {},
         onAppleTap: {},
         onGoogleTap: {},
-        onEmailTap: {}
+        onEmailTap: {},
+        onSupportTap: {}
     )
     .padding()
 }

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/BootstrapView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/BootstrapView.swift
@@ -35,6 +35,7 @@ import AuthDomain
 import CoreDesignSystem
 import CoreDI
 import CoreDomain
+import CoreNetwork
 import CoreUIComponents
 import SwiftUI
 import UMCFoundation
@@ -66,6 +67,7 @@ public struct BootstrapView: View {
     /// 이메일 로그인 화면을 push할 때 그대로 전달하기 위해 보관한다.
     private let container: DIContainer
     private let errorHandler: ErrorHandler
+    private let kakaoPlusManager = KakaoPlusManager()
 
     private enum Constants {
         /// 시네마틱 종료 시점. `RefractiveCinematic` 시퀀스 총 길이(preDelay 0.4 + bloom 1.0 +
@@ -138,7 +140,10 @@ public struct BootstrapView: View {
                     onKakaoTap: { Task { await loginViewModel.loginWithKakao() } },
                     onAppleTap: { loginViewModel.loginWithApple() },
                     onGoogleTap: { Task { await loginViewModel.loginWithGoogle() } },
-                    onEmailTap: { isEmailLoginPresented = true }
+                    onEmailTap: { isEmailLoginPresented = true },
+                    onSupportTap: {
+                        kakaoPlusManager.openKakaoChannel(errorHandler: errorHandler)
+                    }
                 )
                 .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
                 .padding(.bottom, DefaultConstant.defaultSafeBottom)

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/LoginView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/LoginView.swift
@@ -9,6 +9,7 @@ import AuthDomain
 import CoreDesignSystem
 import CoreDI
 import CoreDomain
+import CoreNetwork
 import CoreUIComponents
 import SwiftUI
 import UMCFoundation
@@ -29,6 +30,7 @@ public struct LoginView: View {
     /// 이메일 로그인 화면을 push할 때 그대로 전달하기 위해 보관한다.
     private let container: DIContainer
     private let errorHandler: ErrorHandler
+    private let kakaoPlusManager = KakaoPlusManager()
 
     // MARK: - Init
 
@@ -57,7 +59,10 @@ public struct LoginView: View {
                     onKakaoTap: { Task { await viewModel.loginWithKakao() } },
                     onAppleTap: { viewModel.loginWithApple() },
                     onGoogleTap: { Task { await viewModel.loginWithGoogle() } },
-                    onEmailTap: { isEmailLoginPresented = true }
+                    onEmailTap: { isEmailLoginPresented = true },
+                    onSupportTap: {
+                        kakaoPlusManager.openKakaoChannel(errorHandler: errorHandler)
+                    }
                 )
                 .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
                 .padding(.bottom, DefaultConstant.defaultSafeBottom)


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 레거시(`AppProduct`) 이식 과정에서 누락된 로그인 화면 고객센터 진입 경로 복원. Resolves #1089

레거시 `LoginActionStack` 에 있던 "로그인에 문제가 있으신가요? / **고객센터**로 문의해 주세요." 푸터가 UMCApp 이식본에서 `onSupportTap` 파라미터·`supportFooter` 서브뷰째로 누락돼, 로그인이 막힌 사용자(승인 대기·계정 분실·소셜 연동 실패)가 인앱에서 CS 채널에 도달할 방법이 없었습니다. 남아 있던 유일한 진입점 `FailedVerificationUMC` 는 로그인 성공 이후에만 도달하는 화면이라 정작 필요한 사용자가 접근할 수 없는 상태였습니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- UI 변경이 포함되어 있습니다. LoginView / BootstrapView(.loginReady) 두 화면의 하단 푸터 스크린샷 첨부 필요 -->

## 🛠️ 작업내용

**`CoreUIComponents` — `LoginActionStack` 복원**
- `onSupportTap: () -> Void` 파라미터를 저장 프로퍼티 + `public init` 에 추가
- 문구 상수 `Constants`(`supportInquiryPrompt` / `supportChannelLabel` / `supportChannelSuffix`) 레거시 문구 그대로 복원
- `supportFooter` 서브뷰 복원 — 레거시와 동일하게 `VStack(spacing: spacing12) { emailLoginButton; supportFooter }` 배치
- 접근성 라벨·힌트 복원 (`고객센터로 문의하기` / `카카오톡 UMC 문의 채널을 엽니다`)
- "고객센터 문의 버튼은 이 컴포넌트의 스코프에 포함되지 않는다" 주석 제거 및 doc comment 갱신
- `#if DEBUG` Preview 호출부에 `onSupportTap` 추가

**`AuthPresentation` — 두 로그인 표면 결선**
- `LoginView` 에 `KakaoPlusManager` 보관 + `openKakaoChannel(errorHandler:)` 결선
- `BootstrapView` 의 `.loginReady` 단계도 동일하게 결선
- 두 파일 모두 기존 `FailedVerificationUMC` 의 사용 패턴을 그대로 따름 (`private let kakaoPlusManager = KakaoPlusManager()`)

## 📋 추후 진행 상황

- 실기기에서 두 화면의 카카오 채널 실제 진입 확인 (SDK 미설치 시 웹 폴백 동작 포함)

## 📌 리뷰 포인트

- `UMCApp/Core/UIComponents/Sources/Auth/LoginActionStack.swift` — `supportFooter` 배치/간격/타이포가 레거시(`AppProduct/.../Auth/LoginActionStack.swift:122-134`)와 일치하는지, 접근성 라벨 문구 확인
- `UMCApp/Features/Auth/Presentation/Sources/Views/LoginView.swift` — `KakaoPlusManager` 인스턴스 보관 위치와 `ErrorHandler` 경유 여부
- `UMCApp/Features/Auth/Presentation/Sources/Views/BootstrapView.swift` — `.loginReady` 레이아웃이 `LoginView` body 와 동일 구조를 유지하는지 (푸터 추가로 인한 로고 위치 어긋남 여부)

**검증**
- `cd UMCApp && make build` → `** BUILD SUCCEEDED **`
- `AuthPresentation` 은 이미 `CoreNetwork` 에 의존하므로 Tuist 매니페스트 변경 없음
- `AppProduct/`(v2.2.0 동결) 변경 없음

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)