### PR TITLE
♻️ [Refactor] AI 읽기 요약 시트 진입점 결선 — NoticeDetailView 툴바·sheet 복원 (#1092)

### DIFF
--- a/UMCApp/Features/Notice/Presentation/Sources/Views/NoticeDetail/NoticeDetailView.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Views/NoticeDetail/NoticeDetailView.swift
@@ -66,6 +66,7 @@ public struct NoticeDetailView: View {
         static let collapseAnimation: Animation = .spring(response: 0.36, dampingFraction: 0.88)
         static let failedTitleText: String = "공지사항을 불러오지 못했습니다."
         static let failedIconName: String = "exclamationmark.triangle"
+        static let aiSummaryIcon: String = "sparkles"
     }
 
     // MARK: - Body
@@ -78,6 +79,7 @@ public struct NoticeDetailView: View {
             .safeAreaBar(edge: .bottom, alignment: .center, content: expandedReadStatusInset)
             .safeAreaBar(edge: .bottom, alignment: .trailing, content: collapsedReadStatusInset)
             .sheet(isPresented: $viewModel.showReadStatusSheet, content: readStatusSheet)
+            .sheet(isPresented: $viewModel.showReadingSummarySheet, content: readingSummarySheet)
             .alertPrompt(item: $viewModel.alertPrompt)
             .task { await onTask() }
     }
@@ -284,6 +286,17 @@ public struct NoticeDetailView: View {
     /// 수정/삭제 메뉴를 포함하는 네비게이션 툴바
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
+        if viewModel.isAIReadingSummaryAvailable, case .loaded = viewModel.noticeState {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    viewModel.showReadingSummarySheet = true
+                } label: {
+                    Image(systemName: Constants.aiSummaryIcon)
+                        .foregroundStyle(Color.indigo500)
+                }
+            }
+        }
+
         if currentNotice != nil, !toolbarActions.isEmpty {
             ToolBarCollection.ToolbarTrailingMenu(actions: toolbarActions)
         }
@@ -378,6 +391,14 @@ public struct NoticeDetailView: View {
         NoticeReadStatusSheet(viewModel: viewModel)
             .presentationDetents(Constants.detailSheetDetents)
             .interactiveDismissDisabled()
+    }
+
+    /// AI 읽기 요약 시트를 구성합니다.
+    @ViewBuilder
+    private func readingSummarySheet() -> some View {
+        if let content = currentNotice?.content {
+            NoticeReadingSummarySheet(viewModel: viewModel, noticeContent: content)
+        }
     }
 
     // MARK: - Task


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 이관은 끝났으나 진입점이 없어 사문화 상태였던 AI 읽기 요약 기능을 `NoticeDetailView` 에 결선했습니다.

Closes #1092

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 툴바 `sparkles` 버튼 및 요약 시트 스트리밍 동작 영상 첨부 예정 -->

## 🛠️ 작업내용

`NoticeDetailView.swift` 한 파일, +21줄. 이미 이관 완료된 `NoticeReadingSummarySheet` / `NoticeDetailViewModel+AI.swift` 를 실제로 호출하는 두 지점만 복원했습니다.

- `Constants` 에 `aiSummaryIcon`(`"sparkles"`) 추가
- `body` 에 `.sheet(isPresented: $viewModel.showReadingSummarySheet, content: readingSummarySheet)` 추가 (기존 `readStatusSheet` 시트 바로 아래)
- `toolbarContent` 최상단에 `sparkles` 툴바 버튼 분기 추가
  - 노출 조건: `viewModel.isAIReadingSummaryAvailable` && `noticeState == .loaded`
  - 기기 미지원 / FoundationModels 모델 미가용 시 버튼 자체가 렌더링되지 않음
- `readingSummarySheet()` `@ViewBuilder` 추가 — `currentNotice?.content` 언랩 후 `NoticeReadingSummarySheet(viewModel:noticeContent:)` 제시

레거시와 다른 점 1건:
- `.foregroundStyle(.indigo500)` → `.foregroundStyle(Color.indigo500)`
  UMCApp 의 `indigo500` 은 `CoreDesignSystem` 의 `public extension Color` 정적 프로퍼티라 `ShapeStyle` 제네릭 컨텍스트에서 leading-dot 추론이 되지 않습니다. 같은 파일의 `Color.grey900`, `NoticeReadingSummarySheet` 의 `Color.indigo500` 과 동일한 기존 관례를 따랐습니다. 토큰 값은 레거시와 동일합니다.

## 📋 추후 진행 상황

<!-- 실기기에서 FoundationModels 스트리밍 요약 및 일일 토큰 집계(AITokenDailyUsageRecord) 동작 검증 -->

## 📌 리뷰 포인트

- `UMCApp/Features/Notice/Presentation/Sources/Views/NoticeDetail/NoticeDetailView.swift:289-297` — 툴바 버튼 노출 조건. `isAIReadingSummaryAvailable` 단독이 아니라 `case .loaded = viewModel.noticeState` 를 함께 걸어, 본문 로드 전에는 버튼이 뜨지 않도록 했습니다(레거시와 동일).
- `UMCApp/Features/Notice/Presentation/Sources/Views/NoticeDetail/NoticeDetailView.swift:396-401` — `readingSummarySheet()`. `currentNotice?.content` 가 nil 이면 빈 시트가 되는데, 위 툴바 조건이 `.loaded` 를 보장하므로 실제로는 도달하지 않는 경로입니다.
- `UMCApp/Features/Notice/Presentation/Sources/ViewModels/NoticeDetail/NoticeDetailViewModel+AI.swift:29` — 기존 가용성 판정 로직. 이번 PR에서 변경하지 않았습니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)