### PR TITLE
♻️ [Refactor] App Store Lookup 기반 강제 업데이트 2차 게이트 이관 (#1094)

### DIFF
--- a/UMCApp/Features/Maintenance/Data/Sources/AppStoreVersionService.swift
+++ b/UMCApp/Features/Maintenance/Data/Sources/AppStoreVersionService.swift
@@ -1,0 +1,68 @@
+//
+//  AppStoreVersionService.swift
+//  MaintenanceData
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import Foundation
+import MaintenanceDomain
+import os
+
+/// iTunes Lookup API로 App Store 게시 버전을 조회하는 서비스.
+///
+/// 스토어 조회는 강제 업데이트 판정의 보조 게이트라, URL 구성·네트워크·디코딩 중 어디서
+/// 실패하든 `nil`을 반환해 앱 진입을 막지 않는다(fail-open).
+public final class AppStoreVersionService: AppStoreVersionServiceProtocol {
+
+    // MARK: - Constant
+
+    private enum Constants {
+        /// 스토어 게시 정보는 심사에 제출된 번들 식별자로만 조회되므로, 앱 타겟의
+        /// 번들 ID와 별개로 스토어 등재 ID를 그대로 사용한다.
+        static let lookupURLString =
+            "https://itunes.apple.com/lookup?bundleId=com.umc.product&country=kr"
+    }
+
+    // MARK: - Property
+
+    private let session: URLSession
+
+    // MARK: - Init
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    // MARK: - Function
+
+    public func fetchLatestVersion() async -> String? {
+        guard let url = URL(string: Constants.lookupURLString) else { return nil }
+
+        do {
+            let (data, _) = try await session.data(from: url)
+            let response = try JSONDecoder().decode(
+                AppStoreLookupResponseDTO.self,
+                from: data
+            )
+            guard let version = response.results.first?.version, !version.isEmpty else {
+                return nil
+            }
+            return version
+        } catch {
+            Self.logger.error(
+                "App Store Lookup 실패(통과 처리): \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
+    }
+}
+
+// MARK: - Logging
+
+extension AppStoreVersionService {
+    private static let logger = Logger(
+        subsystem: "dev.umc.feature.maintenance.data",
+        category: "AppStoreVersionService"
+    )
+}

--- a/UMCApp/Features/Maintenance/Data/Sources/DTOs/AppStoreLookupResponseDTO.swift
+++ b/UMCApp/Features/Maintenance/Data/Sources/DTOs/AppStoreLookupResponseDTO.swift
@@ -1,0 +1,62 @@
+//
+//  AppStoreLookupResponseDTO.swift
+//  MaintenanceData
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+/// iTunes Lookup API 응답 DTO.
+///
+/// 버전 비교에 쓰지 않는 `resultCount`는 담지 않는다 — 스토어가 정수를 어떤 형태로
+/// 직렬화하든 디코딩이 흔들리지 않게 하려는 의도.
+struct AppStoreLookupResponseDTO: Codable {
+
+    // MARK: - Property
+
+    let results: [AppStoreAppInfoDTO]
+
+    private enum CodingKeys: String, CodingKey {
+        case results
+    }
+
+    // MARK: - Codable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        results = try container.decodeIfPresent(
+            [AppStoreAppInfoDTO].self,
+            forKey: .results
+        ) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(results, forKey: .results)
+    }
+}
+
+// MARK: - AppStoreAppInfoDTO
+
+/// 스토어에 게시된 앱 정보.
+struct AppStoreAppInfoDTO: Codable {
+
+    // MARK: - Property
+
+    let version: String
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+    }
+
+    // MARK: - Codable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decodeIfPresent(String.self, forKey: .version) ?? ""
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+    }
+}

--- a/UMCApp/Features/Maintenance/Domain/Sources/Interfaces/AppStoreVersionServiceProtocol.swift
+++ b/UMCApp/Features/Maintenance/Domain/Sources/Interfaces/AppStoreVersionServiceProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  AppStoreVersionServiceProtocol.swift
+//  MaintenanceDomain
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+/// App Store에 게시된 최신 버전을 제공하는 서비스 인터페이스.
+public protocol AppStoreVersionServiceProtocol {
+    /// 스토어 최신 버전 문자열을 조회한다. 조회에 실패하면 `nil`을 반환한다(fail-open).
+    func fetchLatestVersion() async -> String?
+}

--- a/UMCApp/Features/Maintenance/Domain/Sources/UseCases/Implementations/CheckForceUpdateUseCase.swift
+++ b/UMCApp/Features/Maintenance/Domain/Sources/UseCases/Implementations/CheckForceUpdateUseCase.swift
@@ -7,33 +7,67 @@
 
 import Foundation
 
-/// 원격 최소 지원 버전(RemoteConfig) 대비 강제 업데이트 필요 여부를 판정하는 UseCase 구현체.
+/// 원격 최소 지원 버전(RemoteConfig)과 App Store 게시 버전을 함께 보고
+/// 강제 업데이트 필요 여부를 판정하는 UseCase 구현체.
 public final class CheckForceUpdateUseCase: CheckForceUpdateUseCaseProtocol {
 
     // MARK: - Property
 
     private let service: RemoteConfigServiceProtocol
+    private let appStoreVersionService: AppStoreVersionServiceProtocol?
     private let currentVersion: String
 
     // MARK: - Init
 
     public init(
         service: RemoteConfigServiceProtocol,
+        appStoreVersionService: AppStoreVersionServiceProtocol? = nil,
         currentVersion: String = Bundle.main.infoDictionary?[
             "CFBundleShortVersionString"
         ] as? String ?? "0.0.0"
     ) {
         self.service = service
+        self.appStoreVersionService = appStoreVersionService
         self.currentVersion = currentVersion
     }
 
     // MARK: - Function
 
+    /// 두 게이트 중 하나라도 걸리면 강제 업데이트가 필요하다고 판정한다.
+    ///
+    /// - RemoteConfig 게이트: 패치 자리까지 비교하므로 운영자가 콘솔 값으로 차단선을
+    ///   직접 올릴 수 있다.
+    /// - App Store 게이트: 스토어 최신 버전과 Major.Minor 만 비교해, 콘솔 갱신을 빠뜨린
+    ///   릴리즈에서도 마이너 이상 변경이면 자동으로 차단되는 안전망.
     public func execute() async -> Bool {
+        async let remoteConfigGate = isBelowMinimumSupportedVersion()
+        async let appStoreGate = isBelowAppStoreVersion()
+        let (isBelowMinimum, isBelowAppStore) = await (remoteConfigGate, appStoreGate)
+        return isBelowMinimum || isBelowAppStore
+    }
+}
+
+// MARK: - Gate
+
+extension CheckForceUpdateUseCase {
+    private func isBelowMinimumSupportedVersion() async -> Bool {
         guard let minimumVersion = await service.fetchMinimumSupportedVersion() else {
             return false
         }
         return isVersion(currentVersion, lowerThan: minimumVersion)
+    }
+
+    /// 패치 자리 차단은 RemoteConfig 게이트 책임이라 Major.Minor 까지만 비교한다.
+    /// (1.2 → 1.3 은 차단, 1.2.0 → 1.2.1 은 통과)
+    private func isBelowAppStoreVersion() async -> Bool {
+        guard let appStoreVersionService,
+              let appStoreVersion = await appStoreVersionService.fetchLatestVersion() else {
+            return false
+        }
+        return isVersion(
+            majorMinor(of: currentVersion),
+            lowerThan: majorMinor(of: appStoreVersion)
+        )
     }
 }
 
@@ -56,5 +90,11 @@ extension CheckForceUpdateUseCase {
 
     private func numericParts(of version: String) -> [Int] {
         version.split(separator: ".").map { Int($0) ?? 0 }
+    }
+
+    private func majorMinor(of version: String) -> String {
+        let components = version.split(separator: ".")
+        guard components.count >= 2 else { return version }
+        return "\(components[0]).\(components[1])"
     }
 }

--- a/UMCApp/Features/Maintenance/Domain/Tests/Support/StubAppStoreVersionService.swift
+++ b/UMCApp/Features/Maintenance/Domain/Tests/Support/StubAppStoreVersionService.swift
@@ -1,0 +1,24 @@
+//
+//  StubAppStoreVersionService.swift
+//  MaintenanceDomainTests
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+@testable import MaintenanceDomain
+
+/// `AppStoreVersionServiceProtocol`의 테스트용 Stub 구현체
+///
+/// 실제 iTunes Lookup 호출 없이 고정된 버전 문자열을 반환한다.
+final class StubAppStoreVersionService: AppStoreVersionServiceProtocol, @unchecked Sendable {
+
+    var stubbedLatestVersion: String?
+
+    init(stubbedLatestVersion: String? = nil) {
+        self.stubbedLatestVersion = stubbedLatestVersion
+    }
+
+    func fetchLatestVersion() async -> String? {
+        stubbedLatestVersion
+    }
+}

--- a/UMCApp/Features/Maintenance/Domain/Tests/UseCases/CheckForceUpdateUseCaseTests.swift
+++ b/UMCApp/Features/Maintenance/Domain/Tests/UseCases/CheckForceUpdateUseCaseTests.swift
@@ -12,10 +12,14 @@ import Testing
 
 private func makeUseCase(
     minimumVersion: String?,
-    currentVersion: String
+    currentVersion: String,
+    appStoreVersion: String? = nil
 ) -> CheckForceUpdateUseCase {
     CheckForceUpdateUseCase(
         service: StubRemoteConfigService(stubbedMinimumVersion: minimumVersion),
+        appStoreVersionService: StubAppStoreVersionService(
+            stubbedLatestVersion: appStoreVersion
+        ),
         currentVersion: currentVersion
     )
 }
@@ -81,5 +85,59 @@ struct CheckForceUpdateUseCaseTests {
         let useCase = makeUseCase(minimumVersion: "abc", currentVersion: "1.7.0")
 
         #expect(await useCase.execute() == false)
+    }
+}
+
+@Suite("CheckForceUpdateUseCase — App Store 게시 버전 기반 2차 게이트")
+struct CheckForceUpdateUseCaseAppStoreGateTests {
+
+    @Test("콘솔 값이 없어도 스토어 마이너 버전이 높으면 차단한다 (1.7.0 < 1.8.0)")
+    func blocksWhenAppStoreMinorVersionHigher() async {
+        let useCase = makeUseCase(
+            minimumVersion: nil,
+            currentVersion: "1.7.0",
+            appStoreVersion: "1.8.0"
+        )
+
+        #expect(await useCase.execute() == true)
+    }
+
+    @Test("스토어 패치 버전만 높으면 차단하지 않는다 (1.7.0 vs 1.7.1)")
+    func noBlockWhenOnlyAppStorePatchVersionHigher() async {
+        let useCase = makeUseCase(
+            minimumVersion: nil,
+            currentVersion: "1.7.0",
+            appStoreVersion: "1.7.1"
+        )
+
+        #expect(await useCase.execute() == false)
+    }
+
+    @Test("스토어 조회 실패 시 RemoteConfig 판정만 반영한다 (fail-open)")
+    func fallsBackToRemoteConfigWhenLookupFails() async {
+        let passingCase = makeUseCase(
+            minimumVersion: "1.7.0",
+            currentVersion: "1.7.0",
+            appStoreVersion: nil
+        )
+        let blockingCase = makeUseCase(
+            minimumVersion: "1.8.0",
+            currentVersion: "1.7.0",
+            appStoreVersion: nil
+        )
+
+        #expect(await passingCase.execute() == false)
+        #expect(await blockingCase.execute() == true)
+    }
+
+    @Test("스토어가 통과여도 RemoteConfig 가 차단이면 차단한다 (OR 결합)")
+    func blocksWhenOnlyRemoteConfigGateRequiresUpdate() async {
+        let useCase = makeUseCase(
+            minimumVersion: "1.7.1",
+            currentVersion: "1.7.0",
+            appStoreVersion: "1.7.0"
+        )
+
+        #expect(await useCase.execute() == true)
     }
 }

--- a/UMCApp/UMCApp/Sources/DIContainer+Maintenance.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Maintenance.swift
@@ -17,8 +17,14 @@ extension DIContainer {
         register(CheckMaintenanceUseCaseProtocol.self) {
             CheckMaintenanceUseCase(service: self.resolve(RemoteConfigServiceProtocol.self))
         }
+        register(AppStoreVersionServiceProtocol.self) {
+            AppStoreVersionService()
+        }
         register(CheckForceUpdateUseCaseProtocol.self) {
-            CheckForceUpdateUseCase(service: self.resolve(RemoteConfigServiceProtocol.self))
+            CheckForceUpdateUseCase(
+                service: self.resolve(RemoteConfigServiceProtocol.self),
+                appStoreVersionService: self.resolve(AppStoreVersionServiceProtocol.self)
+            )
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 레거시(AppProduct)에만 있던 **App Store Lookup 강제 업데이트 2차 게이트**를 UMCApp Maintenance 모듈로 이관합니다. (closes #1094)

기존 UMCApp은 Firebase RemoteConfig `minimumSupportedVersion` **단일 게이트**만 판정하고 있어, RemoteConfig 콘솔 갱신을 빠뜨린 릴리즈에서는 구버전 클라이언트가 그대로 통과하는 상태였습니다. 스토어 게시 버전과 Major.Minor를 비교하는 자동 안전망을 복원해 게이트를 이중화합니다.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (Domain/Data 레이어 + DI 등록만 변경).

## 🛠️ 작업내용

- `MaintenanceDomain`에 `AppStoreVersionServiceProtocol` 추가 — `fetchLatestVersion() async -> String?`
- `MaintenanceData`에 iTunes Lookup 기반 `AppStoreVersionService` 이식 (URLSession + os.Logger)
- `AppStoreLookupResponseDTO` / `AppStoreAppInfoDTO` 추가 — 절대 규칙 #3에 따라 custom `init(from:)` + `encode(to:)` 구현
- `CheckForceUpdateUseCase`에서 두 게이트를 `async let`으로 동시 실행 후 OR 결합
  - RemoteConfig 게이트: 패치 자리까지 비교 (운영자 제어)
  - App Store 게이트: Major.Minor만 비교 (1.2 → 1.3 차단, 1.2.0 → 1.2.1 통과)
- `DIContainer+Maintenance`에 `AppStoreVersionServiceProtocol` 등록 및 UseCase 주입
- 2차 게이트 시나리오 테스트 4건 추가 (마이너 상승 차단 / 패치 상승 통과 / 조회 실패 fail-open / OR 결합)

### 설계 판단

- **별도 비교 UseCase를 신설하지 않음** — `CheckForceUpdateUseCase`가 이미 자리별 버전 비교 헬퍼(`isVersion(_:lowerThan:)`)를 갖고 있어, Major.Minor 절삭만 추가해 재사용했습니다. 타입을 하나 더 만들어도 얻는 게 없어 게이트 결합 지점을 한 곳으로 유지했습니다.
- **`resultCount` 필드는 DTO에서 제외** — 사용하지 않는 필드라 담지 않았고, 덕분에 정수 유연 디코딩 헬퍼 의존도 불필요해졌습니다.
- **`MaintenanceViewModel`은 무수정** — `needsForceUpdate`가 이미 `checkForceUpdateUseCase.execute()` 결과를 그대로 반영하므로, UseCase 내부 OR 결합만으로 화면까지 전달됩니다.

### fail-open 보장

URL 구성 실패 · 네트워크 오류 · 디코딩 실패 · `results` 비어 있음 · 빈 버전 문자열 — **모든 실패 경로에서 `nil` 반환**하여 스토어 조회 문제로 앱이 잠기지 않습니다. `CheckForceUpdateUseCase`는 이 경우 RemoteConfig 판정만 반영합니다.

## 📋 추후 진행 상황

- 스토어 조회 결과 캐싱(부트스트랩마다 매번 네트워크 호출)은 필요성이 확인되면 별도 이슈로 분리

## 📌 리뷰 포인트

- `UMCApp/Features/Maintenance/Data/Sources/AppStoreVersionService.swift` — fail-open 경로가 빠짐없이 `nil`을 반환하는지, Lookup URL의 `bundleId=com.umc.product`가 스토어 등재 번들 ID와 일치하는지
- `UMCApp/Features/Maintenance/Data/Sources/DTOs/AppStoreLookupResponseDTO.swift` — Response DTO 디코딩 규약(custom `init(from:)`/`encode(to:)`) 준수 여부
- `UMCApp/Features/Maintenance/Domain/Sources/UseCases/Implementations/CheckForceUpdateUseCase.swift` — 두 게이트 OR 결합과 Major.Minor 절삭 비교 로직
- `UMCApp/UMCApp/Sources/DIContainer+Maintenance.swift` — 서비스 등록·주입 지점

## ✅ 검증

- `make build` → **BUILD SUCCEEDED**
- `MaintenanceDomain` 테스트 → **14 tests in 3 suites passed** (신규 4건 포함)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)