### PR TITLE
♻️ [Refactor] 공지 목록 지부명·기수 보정 로직 복원 — 칩 라벨 오표시 해소 (#1090)

### DIFF
--- a/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDTO.swift
+++ b/UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDTO.swift
@@ -58,14 +58,11 @@ public struct NoticeDTO: Codable {
 // MARK: - Mapping
 extension NoticeDTO {
     /// NoticeDTO → NoticeItemModel 변환 (공지 목록용)
-    func toItemModel(
-        generationOverride: String? = nil,
-        scopeDisplayNameOverride: String? = nil
-    ) -> NoticeItemModel {
-        let generation = generationOverride ?? String(targetInfo.generationValue)
+    func toItemModel() -> NoticeItemModel {
+        let generation = String(targetInfo.generationValue)
         let scope = targetInfo.resolvedScope
         let category = targetInfo.resolvedCategory
-        let scopeDisplayName = scopeDisplayNameOverride ?? targetInfo.resolvedScopeDisplayName
+        let scopeDisplayName = targetInfo.resolvedScopeDisplayName
         let targetsAllGenerations = (Int(generation) ?? 0) <= 0 && targetInfo.targetsAllGenerations
         
         let resolvedAuthorName = resolvedAuthorName(authorName)
@@ -89,6 +86,8 @@ extension NoticeDTO {
             viewCount: viewCount,
             scopeDisplayName: scopeDisplayName,
             targetsAllGenerations: targetsAllGenerations,
+            targetChapterId: targetInfo.targetChapterId,
+            targetGisuId: targetInfo.targetGisuId,
             parts: targetInfo.resolvedParts,
             isRead: false
         )

--- a/UMCApp/Features/Notice/Domain/Sources/Models/NoticeItemModel.swift
+++ b/UMCApp/Features/Notice/Domain/Sources/Models/NoticeItemModel.swift
@@ -14,7 +14,7 @@ import UMCFoundation
 public struct NoticeItemModel: Equatable, Identifiable {
     public let id = UUID()
     public let noticeId: String
-    public let generation: String
+    public var generation: String
     // 공지 출처 (중앙/지부/교내)
     public let scope: NoticeScope
     // 공지 카테고리 (일반/파트별)
@@ -31,10 +31,14 @@ public struct NoticeItemModel: Equatable, Identifiable {
     public let images: [String]
     public let vote: NoticeVote?
     public let viewCount: String
-    public let scopeDisplayName: String?
-    public let targetsAllGenerations: Bool
+    public var scopeDisplayName: String?
+    public var targetsAllGenerations: Bool
+    /// 지부명 보정을 위한 원본 지부 식별자
+    public let targetChapterId: String?
+    /// 기수 역매핑을 위한 원본 기수 식별자
+    public let targetGisuId: String?
     public let parts: [UMCPartType]
-    public let isRead: Bool
+    public var isRead: Bool
 
     public init(
         noticeId: String = UUID().uuidString,
@@ -55,6 +59,8 @@ public struct NoticeItemModel: Equatable, Identifiable {
         viewCount: String,
         scopeDisplayName: String? = nil,
         targetsAllGenerations: Bool = false,
+        targetChapterId: String? = nil,
+        targetGisuId: String? = nil,
         parts: [UMCPartType] = [],
         isRead: Bool = false
     ) {
@@ -76,6 +82,8 @@ public struct NoticeItemModel: Equatable, Identifiable {
         self.viewCount = viewCount
         self.scopeDisplayName = scopeDisplayName
         self.targetsAllGenerations = targetsAllGenerations
+        self.targetChapterId = targetChapterId
+        self.targetGisuId = targetGisuId
         self.parts = parts
         self.isRead = isRead
     }

--- a/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Fetch.swift
@@ -110,7 +110,7 @@ extension NoticeViewModel {
         do {
             let request = buildNoticeListRequest(gisuId: gisuId, page: page)
             let response = try await requestAction(request)
-            applyPagedResponse(response, page: page)
+            try await applyPagedResponse(response, page: page)
         } catch is CancellationError {
             handleCancelledFetch(page: page, previousState: previousState)
         } catch let error as NSError where isRequestCancellation(error) {
@@ -186,7 +186,7 @@ extension NoticeViewModel {
     ///   - response: 공지 페이징 응답 DTO
     ///   - page: 조회한 페이지 인덱스
     @MainActor
-    private func applyPagedResponse(_ response: NoticePage, page: Int) {
+    private func applyPagedResponse(_ response: NoticePage, page: Int) async throws {
         #if DEBUG
         print(
             "[NoticeViewModel] applyPagedResponse " +
@@ -213,54 +213,92 @@ extension NoticeViewModel {
             return
         }
 
-        let readNoticeIDs = resolvedReadNoticeIDs()
-        let mappedItems = response.items.map { item -> NoticeItemModel in
-
-            guard readNoticeIDs.contains(item.noticeId) else {
-                return item
-            }
-
-            return NoticeItemModel(
-                noticeId: item.noticeId,
-                generation: item.generation,
-                scope: item.scope,
-                category: item.category,
-                mustRead: item.mustRead,
-                isAlert: item.isAlert,
-                date: item.date,
-                title: item.title,
-                content: item.content,
-                writer: item.writer,
-                authorNickname: item.authorNickname,
-                authorName: item.authorName,
-                links: item.links,
-                images: item.images,
-                vote: item.vote,
-                viewCount: item.viewCount,
-                scopeDisplayName: item.scopeDisplayName,
-                targetsAllGenerations: item.targetsAllGenerations,
-                parts: item.parts,
-                isRead: true
-            )
-        }
-        pagingState.applySuccess(page: page, hasNextPage: response.hasNext)
-
         /// 현재 선택된 조회 필터에 맞지 않는 공지를 클라이언트 측에서 정리합니다.
         ///
         /// iOS-01은 서버-01, 서버-03만 노출하도록 후처리합니다.
-        let items: [NoticeItemModel]
+        let filteredItems: [NoticeItemModel]
         if case .central = selectedMainFilter {
-            items = mappedItems.filter { $0.scope == .central && $0.category == .general }
+            filteredItems = response.items.filter {
+                $0.scope == .central && $0.category == .general
+            }
         } else {
-            items = mappedItems
+            filteredItems = response.items
         }
-        
+
+        let branchNames = await resolveBranchNameOverrides(from: filteredItems)
+        // 지부명 조회 중 취소된 요청의 결과가 목록에 커밋되지 않도록 차단
+        try Task.checkCancellation()
+
+        let readNoticeIDs = resolvedReadNoticeIDs()
+        let items = filteredItems.map { item -> NoticeItemModel in
+            var corrected = item
+            if let generation = resolvedGeneration(for: item) {
+                corrected.generation = generation
+                corrected.targetsAllGenerations = false
+            }
+            if let chapterId = item.targetChapterId, let branchName = branchNames[chapterId] {
+                corrected.scopeDisplayName = branchName
+            }
+            corrected.isRead = readNoticeIDs.contains(item.noticeId)
+            return corrected
+        }
+        pagingState.applySuccess(page: page, hasNextPage: response.hasNext)
+
         if page == 0 {
             noticeItems = .loaded(items)
         } else {
             let mergedItems = (noticeItems.value ?? []) + items
             noticeItems = .loaded(mergedItems)
         }
+    }
+
+    /// 지부 공지 중 지부명이 비어 있는 항목의 chapterId를 실제 지부명으로 해석합니다.
+    /// - Returns: chapterId → 지부명 매핑. 조회에 실패한 chapterId는 포함하지 않습니다.
+    @MainActor
+    private func resolveBranchNameOverrides(
+        from items: [NoticeItemModel]
+    ) async -> [String: String] {
+        let missingBranchIds = Set(
+            items.compactMap { item -> String? in
+                guard item.scope == .branch else { return nil }
+                let displayName = item.scopeDisplayName?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                guard displayName.isEmpty else { return nil }
+                guard let chapterId = item.targetChapterId,
+                      !chapterId.isEmpty, chapterId != "0" else { return nil }
+                return chapterId
+            }
+        )
+
+        guard !missingBranchIds.isEmpty else { return [:] }
+
+        var resolved: [String: String] = [:]
+        for chapterId in missingBranchIds {
+            if let cached = chapterNameCache[chapterId] {
+                resolved[chapterId] = cached
+                continue
+            }
+            // 조회 실패 시 기본 칩 라벨(지부)로 fallback
+            guard let chapterName = try? await noticeEditorTargetUseCase
+                .fetchBranchName(chapterId: chapterId) else { continue }
+            chapterNameCache[chapterId] = chapterName
+            resolved[chapterId] = chapterName
+        }
+        return resolved
+    }
+
+    /// 기수 값이 유효하지 않으면 gisuId로 기수를 역매핑합니다.
+    /// - Returns: 보정된 기수. 보정할 수 없으면 `nil`
+    private func resolvedGeneration(for item: NoticeItemModel) -> String? {
+        if let generation = Int(item.generation), generation > 0 {
+            return item.generation
+        }
+
+        guard let gisuId = item.targetGisuId, !gisuId.isEmpty, gisuId != "0" else {
+            return nil
+        }
+
+        return gisuPairs.first(where: { $0.gisuId == gisuId })?.gen
     }
 
     private func resolvedReadNoticeIDs() -> Set<String> {


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 이관 과정에서 누락된 공지 목록 보정 로직 복원 (closes #1090)

레거시 `NoticeViewModel+Fetch` 의 보정 함수 2종이 통째로 빠지면서, 공지 칩이
`targetGisu` nil 시 **"0기"** 로 깨지고 지부 공지가 실제 지부명 대신 기본 라벨("지부")로
표시되던 문제를 해소합니다. 쓰기 전용으로 방치돼 있던 `chapterNameCache` 도 실제 캐시로 결선했습니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 칩 라벨 렌더링 변화라 시각 확인이 필요하나, `targetGisu` 가 null 인 실제 공지 데이터가
있어야 재현됩니다. 해당 데이터 확보 후 캡처 첨부 예정입니다. -->

## 🛠️ 작업내용

**오버라이드 전달 경로 재설계**

DTO→Domain 매핑이 Repository 로 내려간 구조를 그대로 유지하기 위해, Repository 에
UseCase·`gisuPairs` 같은 Presentation 관심사를 주입하지 않았습니다. 대신 **도메인 모델이 보정용
원본 식별자를 들고 나오고, ViewModel 이 사후 보정**하는 방향으로 정리했습니다.

- `NoticeItemModel` — 보정용 원본 식별자 `targetChapterId` / `targetGisuId` 추가
  (절대 규칙 #2에 맞춰 둘 다 `String?`). 보정 대상 4개 필드(`generation`,
  `scopeDisplayName`, `targetsAllGenerations`, `isRead`)를 `let` → `var` 전환
- `NoticeDTO.toItemModel()` — 위 두 식별자를 도메인으로 전달.
  호출부가 0건이던 `generationOverride:` / `scopeDisplayNameOverride:` 파라미터 삭제
- `NoticeViewModel+Fetch` — `resolveBranchNameOverrides(from:)` 복원
  (`chapterNameCache` 읽기 결선, 캐시 미스만 `fetchBranchName` 호출, 실패 시 기본 라벨 유지)
- `NoticeViewModel+Fetch` — `resolvedGeneration(for:)` 복원 (`gisuPairs` 로 기수 역매핑).
  역매핑 성사 시 `targetsAllGenerations` 도 함께 해제해 레거시와 동일 결과 유지
- 보정 지점을 `applyPagedResponse` **한 곳으로 단일화** — 목록 조회·검색·검색해제·재시도·
  다음 페이지 로드가 모두 이 지점으로 수렴하므로 호출부 분산 없음
- 필터링을 보정보다 앞으로 이동 — `.central` 필터로 잘려나갈 항목에 불필요한
  `fetchBranchName` 네트워크 호출이 나가지 않도록 (레거시와 동일 순서)
- 기존 `isRead` 보정의 20필드 재-init 블록(22줄)을 `var corrected = item` 패턴으로 대체.
  부수효과로 `id = UUID()` 가 보존돼 페이지네이션 diffing 안정성이 개선됩니다
- `applyPagedResponse` 를 `async throws` 로 바꾸고 `await` 서스펜션 직후
  `try Task.checkCancellation()` 추가 — 취소된 요청이 페이지 상태를 커밋하지 않도록 방어

## 📋 추후 진행 상황

- **`StaffNoticeViewModel`** (`StaffNoticeViewModel.swift:253`) 은 이번 범위에서 제외했습니다.
  해당 VM 에는 `gisuPairs`·`chapterNameCache` 가 없어 운영진 탭에도 같은 칩 오표시가
  남아있을 가능성이 있습니다 — 별도 이슈 분리 여부 판단 필요
- 목록 새로고침(page 0)과 무한스크롤(page > 0) 간 상호 배제가 없어 응답 역전이
  가능한 구조가 남아있습니다. **v2.2.0 레거시에도 동일하게 존재하던 기존 설계**라 이번
  범위 밖으로 두었고, 요청 시퀀스 토큰 가드는 후속 이슈로 다루는 게 적절해 보입니다
- `resolvedGeneration` / `resolveBranchNameOverrides` 회귀 테스트 추가

## 📌 리뷰 포인트

- `UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeList/NoticeViewModel+Fetch.swift:228-251`
  — 보정 → 취소 가드 → 페이지 상태 커밋 순서. 특히 `try Task.checkCancellation()` 이
  `pagingState.applySuccess` / `noticeItems` 대입보다 **앞**에 있는지
- `.../NoticeViewModel+Fetch.swift:253-283` — `resolveBranchNameOverrides` 의 캐시 hit/miss 분기와
  실패 시 fallback(기본 라벨 유지) 처리가 레거시와 동등한지
- `.../NoticeViewModel+Fetch.swift:285-297` — `resolvedGeneration` 의 `!isEmpty && != "0"` 가드가
  서버의 빈 값 표현을 충분히 커버하는지
- `UMCApp/Features/Notice/Domain/Sources/Models/NoticeItemModel.swift:17,34-40`
  — 도메인 모델에 보정용 원본 식별자를 노출하는 선택이 적절한지 (Repository 에 Presentation
  관심사를 주입하지 않기 위한 트레이드오프)
- `UMCApp/Features/Notice/Data/Sources/DTOs/Response/NoticeDTO.swift:61` — 오버라이드 파라미터
  삭제. 프로젝트 전체 grep 상 호출부 0건 확인했으나 교차 확인 부탁드립니다

**검증 상태**: `make build` 통과. 실기기 칩 렌더링 육안 확인은 `targetGisu` 가 null 인
실제 공지 데이터가 필요해 미실시 상태입니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)