### PR TITLE
♻️ [Refactor] ScheduleCapabilities 체인 이식 (DTO·Repository·UseCase·Router)

### DIFF
--- a/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleCapabilitiesDTO.swift
+++ b/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleCapabilitiesDTO.swift
@@ -1,0 +1,74 @@
+//
+//  ScheduleCapabilitiesDTO.swift
+//  HomeData
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import Foundation
+import HomeDomain
+import UMCFoundation
+
+/// `GET /api/v2/schedules/capabilities` 응답 DTO
+///
+/// - SeeAlso: ``HomeDomain/ScheduleCapabilities``
+public struct ScheduleCapabilitiesDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    /// 일정 생성 가능 여부
+    public let canCreateSchedule: Bool
+
+    /// 출석 정책을 포함한 일정을 만들 수 있는지 여부 (운영진 `true` / 일반 챌린저 `false`)
+    public let canCreateAttendanceRequiredSchedule: Bool
+
+    /// 직책별 최대 초대 가능 인원. 식별자가 아닌 수량이므로 `Int` 로 흡수한다.
+    public let maxParticipantCount: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case canCreateSchedule
+        case canCreateAttendanceRequiredSchedule
+        case maxParticipantCount
+    }
+
+    // MARK: - Init
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        canCreateSchedule = try container.decodeBoolFlexibleIfPresent(
+            forKey: .canCreateSchedule
+        ) ?? false
+        canCreateAttendanceRequiredSchedule = try container.decodeBoolFlexibleIfPresent(
+            forKey: .canCreateAttendanceRequiredSchedule
+        ) ?? false
+        maxParticipantCount = try container.decodeIntFlexibleIfPresent(
+            forKey: .maxParticipantCount
+        ) ?? 0
+    }
+
+    // MARK: - Function
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(canCreateSchedule, forKey: .canCreateSchedule)
+        try container.encode(
+            canCreateAttendanceRequiredSchedule,
+            forKey: .canCreateAttendanceRequiredSchedule
+        )
+        try container.encode(maxParticipantCount, forKey: .maxParticipantCount)
+    }
+}
+
+// MARK: - Domain 변환
+
+extension ScheduleCapabilitiesDTO {
+
+    /// DTO → 도메인 변환
+    func toDomain() -> ScheduleCapabilities {
+        ScheduleCapabilities(
+            canCreateSchedule: canCreateSchedule,
+            canCreateAttendanceRequiredSchedule: canCreateAttendanceRequiredSchedule,
+            maxParticipantCount: maxParticipantCount
+        )
+    }
+}

--- a/UMCApp/Features/Home/Data/Sources/Repositories/ScheduleCapabilitiesRepository.swift
+++ b/UMCApp/Features/Home/Data/Sources/Repositories/ScheduleCapabilitiesRepository.swift
@@ -1,0 +1,54 @@
+//
+//  ScheduleCapabilitiesRepository.swift
+//  HomeData
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import CoreNetwork
+import Foundation
+import HomeDomain
+import UMCFoundation
+
+/// 일정 생성/수정 권한 조회 Repository 구현체
+public final class ScheduleCapabilitiesRepository: ScheduleCapabilitiesRepositoryProtocol,
+    @unchecked Sendable {
+
+    // MARK: - Property
+
+    private let networkRequesting: any HomeNetworkRequesting
+
+    // MARK: - Init
+
+    /// 운영(DI) 진입점.
+    public convenience init(adapter: MoyaNetworkAdapter) {
+        self.init(networkRequesting: adapter)
+    }
+
+    /// 네트워크 추상화를 직접 주입하는 지정 이니셜라이저 (모듈 내부 · 테스트 전용).
+    init(networkRequesting: any HomeNetworkRequesting) {
+        self.networkRequesting = networkRequesting
+    }
+
+    // MARK: - Function
+
+    /// 현재 사용자의 일정 생성/수정 권한을 조회한다.
+    public func fetchCapabilities() async throws -> ScheduleCapabilities {
+        let response = try await networkRequesting.request(ScheduleV2Router.getCapabilities)
+
+        do {
+            let apiResponse = try JSONDecoder().decode(
+                APIResponse<ScheduleCapabilitiesDTO>.self,
+                from: response.data
+            )
+            return try apiResponse.unwrap().toDomain()
+        } catch let decodingError as DecodingError {
+            #if DEBUG
+            print(
+                "[ScheduleCapabilitiesRepository] fetchCapabilities error=\(decodingError)"
+            )
+            #endif
+            throw RepositoryError.decodingError(detail: "\(decodingError)")
+        }
+    }
+}

--- a/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
+++ b/UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift
@@ -12,7 +12,7 @@ import Moya
 
 /// 일정 V2 API 라우터
 ///
-/// 일정 도메인의 목록 조회와 생성/삭제를 다룬다. 출석 관련 엔드포인트
+/// 일정 도메인의 목록·권한 조회와 생성/삭제를 다룬다. 출석 관련 엔드포인트
 /// (`/api/v2/schedules/attendance`, `/api/v2/schedules/{id}/attendance`,
 /// `.../attendances/decide`, `.../attendances/excuse`, `.../attendances/request`)는
 /// `ActivityData`의 `AttendanceRouter`에 있다.
@@ -27,6 +27,8 @@ enum ScheduleV2Router: BaseTargetType {
     case getMySchedules(query: MySchedulesQuery)
     /// 단일 일정 상세 조회 (`deleteSchedule` 과 경로가 같고 method 로만 갈린다)
     case getScheduleDetail(scheduleId: String)
+    /// 일정 생성/수정 권한 조회 (생성 가능 여부 · 출석 정책 부착 권한 · 최대 초대 인원)
+    case getCapabilities
     /// 일정 생성
     case postSchedule(body: ScheduleCreateRequestDTO)
     /// 일정 수정 (부분 갱신 — 본문에 실린 필드만 반영된다)
@@ -42,6 +44,8 @@ enum ScheduleV2Router: BaseTargetType {
         switch self {
         case .getMySchedules:
             return "/api/v2/schedules/me"
+        case .getCapabilities:
+            return "/api/v2/schedules/capabilities"
         case .postSchedule:
             return "/api/v2/schedules"
         case .getScheduleDetail(let scheduleId), .deleteSchedule(let scheduleId):
@@ -57,7 +61,7 @@ enum ScheduleV2Router: BaseTargetType {
 
     var method: Moya.Method {
         switch self {
-        case .getMySchedules, .getScheduleDetail:
+        case .getMySchedules, .getScheduleDetail, .getCapabilities:
             return .get
         case .postSchedule:
             return .post
@@ -81,7 +85,7 @@ enum ScheduleV2Router: BaseTargetType {
             return .requestJSONEncodable(body)
         case .patchSchedule(_, let body):
             return .requestJSONEncodable(body)
-        case .getScheduleDetail, .deleteSchedule, .forceDeleteSchedule:
+        case .getScheduleDetail, .getCapabilities, .deleteSchedule, .forceDeleteSchedule:
             return .requestPlain
         }
     }

--- a/UMCApp/Features/Home/Data/Tests/ScheduleCapabilitiesDTOTests.swift
+++ b/UMCApp/Features/Home/Data/Tests/ScheduleCapabilitiesDTOTests.swift
@@ -1,0 +1,53 @@
+//
+//  ScheduleCapabilitiesDTOTests.swift
+//  HomeDataTests
+//
+//  Created by euijjang97 on 8/9/26.
+//
+//  서버가 `maxParticipantCount` 를 숫자로 주든 문자열로 주든 같은 도메인 값이 나오는지,
+//  키 누락 시 크래시 없이 기본값으로 흡수되는지 검증한다.
+//
+
+import Foundation
+import Testing
+import HomeDomain
+@testable import HomeData
+
+@Suite("ScheduleCapabilitiesDTO — 디코딩 & 도메인 매핑")
+struct ScheduleCapabilitiesDTOTests {
+
+    @Test(
+        "maxParticipantCount 가 숫자든 문자열이든 동일한 도메인 값으로 매핑된다",
+        arguments: ["30", "\"30\""]
+    )
+    func decodesFlexibleMaxParticipantCount(rawValue: String) throws {
+        let json = """
+        {
+            "canCreateSchedule": true,
+            "canCreateAttendanceRequiredSchedule": true,
+            "maxParticipantCount": \(rawValue)
+        }
+        """
+
+        let domain = try decodeCapabilities(json).toDomain()
+
+        #expect(domain.canCreateSchedule)
+        #expect(domain.canCreateAttendanceRequiredSchedule)
+        #expect(domain.maxParticipantCount == 30)
+    }
+
+    @Test("키가 누락되면 권한 없음 · 초대 인원 0 으로 흡수된다")
+    func missingKeysFallBackToDefaults() throws {
+        let domain = try decodeCapabilities("{}").toDomain()
+
+        #expect(domain.canCreateSchedule == false)
+        #expect(domain.canCreateAttendanceRequiredSchedule == false)
+        #expect(domain.maxParticipantCount == 0)
+    }
+}
+
+// MARK: - Helpers
+
+private func decodeCapabilities(_ json: String) throws -> ScheduleCapabilitiesDTO {
+    try JSONDecoder().decode(ScheduleCapabilitiesDTO.self, from: Data(json.utf8))
+}

--- a/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleCapabilitiesRepositoryProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Interfaces/ScheduleCapabilitiesRepositoryProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  ScheduleCapabilitiesRepositoryProtocol.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import Foundation
+
+/// 일정 생성/수정 권한 조회 인터페이스.
+///
+/// 권한은 직책 변경으로 언제든 바뀔 수 있어 이 계층은 매번 서버 값을 그대로 조회한다.
+/// 캐싱이 필요하면 호출처가 결정한다.
+public protocol ScheduleCapabilitiesRepositoryProtocol {
+
+    /// 현재 사용자의 일정 생성/수정 권한을 조회한다.
+    func fetchCapabilities() async throws -> ScheduleCapabilities
+}

--- a/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleCapabilities.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleCapabilities.swift
@@ -1,0 +1,38 @@
+//
+//  ScheduleCapabilities.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import Foundation
+
+/// 일정 생성/수정 권한 도메인 모델
+///
+/// 일정 생성/수정 화면에서 버튼 활성화 여부, 출석 정책 토글 노출 여부,
+/// 참여자 선택 상한을 서버 주도로 결정할 때 사용한다.
+public struct ScheduleCapabilities: Equatable, Sendable {
+
+    // MARK: - Property
+
+    /// 일정 생성 가능 여부
+    public let canCreateSchedule: Bool
+
+    /// 출석 정책을 포함한 일정을 만들 수 있는지 여부 (운영진 `true` / 일반 챌린저 `false`)
+    public let canCreateAttendanceRequiredSchedule: Bool
+
+    /// 직책별 최대 초대 가능 인원
+    public let maxParticipantCount: Int
+
+    // MARK: - Init
+
+    public init(
+        canCreateSchedule: Bool,
+        canCreateAttendanceRequiredSchedule: Bool,
+        maxParticipantCount: Int
+    ) {
+        self.canCreateSchedule = canCreateSchedule
+        self.canCreateAttendanceRequiredSchedule = canCreateAttendanceRequiredSchedule
+        self.maxParticipantCount = maxParticipantCount
+    }
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/FetchScheduleCapabilitiesUseCaseProtocol.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/FetchScheduleCapabilitiesUseCaseProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  FetchScheduleCapabilitiesUseCaseProtocol.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import Foundation
+
+/// 일정 생성/수정 권한 조회 UseCase 인터페이스
+public protocol FetchScheduleCapabilitiesUseCaseProtocol {
+
+    /// - Returns: 생성 가능 여부 · 출석 정책 부착 권한 · 최대 초대 인원
+    func execute() async throws -> ScheduleCapabilities
+}

--- a/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchScheduleCapabilitiesUseCase.swift
+++ b/UMCApp/Features/Home/Domain/Sources/UseCases/Implementations/FetchScheduleCapabilitiesUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  FetchScheduleCapabilitiesUseCase.swift
+//  HomeDomain
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import Foundation
+
+/// 일정 생성/수정 권한 조회 UseCase 구현체
+public final class FetchScheduleCapabilitiesUseCase: FetchScheduleCapabilitiesUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: ScheduleCapabilitiesRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: ScheduleCapabilitiesRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute() async throws -> ScheduleCapabilities {
+        try await repository.fetchCapabilities()
+    }
+}

--- a/UMCApp/UMCApp/Sources/DIContainer+Home.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Home.swift
@@ -52,6 +52,14 @@ extension DIContainer {
         register(ForceDeleteScheduleUseCaseProtocol.self) {
             ForceDeleteScheduleUseCase(repository: self.resolve(ScheduleRepositoryProtocol.self))
         }
+        register(ScheduleCapabilitiesRepositoryProtocol.self) {
+            ScheduleCapabilitiesRepository(adapter: self.resolve(MoyaNetworkAdapter.self))
+        }
+        register(FetchScheduleCapabilitiesUseCaseProtocol.self) {
+            FetchScheduleCapabilitiesUseCase(
+                repository: self.resolve(ScheduleCapabilitiesRepositoryProtocol.self)
+            )
+        }
         register(RegisterFCMTokenUseCaseProtocol.self) {
             RegisterFCMTokenUseCase(repository: self.resolve(HomeRepositoryProtocol.self))
         }


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 레거시(`AppProduct/`)에만 있던 `GET /api/v2/schedules/capabilities` 조회 체인을 `UMCApp/`(Tuist)으로 이식합니다. Resolves #1091

화면이 없는 순수 데이터 체인이라 UI 변화는 없습니다. 후속 #1087(일정 수정·삭제) / #1088(일정 등록 화면)의 선행 블로커 해제가 목적입니다.

## 📷 스크린샷 or 영상(UI 변경 시)

해당 없음 — Presentation 레이어 변경이 없습니다.

## 🛠️ 작업내용

- `ScheduleV2Router` 에 `getCapabilities` 케이스 추가 (`GET /api/v2/schedules/capabilities`, `.requestPlain`)
- `ScheduleCapabilitiesDTO` 를 **HomeData** 에 추가 — Response DTO 규약대로 custom `init(from:)` + `encode(to:)` 구현
- `ScheduleCapabilities` 도메인 모델을 **HomeDomain** 에 추가
- `ScheduleCapabilitiesRepositoryProtocol`(HomeDomain/Interfaces) + `ScheduleCapabilitiesRepository`(HomeData) 이식
- `FetchScheduleCapabilitiesUseCaseProtocol` + `FetchScheduleCapabilitiesUseCase` 를 **HomeDomain** 에 추가
- `DIContainer+Home` 에 Repository/UseCase 등록
- `HomeDataTests` 에 DTO 디코딩 테스트 추가

### 레거시 대비 조정한 점

- **네트워크 계층 통일** — 레거시는 `MoyaNetworkAdapter` 를 직접 보유했지만, 형제인 `ScheduleRepository` 와 동일하게 `HomeNetworkRequesting` 추상화를 주입받고 `DecodingError` 를 `RepositoryError.decodingError` 로 변환하도록 맞췄습니다.
- **디코딩 헬퍼 중복 제거** — 레거시 DTO 하단에 있던 로컬 `KeyedDecodingContainer` 확장을 삭제하고 `UMCFoundation` 공용 헬퍼(`decodeIntFlexibleIfPresent` / `decodeBoolFlexibleIfPresent`)를 사용합니다.
- **`maxParticipantCount` 는 `Int` 유지** — 공용 헬퍼의 네이밍 규약이 *식별자/커서류 → `decodeFlexibleString*`, 실제 수량 → `decodeIntFlexible*`* 로 갈라져 있고, 형제 `ScheduleDetailDTO` 도 String 처리는 `scheduleId` / `authorMemberId` 같은 식별자에만 적용합니다. 최대 초대 인원은 수량이므로 `Int` 로 흡수했습니다.

### 검증

- `make build` → **BUILD SUCCEEDED**
- `HomeData` 스킴 테스트 → **TEST SUCCEEDED** (33 tests / 6 suites)
- 신규 스위트 단독 실행 확인 — `maxParticipantCount` 가 숫자(`30`) / 문자열(`"30"`) 어느 쪽으로 와도 동일 도메인 값, 키 누락 시 기본값 폴백

## 📋 추후 진행 상황

- #1087 일정 수정·삭제 이식
- #1088 일정 등록 화면 이식 — 이 체인을 소비해 버튼 활성화 / 출석 정책 토글 노출 / 참여자 상한을 서버 주도로 결정

## 📌 리뷰 포인트

- `UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleCapabilitiesDTO.swift` — `maxParticipantCount` 를 `Int` 로 둔 판단이 팀 컨벤션과 맞는지 (절대 규칙 #2 의 "서버 정수 String 통일" 은 식별자 대상이라는 해석)
- `UMCApp/Features/Home/Data/Sources/Repositories/ScheduleCapabilitiesRepository.swift` — `ScheduleRepository` 와 동일한 `HomeNetworkRequesting` 주입 / 에러 변환 패턴인지
- `UMCApp/Features/Home/Data/Sources/Router/ScheduleV2Router.swift` — `getCapabilities` 케이스 배치와 path/method/task 세 switch 반영 여부
- `UMCApp/UMCApp/Sources/DIContainer+Home.swift` — Repository → UseCase 등록 순서 및 resolve 대상
- `UMCApp/Features/Home/Data/Tests/ScheduleCapabilitiesDTOTests.swift` — 케이스가 충분한지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)