### PR TITLE
♻️ [Refactor] Notice 이관 잔여 정리 — 매핑표 배치 동기화 및 stale 주석 제거 (#1096)

### DIFF
--- a/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeDetail+UI.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeDetail+UI.swift
@@ -65,12 +65,3 @@ extension TargetAudience {
         .joined(separator: " / ")
     }
 }
-
-// TODO: dateRange 모듈 추가
-
-//extension NoticeVote {
-//    /// 날짜 포맷 (MM.dd - MM.dd)
-//    public var formattedPeriod: String {
-//        startDate.dateRange(to: endDate)
-//    }
-//}

--- a/docs/claude/tuist-file-mapping.md
+++ b/docs/claude/tuist-file-mapping.md
@@ -609,7 +609,7 @@
 
 | 레거시 파일 | → Tuist 목적지 |
 |---|---|
-| `Data/AITokenDailyUsageRecord.swift` | NoticeData |
+| `Data/AITokenDailyUsageRecord.swift` | **NoticeDomain** (`Sources/Models/`) — SwiftData 영속 모델이지만 소비자가 `NoticeEditorViewModel+AI` / `NoticeDetailViewModel+AI` / `ScheduleRegistrationViewModel+AI` 로 전부 Presentation 이라, NoticeData 로 내리면 NoticePresentation·HomePresentation → NoticeData 역방향 의존이 생긴다. `Home/Domain/.../NoticeHistoryData.swift` 와 동일 선례(#1096) |
 | `Data/DTOs/NoticeDTO.swift` | NoticeData |
 | `Data/DTOs/NoticeDetailContentDTO.swift` | NoticeData |
 | `Data/DTOs/NoticeDetailDTO.swift` | NoticeData |
@@ -633,8 +633,8 @@
 | `Data/Repositories/NoticeRepository.swift` | NoticeData |
 | `Data/Router/NoticeEditorTargetRouter.swift` | NoticeData |
 | `Data/Router/NoticeRouter.swift` | NoticeData |
-| `Domain/Enums/NoticeItemTag.swift` | NoticeDomain |
-| `Domain/Enums/NoticeRequestFactory.swift` | NoticeData (`Sources/DTOs/`) — 요청 Query DTO(`NoticeListQuery`) 생성 → Data 레이어 |
+| `Domain/Enums/NoticeItemTag.swift` | **NoticePresentation** (`Sources/Tags/`) — `SwiftUI.Color` 를 프로퍼티로 갖는 UI 표시용 값 타입이고 소비자도 `NoticeItemModel+Tags` / `NoticeDetail+UI` / `NoticeDetailView` 로 전부 Presentation 이다(#1096) |
+| `Domain/Enums/NoticeRequestFactory.swift` | **이식 제외(dead)** — 이식됐다가 소비자 0건으로 확인돼 제거됨(#1028). `NoticeListRequest` 조립은 `NoticeViewModel+Fetch.buildNoticeListRequest` 가 담당 |
 | `Domain/Enums/NoticeType.swift` | NoticeDomain |
 | `Domain/Enums/StaffNoticeTab.swift` | NoticeDomain |
 | `Domain/Interfaces/NoticeEditorTargetRepositoryProtocol.swift` | NoticeDomain |


### PR DESCRIPTION
## ✨ PR 유형

Refactor — Notice 이관 잔여 정리. 동작 변경 없음(no-op). 매핑표(`docs/claude/tuist-file-mapping.md`)를 실제 배치와 일치시키고, 사문화된 주석 블록을 제거해 이관 완료 판정이 신뢰 가능하도록 정리합니다.

Closes #1096

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (주석 삭제 + 문서 동기화)

## 🛠️ 작업내용

**(a) `AITokenDailyUsageRecord` — NoticeDomain 유지로 확정, 매핑표 정정**

이슈에는 "NoticeData 로 이동"으로 적혀 있었으나, 실제 소비자를 확인한 결과 **이동이 불가능**합니다.

- 소비자 4곳이 전부 Presentation·App 계층
  - `Notice/Presentation/.../NoticeEditorViewModel+AI.swift:432,453,459`
  - `Notice/Presentation/.../NoticeDetailViewModel+AI.swift:134,140`
  - `Home/Presentation/.../ScheduleRegistrationViewModel+AI.swift:71,150,156`
  - `UMCApp/Sources/UMCAppApp.swift:188` (SwiftData `ModelContainer` 스키마 등록)
- `NoticePresentation`·`HomePresentation` 모두 **NoticeDomain 에만** 의존
  (`Features/Home/Project.swift:30`, `Tuist/ProjectDescriptionHelpers/Project+Feature.swift:82`)
- → NoticeData 로 내리면 **Presentation → Data 역방향 의존**이 발생하므로, 매핑표 행을 실제 배치(NoticeDomain)로 정정하고 사유를 함께 기록

**(b) `NoticeItemTag` — NoticePresentation 유지로 확정, 매핑표 정정**

- `import SwiftUI` + `backColor: Color` 를 갖는 UI 표시용 값 타입
- 소비자 3곳(`NoticeItemModel+Tags`, `NoticeDetail+UI`, `NoticeDetailView`)이 전부 Presentation
- → Presentation 이 올바른 배치. 매핑표 행 정정

**(c) `NoticeRequestFactory` — 이슈 본문이 stale, 이미 제거된 상태**

- 커밋 `691aa35a`(#1028)에서 74줄 삭제 완료 (해당 커밋 메시지에도 "어디에서도 호출되지 않는 NoticeRequestFactory 삭제" 명시)
- 이번 PR의 삭제 대상 아님. 매핑표에 "이식 제외(dead)" 로 표기하고 대체 로직 위치를 명기

**(d) stale TODO 주석 제거**

- `NoticeDetail+UI.swift:69-79` 의 주석 처리된 `formattedPeriod` 블록 삭제
- 실물이 `NoticeDetail.swift:294` 에 이미 존재하고 `NoticeVoteCard.swift:117` 에서 실사용 중

**(e) 매핑표 동기화**

- `docs/claude/tuist-file-mapping.md` 3개 행을 실제 배치와 일치시키고 판단 근거를 인라인 기록

## 📋 추후 진행 상황

없음. 이슈 #1096 의 잔여 항목은 이 PR로 종결됩니다.

## 📌 리뷰 포인트

- `docs/claude/tuist-file-mapping.md:612` — `AITokenDailyUsageRecord` 를 Domain 에 남긴 판단이 타당한지. **SwiftData 영속 모델이 Domain 에 있는 것 자체는 레이어 규약상 이상적이지 않으므로**, 이 절충안을 받아들일지 / 아니면 별도 이슈로 "AI 토큰 사용량 집계를 UseCase 뒤로 숨기고 레코드를 Data 로 내리는" 구조 개선을 잡을지 의견 부탁드립니다.
- `docs/claude/tuist-file-mapping.md:636` — `NoticeItemTag` 를 Presentation 으로 확정한 판단
- `UMCApp/Features/Notice/Presentation/Sources/Extensions/NoticeDetail+UI.swift` — 삭제한 주석 블록이 정말 불필요한지 (`NoticeDetail.swift:294` 실물 확인)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
- [x] `make build` 성공 확인 (`** BUILD SUCCEEDED **`)