### PR TITLE
✨[Feat] 카카오 로그인 요청에 clientType 필드 추가 (#804)

### DIFF
--- a/UMCApp/Features/Auth/Data/Sources/DTOs/Request/LoginKakaoRequestDTO.swift
+++ b/UMCApp/Features/Auth/Data/Sources/DTOs/Request/LoginKakaoRequestDTO.swift
@@ -13,9 +13,15 @@ public struct LoginKakaoRequestDTO: Encodable {
     public let accessToken: String
     /// 카카오 계정 이메일
     public let email: String
+    /// 클라이언트 플랫폼 (`ANDROID` / `IOS` / `WEB`)
+    ///
+    /// 서버가 로그인 시 전달된 값을 Access Token claim에 넣어
+    /// 이후 API 호출을 디바이스 유형별로 라벨링한다.
+    public let clientType: String
 
-    public init(accessToken: String, email: String) {
+    public init(accessToken: String, email: String, clientType: String = "IOS") {
         self.accessToken = accessToken
         self.email = email
+        self.clientType = clientType
     }
 }

--- a/UMCApp/Features/Auth/Data/Tests/AuthRouterTests.swift
+++ b/UMCApp/Features/Auth/Data/Tests/AuthRouterTests.swift
@@ -210,6 +210,16 @@ struct AuthRouterRequestDTOEncodingTests {
         #expect(json["oAuthVerificationToken"] as? String == "oauth-token")
     }
 
+    @Test("LoginKakaoRequestDTO — clientType 기본값 \"IOS\"가 함께 인코딩됨")
+    func loginKakaoDTOEncodesClientType() throws {
+        let json = try encodeToJSON(
+            LoginKakaoRequestDTO(accessToken: "kakao-token", email: "a@umc.kr")
+        )
+        #expect(json["accessToken"] as? String == "kakao-token")
+        #expect(json["email"] as? String == "a@umc.kr")
+        #expect(json["clientType"] as? String == "IOS")
+    }
+
     @Test("CheckEmailAvailabilityQuery.toParameters — email 단일 키")
     func checkEmailAvailabilityQueryParameters() {
         let query = CheckEmailAvailabilityQuery(email: "a@umc.kr")


### PR DESCRIPTION
## ✨ PR 유형

Feature — 카카오 소셜 로그인 요청 본문에 디바이스 유형 트래픽 분석용 `clientType` 필드를 추가합니다. (close #804)

> 이슈 본문은 `AppProduct/` 경로를 가리키지만, **절대 규칙 #9**(AppProduct는 `v2.2.0` 동결)에 따라 동일 변경을 `UMCApp/`(Tuist) 활성 코드베이스에 적용했습니다.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 (네트워크 Request DTO 변경).

## 🛠️ 작업내용

- `LoginKakaoRequestDTO`에 `clientType: String` 필드 추가 (기본값 `"IOS"`)
  - 기존 `LoginAppleRequestDTO` / `LoginGoogleRequestDTO`와 동일하게 이니셜라이저 기본값으로 주입 → 호출부(`AuthRepository.loginKakao`) 변경 불필요
- `AuthRouterTests`에 인코딩 계약 테스트 추가 — `{ accessToken, email, clientType: "IOS" }` 로 직렬화되는지 검증

## 📋 추후 진행 상황

- 실기기에서 카카오 로그인 정상 동작 확인 (기존 회원 / 신규 회원 분기 모두) — 수동 검증 필요

## 📌 리뷰 포인트

- `UMCApp/Features/Auth/Data/Sources/DTOs/Request/LoginKakaoRequestDTO.swift` - 대문자 `"IOS"` 정확히 전송되는지 (잘못된 값은 400), 기본값 방식이 Apple/Google DTO와 일관적인지
- `UMCApp/Features/Auth/Data/Tests/AuthRouterTests.swift` - 인코딩 계약 테스트 (`AuthDataTests` 5/5 통과 확인)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)