### PR TITLE
♻️ [Refactor] 홈 캘린더 가로(horizon) 모드 및 모드 토글 이식 (#1093)

### DIFF
--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/CalendarGridCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/CalendarGridCard.swift
@@ -1,0 +1,150 @@
+//
+//  CalendarGridCard.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+import UMCFoundation
+
+/// 표시 월 전체를 7열 달력 그리드로 보여주는 카드.
+///
+/// 인접 월의 날짜는 자리만 채워 주 단위 정렬을 유지하고, 일정이 있는 날짜에는 점을 표시한다.
+struct CalendarGridCard: View, Equatable {
+
+    // MARK: - Property
+
+    @Binding var selectedDate: Date
+    @Binding var month: Date
+    let scheduledDates: Set<Date>
+
+    fileprivate enum Constants {
+        static let padding: CGFloat = 24
+        static let weekdayCount = 7
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.selectedDate == rhs.selectedDate &&
+        lhs.month == rhs.month &&
+        lhs.scheduledDates == rhs.scheduledDates
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing24) {
+            weekdayHeader
+            dateGrid
+        }
+        .padding(Constants.padding)
+        .glassEffect(
+            .regular,
+            in: .rect(
+                corners: .concentric(minimum: DefaultConstant.concentricRadius),
+                isUniform: true
+            )
+        )
+    }
+
+    // MARK: - Weekday Header
+
+    private var weekdayHeader: some View {
+        HStack(spacing: .zero) {
+            ForEach(Date.weekDaySymbols(), id: \.self) { symbol in
+                Text(symbol)
+                    .appFont(.subheadline, weight: .medium, color: .grey400)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    // MARK: - Date Grid
+
+    private var columns: [GridItem] {
+        Array(
+            repeating: GridItem(.flexible(), spacing: DefaultSpacing.spacing8),
+            count: Constants.weekdayCount
+        )
+    }
+
+    private var dateGrid: some View {
+        LazyVGrid(columns: columns, spacing: DefaultSpacing.spacing8) {
+            ForEach(adjustedDates, id: \.self) { date in
+                if Calendar.kstGregorian.isDate(date, equalTo: month, toGranularity: .month) {
+                    DateCell(
+                        date: date,
+                        isSelected: date.isSameDay(selectedDate),
+                        hasSchedule: hasSchedule(date),
+                        isToday: date.isSameDay(.now)
+                    )
+                    .onTapGesture {
+                        withAnimation(.easeInOut(duration: DefaultConstant.animationTime)) {
+                            selectedDate = date
+                        }
+                    }
+                } else {
+                    Color.clear
+                }
+            }
+        }
+    }
+
+    // MARK: - Function
+
+    /// 표시 월의 날짜 앞/뒤에 인접 월의 날짜를 채워 7일 단위 그리드를 완성한다.
+    private var adjustedDates: [Date] {
+        let calendar = Calendar.kstGregorian
+        let datesInMonth = month.datesInMonth()
+        guard
+            let firstDate = datesInMonth.first,
+            let lastDate = datesInMonth.last
+        else { return [] }
+
+        let firstWeekday = calendar.component(.weekday, from: firstDate)
+        let lastWeekday = calendar.component(.weekday, from: lastDate)
+
+        var dates: [Date] = []
+        let emptyDaysBefore = firstWeekday - 1
+        for offset in 0..<emptyDaysBefore {
+            let value = -(emptyDaysBefore - offset)
+            if let date = calendar.date(byAdding: .day, value: value, to: firstDate) {
+                dates.append(date)
+            }
+        }
+
+        dates.append(contentsOf: datesInMonth)
+
+        let emptyDaysAfter = Constants.weekdayCount - lastWeekday
+        if emptyDaysAfter > 0 {
+            for offset in 1...emptyDaysAfter {
+                if let date = calendar.date(byAdding: .day, value: offset, to: lastDate) {
+                    dates.append(date)
+                }
+            }
+        }
+
+        return dates
+    }
+
+    private func hasSchedule(_ date: Date) -> Bool {
+        scheduledDates.contains { $0.isSameDay(date) }
+    }
+}
+
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    @Previewable @State var selectedDate: Date = .now
+    @Previewable @State var month: Date = .now
+
+    CalendarGridCard(
+        selectedDate: $selectedDate,
+        month: $month,
+        scheduledDates: [.now, .now.addingTimeInterval(60 * 60 * 24 * 3)]
+    )
+    .padding()
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/CalendarHorizonCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/CalendarHorizonCard.swift
@@ -1,0 +1,112 @@
+//
+//  CalendarHorizonCard.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+import UMCFoundation
+
+/// 표시 월의 날짜를 가로로 나열해 보여주는 캘린더 카드.
+///
+/// 각 날짜 캡슐이 개별 유리 배경을 가지므로 그리드 모드와 달리 바깥 유리 컨테이너를 두지 않는다.
+struct CalendarHorizonCard: View, Equatable {
+
+    // MARK: - Property
+
+    @Binding var selectedDate: Date
+    @Binding var month: Date
+    let scheduledDates: Set<Date>
+
+    @State private var scrolledDate: Date?
+
+    fileprivate enum Constants {
+        static let contentHeight: CGFloat = 200
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.selectedDate == rhs.selectedDate &&
+        lhs.month == rhs.month &&
+        lhs.scheduledDates == rhs.scheduledDates
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: DefaultSpacing.spacing12) {
+                ForEach(dates, id: \.self) { date in
+                    datePill(date)
+                }
+            }
+            .scrollTargetLayout()
+            .frame(height: Constants.contentHeight)
+        }
+        .scrollIndicators(.hidden)
+        .scrollTargetBehavior(.viewAligned)
+        .scrollPosition(id: $scrolledDate, anchor: .center)
+        .task {
+            scrollToFocusedDate()
+        }
+        .onChange(of: month) { _, _ in
+            scrollToFocusedDate()
+        }
+    }
+
+    // MARK: - Component
+
+    private func datePill(_ date: Date) -> some View {
+        DatePill(
+            date: date,
+            isSelected: date.isSameDay(selectedDate),
+            hasSchedule: hasSchedule(date),
+            isToday: date.isSameDay(.now)
+        ) {
+            withAnimation(.easeInOut(duration: DefaultConstant.animationTime)) {
+                selectedDate = date
+                if !Calendar.kstGregorian.isDate(date, equalTo: month, toGranularity: .month) {
+                    month = date
+                }
+            }
+        }
+        .id(date)
+    }
+
+    // MARK: - Function
+
+    private var dates: [Date] {
+        month.datesInMonth()
+    }
+
+    private func hasSchedule(_ date: Date) -> Bool {
+        scheduledDates.contains { $0.isSameDay(date) }
+    }
+
+    /// 표시할 날짜 중 오늘 → 선택 날짜 → 첫 날짜 순으로 스크롤 위치를 맞춘다.
+    private func scrollToFocusedDate() {
+        if let today = dates.first(where: { $0.isSameDay(.now) }) {
+            scrolledDate = today
+        } else if let selected = dates.first(where: { $0.isSameDay(selectedDate) }) {
+            scrolledDate = selected
+        } else {
+            scrolledDate = dates.first
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    @Previewable @State var selectedDate: Date = .now
+    @Previewable @State var month: Date = .now
+
+    CalendarHorizonCard(
+        selectedDate: $selectedDate,
+        month: $month,
+        scheduledDates: [.now, .now.addingTimeInterval(60 * 60 * 24 * 3)]
+    )
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/DateCell.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/DateCell.swift
@@ -1,0 +1,75 @@
+//
+//  DateCell.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+import UMCFoundation
+
+/// 캘린더 그리드의 개별 날짜 셀.
+struct DateCell: View {
+
+    // MARK: - Property
+
+    let date: Date
+    let isSelected: Bool
+    let hasSchedule: Bool
+    let isToday: Bool
+
+    fileprivate enum Constants {
+        static let cellSize: CGFloat = 40
+        static let dotSize: CGFloat = 6
+        static let todayBorderWidth: CGFloat = 2
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing4) {
+            Text(dayText)
+                .appFont(.callout, color: isSelected ? .grey000 : .grey900)
+                .frame(maxWidth: .infinity)
+                .frame(height: Constants.cellSize)
+                .background {
+                    if isSelected {
+                        Color.indigo500.glassEffect(.regular.interactive(), in: .circle)
+                    }
+                }
+                .clipShape(.circle)
+                .overlay {
+                    if isToday && !isSelected {
+                        Circle()
+                            .strokeBorder(Color.indigo500, lineWidth: Constants.todayBorderWidth)
+                    }
+                }
+
+            Circle()
+                .fill(hasSchedule ? dotColor : .clear)
+                .frame(width: Constants.dotSize, height: Constants.dotSize)
+        }
+    }
+
+    // MARK: - Function
+
+    private var dayText: String {
+        "\(Calendar.kstGregorian.component(.day, from: date))"
+    }
+
+    private var dotColor: Color {
+        isSelected ? .grey000 : .red500
+    }
+}
+
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    HStack(spacing: DefaultSpacing.spacing8) {
+        DateCell(date: .now, isSelected: true, hasSchedule: true, isToday: true)
+        DateCell(date: .now, isSelected: false, hasSchedule: true, isToday: true)
+        DateCell(date: .now, isSelected: false, hasSchedule: false, isToday: false)
+    }
+    .padding()
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/DatePill.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/DatePill.swift
@@ -1,0 +1,98 @@
+//
+//  DatePill.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+import UMCFoundation
+
+/// 가로 스크롤 캘린더의 개별 날짜 캡슐.
+///
+/// 요일·일·일정 유무를 세로로 쌓아 보여주며, 탭하면 해당 날짜를 선택한다.
+struct DatePill: View {
+
+    // MARK: - Property
+
+    let date: Date
+    let isSelected: Bool
+    let hasSchedule: Bool
+    let isToday: Bool
+    let action: () -> Void
+
+    fileprivate enum Constants {
+        static let pillSize = CGSize(width: 80, height: 140)
+        static let dotSize: CGFloat = 6
+        static let todayBorderWidth: CGFloat = 2
+        /// 셀마다 Calendar를 새로 만들지 않도록 요일 심볼을 한 번만 계산해 재사용한다.
+        static let weekdaySymbols = Date.weekDaySymbols()
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: DefaultSpacing.spacing16) {
+                Text(weekdayText)
+                    .appFont(.callout, weight: .semibold, color: isSelected ? .grey000 : .grey600)
+
+                VStack(spacing: DefaultSpacing.spacing8) {
+                    Text(dayText)
+                        .appFont(.body, weight: .medium, color: isSelected ? .grey000 : .grey900)
+
+                    Circle()
+                        .fill(hasSchedule ? dotColor : .clear)
+                        .frame(width: Constants.dotSize, height: Constants.dotSize)
+                }
+            }
+            .frame(width: Constants.pillSize.width, height: Constants.pillSize.height)
+            .background {
+                pillBackground
+            }
+            .clipShape(.capsule)
+            .overlay {
+                if isToday && !isSelected {
+                    Capsule()
+                        .strokeBorder(Color.indigo500, lineWidth: Constants.todayBorderWidth)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Component
+
+    private var pillBackground: some View {
+        (isSelected ? Color.indigo500 : Color.grey000)
+            .glassEffect(.regular.interactive(), in: .capsule)
+    }
+
+    // MARK: - Function
+
+    private var weekdayText: String {
+        let index = Calendar.kstGregorian.component(.weekday, from: date) - 1
+        guard Constants.weekdaySymbols.indices.contains(index) else { return "" }
+        return Constants.weekdaySymbols[index]
+    }
+
+    private var dayText: String {
+        "\(Calendar.kstGregorian.component(.day, from: date))"
+    }
+
+    private var dotColor: Color {
+        isSelected ? .grey000 : .red500
+    }
+}
+
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    HStack(spacing: DefaultSpacing.spacing12) {
+        DatePill(date: .now, isSelected: true, hasSchedule: true, isToday: true) {}
+        DatePill(date: .now, isSelected: false, hasSchedule: true, isToday: true) {}
+        DatePill(date: .now, isSelected: false, hasSchedule: false, isToday: false) {}
+    }
+    .padding()
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/ScheduleHeader.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/ScheduleHeader.swift
@@ -1,0 +1,164 @@
+//
+//  ScheduleHeader.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+import UMCFoundation
+
+/// 일정 캘린더 카드의 헤더.
+///
+/// 표시 중인 연월 타이틀(탭 시 날짜 선택 시트), 표시 모드 전환 세그먼트, 월 이동 스테퍼를 제공한다.
+struct ScheduleHeader: View {
+
+    // MARK: - Property
+
+    @Binding var month: Date
+    @Binding var selectedDate: Date
+    @Binding var scheduleMode: ScheduleMode
+
+    @State private var showDatePicker = false
+
+    fileprivate enum Constants {
+        static let segmentWidth: CGFloat = 80
+        static let sheetHeight: CGFloat = 300
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            title
+            Spacer(minLength: DefaultSpacing.spacing8)
+            modePicker
+            monthStepper
+        }
+        .sheet(isPresented: $showDatePicker) {
+            DateSheetPicker(month: $month, selectedDate: $selectedDate)
+                .presentationDetents([.height(Constants.sheetHeight)])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    // MARK: - Component
+
+    private var title: some View {
+        Button {
+            showDatePicker = true
+        } label: {
+            Text(monthTitle)
+                .appFont(.body, weight: .semibold, color: .grey900)
+                .fixedSize()
+        }
+    }
+
+    private var modePicker: some View {
+        Picker(selection: $scheduleMode) {
+            Image(systemName: "calendar")
+                .tag(ScheduleMode.grid)
+            Image(systemName: "list.bullet")
+                .tag(ScheduleMode.horizon)
+        } label: {
+            Text("일정 표시 모드")
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(width: Constants.segmentWidth)
+    }
+
+    private var monthStepper: some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            Button {
+                changeMonth(by: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+            }
+            Button {
+                changeMonth(by: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+            }
+        }
+        .foregroundStyle(Color.grey600)
+    }
+
+    // MARK: - Function
+
+    private var monthTitle: String {
+        let calendar = Calendar.kstGregorian
+        let year = calendar.component(.year, from: month)
+        let monthNumber = calendar.component(.month, from: month)
+        return "\(year)년 \(monthNumber)월 일정"
+    }
+
+    private func changeMonth(by offset: Int) {
+        guard
+            let newMonth = Calendar.kstGregorian.date(byAdding: .month, value: offset, to: month)
+        else { return }
+
+        withAnimation(.smooth(duration: DefaultConstant.animationTime)) {
+            month = newMonth
+        }
+    }
+}
+
+// MARK: - DateSheetPicker
+
+/// 연월 이동을 위한 휠 스타일 날짜 선택 시트.
+fileprivate struct DateSheetPicker: View {
+
+    // MARK: - Property
+
+    @Environment(\.dismiss) private var dismiss
+    @Binding var month: Date
+    @Binding var selectedDate: Date
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing16) {
+            title
+            datePicker
+        }
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    private var title: some View {
+        HStack {
+            Spacer()
+            Text("날짜 선택")
+                .appFont(.body, weight: .semibold, color: .grey900)
+            Spacer()
+        }
+        .overlay(alignment: .trailing) {
+            Button(role: .confirm) {
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.indigo500)
+        }
+    }
+
+    private var datePicker: some View {
+        DatePicker("", selection: $selectedDate, displayedComponents: .date)
+            .datePickerStyle(.wheel)
+            .labelsHidden()
+            .onChange(of: selectedDate) { _, newDate in
+                month = newDate
+            }
+    }
+}
+
+// MARK: - Preview
+
+#Preview(traits: .sizeThatFitsLayout) {
+    @Previewable @State var month: Date = .now
+    @Previewable @State var selectedDate: Date = .now
+    @Previewable @State var scheduleMode: ScheduleMode = .grid
+
+    ScheduleHeader(month: $month, selectedDate: $selectedDate, scheduleMode: $scheduleMode)
+        .padding()
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/ScheduleMode.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/ScheduleMode.swift
@@ -1,0 +1,18 @@
+//
+//  ScheduleMode.swift
+//  HomePresentation
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import Foundation
+
+/// 홈 일정 캘린더의 표시 모드.
+enum ScheduleMode {
+
+    /// 월별 그리드 모드 — 한 달 전체를 7열 달력으로 표시한다.
+    case grid
+
+    /// 가로 스크롤 모드 — 한 달의 날짜를 캡슐 리스트로 가로 나열한다.
+    case horizon
+}

--- a/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleCard.swift
@@ -9,10 +9,10 @@ import CoreDesignSystem
 import SwiftUI
 import UMCFoundation
 
-/// 홈 화면 일정 캘린더 카드 — 월별 그리드로 일정 유무를 표시한다.
+/// 홈 화면 일정 캘린더 카드.
 ///
-/// 슬라이스 2(#914) 범위는 캘린더 그리드 표시만 다룬다. 가로 스크롤(리스트) 모드 전환은
-/// 후속 슬라이스에서 추가한다.
+/// 헤더의 세그먼트로 월별 그리드(``CalendarGridCard``)와 가로 스크롤(``CalendarHorizonCard``)
+/// 모드를 전환한다. 헤더는 두 모드가 공유하므로 유리 카드 바깥에 둔다.
 struct ScheduleCard: View, Equatable {
 
     // MARK: - Property
@@ -21,264 +21,62 @@ struct ScheduleCard: View, Equatable {
     @Binding var currentMonth: Date
     let scheduledDates: Set<Date>
 
-    @State private var showDatePicker = false
-
-    // MARK: - Constants
-
-    fileprivate enum Constants {
-        static let padding: CGFloat = 24
-        static let weekdayCount = 7
-    }
+    @State private var scheduleMode: ScheduleMode = .grid
 
     // MARK: - Equatable
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.selectedDate == rhs.selectedDate &&
         lhs.currentMonth == rhs.currentMonth &&
+        lhs.scheduleMode == rhs.scheduleMode &&
         lhs.scheduledDates == rhs.scheduledDates
     }
 
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: DefaultSpacing.spacing24) {
-            header
-            weekdayHeader
-            dateGrid
-        }
-        .padding(Constants.padding)
-        .glassEffect(
-            .regular,
-            in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
-        )
-        .sheet(isPresented: $showDatePicker) {
-            DateSheetPicker(month: $currentMonth, selectedDate: $selectedDate)
-                .presentationDetents([.height(300)])
-                .presentationDragIndicator(.visible)
+        VStack(spacing: DefaultSpacing.spacing8) {
+            ScheduleHeader(
+                month: $currentMonth,
+                selectedDate: $selectedDate,
+                scheduleMode: $scheduleMode
+            )
+
+            calendar
         }
     }
 
-    // MARK: - Header
+    // MARK: - Component
 
-    private var header: some View {
-        HStack {
-            Button {
-                showDatePicker = true
-            } label: {
-                Text(monthTitle)
-                    .appFont(.body, weight: .semibold, color: .grey900)
-            }
-            Spacer()
-            monthStepper
-        }
-    }
-
-    private var monthStepper: some View {
-        HStack(spacing: DefaultSpacing.spacing16) {
-            Button {
-                changeMonth(by: -1)
-            } label: {
-                Image(systemName: "chevron.left")
-            }
-            Button {
-                changeMonth(by: 1)
-            } label: {
-                Image(systemName: "chevron.right")
+    private var calendar: some View {
+        ZStack {
+            if scheduleMode == .horizon {
+                CalendarHorizonCard(
+                    selectedDate: $selectedDate,
+                    month: $currentMonth,
+                    scheduledDates: scheduledDates
+                )
+                .equatable()
+                .transition(.asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                ))
+                .id("horizon")
+            } else {
+                CalendarGridCard(
+                    selectedDate: $selectedDate,
+                    month: $currentMonth,
+                    scheduledDates: scheduledDates
+                )
+                .equatable()
+                .transition(.asymmetric(
+                    insertion: .move(edge: .leading).combined(with: .opacity),
+                    removal: .move(edge: .trailing).combined(with: .opacity)
+                ))
+                .id("grid")
             }
         }
-        .foregroundStyle(Color.grey600)
-    }
-
-    private var monthTitle: String {
-        let calendar = Calendar.kstGregorian
-        let year = calendar.component(.year, from: currentMonth)
-        let month = calendar.component(.month, from: currentMonth)
-        return "\(year)년 \(month)월 일정"
-    }
-
-    private func changeMonth(by offset: Int) {
-        guard
-            let newMonth = Calendar.kstGregorian.date(byAdding: .month, value: offset, to: currentMonth)
-        else { return }
-
-        withAnimation(.smooth(duration: DefaultConstant.animationTime)) {
-            currentMonth = newMonth
-        }
-    }
-
-    // MARK: - Weekday Header
-
-    private var weekdayHeader: some View {
-        HStack(spacing: .zero) {
-            ForEach(Date.weekDaySymbols(), id: \.self) { symbol in
-                Text(symbol)
-                    .appFont(.subheadline, weight: .medium, color: .grey400)
-                    .frame(maxWidth: .infinity)
-            }
-        }
-    }
-
-    // MARK: - Date Grid
-
-    private var columns: [GridItem] {
-        Array(repeating: GridItem(.flexible(), spacing: DefaultSpacing.spacing8), count: Constants.weekdayCount)
-    }
-
-    private var dateGrid: some View {
-        LazyVGrid(columns: columns, spacing: DefaultSpacing.spacing8) {
-            ForEach(adjustedDates, id: \.self) { date in
-                if Calendar.kstGregorian.isDate(date, equalTo: currentMonth, toGranularity: .month) {
-                    ScheduleDateCell(
-                        date: date,
-                        isSelected: date.isSameDay(selectedDate),
-                        hasSchedule: hasSchedule(date),
-                        isToday: date.isSameDay(.now)
-                    )
-                    .onTapGesture {
-                        withAnimation(.easeInOut(duration: DefaultConstant.animationTime)) {
-                            selectedDate = date
-                        }
-                    }
-                } else {
-                    Color.clear
-                }
-            }
-        }
-    }
-
-    /// 표시 월의 날짜 앞/뒤에 인접 월의 날짜를 채워 7일 단위 그리드를 완성한다.
-    private var adjustedDates: [Date] {
-        let calendar = Calendar.kstGregorian
-        let datesInMonth = currentMonth.datesInMonth()
-        guard let firstDate = datesInMonth.first, let lastDate = datesInMonth.last else { return [] }
-
-        let firstWeekday = calendar.component(.weekday, from: firstDate)
-        let lastWeekday = calendar.component(.weekday, from: lastDate)
-
-        var dates: [Date] = []
-        let emptyDaysBefore = firstWeekday - 1
-        for offset in 0..<emptyDaysBefore {
-            if let date = calendar.date(byAdding: .day, value: -(emptyDaysBefore - offset), to: firstDate) {
-                dates.append(date)
-            }
-        }
-
-        dates.append(contentsOf: datesInMonth)
-
-        let emptyDaysAfter = Constants.weekdayCount - lastWeekday
-        if emptyDaysAfter > 0 {
-            for offset in 1...emptyDaysAfter {
-                if let date = calendar.date(byAdding: .day, value: offset, to: lastDate) {
-                    dates.append(date)
-                }
-            }
-        }
-
-        return dates
-    }
-
-    private func hasSchedule(_ date: Date) -> Bool {
-        scheduledDates.contains { $0.isSameDay(date) }
-    }
-}
-
-// MARK: - ScheduleDateCell
-
-/// 캘린더 그리드의 개별 날짜 셀.
-fileprivate struct ScheduleDateCell: View {
-
-    // MARK: - Property
-
-    let date: Date
-    let isSelected: Bool
-    let hasSchedule: Bool
-    let isToday: Bool
-
-    fileprivate enum Constants {
-        static let cellSize: CGFloat = 40
-        static let dotSize: CGFloat = 6
-        static let todayBorderWidth: CGFloat = 2
-    }
-
-    // MARK: - Body
-
-    var body: some View {
-        VStack(spacing: DefaultSpacing.spacing4) {
-            Text(dayText)
-                .appFont(.callout, color: isSelected ? .grey000 : .grey900)
-                .frame(maxWidth: .infinity)
-                .frame(height: Constants.cellSize)
-                .background {
-                    if isSelected {
-                        Color.indigo500.glassEffect(.regular.interactive(), in: .circle)
-                    }
-                }
-                .clipShape(.circle)
-                .overlay {
-                    if isToday && !isSelected {
-                        Circle().strokeBorder(Color.indigo500, lineWidth: Constants.todayBorderWidth)
-                    }
-                }
-
-            Circle()
-                .fill(hasSchedule ? dotColor : .clear)
-                .frame(width: Constants.dotSize, height: Constants.dotSize)
-        }
-    }
-
-    private var dayText: String {
-        "\(Calendar.kstGregorian.component(.day, from: date))"
-    }
-
-    private var dotColor: Color {
-        isSelected ? .grey000 : .red500
-    }
-}
-
-// MARK: - DateSheetPicker
-
-/// 연월 이동을 위한 휠 스타일 날짜 선택 시트.
-fileprivate struct DateSheetPicker: View {
-
-    // MARK: - Property
-
-    @Environment(\.dismiss) private var dismiss
-    @Binding var month: Date
-    @Binding var selectedDate: Date
-
-    // MARK: - Body
-
-    var body: some View {
-        VStack(spacing: DefaultSpacing.spacing16) {
-            title
-            datePicker
-        }
-        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-    }
-
-    private var title: some View {
-        HStack {
-            Spacer()
-            Text("날짜 선택")
-                .appFont(.body, weight: .semibold, color: .grey900)
-            Spacer()
-        }
-        .overlay(alignment: .trailing) {
-            Button(role: .confirm) {
-                dismiss()
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(.indigo500)
-        }
-    }
-
-    private var datePicker: some View {
-        DatePicker("", selection: $selectedDate, displayedComponents: .date)
-            .datePickerStyle(.wheel)
-            .labelsHidden()
-            .onChange(of: selectedDate) { _, newDate in
-                month = newDate
-            }
+        .animation(.smooth(duration: DefaultConstant.animationTime), value: scheduleMode)
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 홈 캘린더 컴포넌트 분리 및 레거시 가로(horizon) 모드·모드 토글 이식

Close #1093

홈 캘린더가 그리드 모드만 지원하던 문제를 해결합니다. `ScheduleCard` 안에 인라인으로 뭉쳐 있던
그리드 구현을 독립 컴포넌트로 분리하고, 레거시(`AppProduct/`)의 가로 스크롤 모드와 헤더 세그먼트
토글을 이식했습니다. `ScheduleCard.swift` 헤더의 `슬라이스 2(#914) ... 후속 슬라이스에서 추가한다`
주석도 함께 제거했습니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 시뮬레이터 실행 캡처 첨부 예정 — 헤더 세그먼트로 grid ↔ horizon 전환하는 화면 -->

## 🛠️ 작업내용

**신규 — `UMCApp/Features/Home/Presentation/Sources/Components/Calendar/`**

- `ScheduleMode.swift` — `grid` / `horizon` 표시 모드 enum 이식
- `ScheduleHeader.swift` — 연월 타이틀(날짜 선택 시트) + 모드 전환 세그먼트 + 월 이동 스테퍼
- `CalendarGridCard.swift` — 요일 헤더 · `LazyVGrid` · `adjustedDates` 를 독립 컴포넌트로 분리
  (기존 `ScheduleCard` 인라인 구현 이동, 유리 배경도 함께 이동)
- `DateCell.swift` — 기존 `fileprivate ScheduleDateCell` 을 모듈 내부 컴포넌트로 승격
- `CalendarHorizonCard.swift` — 표시 월 날짜를 가로 캡슐 리스트로 표시, 오늘/선택 날짜 스크롤 복원
- `DatePill.swift` — 요일 · 일 · 일정 점을 담는 캡슐 셀

**수정 — `ScheduleCard.swift` (294줄 → 92줄)**

- 헤더 + 모드별 카드 전환(asymmetric transition)만 담당하는 조합 뷰로 축소
- `HomeView` 호출부 시그니처(`selectedDate:currentMonth:scheduledDates:`) 유지 → 호출부 변경 없음

**레거시 대비 조정한 부분**

- `Calendar.current` → `Calendar.kstGregorian` 통일
- `DatePill` 요일 텍스트: 셀마다 `DateFormatter` 를 새로 만들던 레거시 대신
  `Date.weekDaySymbols()` 정적 캐시를 인덱스 조회. 표기도 영문 `MON` → 한국어 `월` 로 바꿔
  같은 카드의 그리드 요일 헤더와 일치시킴
- `ConcentricRectangle(...).fill(.white).glass()` → iOS 26 `glassEffect(_:in:)` 관용구
- 헤더의 월 이동 chevron 스테퍼는 **유지**. 레거시 `ScheduleHeader` 에는 없지만 현행 UMCApp
  `ScheduleCard` 에 있던 기능이라 제거하면 회귀
- 그리드 유리 배경은 `CalendarGridCard` 로 이동(헤더는 카드 바깥에 배치). horizon 모드는
  캡슐마다 개별 유리를 갖기 때문에 두 모드를 감싸는 바깥 유리 컨테이너를 둘 수 없음
- 레거시 `DateCell` 의 `isCurrentMonth` 파라미터는 이식 제외 — 현행 그리드는 타 월 날짜를
  `Color.clear` 로 처리하므로 항상 `true` 인 죽은 파라미터

## 📋 추후 진행 상황

- 시뮬레이터에서 두 모드의 일정 선택 · 월 이동 실동작 확인 후 영상 첨부
- `adjustedDates` 주 단위 정렬 테스트는 이번 PR 범위 밖(이식만 하고 로직 변경 없음) — 필요 시 별도 이슈

## 📌 리뷰 포인트

- `UMCApp/Features/Home/Presentation/Sources/Components/ScheduleCard.swift` —
  헤더/카드 분리 구조와 `Equatable` 비교에 `scheduleMode` 포함 여부
- `.../Components/Calendar/ScheduleHeader.swift` —
  타이틀 · 세그먼트 · 스테퍼가 좁은 폭에서 잘리지 않는지 (`Spacer(minLength:)` + `fixedSize()`)
- `.../Components/Calendar/CalendarHorizonCard.swift` —
  `scrollPosition(id:anchor:)` 와 `scrollToFocusedDate()` 의 오늘 → 선택일 → 첫날 우선순위
- `.../Components/Calendar/CalendarGridCard.swift` —
  `adjustedDates` 가 기존 `ScheduleCard` 구현과 동일하게 이동됐는지 (로직 변경 없음)
- `.../Components/Calendar/DatePill.swift` —
  요일 심볼 정적 캐시 조회 방식과 인덱스 범위 가드

**빌드 확인**

- `cd UMCApp && make build` → `** BUILD SUCCEEDED **`
- `AppProduct/` 변경 0줄 (절대 규칙 #9 준수)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)