### PR TITLE
♻️ [Refactor] 홈 일정 등록 화면·ViewModel 이식 + 라우팅 결선 (#1088)

### DIFF
--- a/UMCApp/Core/UIComponents/Sources/Utilities/NavigationTitle.swift
+++ b/UMCApp/Core/UIComponents/Sources/Utilities/NavigationTitle.swift
@@ -84,5 +84,6 @@ public enum NavigationTitle {
         case school = "학교 선택"
         case part = "파트 선택"
         case placeSearch = "어느 위치를 찾고 있나요?"
+        case tag = "태그"
     }
 }

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/GenerateScheduleUseCaseProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/GenerateScheduleUseCaseProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  GenerateScheduleUseCaseProtocol.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+
+/// 일정 생성 UseCase 인터페이스
+public protocol GenerateScheduleUseCaseProtocol {
+
+    /// - Parameter request: 일정 생성 입력 모델
+    /// - Returns: 생성된 일정 식별자 (서버 정수를 절대 규칙 #2 에 따라 `String` 으로 보존)
+    @discardableResult
+    func execute(request: ScheduleCreationRequest) async throws -> String
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/GenerateScheduleUseCase.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/GenerateScheduleUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  GenerateScheduleUseCase.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/8/26.
+//
+
+import Foundation
+
+/// 일정 생성 UseCase 구현체
+public final class GenerateScheduleUseCase: GenerateScheduleUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: ScheduleRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: ScheduleRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    @discardableResult
+    public func execute(request: ScheduleCreationRequest) async throws -> String {
+        try await repository.createSchedule(request)
+    }
+}

--- a/UMCApp/Features/Home/Presentation/Sources/HomeFeatureView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/HomeFeatureView.swift
@@ -18,6 +18,7 @@ public struct HomeFeatureView: View {
     private let onNoticeSelected: (NoticeDetail) -> Void
     private let onScheduleSelected: (String) -> Void
     private let onAlarmHistoryTapped: () -> Void
+    private let onScheduleRegistrationTapped: () -> Void
 
     // MARK: - Init
 
@@ -28,14 +29,17 @@ public struct HomeFeatureView: View {
     ///   - onNoticeSelected: 최근 공지 카드 탭 시 공지 상세 이동 콜백
     ///   - onScheduleSelected: 일정 카드 탭 시 일정 상세 이동 콜백 (일정 ID 전달)
     ///   - onAlarmHistoryTapped: 툴바 알림 버튼 탭 시 알림 보관함 이동 콜백
+    ///   - onScheduleRegistrationTapped: 일정 등록 버튼 탭 시 일정 등록 화면 이동 콜백
     public init(
         onNoticeSelected: @escaping (NoticeDetail) -> Void,
         onScheduleSelected: @escaping (String) -> Void,
-        onAlarmHistoryTapped: @escaping () -> Void
+        onAlarmHistoryTapped: @escaping () -> Void,
+        onScheduleRegistrationTapped: @escaping () -> Void
     ) {
         self.onNoticeSelected = onNoticeSelected
         self.onScheduleSelected = onScheduleSelected
         self.onAlarmHistoryTapped = onAlarmHistoryTapped
+        self.onScheduleRegistrationTapped = onScheduleRegistrationTapped
     }
 
     // MARK: - Body
@@ -45,7 +49,8 @@ public struct HomeFeatureView: View {
             container: di,
             onNoticeSelected: onNoticeSelected,
             onScheduleSelected: onScheduleSelected,
-            onAlarmHistoryTapped: onAlarmHistoryTapped
+            onAlarmHistoryTapped: onAlarmHistoryTapped,
+            onScheduleRegistrationTapped: onScheduleRegistrationTapped
         )
     }
 }

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDraft.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDraft.swift
@@ -1,0 +1,55 @@
+//
+//  ScheduleDraft.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 5/31/26.
+//
+
+import Foundation
+import FoundationModels
+
+/// 온디바이스 LLM이 자연어 입력으로부터 추출하는 일정 초안 구조체.
+///
+/// 장소 좌표는 환각 위험이 높아 절대 포함하지 않는다. 장소 이름만 제안하며, 실제 좌표 확정은
+/// 사용자가 지도 장소 선택 플로우에서 수행한다. 출석 정책도 AI 가 건드리지 않는다.
+///
+/// `startDateISO` / `endDateISO` 는 LLM 이 반환한 ISO 8601 문자열이며
+/// ``ScheduleRegistrationViewModel/applyDraft(_:)`` 에서 파싱한 뒤 폼 필드에 매핑한다.
+@Generable(description: "자연어 일정 설명에서 추출한 일정 초안")
+struct ScheduleDraft {
+
+    // MARK: - Property
+
+    @Guide(description: "일정 제목. 자연어에서 핵심 이름을 추출합니다. 예: '다음주 화요일 스터디 모임' → '스터디 모임'")
+    var title: String
+
+    @Guide(description: """
+    일정 시작 시각 (ISO 8601 형식). 자연어 날짜/시간 표현을 파싱합니다.
+    예: '다음주 화요일 오후 2시' → '2026-06-09T14:00:00+09:00'
+    '내일 저녁 7시' → 내일 날짜로 계산.
+    시각이 명시되지 않으면 해당 날짜의 09:00:00+09:00 로 기본 설정합니다.
+    """)
+    var startDateISO: String
+
+    @Guide(description: """
+    일정 종료 시각 (ISO 8601 형식). 명시되지 않은 경우 startDateISO + 1시간으로 추정합니다.
+    """)
+    var endDateISO: String
+
+    @Guide(description: "하루 종일 일정 여부. '하루종일', '종일', '전일' 같은 표현이 있거나 시각이 명시되지 않으면 true.")
+    var isAllDay: Bool
+
+    @Guide(description: """
+    일정 카테고리. 다음 rawValue 중 하나를 정확히 반환하세요:
+    LEADERSHIP, DUES, MEETING, NETWORKING, HACKATHON, PROJECT,
+    PRESENTATION, WORKSHOP, RETROSPECTIVE, AFTER_PARTY, ORIENTATION, GENERAL.
+    입력에 가장 잘 맞는 카테고리를 선택하세요.
+    """)
+    var tag: String
+
+    @Guide(description: "일정에 대한 추가 메모나 설명. 자연어 입력에서 부가 내용을 추출합니다. 없으면 빈 문자열.")
+    var memo: String
+
+    @Guide(description: "장소 이름만 추출합니다. 좌표나 주소는 절대 포함하지 않습니다. 장소 언급이 없으면 빈 문자열.")
+    var placeName: String
+}

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel+AI.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel+AI.swift
@@ -1,0 +1,168 @@
+//
+//  ScheduleRegistrationViewModel+AI.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 5/31/26.
+//
+
+import Foundation
+import FoundationModels
+import NoticeDomain
+import SwiftData
+import UMCFoundation
+
+fileprivate enum Constants {
+    static let fallbackDuration: TimeInterval = 3_600
+    static let instructions = """
+    당신은 한국 대학 동아리 일정 등록을 돕는 보조 시스템입니다.
+    사용자가 입력한 자연어 일정 설명에서 필요한 정보를 추출하세요.
+    날짜/시간이 명확하지 않으면 합리적인 기본값을 사용하세요.
+    장소는 이름만 추출하고 좌표나 주소는 절대 생성하지 마세요.
+    오늘 날짜는 현재 시스템 날짜를 기준으로 합니다.
+    """
+}
+
+extension ScheduleRegistrationViewModel {
+
+    // MARK: - Function
+
+    /// 온디바이스 AI로 자연어 일정 설명을 분석해 폼 필드를 자동으로 채운다.
+    ///
+    /// 장소 좌표는 절대 AI 로 채우지 않는다. `placeName` 만 제안으로 반영하고 좌표는 (0, 0) 으로
+    /// 남겨, 사용자가 지도에서 장소를 확정하기 전까지는 제출이 열리지 않게 한다. 참여자와 출석
+    /// 정책도 건드리지 않는다.
+    func requestAIAutofill() async {
+        let rawText = aiRawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawText.isEmpty, !aiAutofillState.isLoading else { return }
+        guard case .available = SystemLanguageModel.default.availability else { return }
+
+        aiAutofillState = .loading
+
+        do {
+            let session = LanguageModelSession { Constants.instructions }
+            let response = try await session.respond(to: rawText, generating: ScheduleDraft.self)
+            applyDraft(response.content)
+            await persistDailyTokenUsage(session: session)
+            aiAutofillState = .loaded(true)
+        } catch {
+            aiAutofillState = .idle
+            errorHandler?.handle(error, context: ErrorContext(
+                feature: "Home",
+                action: "requestAIAutofill"
+            ))
+        }
+    }
+
+    /// AI 자동완성 상태를 초기로 되돌린다. (시트를 닫을 때 호출)
+    func resetAIAutofillState() {
+        aiAutofillState = .idle
+    }
+
+    /// 화면 진입 시 당일 누적 토큰 사용량을 복원한다.
+    ///
+    /// 복원에 실패해도 0 을 유지하며 등록 흐름에는 영향이 없다.
+    func restoreDailyTokenUsage() {
+        guard let modelContext, let currentMemberId = AppStorageKey.memberIdString() else {
+            return
+        }
+
+        let today = Calendar.current.startOfDay(for: Date())
+        do {
+            let records = try modelContext.fetch(FetchDescriptor<AITokenDailyUsageRecord>())
+            if let record = records.first(where: {
+                $0.memberId == currentMemberId && $0.date == today
+            }) {
+                aiCumulativeUsedTokens = record.usedTokens
+            }
+        } catch {
+            // 복원 실패해도 일정 등록 동작에 영향 없음
+        }
+    }
+
+    // MARK: - Private Function
+
+    /// ``ScheduleDraft`` 결과를 폼 필드에 반영한다.
+    ///
+    /// ISO 8601 파싱에 실패한 필드는 기존 값을 유지한다.
+    private func applyDraft(_ draft: ScheduleDraft) {
+        if !draft.title.isEmpty {
+            title = draft.title
+        }
+
+        if let start = Self.parseISODate(draft.startDateISO) {
+            startDate = start
+            if let parsedEnd = Self.parseISODate(draft.endDateISO), parsedEnd > start {
+                endDate = parsedEnd
+            } else {
+                endDate = start.addingTimeInterval(Constants.fallbackDuration)
+            }
+        }
+
+        isAllDay = draft.isAllDay
+
+        if let category = ScheduleIconCategory(rawValue: draft.tag), !category.isDeprecated {
+            updateTagsFromUser([category])
+        }
+
+        if !draft.memo.isEmpty {
+            memo = draft.memo
+        }
+
+        // 좌표 없이 이름만 채우므로 hasValidPlace 가 거짓으로 남아 제출이 막힌다. 사용자가 지도에서
+        // 장소를 확정해야 (0, 0) 기준 지오펜스가 만들어지지 않는다.
+        if !draft.placeName.isEmpty {
+            placeSelectionChanged(name: draft.placeName, address: "", latitude: 0, longitude: 0)
+        }
+
+        prefillAttendancePolicyIfNeeded()
+    }
+
+    /// 소수점 초 유무를 모두 허용해 ISO 8601 문자열을 파싱한다.
+    ///
+    /// 온디바이스 모델이 두 형식을 오가며 내놓기 때문에 한 포맷터만으로는 파싱이 자주 실패한다.
+    private static func parseISODate(_ string: String) -> Date? {
+        let withFraction = ISO8601DateFormatter()
+        withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let withoutFraction = ISO8601DateFormatter()
+        withoutFraction.formatOptions = [.withInternetDateTime]
+        return withFraction.date(from: string) ?? withoutFraction.date(from: string)
+    }
+
+    /// AI 실행 후 당일 토큰 사용량을 SwiftData 에 누적 기록한다.
+    ///
+    /// 컨텍스트가 없거나 저장에 실패해도 AI 결과에는 영향이 없다.
+    private func persistDailyTokenUsage(session: LanguageModelSession) async {
+        guard #available(iOS 26.4, *) else { return }
+        guard let modelContext, let currentMemberId = AppStorageKey.memberIdString() else {
+            return
+        }
+
+        let used: Int
+        do {
+            used = try await SystemLanguageModel.default.tokenCount(for: session.transcript)
+        } catch {
+            return
+        }
+        guard used > 0 else { return }
+
+        let today = Calendar.current.startOfDay(for: Date())
+        do {
+            let records = try modelContext.fetch(FetchDescriptor<AITokenDailyUsageRecord>())
+            if let record = records.first(where: {
+                $0.memberId == currentMemberId && $0.date == today
+            }) {
+                record.usedTokens += used
+            } else {
+                modelContext.insert(AITokenDailyUsageRecord(
+                    memberId: currentMemberId,
+                    date: today,
+                    usedTokens: used
+                ))
+            }
+            try modelContext.save()
+            aiCumulativeUsedTokens += used
+        } catch {
+            // 저장 실패해도 AI 실행 결과에 영향 없음
+        }
+    }
+}

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel.swift
@@ -1,0 +1,553 @@
+//
+//  ScheduleRegistrationViewModel.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 1/22/26.
+//
+
+import CoreDI
+import Foundation
+import HomeDomain
+import SwiftData
+import UMCFoundation
+
+/// 일정 등록/수정 화면의 상태를 관리하는 뷰 모델.
+///
+/// 생성과 수정을 한 폼으로 다룬다. 수정 모드는 ``applyPrefill(from:roadAddress:)`` 로 진입
+/// 시점 스냅샷을 만들어 두고, 스냅샷과 달라진 게 있을 때만 저장 버튼을 연다.
+///
+/// `isAllDay` 는 서버 필드가 아니라 폼 토글이며, 송신 시점에 KST 자정 / 23:59:59.999 로
+/// 정규화된다.
+@MainActor
+@Observable
+final class ScheduleRegistrationViewModel {
+
+    // MARK: - Dependency
+
+    private let generateScheduleUseCase: GenerateScheduleUseCaseProtocol
+    private let updateScheduleUseCase: UpdateScheduleUseCaseProtocol
+    private let classifyScheduleUseCase: ClassifyScheduleUseCaseProtocol
+
+    /// 전역 에러 핸들러. 뷰가 Environment 값을 넘겨준다.
+    var errorHandler: ErrorHandler?
+
+    /// AI 일일 토큰 사용량 기록용 컨텍스트. 뷰가 Environment 값을 넘겨준다.
+    var modelContext: ModelContext?
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let defaultStartOffset: TimeInterval = 3_600
+        static let defaultDuration: TimeInterval = 3_600
+        /// 일정 시작 기준 체크인 오픈 시각 오프셋
+        static let checkInLeadTime: TimeInterval = -20 * 60
+        /// 일정 시작 기준 지각 인정 마감 오프셋
+        static let lateGraceTime: TimeInterval = 60 * 60
+        static let startedScheduleMessage = "이미 시작된 일정은 수정할 수 없습니다."
+        /// 시작된 일정 수정을 거부하는 서버 에러 코드
+        static let startedScheduleCode = "SCHEDULE-0028"
+    }
+
+    // MARK: - Property
+
+    var title: String = ""
+    var memo: String = ""
+    var isAllDay: Bool = false
+    var isOnline: Bool = false
+
+    var startDate: Date = .now.addingTimeInterval(Constants.defaultStartOffset)
+    var endDate: Date = .now.addingTimeInterval(
+        Constants.defaultStartOffset + Constants.defaultDuration
+    )
+
+    /// 선택된 장소. 이름과 좌표를 함께 들고 있어 부분적으로 어긋난 상태가 생기지 않는다.
+    private(set) var placeLocation: ScheduleLocation?
+
+    /// 선택된 장소의 주소. 서버로 보내지 않고 장소 선택 UI 의 부제로만 쓴다.
+    private(set) var placeAddress: String = ""
+
+    private(set) var tags: [ScheduleIconCategory] = []
+
+    /// 사용자가 태그를 직접 조정했는지 여부. `true` 면 제목 기반 자동 추천이 덮어쓰지 않는다.
+    private(set) var isTagManuallyOverridden: Bool = false
+
+    /// 생성/수정 요청 상태. 툴바 로딩 표시와 성공 시 화면 닫기를 함께 제어한다.
+    private(set) var submitState: Loadable<Bool> = .idle
+
+    /// 화면 내 인라인 에러 메시지 (시작된 일정 수정 차단 등)
+    private(set) var inlineErrorMessage: String?
+
+    var alertPrompt: AlertPrompt?
+
+    // MARK: - Attendance Policy Property
+
+    var isAttendanceRequired: Bool = false
+    var attendanceCheckInStartAt: Date = .now
+    var attendanceOnTimeEndAt: Date = .now
+    var attendanceLateEndAt: Date = .now
+
+    /// 출석 정책 인라인 검증 메시지. `nil` 이면 통과.
+    private(set) var attendancePolicyErrorMessage: String?
+
+    /// 사용자가 출석 정책 시각을 직접 수정한 적이 있는지 여부 (자동 prefill 차단용)
+    private var isAttendancePolicyDirty: Bool = false
+
+    /// 수정 모드 진입 시점의 출석 필수 여부 (PATCH 전환 플래그 산출용)
+    private var initialIsAttendanceRequired: Bool = false
+
+    // MARK: - AI Autofill Property
+
+    var aiRawInput: String = ""
+    var aiAutofillState: Loadable<Bool> = .idle
+
+    /// 당일 누적 AI 토큰 사용량 (SwiftData 에서 복원)
+    var aiCumulativeUsedTokens: Int = 0
+
+    // MARK: - Edit Mode Property
+
+    private(set) var editingScheduleId: String?
+
+    /// 수정 모드 진입 시점의 일정 시작 시각 (이미 시작된 일정 가드용)
+    private var editingStartsAt: Date?
+
+    private var initialEditSnapshot: EditFormSnapshot?
+
+    // MARK: - Computed Property
+
+    /// 필수 입력이 모두 채워졌는지 여부. 비대면 일정은 장소 검증을 건너뛴다.
+    var canSubmit: Bool {
+        guard !trimmedTitle.isEmpty, !sanitizedTags.isEmpty else { return false }
+        guard attendancePolicyErrorMessage == nil else { return false }
+        return isOnline || hasValidPlace
+    }
+
+    /// 대면 일정에 필요한 장소 정보(이름 + 실좌표)가 모두 갖춰졌는지.
+    ///
+    /// AI 자동완성은 이름만 제안하고 좌표를 (0, 0) 으로 남기므로, 좌표까지 확정되기 전에는
+    /// 제출을 막아 (0, 0) 기준 지오펜스가 만들어지는 것을 방지한다.
+    var hasValidPlace: Bool {
+        guard let placeLocation else { return false }
+        let name = placeLocation.locationName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return false }
+
+        let latitude = placeLocation.latitude
+        let longitude = placeLocation.longitude
+        guard latitude.isFinite, longitude.isFinite else { return false }
+        guard (-90.0...90.0).contains(latitude), (-180.0...180.0).contains(longitude) else {
+            return false
+        }
+        return !(latitude == 0 && longitude == 0)
+    }
+
+    /// 수정 모드에서 진입 시점 대비 변경 사항이 있는지 여부.
+    var hasChangesInEditMode: Bool {
+        guard let initialEditSnapshot else { return true }
+        return initialEditSnapshot != currentEditSnapshot
+    }
+
+    /// 이미 시작된 일정인지 여부 (수정 모드 가드용).
+    var isEditingStartedSchedule: Bool {
+        guard let editingStartsAt else { return false }
+        return Date() >= editingStartsAt
+    }
+
+    private var trimmedTitle: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var sanitizedTags: [ScheduleIconCategory] {
+        tags.filter { !$0.isDeprecated }
+    }
+
+    /// 송신용 시작 시각 — 하루 종일이면 KST 자정으로 정규화
+    private var effectiveStartsAt: Date {
+        isAllDay ? startDate.kstStartOfDay : startDate
+    }
+
+    /// 송신용 종료 시각 — 하루 종일이면 KST 23:59:59.999 로 정규화
+    private var effectiveEndsAt: Date {
+        isAllDay ? endDate.kstEndOfDay : endDate
+    }
+
+    /// 송신용 장소 — 비대면이면 `nil`
+    private var submitLocation: ScheduleLocation? {
+        isOnline ? nil : placeLocation
+    }
+
+    /// 송신용 출석 정책 — 토글 OFF 또는 하루 종일이면 `nil`
+    private var submitAttendancePolicy: ScheduleAttendancePolicy? {
+        guard isAttendanceRequired, !isAllDay else { return nil }
+        return ScheduleAttendancePolicy(
+            checkInStartAt: attendanceCheckInStartAt,
+            onTimeEndAt: attendanceOnTimeEndAt,
+            lateEndAt: attendanceLateEndAt
+        )
+    }
+
+    /// 수정 모드 PATCH 의 출석 필수 전환 플래그. 변화가 없으면 `nil` 로 필드를 빼 기존 상태를 둔다.
+    private var attendanceRequiredTransitionFlag: Bool? {
+        initialIsAttendanceRequired == isAttendanceRequired ? nil : isAttendanceRequired
+    }
+
+    /// 수정 모드 PATCH 의 대면/비대면 전환 플래그. 변화가 없으면 `nil`.
+    private var isOnlineTransitionFlag: Bool? {
+        guard let initialEditSnapshot else { return nil }
+        return initialEditSnapshot.isOnline == isOnline ? nil : isOnline
+    }
+
+    // MARK: - Init
+
+    init(container: DIContainer) {
+        generateScheduleUseCase = container.resolve(GenerateScheduleUseCaseProtocol.self)
+        updateScheduleUseCase = container.resolve(UpdateScheduleUseCaseProtocol.self)
+        classifyScheduleUseCase = container.resolve(ClassifyScheduleUseCaseProtocol.self)
+        prefillAttendancePolicyIfNeeded()
+    }
+
+    // MARK: - Prefill
+
+    /// 일정 상세를 폼에 반영하고 변경 감지용 초기 스냅샷을 만든다.
+    ///
+    /// - Parameters:
+    ///   - detail: 수정 대상 일정
+    ///   - roadAddress: 장소 부제로 우선 노출할 도로명 주소
+    func applyPrefill(from detail: ScheduleDetailData, roadAddress: String? = nil) {
+        editingScheduleId = detail.scheduleId
+        editingStartsAt = detail.startsAt
+        title = detail.name
+        memo = detail.description
+        isAllDay = detail.isAllDay
+        isOnline = detail.isOnline
+        startDate = detail.startsAt
+        endDate = detail.endsAt
+        placeLocation = detail.location
+        placeAddress = roadAddress ?? detail.location?.locationName ?? ""
+        tags = detail.tags.compactMap(Self.scheduleTag(from:))
+        isTagManuallyOverridden = !tags.isEmpty
+
+        // ponytail: 참여자 선택은 SelectedChallengerView 가 ActivityPresentation internal 이라
+        // 제외 — 공용 승격 후 결선. 수정 시 participantMemberIds 는 nil 로 보내 서버 값을 보존한다.
+
+        if let policy = detail.attendancePolicy {
+            isAttendanceRequired = true
+            attendanceCheckInStartAt = policy.checkInStartAt
+            attendanceOnTimeEndAt = policy.onTimeEndAt
+            attendanceLateEndAt = policy.lateEndAt
+            isAttendancePolicyDirty = true
+        }
+        initialIsAttendanceRequired = isAttendanceRequired
+
+        prefillAttendancePolicyIfNeeded()
+        initialEditSnapshot = currentEditSnapshot
+    }
+
+    /// 서버 태그 문자열을 ``ScheduleIconCategory`` 로 매핑한다.
+    ///
+    /// rawValue 직접 매핑 → 대문자 매핑 → 한글 매핑 순으로 시도하고, 신규 입력에 쓰지 않는
+    /// 레거시 카테고리는 걸러낸다.
+    private static func scheduleTag(from raw: String) -> ScheduleIconCategory? {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let matched = ScheduleIconCategory(rawValue: normalized)
+            ?? ScheduleIconCategory(rawValue: normalized.uppercased())
+            ?? ScheduleIconCategory.selectableCases.first { $0.korean == normalized }
+        guard let matched, !matched.isDeprecated else { return nil }
+        return matched
+    }
+
+    // MARK: - Input Function
+
+    /// 제목 변경 시 자동 태그 추천을 반영한다.
+    ///
+    /// 사용자가 태그를 직접 고른 뒤에는 추천이 선택을 덮어쓰지 않는다. 분류는 비동기라 결과가
+    /// 돌아왔을 때 제목이 이미 바뀌었으면 버린다.
+    func titleDidChange(to newTitle: String) async {
+        title = newTitle
+
+        let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            if !isTagManuallyOverridden {
+                tags.removeAll()
+            }
+            return
+        }
+        guard !isTagManuallyOverridden else { return }
+
+        let suggested = await classifyScheduleUseCase.execute(title: trimmed)
+
+        guard !isTagManuallyOverridden, trimmedTitle == trimmed else { return }
+        tags = [suggested]
+    }
+
+    /// 태그 선택을 사용자 입력으로 반영한다.
+    ///
+    /// 사용자가 태그를 모두 비우면 이후 제목 변경 시 자동 추천이 다시 동작한다.
+    func updateTagsFromUser(_ newTags: [ScheduleIconCategory]) {
+        let sanitized = Array(Set(newTags.filter { !$0.isDeprecated }))
+            .sorted { $0.rawValue < $1.rawValue }
+        guard tags != sanitized else { return }
+
+        tags = sanitized
+        isTagManuallyOverridden = !sanitized.isEmpty
+    }
+
+    /// 장소 선택 결과를 반영한다.
+    ///
+    /// 이름이 비면 "선택 해제" 로 보고 좌표까지 함께 비운다. 이름만 지우고 좌표를 남기면 화면에는
+    /// 장소가 없는데 페이로드에는 좌표가 실린다.
+    func placeSelectionChanged(
+        name: String,
+        address: String,
+        latitude: Double,
+        longitude: Double
+    ) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            clearPlaceSelection()
+            return
+        }
+        placeLocation = ScheduleLocation(
+            latitude: latitude,
+            longitude: longitude,
+            locationName: trimmedName
+        )
+        placeAddress = address
+    }
+
+    /// 대면/비대면 토글 변경을 처리한다. 비대면으로 바꾸면 장소를 비운다.
+    func inPersonModeToggleChanged(to isInPerson: Bool) {
+        isOnline = !isInPerson
+        if isOnline {
+            clearPlaceSelection()
+        }
+    }
+
+    private func clearPlaceSelection() {
+        placeLocation = nil
+        placeAddress = ""
+    }
+
+    /// 시작 시각 변경 처리 — 종료가 앞서면 함께 밀고 출석 정책 기본값을 다시 계산한다.
+    func startDateChanged() {
+        if endDate < startDate {
+            endDate = startDate
+        }
+        prefillAttendancePolicyIfNeeded()
+    }
+
+    /// 종료 시각 변경 처리 — 시작보다 앞서면 시작 시각으로 되돌린다.
+    func endDateChanged() {
+        if endDate < startDate {
+            endDate = startDate
+        }
+        validateAttendancePolicy()
+    }
+
+    // MARK: - Attendance Policy Function
+
+    /// 일정 시작 시각을 기준으로 출석 정책 기본값을 채운다.
+    ///
+    /// 사용자가 한 번이라도 시각을 직접 고쳤거나 하루 종일 일정이면 값은 건드리지 않는다. 다만
+    /// 검증은 일정 시작/종료에 의존하므로 건너뛰는 경우에도 항상 갱신한다.
+    func prefillAttendancePolicyIfNeeded() {
+        defer { validateAttendancePolicy() }
+        guard !isAttendancePolicyDirty, !isAllDay else { return }
+
+        attendanceCheckInStartAt = startDate.addingTimeInterval(Constants.checkInLeadTime)
+        attendanceOnTimeEndAt = startDate
+        attendanceLateEndAt = startDate.addingTimeInterval(Constants.lateGraceTime)
+    }
+
+    /// 출석 정책 시각 변경 시 dirty 표시 + 검증을 갱신한다.
+    func attendanceTimesChanged() {
+        isAttendancePolicyDirty = true
+        validateAttendancePolicy()
+    }
+
+    /// 출석 필수 토글 변경 진입점.
+    ///
+    /// 기존에 출석이 필수였던 일정을 OFF 로 되돌릴 때만 확인 다이얼로그를 띄운다. 서버가 이
+    /// 전환에서 기존 출석 데이터를 지우기 때문이다.
+    func attendanceToggleChanged(to newValue: Bool) {
+        guard !newValue, initialIsAttendanceRequired else {
+            applyAttendanceToggle(to: newValue)
+            return
+        }
+        alertPrompt = AlertPrompt(
+            title: "출석 데이터 삭제",
+            message: "출석 필수를 해제하면 기존 출석 데이터가 삭제됩니다. 계속하시겠습니까?",
+            positiveBtnTitle: "해제",
+            positiveBtnAction: { [weak self] in
+                self?.applyAttendanceToggle(to: false)
+            },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    /// 출석 필수 토글을 실제로 적용한다.
+    ///
+    /// OFF → ON 은 정책을 새로 부여하려는 의도이므로 이전 dirty 표시를 버리고 일정 시각 기준
+    /// 기본값으로 다시 채운다.
+    private func applyAttendanceToggle(to newValue: Bool) {
+        isAttendanceRequired = newValue
+        if newValue {
+            isAttendancePolicyDirty = false
+        }
+        prefillAttendancePolicyIfNeeded()
+    }
+
+    /// 출석 정책 세 시각의 순서와 일정 범위 정합성을 검증한다.
+    private func validateAttendancePolicy() {
+        guard isAttendanceRequired, !isAllDay else {
+            attendancePolicyErrorMessage = nil
+            return
+        }
+        guard attendanceCheckInStartAt < attendanceOnTimeEndAt else {
+            attendancePolicyErrorMessage = "출석 시작은 출석 인정 마감보다 빨라야 합니다."
+            return
+        }
+        guard attendanceOnTimeEndAt < attendanceLateEndAt else {
+            attendancePolicyErrorMessage = "출석 인정 마감은 지각 인정 마감보다 빨라야 합니다."
+            return
+        }
+        guard attendanceCheckInStartAt < startDate else {
+            attendancePolicyErrorMessage = "출석 시작은 일정 시작보다 빨라야 합니다."
+            return
+        }
+        guard attendanceLateEndAt <= endDate else {
+            attendancePolicyErrorMessage = "지각 인정 마감은 일정 종료 시각을 넘을 수 없습니다."
+            return
+        }
+        attendancePolicyErrorMessage = nil
+    }
+
+    // MARK: - Submit Function
+
+    /// 일정을 새로 생성한다.
+    func submitSchedule() async {
+        guard !submitState.isLoading else { return }
+        validateAttendancePolicy()
+        guard attendancePolicyErrorMessage == nil else { return }
+
+        submitState = .loading
+        inlineErrorMessage = nil
+
+        let request = ScheduleCreationRequest(
+            name: trimmedTitle,
+            description: memo,
+            startsAt: effectiveStartsAt,
+            endsAt: effectiveEndsAt,
+            location: submitLocation,
+            // ponytail: 참여자 선택은 SelectedChallengerView 가 ActivityPresentation internal
+            // 이라 제외 — 공용 승격 후 결선.
+            participantMemberIds: [],
+            tags: sanitizedTags.map(\.rawValue),
+            attendancePolicy: submitAttendancePolicy
+        )
+
+        do {
+            try await generateScheduleUseCase.execute(request: request)
+            submitState = .loaded(true)
+        } catch {
+            submitState = .idle
+            errorHandler?.handle(error, context: ErrorContext(
+                feature: "Home",
+                action: "submitSchedule",
+                retryAction: { [weak self] in
+                    await self?.submitSchedule()
+                }
+            ))
+        }
+    }
+
+    /// 일정을 수정한다.
+    ///
+    /// 이미 시작된 일정은 클라이언트에서 먼저 막고, 서버가 `SCHEDULE-0028` 로 거부하는 경우도
+    /// 흐름을 끊지 않고 인라인 메시지로 알린다.
+    func updateSchedule() async {
+        guard let scheduleId = editingScheduleId, !submitState.isLoading else { return }
+
+        guard !isEditingStartedSchedule else {
+            inlineErrorMessage = Constants.startedScheduleMessage
+            return
+        }
+
+        validateAttendancePolicy()
+        guard attendancePolicyErrorMessage == nil else { return }
+
+        submitState = .loading
+        inlineErrorMessage = nil
+
+        let request = ScheduleUpdateRequest(
+            name: trimmedTitle,
+            description: memo,
+            startsAt: effectiveStartsAt,
+            endsAt: effectiveEndsAt,
+            location: submitLocation,
+            // ponytail: 참여자 선택 UI 를 이식하지 않아 nil(변경 없음)로 서버 값을 보존한다.
+            participantMemberIds: nil,
+            tags: sanitizedTags.map(\.rawValue),
+            attendancePolicy: submitAttendancePolicy,
+            isOnline: isOnlineTransitionFlag,
+            isAttendanceRequired: attendanceRequiredTransitionFlag
+        )
+
+        do {
+            try await updateScheduleUseCase.execute(scheduleId: scheduleId, request: request)
+            submitState = .loaded(true)
+        } catch let error as RepositoryError where error.code == Constants.startedScheduleCode {
+            submitState = .idle
+            inlineErrorMessage = Constants.startedScheduleMessage
+        } catch {
+            submitState = .idle
+            errorHandler?.handle(error, context: ErrorContext(
+                feature: "Home",
+                action: "updateSchedule",
+                retryAction: { [weak self] in
+                    await self?.updateSchedule()
+                }
+            ))
+        }
+    }
+
+    // MARK: - Edit Snapshot
+
+    private var currentEditSnapshot: EditFormSnapshot {
+        EditFormSnapshot(
+            title: title,
+            placeName: placeLocation?.locationName ?? "",
+            placeAddress: placeAddress,
+            latitude: placeLocation?.latitude ?? 0,
+            longitude: placeLocation?.longitude ?? 0,
+            isAllDay: isAllDay,
+            isOnline: isOnline,
+            startDate: startDate,
+            endDate: endDate,
+            memo: memo,
+            tags: sanitizedTags.map(\.rawValue).sorted(),
+            isAttendanceRequired: isAttendanceRequired,
+            checkInStartAt: attendanceCheckInStartAt,
+            onTimeEndAt: attendanceOnTimeEndAt,
+            lateEndAt: attendanceLateEndAt
+        )
+    }
+
+    /// 수정 모드에서 변경 감지에 쓰는 폼 상태 스냅샷
+    private struct EditFormSnapshot: Equatable {
+        let title: String
+        let placeName: String
+        let placeAddress: String
+        let latitude: Double
+        let longitude: Double
+        let isAllDay: Bool
+        let isOnline: Bool
+        let startDate: Date
+        let endDate: Date
+        let memo: String
+        let tags: [String]
+        let isAttendanceRequired: Bool
+        let checkInStartAt: Date
+        let onTimeEndAt: Date
+        let lateEndAt: Date
+    }
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
@@ -8,6 +8,7 @@
 import CoreDesignSystem
 import CoreDI
 import CoreDomain
+import CoreRouting
 import CoreUIComponents
 import HomeDomain
 import NoticeDomain
@@ -28,12 +29,16 @@ struct HomeView: View {
     // MARK: - Property
 
     @Environment(\.requestReview) private var requestReview
+    /// 홈 탭 스택의 공유 경로. 루트 복귀 감지에만 쓰므로, 경로 저장소를 주입하지 않는
+    /// 프리뷰/테스트 호출부가 깨지지 않도록 옵셔널로 받는다.
+    @Environment(PathStore.self) private var pathStore: PathStore?
     @State private var viewModel: HomeViewModel
     @State private var selectedDate: Date = .now
     @State private var currentMonth: Date = .now
     private let onNoticeSelected: (NoticeDetail) -> Void
     private let onScheduleSelected: (String) -> Void
     private let onAlarmHistoryTapped: () -> Void
+    private let onScheduleRegistrationTapped: () -> Void
     private let reviewRequestPolicy: ReviewRequestPolicy
 
     // MARK: - Constants
@@ -52,6 +57,7 @@ struct HomeView: View {
     ///   - onNoticeSelected: 최근 공지 카드 탭 시 상세 화면 이동을 위임하는 콜백
     ///   - onScheduleSelected: 일정 카드 탭 시 일정 상세 이동을 위임하는 콜백
     ///   - onAlarmHistoryTapped: 툴바 알림 버튼 탭 시 알림 보관함 이동을 위임하는 콜백
+    ///   - onScheduleRegistrationTapped: 툴바 일정 등록 버튼 탭 시 등록 화면 이동을 위임하는 콜백
     ///   - reviewRequestPolicy: 리뷰 요청 간격 정책 (프리뷰/테스트용 주입 지점)
     init(
         container: DIContainer,
@@ -59,12 +65,14 @@ struct HomeView: View {
         onNoticeSelected: @escaping (NoticeDetail) -> Void = { _ in },
         onScheduleSelected: @escaping (String) -> Void = { _ in },
         onAlarmHistoryTapped: @escaping () -> Void = {},
+        onScheduleRegistrationTapped: @escaping () -> Void = {},
         reviewRequestPolicy: ReviewRequestPolicy = ReviewRequestPolicy()
     ) {
         _viewModel = State(initialValue: viewModel ?? HomeViewModel(container: container))
         self.onNoticeSelected = onNoticeSelected
         self.onScheduleSelected = onScheduleSelected
         self.onAlarmHistoryTapped = onAlarmHistoryTapped
+        self.onScheduleRegistrationTapped = onScheduleRegistrationTapped
         self.reviewRequestPolicy = reviewRequestPolicy
     }
 
@@ -87,23 +95,22 @@ struct HomeView: View {
         .umcDefaultBackground()
         .toolbar {
             ToolBarCollection.Logo()
+            // ponytail: 임시 진입점 — 하단 탭 액세서리(#1057) 결선 후 제거.
+            ToolBarCollection.AddBtn(action: onScheduleRegistrationTapped)
             ToolBarCollection.BellBtn(action: onAlarmHistoryTapped)
         }
         .task {
             await viewModel.fetchProfileIfNeeded()
             requestReviewIfDue()
         }
-        .task {
-            await viewModel.fetchSchedules()
+        // 최초 진입(depth 0)과 홈 루트 복귀를 한 트리거로 처리한다. 별도 `.task`를 두면
+        // 최초 진입에서 같은 달을 두 번 조회하게 된다.
+        .task(id: pathStore?.depth(of: .home) ?? 0) {
+            guard pathStore?.isAtRoot(.home) ?? true else { return }
+            await fetchSchedules(of: currentMonth)
         }
         .onChange(of: currentMonth) { _, newMonth in
-            let calendar = Calendar.kstGregorian
-            Task {
-                await viewModel.fetchSchedules(
-                    year: calendar.component(.year, from: newMonth),
-                    month: calendar.component(.month, from: newMonth)
-                )
-            }
+            Task { await fetchSchedules(of: newMonth) }
         }
         .onReceive(NotificationCenter.default.publisher(for: .memberPenaltyUpdated)) { _ in
             // 상벌점이 방금 변경됐으므로 세션 프로필 캐시를 우회해 서버 최신값으로 갱신한다.
@@ -280,6 +287,15 @@ struct HomeView: View {
     }
 
     // MARK: - Function
+
+    /// 지정한 달(KST 기준 연/월)의 일정을 조회한다.
+    private func fetchSchedules(of month: Date) async {
+        let calendar = Calendar.kstGregorian
+        await viewModel.fetchSchedules(
+            year: calendar.component(.year, from: month),
+            month: calendar.component(.month, from: month)
+        )
+    }
 
     /// 마지막 요청 이후 4주가 지났으면 앱스토어 리뷰를 요청한다.
     private func requestReviewIfDue() {

--- a/UMCApp/Features/Home/Presentation/Sources/Views/Registration/ScheduleRegistrationView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/Registration/ScheduleRegistrationView.swift
@@ -1,0 +1,652 @@
+//
+//  ScheduleRegistrationView.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 1/22/26.
+//
+
+import CoreDesignSystem
+import CoreDI
+import CoreLocation
+import CoreUIComponents
+import FoundationModels
+import HomeDomain
+import SwiftData
+import SwiftUI
+import UMCFoundation
+
+/// 일정 등록/수정 화면.
+///
+/// 제목·장소·일시·태그·메모·출석 정책을 입력받아 생성 또는 수정을 수행한다. 생성 모드에서는
+/// 온디바이스 AI 로 폼을 한 번에 채우는 시트를 제공한다.
+///
+/// `navigationDestination` 으로 실리므로 자체 `NavigationStack` 을 만들지 않는다.
+public struct ScheduleRegistrationView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: ScheduleRegistrationViewModel
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Environment(ErrorHandler.self) private var errorHandler
+
+    private let mode: Mode
+
+    @State private var showAISheet: Bool = false
+
+    /// 현재 펼쳐진 시작/종료 피커. `nil` 이면 모두 접힌 상태다.
+    @State private var openScheduleSlot: ScheduleDateSlot?
+
+    /// 화면의 동작 모드
+    public enum Mode {
+        case create
+        case edit
+    }
+
+    // MARK: - Initializer
+
+    /// - Parameters:
+    ///   - container: UseCase 를 resolve 할 DI 컨테이너
+    ///   - mode: 생성/수정 모드
+    ///   - prefill: 수정 모드에서 폼에 채울 기존 일정
+    ///   - prefillRoadAddress: 장소 프리필 시 우선 노출할 도로명 주소
+    public init(
+        container: DIContainer,
+        mode: Mode = .create,
+        prefill: ScheduleDetailData? = nil,
+        prefillRoadAddress: String? = nil
+    ) {
+        self.mode = mode
+
+        let viewModel = ScheduleRegistrationViewModel(container: container)
+        if let prefill {
+            viewModel.applyPrefill(from: prefill, roadAddress: prefillRoadAddress)
+        }
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        formContent
+            .scrollDismissesKeyboard(.immediately)
+            .navigation(naviTitle: navigationTitle, displayMode: .inline)
+            .toolbar { toolbarContent }
+            .alertPrompt(item: $viewModel.alertPrompt)
+            .sheet(isPresented: $showAISheet) {
+                AIAutofillSheet(viewModel: viewModel, isPresented: $showAISheet)
+            }
+            .task {
+                viewModel.errorHandler = errorHandler
+                viewModel.modelContext = modelContext
+                viewModel.restoreDailyTokenUsage()
+            }
+    }
+
+    // MARK: - Sections
+
+    private var formContent: some View {
+        Form {
+            inlineErrorSection
+
+            Section {
+                titleField
+            }
+
+            placeSection
+
+            Section {
+                allDayToggle
+                scheduleDateTimeSection
+            }
+
+            attendancePolicySection
+
+            Section {
+                TagSelectionRow(tagList: tagBinding)
+            }
+
+            Section {
+                MemoEditor(memo: $viewModel.memo)
+                    .equatable()
+            }
+        }
+        .onChange(of: viewModel.startDate) { viewModel.startDateChanged() }
+        .onChange(of: viewModel.endDate) { viewModel.endDateChanged() }
+        .onChange(of: viewModel.isAllDay) { viewModel.prefillAttendancePolicyIfNeeded() }
+        .onChange(of: viewModel.submitState) {
+            if case .loaded = viewModel.submitState {
+                dismiss()
+            }
+        }
+    }
+
+    /// 수정 모드 가드 또는 서버 거부 메시지
+    @ViewBuilder
+    private var inlineErrorSection: some View {
+        if let message = inlineErrorDisplayMessage {
+            Section {
+                Text(message)
+                    .appFont(.subheadline, color: Color.red500)
+            }
+        }
+    }
+
+    private var titleField: some View {
+        TextField(
+            "",
+            text: titleBinding,
+            prompt: Text("일정 제목")
+                .foregroundStyle(Color.grey400)
+        )
+        .appFont(.body, color: Color.grey900)
+        .submitLabel(.return)
+        .tint(.indigo500)
+    }
+
+    private var allDayToggle: some View {
+        Toggle(isOn: $viewModel.isAllDay) {
+            Text("하루 종일")
+                .appFont(.body, color: Color.grey900)
+        }
+        .tint(.indigo500)
+    }
+
+    /// 대면/비대면 토글 + 장소 선택 섹션
+    private var placeSection: some View {
+        Section {
+            InPersonToggle(
+                isInPerson: Binding(
+                    get: { !viewModel.isOnline },
+                    set: { viewModel.inPersonModeToggleChanged(to: $0) }
+                )
+            )
+
+            if viewModel.isOnline {
+                Text("비대면 일정은 장소가 자동으로 비워집니다")
+                    .appFont(.footnote, color: Color.grey500)
+            } else {
+                PlaceSelectView(place: placeBinding)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var scheduleDateTimeSection: some View {
+        dateTimeRow(title: "시작", date: $viewModel.startDate, field: .start)
+        dateTimeRow(title: "종료", date: $viewModel.endDate, field: .end)
+    }
+
+    /// 출석 정책 입력 섹션
+    ///
+    /// ponytail: `ScheduleCapabilities` 권한 조회를 이식하지 않아 토글을 항상 노출한다. 권한이
+    /// 없는 사용자는 서버가 생성을 거부한다 — 권한 UseCase 이식 후 사전 차단으로 승격.
+    @ViewBuilder
+    private var attendancePolicySection: some View {
+        if !viewModel.isAllDay {
+            Section {
+                Toggle(isOn: attendanceToggleBinding) {
+                    Text("출석 필수")
+                        .appFont(.body, color: Color.grey900)
+                }
+                .tint(.indigo500)
+
+                if viewModel.isAttendanceRequired {
+                    AttendancePolicyTimeSection(
+                        checkInStartAt: $viewModel.attendanceCheckInStartAt,
+                        onTimeEndAt: $viewModel.attendanceOnTimeEndAt,
+                        lateEndAt: $viewModel.attendanceLateEndAt,
+                        onTimesChanged: viewModel.attendanceTimesChanged
+                    )
+
+                    if let message = viewModel.attendancePolicyErrorMessage {
+                        Text(message)
+                            .appFont(.footnote, color: Color.red500)
+                    }
+                }
+            }
+        }
+    }
+
+    // ponytail: 참여자 선택은 SelectedChallengerView 가 ActivityPresentation internal 이라 제외
+    // — 공용 승격 후 결선. 최대 초대 인원 표시도 참여자 섹션과 함께 빠졌다.
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        if mode == .edit {
+            ToolBarCollection.RejectBtn(action: {})
+
+            ToolBarCollection.ConfirmBtn(
+                action: { Task { await viewModel.updateSchedule() } },
+                disable: isActionDisabled,
+                isLoading: isSubmitting,
+                // 성공(.loaded)을 확인한 뒤 닫아야 실패 시 입력이 살아 있다.
+                dismissOnTap: false
+            )
+        } else {
+            if isAIAvailable {
+                ToolBarCollection.AddBtn(
+                    imageSystemName: "sparkles",
+                    action: { showAISheet = true }
+                )
+            }
+
+            ToolBarCollection.AddBtn(
+                action: { Task { await viewModel.submitSchedule() } },
+                disable: isActionDisabled,
+                isLoading: isSubmitting
+            )
+        }
+    }
+
+    // MARK: - Binding
+
+    /// 제목 입력 바인딩. 입력마다 태그 자동 추천을 비동기로 갱신한다.
+    private var titleBinding: Binding<String> {
+        Binding(
+            get: { viewModel.title },
+            set: { newValue in
+                viewModel.title = newValue
+                Task { await viewModel.titleDidChange(to: newValue) }
+            }
+        )
+    }
+
+    private var tagBinding: Binding<[ScheduleIconCategory]> {
+        Binding(
+            get: { viewModel.tags },
+            set: { viewModel.updateTagsFromUser($0) }
+        )
+    }
+
+    private var attendanceToggleBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.isAttendanceRequired },
+            set: { viewModel.attendanceToggleChanged(to: $0) }
+        )
+    }
+
+    /// 장소 선택 UI 와 뷰모델을 잇는 바인딩.
+    ///
+    /// `PlaceSelection` 은 표시용 묶음이고 뷰모델은 도메인 모델(`ScheduleLocation`)을 들고 있어
+    /// 여기서 한 번만 변환한다. 선택 해제(빈 이름)의 의미 부여는 뷰모델이 판단한다.
+    private var placeBinding: Binding<PlaceSelection> {
+        Binding(
+            get: {
+                guard let location = viewModel.placeLocation else { return .empty }
+                return PlaceSelection(
+                    name: location.locationName,
+                    address: viewModel.placeAddress,
+                    coordinate: CLLocationCoordinate2D(
+                        latitude: location.latitude,
+                        longitude: location.longitude
+                    )
+                )
+            },
+            set: { selected in
+                viewModel.placeSelectionChanged(
+                    name: selected.name,
+                    address: selected.address,
+                    latitude: selected.coordinate.latitude,
+                    longitude: selected.coordinate.longitude
+                )
+            }
+        )
+    }
+
+    // MARK: - Helper
+
+    private var navigationTitle: NavigationTitle.Activity {
+        mode == .create ? .addSchedule : .editSchedule
+    }
+
+    private var isSubmitting: Bool {
+        viewModel.submitState.isLoading
+    }
+
+    /// 저장 액션을 막아야 하는지 계산한다.
+    ///
+    /// 수정 모드는 필수값 충족에 더해 변경 사항 존재 여부와 이미 시작된 일정인지
+    /// (SCHEDULE-0028 사전 차단)를 함께 확인한다.
+    private var isActionDisabled: Bool {
+        guard mode == .edit else {
+            return !viewModel.canSubmit || isSubmitting
+        }
+        if viewModel.isEditingStartedSchedule { return true }
+        return !viewModel.canSubmit || !viewModel.hasChangesInEditMode || isSubmitting
+    }
+
+    private var inlineErrorDisplayMessage: String? {
+        if mode == .edit, viewModel.isEditingStartedSchedule {
+            return "이미 시작된 일정은 수정할 수 없습니다."
+        }
+        return viewModel.inlineErrorMessage
+    }
+
+    private var isAIAvailable: Bool {
+        if case .available = SystemLanguageModel.default.availability {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Function
+
+    /// 시작/종료 한 행 + 펼쳐진 피커를 함께 그린다.
+    @ViewBuilder
+    private func dateTimeRow(
+        title: String,
+        date: Binding<Date>,
+        field: ScheduleDateSlot.Field
+    ) -> some View {
+        let dateSlot = ScheduleDateSlot(field: field, component: .date)
+        let timeSlot = ScheduleDateSlot(field: field, component: .time)
+
+        DateTimeRow(
+            title: title,
+            date: date.wrappedValue,
+            isAllDay: viewModel.isAllDay,
+            isDatePickerActive: openScheduleSlot == dateSlot,
+            isTimePickerActive: openScheduleSlot == timeSlot,
+            dateTap: { toggleScheduleSlot(dateSlot) },
+            timeTap: { toggleScheduleSlot(timeSlot) }
+        )
+        .equatable()
+
+        if openScheduleSlot == dateSlot {
+            DatePickerRow(date: date, range: pickerRange(for: field))
+        }
+
+        if openScheduleSlot == timeSlot {
+            TimePickerRow(date: date, range: pickerRange(for: field))
+        }
+    }
+
+    /// 종료 피커는 시작 시각 이전을 고를 수 없게 막는다.
+    private func pickerRange(for field: ScheduleDateSlot.Field) -> ClosedRange<Date>? {
+        field == .end ? viewModel.startDate...Date.distantFuture : nil
+    }
+
+    /// 같은 슬롯을 다시 누르면 접고, 다른 슬롯을 누르면 그쪽으로 옮긴다.
+    private func toggleScheduleSlot(_ slot: ScheduleDateSlot) {
+        withAnimation {
+            openScheduleSlot = (openScheduleSlot == slot) ? nil : slot
+        }
+    }
+
+    // MARK: - ScheduleDateSlot
+
+    /// 시작/종료 일시에서 열려 있을 수 있는 피커 하나를 가리키는 식별자.
+    fileprivate struct ScheduleDateSlot: Hashable {
+
+        enum Field: Hashable {
+            case start
+            case end
+        }
+
+        enum Component: Hashable {
+            case date
+            case time
+        }
+
+        let field: Field
+        let component: Component
+    }
+}
+
+// MARK: - TagSelectionRow
+
+/// 태그 선택 시트를 여는 행
+private struct TagSelectionRow: View {
+
+    // MARK: - Property
+
+    @Binding var tagList: [ScheduleIconCategory]
+
+    @State private var showTagList: Bool = false
+
+    private enum Constants {
+        static let title = "태그"
+        static let chevron = "chevron.right"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Button {
+            showTagList.toggle()
+        } label: {
+            HStack {
+                Text(Constants.title)
+                    .appFont(.body, color: Color.grey900)
+
+                Spacer()
+
+                selectedCount
+            }
+        }
+        .sheet(isPresented: $showTagList) {
+            TagListView(tagList: $tagList)
+                .presentationDragIndicator(.visible)
+                .interactiveDismissDisabled()
+        }
+    }
+
+    private var selectedCount: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            if !tagList.isEmpty {
+                Text("\(tagList.count)개 선택됨")
+                    .appFont(.callout, color: Color.grey500)
+            }
+
+            Image(systemName: Constants.chevron)
+                .foregroundStyle(Color.grey500)
+        }
+    }
+}
+
+// MARK: - MemoEditor
+
+/// 메모 입력 에디터
+private struct MemoEditor: View, Equatable {
+
+    // MARK: - Property
+
+    @Binding var memo: String
+
+    private enum Constants {
+        static let height: CGFloat = 200
+        static let placeholder = "메모"
+        static let placeholderPadding = EdgeInsets(top: 8, leading: 4, bottom: 8, trailing: 4)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.memo == rhs.memo
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        TextEditor(text: $memo)
+            .overlay(alignment: .topLeading) {
+                if memo.isEmpty {
+                    Text(Constants.placeholder)
+                        .appFont(.body, color: Color.grey400)
+                        .padding(Constants.placeholderPadding)
+                }
+            }
+            .frame(height: Constants.height)
+    }
+}
+
+// MARK: - AIAutofillSheet
+
+/// 자연어 입력으로 폼을 채워 주는 AI 자동완성 시트.
+///
+/// 성공하면 시트를 자동으로 닫아 채워진 폼을 바로 확인하게 한다. 장소는 이름만 제안하고 좌표는
+/// 만들지 않으며, 출석 정책은 건드리지 않는다.
+private struct AIAutofillSheet: View {
+
+    // MARK: - Property
+
+    @Bindable var viewModel: ScheduleRegistrationViewModel
+    @Binding var isPresented: Bool
+
+    private enum Constants {
+        static let placeholder = "예: 다음 주 화요일 저녁 7시 스터디 모임 강남역 근처"
+        static let buttonLabel = "AI로 정리"
+        static let sheetTitle = "AI 자동완성"
+        static let sheetDescription = "일정 내용을 자연어로 입력하면 AI가 폼을 자동으로 채웁니다."
+        static let headerLabel = "Apple Intelligence"
+        static let headerIconSize: CGFloat = 16
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+                headerSection
+
+                Text(Constants.sheetDescription)
+                    .appFont(.subheadline, color: Color.grey600)
+                    .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+
+                inputArea
+
+                autofillButton
+
+                usageFootnote
+
+                Spacer()
+            }
+            .padding(.top, DefaultSpacing.spacing16)
+            .navigationTitle(Constants.sheetTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        viewModel.resetAIAutofillState()
+                        isPresented = false
+                    } label: {
+                        Image(systemName: "xmark")
+                            .foregroundStyle(Color.grey500)
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+        .onChange(of: viewModel.aiAutofillState) {
+            if case .loaded = viewModel.aiAutofillState {
+                viewModel.resetAIAutofillState()
+                isPresented = false
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var headerSection: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: Constants.headerIconSize, weight: .medium))
+                .foregroundStyle(Color.indigo500)
+
+            Text(Constants.headerLabel)
+                .appFont(.callout, weight: .semibold, color: Color.grey700)
+        }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    private var inputArea: some View {
+        TextField(
+            "",
+            text: $viewModel.aiRawInput,
+            prompt: Text(Constants.placeholder)
+                .foregroundStyle(Color.grey400),
+            axis: .vertical
+        )
+        .appFont(.body, color: Color.grey900)
+        .lineLimit(3...6)
+        .padding(DefaultSpacing.spacing12)
+        .background(Color.grey100)
+        .clipShape(RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius))
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    @ViewBuilder
+    private var autofillButton: some View {
+        Group {
+            if viewModel.aiAutofillState.isLoading {
+                ProgressView()
+                    .controlSize(.regular)
+                    .tint(.indigo500)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, DefaultSpacing.spacing8)
+            } else {
+                Button {
+                    Task { await viewModel.requestAIAutofill() }
+                } label: {
+                    Text(Constants.buttonLabel)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.glassProminent)
+                .tint(.indigo500)
+                .controlSize(.large)
+                .disabled(isInputEmpty)
+            }
+        }
+        .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    @ViewBuilder
+    private var usageFootnote: some View {
+        if viewModel.aiCumulativeUsedTokens > 0 {
+            Text("오늘 사용한 토큰 \(viewModel.aiCumulativeUsedTokens)")
+                .appFont(.caption1, color: Color.grey500)
+                .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        }
+    }
+
+    private var isInputEmpty: Bool {
+        viewModel.aiRawInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+/// 네트워크 없이 화면을 확인하기 위한 프리뷰 전용 UseCase (절대규칙 #5)
+private struct PreviewGenerateScheduleUseCase: GenerateScheduleUseCaseProtocol {
+    @discardableResult
+    func execute(request: ScheduleCreationRequest) async throws -> String { "1" }
+}
+
+private struct PreviewUpdateScheduleUseCase: UpdateScheduleUseCaseProtocol {
+    func execute(scheduleId: String, request: ScheduleUpdateRequest) async throws {}
+}
+
+private struct PreviewClassifyScheduleUseCase: ClassifyScheduleUseCaseProtocol {
+    func execute(title: String) async -> ScheduleIconCategory { .study }
+}
+
+#Preview("ScheduleRegistrationView") {
+    let container = DIContainer()
+    container.register(GenerateScheduleUseCaseProtocol.self) {
+        PreviewGenerateScheduleUseCase()
+    }
+    container.register(UpdateScheduleUseCaseProtocol.self) {
+        PreviewUpdateScheduleUseCase()
+    }
+    container.register(ClassifyScheduleUseCaseProtocol.self) {
+        PreviewClassifyScheduleUseCase()
+    }
+
+    return NavigationStack {
+        ScheduleRegistrationView(container: container)
+    }
+    .environment(ErrorHandler())
+}
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Views/Registration/TagListView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/Registration/TagListView.swift
@@ -1,0 +1,109 @@
+//
+//  TagListView.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 1/23/26.
+//
+
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 일정 태그를 고르는 시트
+struct TagListView: View {
+
+    // MARK: - Property
+
+    @Binding var tagList: [ScheduleIconCategory]
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                ForEach(ScheduleIconCategory.selectableCases, id: \.self) { category in
+                    TagRow(
+                        category: category,
+                        isSelected: tagList.contains(category),
+                        tap: { toggleSelection(category) }
+                    )
+                    .equatable()
+                }
+            }
+            .navigation(naviTitle: NavigationTitle.Shared.tag, displayMode: .inline)
+            .toolbar {
+                ToolBarCollection.CancelBtn(action: { tagList.removeAll() })
+
+                ToolBarCollection.ConfirmBtn(action: {})
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    private func toggleSelection(_ category: ScheduleIconCategory) {
+        if let index = tagList.firstIndex(of: category) {
+            tagList.remove(at: index)
+        } else {
+            tagList.append(category)
+        }
+    }
+}
+
+// MARK: - TagRow
+
+/// 태그 한 줄. 선택 상태만 바뀌면 다시 그리도록 `Equatable` 로 비교한다.
+private struct TagRow: View, Equatable {
+
+    // MARK: - Property
+
+    let category: ScheduleIconCategory
+    let isSelected: Bool
+    let tap: () -> Void
+
+    private enum Constants {
+        static let iconSize: CGFloat = 40
+        static let checkMark = "checkmark.circle.fill"
+        static let circle = "circle"
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.category == rhs.category && lhs.isSelected == rhs.isSelected
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Button(action: tap) {
+            HStack(spacing: DefaultSpacing.spacing12) {
+                Image(systemName: category.symbol)
+                    .font(.body)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: Constants.iconSize, height: Constants.iconSize)
+                    .foregroundStyle(.white)
+                    .clipShape(.circle)
+                    .glassEffect(.clear.tint(category.color), in: .circle)
+
+                Text(category.korean)
+                    .appFont(.body, color: Color.grey900)
+
+                Spacer()
+
+                Image(systemName: isSelected ? Constants.checkMark : Constants.circle)
+                    .font(.title2)
+                    .foregroundStyle(isSelected ? Color.indigo500 : Color.grey300)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#if DEBUG
+#Preview {
+    @Previewable @State var tagList: [ScheduleIconCategory] = []
+
+    TagListView(tagList: $tagList)
+}
+#endif

--- a/UMCApp/Features/Home/Project.swift
+++ b/UMCApp/Features/Home/Project.swift
@@ -25,6 +25,8 @@ let project = featureProject(
         // 일정 상세의 출석 진입 분기가 전역 `UserSessionManager`의 활동 모드를 읽는다.
         .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
+        // 홈 루트가 공유 `PathStore` 의 홈 스택 깊이로 루트 복귀를 감지해 월별 일정을 재조회한다.
+        .project(target: "CoreRouting", path: .relativeToRoot("Core/Routing")),
         .project(target: "NoticeDomain", path: .relativeToRoot("Features/Notice")),
     ],
     includesDomainTests: true,

--- a/UMCApp/UMCApp/Sources/DIContainer+Home.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Home.swift
@@ -40,6 +40,9 @@ extension DIContainer {
         register(FetchScheduleDetailUseCaseProtocol.self) {
             FetchScheduleDetailUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
         }
+        register(GenerateScheduleUseCaseProtocol.self) {
+            GenerateScheduleUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
+        }
         register(UpdateScheduleUseCaseProtocol.self) {
             UpdateScheduleUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
         }

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationDestination.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationDestination.swift
@@ -27,6 +27,7 @@ enum NavigationDestination: Hashable {
 
     enum Home: Hashable {
         case alarmHistory
+        case registrationSchedule
         case scheduleDetail(scheduleId: String)
     }
 

--- a/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
+++ b/UMCApp/UMCApp/Sources/Navigation/NavigationRoutingView.swift
@@ -55,6 +55,8 @@ private extension NavigationRoutingView {
         switch route {
         case .alarmHistory:
             NoticeAlarmView()
+        case .registrationSchedule:
+            ScheduleRegistrationView(container: di)
         case .scheduleDetail(let scheduleId):
             ScheduleDetailView(
                 container: di,

--- a/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
+++ b/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
@@ -102,6 +102,9 @@ struct RootTabView: View {
                 },
                 onAlarmHistoryTapped: {
                     pathStore.push(NavigationDestination.home(.alarmHistory), on: .home)
+                },
+                onScheduleRegistrationTapped: {
+                    pathStore.push(NavigationDestination.home(.registrationSchedule), on: .home)
                 }
             )
         case .notice:


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 홈 탭 일정 등록 화면(`ScheduleRegistrationView`)과 ViewModel을 `AppProduct/` → `UMCApp/` 로 이식하고, 끊겨 있던 라우팅을 결선했습니다. 홈 루트 복귀 시 월별 일정 재조회 트리거도 함께 붙였습니다. (resolves #1088)

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 신규 화면(일정 등록)과 홈 툴바 진입 버튼이 추가되었습니다. 시뮬레이터 캡처 첨부 예정 -->

## 🛠️ 작업내용

**HomeDomain — 일정 생성 UseCase**
- `GenerateScheduleUseCaseProtocol` / `GenerateScheduleUseCase` 추가
- 기존 `ScheduleRepositoryProtocol.createSchedule(_:)` 을 그대로 위임 — 레거시 `GenerateScheduleRequetDTO` 를 재이식하지 않고 `ScheduleCreationRequest` 재사용
- 일정 수정 파이프라인(`UpdateScheduleUseCase` 등)은 #1087 에서 이미 이식되어 그대로 사용

**HomePresentation — 등록 화면 본체**
- `ScheduleRegistrationView` 이식 (레거시 908줄 → 652줄). 생성/수정 두 모드, 종일 토글, 시작·종료 시각 정합성, 출석 정책 시각 검증 유지
- `ScheduleRegistrationViewModel` 이식 (레거시 734줄 → 553줄) + `+AI` 확장
- `ScheduleDraft`(`@Generable`) / `TagListView` 이식
- FoundationModels 기반 AI 자동 채우기(`requestAIAutofill`) — 일일 토큰 사용량 기록은 `NoticeEditorViewModel+AI` 선례를 따라 `AITokenDailyUsageRecord` 로 영속
- 폼 컴포넌트는 CoreUIComponents 이관분 재사용 (`DatePickerRow` · `TimePickerRow` · `DateTimeRow` · `InPersonToggle` · `AttendancePolicyTimeSection` · `PlaceSelectView`)

**라우팅 결선**
- `NavigationDestination.Home` 에 `.registrationSchedule` 추가
- `NavigationRoutingView.homeView(_:)` 분기 추가
- `HomeFeatureView` 에 `onScheduleRegistrationTapped` 콜백 추가 → `RootTabView` 에서 `pathStore.push(.home(.registrationSchedule), on: .home)` 결선

**홈 루트 복귀 재조회**
- `HomeView` 에 `.task(id: pathStore.depth(of: .home))` 트리거 추가 — 등록/수정 후 홈 복귀 시 캘린더가 스테일하게 남던 문제 해소
- 기존 `.task { fetchSchedules() }` 를 이 트리거로 흡수해 최초 진입 시 같은 달을 두 번 조회하던 동작을 1회로 정리
- `HomePresentation` 에 `CoreRouting` 의존 추가 (Activity 선례와 동일)

## 📋 추후 진행 상황

- **하단 탭 액세서리 진입점 (#1057)** — 현재는 홈 툴바 `+` 버튼이 임시 진입점입니다. 액세서리 결선 시 제거 예정 (`HomeView.swift` 에 `ponytail:` 주석 표시)
- **일정 상세 → 편집 진입 (#1091)** — 편집 화면이 이번 PR로 생겼으므로 상세 화면 툴바에 수정 진입점을 연결할 수 있게 되었습니다
- **참여자 선택** — `SelectedChallengerView` 가 `ActivityPresentation` 의 `internal` 타입이라 이번 범위에서 제외했습니다. 공용 승격 후 결선 필요 (생성은 `[]`, 수정은 `nil` 로 서버 값 보존)
- **`ScheduleCapabilities`** — UMCApp 에 4계층 모두 미존재해 신설하지 않았습니다. 출석 필수 토글은 항상 노출로 단순화

## 📌 리뷰 포인트

- `UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel.swift` — `canSubmit` / `hasChangesInEditMode` / `isEditingStartedSchedule` / `hasValidPlace` 검증 로직과 `EditFormSnapshot` 변경 감지. 레거시 스냅샷이 빠뜨렸던 출석 정책 필드를 포함시켜, 정책 시각만 바꿔도 저장이 활성화됩니다
- `.../ViewModels/ScheduleRegistrationViewModel+AI.swift` — `SystemLanguageModel.default.availability` 가드와 일일 토큰 사용량 영속. `memberId` 가 `String` 인 UMCApp 계약에 맞췄습니다
- `.../Views/Registration/ScheduleRegistrationView.swift` — `PlaceSelection` ↔ `ScheduleLocation` 변환(`placeBinding`). 레거시 `SearchPlaceViewModel` 일가(~790줄)를 이식하는 대신 CoreUIComponents 의 `PlaceSelectView`/`MapPlacePickerView` 로 대체했습니다
- `UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift` — 루트 복귀 트리거의 이중 호출 방지. `@Environment(PathStore.self)` 를 옵셔널로 받아 PathStore 를 주입하지 않는 프리뷰/테스트 호출부가 깨지지 않게 했습니다
- `UMCApp/UMCApp/Sources/DIContainer+Home.swift` — `GenerateScheduleUseCaseProtocol` 등록 (#1087 의 Update/Delete/ForceDelete 등록과 나란히)
- `UMCApp/Core/UIComponents/Sources/Utilities/NavigationTitle.swift` — `Shared.tag` 1줄 추가. `Community.tag` 가 이미 있었으나 네임스페이스가 맞지 않아 공용으로 뺐습니다

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
