### PR TITLE
🔧 [Chore] Features/*/Project.swift 미사용 BusinessCardPresentation 의존성 제거

### DIFF
--- a/UMCApp/Features/Activity/Project.swift
+++ b/UMCApp/Features/Activity/Project.swift
@@ -38,7 +38,6 @@ let project = featureProject(
     presentationExtraDependencies: [
         // 출석 ViewModel 이 ScheduleDetailData·ScheduleAttendancePolicy 를 직접 다룬다.
         .project(target: "HomeDomain", path: .relativeToRoot("Features/Home")),
-        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
         // OperatorStudyManagementViewModel 이 멤버/멘토 선택 입력 타입(ChallengerInfo)을 사용.
         .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
         // ChallengerMemberListView 가 DIContainer 로 UseCase·세션을 resolve (Home/Notice 동일 패턴).

--- a/UMCApp/Features/Auth/Project.swift
+++ b/UMCApp/Features/Auth/Project.swift
@@ -8,7 +8,6 @@ let project = featureProject(
         .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
     ],
     presentationExtraDependencies: [
-        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         // 승인 대기 화면의 로그아웃/탈퇴가 전역 `UserSessionManager.reset()`(#959)을 호출한다.
         .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),

--- a/UMCApp/Features/Community/Project.swift
+++ b/UMCApp/Features/Community/Project.swift
@@ -1,9 +1,4 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = featureProject(
-    name: "Community",
-    presentationExtraDependencies: [
-        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
-    ]
-)
+let project = featureProject(name: "Community")

--- a/UMCApp/Features/Home/Project.swift
+++ b/UMCApp/Features/Home/Project.swift
@@ -20,7 +20,6 @@ let project = featureProject(
         .sdk(name: "StoreKit", type: .framework),
         // 일정 상세의 "지도 보기"가 MKMapItem.openInMaps()로 Apple Maps를 연다.
         .sdk(name: "MapKit", type: .framework),
-        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         // 일정 상세의 출석 진입 분기가 전역 `UserSessionManager`의 활동 모드를 읽는다.
         .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),

--- a/UMCApp/Features/MyPage/Project.swift
+++ b/UMCApp/Features/MyPage/Project.swift
@@ -12,7 +12,6 @@ let project = featureProject(
     presentationExtraDependencies: [
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         .project(target: "CorePhoto", path: .relativeToRoot("Core/Photo")),
-        .project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard")),
         .project(target: "BadgeDomain", path: .relativeToRoot("Features/Badge")),
     ],
     includesDomainTests: true,


### PR DESCRIPTION
## ✨ PR 유형

Chore — Tuist 매니페스트에 복제돼 있던 미사용 모듈 의존성 정리 (동작 변경 없음)

Closes #1097

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (빌드 설정 전용 변경)

## 🛠️ 작업내용

- Home / Auth / Activity / MyPage / Community 5개 피처 소스 전체에서 `BusinessCard*` 실사용 여부 재확인 → **전부 0건**
- 각 `Project.swift` 의 `presentationExtraDependencies` 에서 `.project(target: "BusinessCardPresentation", path: .relativeToRoot("Features/BusinessCard"))` 제거
- `Features/Community/Project.swift` 는 해당 선언이 유일했던 항목이라 `featureProject(name: "Community")` 한 줄로 정리
- 앱 타겟(`UMCApp/Project.swift:63`)의 `BusinessCardPresentation` 링크는 **유지** — 모듈을 의존성 그래프에 남기는 유일한 경로이며 이번 이슈 범위(`Features/*/Project.swift`) 밖

### 검증 결과

| 항목 | 결과 |
|---|---|
| 5개 피처 `BusinessCard*` 사용처 grep | 0건 |
| `make generate` | ✅ Success |
| `make build` | ✅ BUILD SUCCEEDED |
| 생성된 5개 `*.xcodeproj/project.pbxproj` 내 `BusinessCard` 참조 | 0건 (링크 실제 제거 확인) |

## 📋 추후 진행 상황

- `BusinessCard` 모듈 자체는 현재 빈 `public enum` 스텁 상태 — 실제 피처 구현 시점에 필요한 피처에서만 명시적으로 의존성 추가

## 📌 리뷰 포인트

- `UMCApp/Features/Community/Project.swift` - `presentationExtraDependencies` 가 비어 `featureProject(name:)` 축약형으로 바뀐 부분 확인
- `UMCApp/Features/Home/Project.swift`, `UMCApp/Features/Auth/Project.swift`, `UMCApp/Features/Activity/Project.swift`, `UMCApp/Features/MyPage/Project.swift` - 해당 한 줄 외 다른 의존성/주석이 함께 지워지지 않았는지 확인

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
