### PR TITLE
♻️ [Refactor] 일정 상세 수정(연필) 진입점 결선 — 툴바 권한 분기 수정 (#1104)

### DIFF
--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift
@@ -15,7 +15,7 @@ import UMCFoundation
 /// 일정 상세 화면 ViewModel
 ///
 /// 조회 실패는 화면 내 `Loadable` 로, 삭제·강제 삭제 실패는 흐름을 끊는 `ErrorHandler` 로 나눠 처리한다.
-/// 수정은 편집 화면이 아직 이식되지 않아 권한만 계산해 두고 진입점을 노출하지 않는다.
+/// 수정·삭제 진입점 노출 여부는 리소스 권한으로 각각 판단한다.
 @Observable
 @MainActor
 final class ScheduleDetailViewModel {
@@ -26,7 +26,6 @@ final class ScheduleDetailViewModel {
 
     var alertPrompt: AlertPrompt?
 
-    /// - TODO: (#1091) 일정 편집 화면 이식 후 수정 진입점 연결
     private(set) var canEditSchedule: Bool = false
 
     private(set) var canDeleteSchedule: Bool = false

--- a/UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift
@@ -15,8 +15,8 @@ import UMCFoundation
 
 /// 일정 상세 화면.
 ///
-/// 장소는 역지오코딩 없이 좌표 그대로 Apple Maps 로 넘긴다. 수정 진입점은 편집 화면이 아직
-/// 이식되지 않아(#1091) 툴바에 노출하지 않고, 삭제·강제 삭제만 권한에 따라 연다.
+/// 장소는 역지오코딩 없이 좌표 그대로 Apple Maps 로 넘긴다. 툴바 액션(수정/삭제)은 각각의
+/// 리소스 권한에 따라 독립적으로 노출하고, 수정은 편집 모드 등록 화면을 시트로 띄운다.
 ///
 /// 출석 진입은 활동 모드로 갈린다. Admin 모드면 출석 현황 화면으로 이동하는 버튼을, 그 외에는
 /// 내 출석 상태를 read-only 로 보여 준다. 출석 비필수 일정은 두 경우 모두 표시하지 않는다.
@@ -26,6 +26,11 @@ public struct ScheduleDetailView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel: ScheduleDetailViewModel
+
+    /// 편집 시트에 실을 일정. `nil` 이면 시트가 닫힌 상태다.
+    @State private var editingSchedule: ScheduleDetailData?
+
+    private let container: DIContainer
     private let onAttendanceStatusTapped: () -> Void
 
     // MARK: - Constants
@@ -36,6 +41,8 @@ public struct ScheduleDetailView: View {
         static let attendanceTitle: String = "출석"
         static let attendanceStatusButtonTitle: String = "출석 현황"
         static let myAttendanceStatusTitle: String = "내 출석 상태"
+        static let editActionTitle: String = "수정하기"
+        static let editIcon: String = "pencil"
         static let deleteActionTitle: String = "삭제하기"
         static let deleteIcon: String = "trash"
         static let failedTitle: String = "일정을 불러오지 못했어요"
@@ -64,6 +71,7 @@ public struct ScheduleDetailView: View {
                 errorHandler: errorHandler
             )
         )
+        self.container = container
         self.onAttendanceStatusTapped = onAttendanceStatusTapped
     }
 
@@ -78,6 +86,16 @@ public struct ScheduleDetailView: View {
             )
             .toolbar { toolbarContent }
             .alertPrompt(item: $viewModel.alertPrompt)
+            .sheet(
+                item: $editingSchedule,
+                // 저장 여부를 시트에서 돌려받는 배관 대신, 닫힐 때 항상 재조회해 최신 값을 맞춘다.
+                onDismiss: { Task { await viewModel.load() } }
+            ) { detail in
+                // 편집 화면 툴바가 `.toolbar` 기반이라 시트 안에서도 네비게이션 컨테이너가 필요하다.
+                NavigationStack {
+                    ScheduleRegistrationView(container: container, mode: .edit, prefill: detail)
+                }
+            }
             .onChange(of: viewModel.isDeleted) { _, isDeleted in
                 if isDeleted { dismiss() }
             }
@@ -98,20 +116,34 @@ public struct ScheduleDetailView: View {
         }
     }
 
-    /// 삭제 중에는 액션을 비워 중복 요청을 막는다.
+    /// 권한별로 구성되는 툴바 액션 목록. 삭제 중에는 비워 중복 요청을 막는다.
     private var toolbarActions: [ToolBarCollection.ToolbarTrailingMenu.ActionItem] {
-        guard viewModel.data.value != nil,
-              viewModel.canDeleteSchedule,
-              !viewModel.isDeleting else { return [] }
+        guard let detail = viewModel.data.value, !viewModel.isDeleting else { return [] }
 
-        return [
-            .init(
-                title: Constants.deleteActionTitle,
-                icon: Constants.deleteIcon,
-                role: .destructive,
-                action: viewModel.showDeleteConfirmation
+        var actions: [ToolBarCollection.ToolbarTrailingMenu.ActionItem] = []
+
+        if viewModel.canEditSchedule {
+            actions.append(
+                .init(
+                    title: Constants.editActionTitle,
+                    icon: Constants.editIcon,
+                    action: { editingSchedule = detail }
+                )
             )
-        ]
+        }
+
+        if viewModel.canDeleteSchedule {
+            actions.append(
+                .init(
+                    title: Constants.deleteActionTitle,
+                    icon: Constants.deleteIcon,
+                    role: .destructive,
+                    action: viewModel.showDeleteConfirmation
+                )
+            )
+        }
+
+        return actions
     }
 
     // MARK: - Content


### PR DESCRIPTION
## ✨ PR 유형

Refactor — #1087 이 남긴 잔여분(수정 진입점 미노출) 해소. 일정 수정이 "배관만 깔린 상태"에서 실제 사용 가능한 기능이 됩니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 일정 상세 툴바 우측 메뉴에 "수정하기"(pencil) 항목이 추가됩니다. 편집 시트 진입 → 저장 → 상세 갱신 흐름 영상 첨부 예정 -->

## 🛠️ 작업내용

- **툴바 권한 분기 버그 수정** — `toolbarActions` 의 guard 가 `data.value != nil, canDeleteSchedule, !isDeleting` 로 묶여 있어, 연필을 추가해도 **삭제 권한이 없는 사용자에게는 수정 버튼이 노출되지 않는** 구조였습니다. 공통 조건(`data.value`, `isDeleting`)만 guard 로 남기고 수정/삭제를 각각의 권한으로 독립 append 하도록 분해했습니다. (`NoticeDetailView` 의 조건부 append 패턴과 동일)
- **수정(연필) 액션 추가** — `canEditSchedule == true` 일 때만 노출
- **편집 화면 결선** — `.sheet(item:)` 으로 `ScheduleRegistrationView(mode: .edit, prefill:)` 진입. 상세에서 이미 로드한 `ScheduleDetailData` 를 그대로 `prefill` 로 전달합니다. 편집 화면 툴바가 `.toolbar` 기반이라 시트 내부를 `NavigationStack` 으로 감쌌습니다.
- **수정 후 상세 갱신** — 시트 `onDismiss` 에서 `viewModel.load()` 재조회. 시트는 navigation depth 를 바꾸지 않아 `ScheduleDetailView.task` 가 재실행되지 않으므로, 이 재조회가 없으면 상세가 수정 전 값을 그대로 보여줍니다.
- stale 주석 정리 — `ScheduleDetailView` / `ScheduleDetailViewModel` 의 "편집 화면 미이식(#1091)" 문구 및 `TODO: (#1091)` 제거

**재구현하지 않고 재사용한 것** (#1087·#1088 산출물)
- `ScheduleV2Router.patchSchedule`, `ScheduleRepository.updateSchedule`, `ScheduleUpdateRequest(+DTO)`, `UpdateScheduleUseCase`, DIContainer 등록
- `ScheduleRegistrationView.Mode.edit` / `prefill` / `applyPrefill(from:roadAddress:)` / `updateSchedule()`
- `ScheduleDetailViewModel.canEditSchedule` (`.schedule` 리소스 권한 판정), `load()` 재진입 가드

**의도적으로 손대지 않은 것**
- `NavigationDestination` / `NavigationRoutingView` / `RootTabView` — 시트 방식이라 App 타깃 라우팅 변경이 불필요했습니다. `ScheduleDetailData` 에 `Hashable` 을 추가할 필요도 없었습니다.
- `HomeView` / `HomeViewModel` — 홈 캘린더 갱신은 기존 `.task(id: pathStore.depth(of: .home))` + `isAtRoot` 트리거가 커버합니다.
- `ScheduleDetailViewModel.isScheduleStarted` — 시작된 일정 차단은 편집 화면이 인라인 메시지로 이미 처리하므로 중복 게이트를 넣지 않았습니다.

## 📋 추후 진행 상황

- **실서버 왕복 확인 필요** — `PATCH /api/v2/schedules/{id}` 의 부분 갱신 시맨틱(요청에 담기지 않은 필드가 서버에서 유지되는지)은 코드만으로 닫을 수 없습니다. 현재는 `ScheduleUpdatePipelineTests` 의 요청 본문 직렬화 검증까지가 한계입니다.
- **홈 캘린더 반영 실행 확인** — 상세에서 루트로 복귀할 때 월별 재조회가 걸린다는 전제이며, 스테일 여부는 실행 확인이 필요합니다.
- 저장 성공 여부를 시트에서 돌려받는 콜백이 없어 **취소 시에도 재조회 1회**가 발생합니다. 비용이 문제되면 그때 콜백을 추가하는 편이 낫다고 판단했습니다.

## 📌 리뷰 포인트

- `UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift` (`toolbarActions`) — **guard 분해가 이 PR 의 핵심**입니다. 수정/삭제 권한 조합 4가지(둘 다 있음 / 수정만 / 삭제만 / 둘 다 없음)에서 메뉴 노출이 의도대로인지 봐주세요.
- `UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift` (`.sheet(item:onDismiss:)`) — 편집 진입을 App 라우터가 아닌 시트로 처리한 선택이 적절한지. 등록(create)은 push, 수정(edit)은 sheet 로 갈리게 됩니다.
- `onDismiss` 의 무조건 `load()` 재조회 — 저장/취소를 구분하지 않는 트레이드오프에 동의하시는지.
- `prefillRoadAddress` 는 생략했습니다. `ScheduleDetailData`/`ScheduleLocation` 에 도로명 주소 필드가 없고, `ScheduleRegistrationViewModel.applyPrefill` 이 `roadAddress ?? location?.locationName` 으로 폴백합니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)