### PR TITLE
✨[Feat] Home 마이그레이션 잔여 결선 — 참여자 선택·권한·섹션 에러·프로필 저장

### DIFF
--- a/UMCApp/Core/Domain/Sources/Member/SyncProfileStorageUseCase.swift
+++ b/UMCApp/Core/Domain/Sources/Member/SyncProfileStorageUseCase.swift
@@ -1,11 +1,10 @@
 //
 //  SyncProfileStorageUseCase.swift
-//  AuthDomain
+//  CoreDomain
 //
 //  Created by euijjang97 on 7/10/26.
 //
 
-import CoreDomain
 import Foundation
 import UMCFoundation
 

--- a/UMCApp/Core/Domain/Sources/Member/SyncProfileStorageUseCaseProtocol.swift
+++ b/UMCApp/Core/Domain/Sources/Member/SyncProfileStorageUseCaseProtocol.swift
@@ -1,11 +1,9 @@
 //
 //  SyncProfileStorageUseCaseProtocol.swift
-//  AuthDomain
+//  CoreDomain
 //
 //  Created by euijjang97 on 7/10/26.
 //
-
-import CoreDomain
 
 /// 프로필 조회 결과를 로컬 저장소(`UserDefaults`, `UserSessionManager`)에 동기화하는 UseCase 인터페이스
 public protocol SyncProfileStorageUseCaseProtocol {

--- a/UMCApp/Core/UIComponents/Sources/ArticleTextField/ArticleTextField.swift
+++ b/UMCApp/Core/UIComponents/Sources/ArticleTextField/ArticleTextField.swift
@@ -98,7 +98,9 @@ public struct ArticleTextField: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview {
     @Previewable @State var text = ""
     ArticleTextField(placeholder: .title, text: $text)
 }
+#endif

--- a/UMCApp/Core/UIComponents/Sources/Badge/InfoBadge.swift
+++ b/UMCApp/Core/UIComponents/Sources/Badge/InfoBadge.swift
@@ -84,6 +84,7 @@ public struct InfoBadge: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview {
     HStack(spacing: DefaultSpacing.spacing8) {
         InfoBadge("중앙대")
@@ -93,3 +94,4 @@ public struct InfoBadge: View, Equatable {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Core/UIComponents/Sources/Icon/CardIconImage.swift
+++ b/UMCApp/Core/UIComponents/Sources/Icon/CardIconImage.swift
@@ -53,6 +53,7 @@ public struct CardIconImage: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     HStack {
         CardIconImage(image: "calendar.badge", color: .indigo500, isLoading: .constant(false))
@@ -60,3 +61,4 @@ public struct CardIconImage: View {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Core/UIComponents/Sources/MainButton/MainButton.swift
+++ b/UMCApp/Core/UIComponents/Sources/MainButton/MainButton.swift
@@ -101,6 +101,7 @@ extension MainButton: AnyMainButton { }
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview("MainButton with Styles") {
     VStack(spacing: 16) {
         MainButton("Primary Button") { }
@@ -177,3 +178,4 @@ extension MainButton: AnyMainButton { }
     }
     .padding()
 }
+#endif

--- a/UMCApp/Core/UIComponents/Sources/Progress/Progress.swift
+++ b/UMCApp/Core/UIComponents/Sources/Progress/Progress.swift
@@ -48,6 +48,7 @@ public struct Progress: View {
 }
 
 // MARK: - Preview
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     VStack(spacing: 100) {
         Progress(message: "로딩중!", size: .small)
@@ -57,3 +58,4 @@ public struct Progress: View {
         Progress(message: "잠시만 기다려주세요!", size: .large)
     }
 }
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SelectedChallengerView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SelectedChallengerView.swift
@@ -15,8 +15,9 @@ import UMCFoundation
 
 /// 선택된 챌린저(멘토/스터디원) 목록을 확인·삭제하고, 검색으로 새 인원을 추가하는 화면.
 ///
-/// 스터디 그룹 생성 폼과 그룹 관리 화면이 시트로 띄우므로 자체 `NavigationStack` 을 가집니다.
-struct SelectedChallengerView: View {
+/// 스터디 그룹 생성 폼과 그룹 관리 화면, 홈 일정 등록 화면이 시트로 띄우므로 자체
+/// `NavigationStack` 을 가집니다.
+public struct SelectedChallengerView: View {
 
     // MARK: - Property
 
@@ -44,7 +45,7 @@ struct SelectedChallengerView: View {
     /// - Parameters:
     ///   - challenger: 상위 화면의 선택 목록 바인딩
     ///   - searchUseCase: 검색 UseCase (기본값 `nil` — DI 컨테이너에서 해석)
-    init(
+    public init(
         challenger: Binding<[ChallengerInfo]>,
         searchUseCase: SearchChallengersUseCaseProtocol? = nil
     ) {
@@ -54,7 +55,7 @@ struct SelectedChallengerView: View {
 
     // MARK: - Body
 
-    var body: some View {
+    public var body: some View {
         NavigationStack {
             content
                 .navigationTitle(NavigationTitle.Activity.participant.rawValue)

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupLeaderRow.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupLeaderRow.swift
@@ -134,6 +134,7 @@ struct StudyGroupLeaderRow: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview {
     VStack(spacing: DefaultSpacing.spacing16) {
         StudyGroupLeaderRow(
@@ -161,3 +162,4 @@ struct StudyGroupLeaderRow: View, Equatable {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupMemberChip.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupMemberChip.swift
@@ -165,6 +165,7 @@ struct StudyGroupMemberChip: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview("StudyGroupMemberChip") {
     HStack(spacing: DefaultSpacing.spacing8) {
         StudyGroupMemberChip(
@@ -192,3 +193,4 @@ struct StudyGroupMemberChip: View, Equatable {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleCapabilitiesDTO.swift
+++ b/UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleCapabilitiesDTO.swift
@@ -22,8 +22,8 @@ public struct ScheduleCapabilitiesDTO: Codable, Sendable, Equatable {
     /// 출석 정책을 포함한 일정을 만들 수 있는지 여부 (운영진 `true` / 일반 챌린저 `false`)
     public let canCreateAttendanceRequiredSchedule: Bool
 
-    /// 직책별 최대 초대 가능 인원. 식별자가 아닌 수량이므로 `Int` 로 흡수한다.
-    public let maxParticipantCount: Int
+    /// 직책별 최대 초대 가능 인원. 서버 정수를 절대 규칙 #2에 따라 `String`으로 보존한다.
+    public let maxParticipantCount: String
 
     private enum CodingKeys: String, CodingKey {
         case canCreateSchedule
@@ -41,9 +41,11 @@ public struct ScheduleCapabilitiesDTO: Codable, Sendable, Equatable {
         canCreateAttendanceRequiredSchedule = try container.decodeBoolFlexibleIfPresent(
             forKey: .canCreateAttendanceRequiredSchedule
         ) ?? false
-        maxParticipantCount = try container.decodeIntFlexibleIfPresent(
+        // 숫자/문자열 어느 쪽으로 와도 같은 값이 되도록 숫자 파싱을 한 번 거친 뒤 문자열로 보존한다.
+        let parsedMaxParticipantCount = try container.decodeIntFlexibleIfPresent(
             forKey: .maxParticipantCount
-        ) ?? 0
+        )
+        maxParticipantCount = parsedMaxParticipantCount.map { String($0) } ?? "0"
     }
 
     // MARK: - Function

--- a/UMCApp/Features/Home/Data/Sources/Extensions/ProfileChallengerRecord+HomeMapping.swift
+++ b/UMCApp/Features/Home/Data/Sources/Extensions/ProfileChallengerRecord+HomeMapping.swift
@@ -42,24 +42,23 @@ extension ProfileChallengerRecord {
             return lhsDate > rhsDate
         }
 
-        var rewardTotal = 0
-        var penaltyTotal = 0
+        var rewardTotal: Double = 0
+        var penaltyTotal: Double = 0
 
         let pointLogs = sortedPoints.map { point -> PointLog in
             let isReward = Self.rewardPointTypes.contains(point.pointType)
-            let intPoint = Int(point.point)
 
             if isReward {
-                rewardTotal += abs(intPoint)
+                rewardTotal += abs(point.point)
             } else {
-                penaltyTotal += abs(intPoint)
+                penaltyTotal += abs(point.point)
             }
 
             return PointLog(
                 id: point.id,
                 reason: point.description,
                 date: Self.displayDateString(from: point.createdAt),
-                point: intPoint,
+                point: point.point,
                 isReward: isReward
             )
         }

--- a/UMCApp/Features/Home/Data/Tests/HomeRepositoryTests.swift
+++ b/UMCApp/Features/Home/Data/Tests/HomeRepositoryTests.swift
@@ -114,6 +114,29 @@ private enum Fixture {
         """.utf8)
     }
 
+    static func record(
+        gisuId: String,
+        points: [ProfileChallengerPoint]
+    ) -> ProfileChallengerRecord {
+        ProfileChallengerRecord(
+            challengerId: "challenger-1",
+            memberId: "1",
+            gisu: "12",
+            gisuId: gisuId,
+            chapterId: nil,
+            chapterName: nil,
+            part: "IOS",
+            schoolId: "5",
+            schoolName: "한성대",
+            name: nil,
+            nickname: nil,
+            email: nil,
+            profileImageLink: nil,
+            status: .active,
+            challengerPoints: points
+        )
+    }
+
     /// 기수 기록이 없어 기수 상세 네트워크 호출이 발생하지 않는 최소 프로필
     static func minimalProfile(memberId: String) -> Profile {
         Profile(
@@ -218,26 +241,85 @@ struct HomeRepositoryTests {
         let expectedGeneration = HomeGeneration(
             gisuId: "1002",
             gen: "12",
-            penaltyPoint: 1,
-            rewardPoint: 2,
+            penaltyPoint: 1.0,
+            rewardPoint: 2.0,
             pointLogs: [
                 PointLog(
                     id: "point-penalty",
                     reason: "지각",
                     date: expectedFormatter.string(from: newerPointDate),
-                    point: -1,
+                    point: -1.0,
                     isReward: false
                 ),
                 PointLog(
                     id: "point-reward",
                     reason: "우수 워크북",
                     date: expectedFormatter.string(from: olderPointDate),
-                    point: 2,
+                    point: 2.0,
                     isReward: true
                 ),
             ]
         )
         #expect(result.generations == [expectedGeneration])
+    }
+
+    @Test("소수 배점(-0.5)이 절삭되지 않고 로그·합계에 그대로 반영된다")
+    func fetchMyProfileKeepsFractionalPoints() async throws {
+        let now = Date()
+        var kstCalendar = Calendar(identifier: .gregorian)
+        kstCalendar.timeZone = ServerDateTimeConverter.kstTimeZone
+        let startAtString = ServerDateTimeConverter.toUTCDateTimeString(
+            kstCalendar.date(byAdding: .day, value: -3, to: now)!
+        )
+
+        let fractionalPenalty = ProfileChallengerPoint(
+            id: "point-half-penalty",
+            pointType: "LATE_ATTENDANCE",
+            point: -0.5,
+            description: "지각",
+            createdAt: ServerDateTimeConverter.toUTCDateTimeString(now)
+        )
+        let fractionalReward = ProfileChallengerPoint(
+            id: "point-half-reward",
+            pointType: ChallengerPointType.blogChallenge.rawValue,
+            point: 1.5,
+            description: "블로그 챌린지",
+            createdAt: ServerDateTimeConverter.toUTCDateTimeString(now)
+        )
+        let profile = Profile(
+            memberId: "1",
+            name: "홍길동",
+            nickname: "길동",
+            generations: ["12"],
+            roles: [],
+            challengerRecords: [
+                Fixture.record(
+                    gisuId: "1002",
+                    points: [fractionalPenalty, fractionalReward]
+                )
+            ]
+        )
+
+        let memberProfileRepository = MockMemberProfileRepository()
+        memberProfileRepository.result = .success(profile)
+        let network = StubHomeNetwork(
+            .success(Fixture.gisuDetailBody(gisuId: "1002", startAt: startAtString))
+        )
+        let repository = HomeRepository(
+            networkRequesting: network,
+            memberProfileRepository: memberProfileRepository
+        )
+
+        let result = try await repository.fetchMyProfile()
+
+        let generation = try #require(result.generations.first)
+        let penaltyLog = try #require(generation.pointLogs.first { !$0.isReward })
+        let rewardLog = try #require(generation.pointLogs.first { $0.isReward })
+
+        #expect(penaltyLog.point == -0.5, "소수 벌점이 0으로 절삭되면 안 된다")
+        #expect(rewardLog.point == 1.5)
+        #expect(generation.penaltyPoint == 0.5)
+        #expect(generation.rewardPoint == 1.5)
     }
 
     @Test("활동일 계산이 HomeRouter.getGisuDetail(gisuId:)를 호출한다")

--- a/UMCApp/Features/Home/Data/Tests/ScheduleCapabilitiesDTOTests.swift
+++ b/UMCApp/Features/Home/Data/Tests/ScheduleCapabilitiesDTOTests.swift
@@ -33,7 +33,7 @@ struct ScheduleCapabilitiesDTOTests {
 
         #expect(domain.canCreateSchedule)
         #expect(domain.canCreateAttendanceRequiredSchedule)
-        #expect(domain.maxParticipantCount == 30)
+        #expect(domain.maxParticipantCount == "30")
     }
 
     @Test("키가 누락되면 권한 없음 · 초대 인원 0 으로 흡수된다")
@@ -42,7 +42,7 @@ struct ScheduleCapabilitiesDTOTests {
 
         #expect(domain.canCreateSchedule == false)
         #expect(domain.canCreateAttendanceRequiredSchedule == false)
-        #expect(domain.maxParticipantCount == 0)
+        #expect(domain.maxParticipantCount == "0")
     }
 }
 

--- a/UMCApp/Features/Home/Domain/Sources/Models/HomeGeneration.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/HomeGeneration.swift
@@ -17,8 +17,9 @@ public struct HomeGeneration: Identifiable, Equatable, Sendable {
 
     public let gisuId: String
     public let gen: String
-    public let penaltyPoint: Int
-    public let rewardPoint: Int
+    /// ``PointLog/point`` 합계이므로 소수 배점을 잃지 않도록 `Double`로 유지한다.
+    public let penaltyPoint: Double
+    public let rewardPoint: Double
     public let pointLogs: [PointLog]
 
     // MARK: - Init
@@ -26,8 +27,8 @@ public struct HomeGeneration: Identifiable, Equatable, Sendable {
     public init(
         gisuId: String,
         gen: String,
-        penaltyPoint: Int,
-        rewardPoint: Int,
+        penaltyPoint: Double,
+        rewardPoint: Double,
         pointLogs: [PointLog]
     ) {
         self.gisuId = gisuId

--- a/UMCApp/Features/Home/Domain/Sources/Models/PointLog.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/PointLog.swift
@@ -15,13 +15,18 @@ public struct PointLog: Identifiable, Equatable, Sendable {
     public let reason: String
     /// 표시용 날짜 문자열 (예: "07.09")
     public let date: String
-    public let point: Int
+    /// 상벌점 값. 서버가 `-0.5` 같은 소수 배점을 내려주므로 `Double`로 유지한다.
+    ///
+    /// 절대 규칙 #2(서버 응답 "정수"는 전 레이어 `String`)의 대상이 아니다. 원본
+    /// ``ProfileChallengerPoint/point``가 `Double`이라 `String`으로 감싸면 합산·`abs`마다
+    /// 파싱이 필요하고, 실패 시 값이 사라진다. 손실 없이 그대로 옮기는 쪽이 단순하고 안전하다.
+    public let point: Double
     /// 상벌점 여부 (`true`: 상점, `false`: 벌점)
     public let isReward: Bool
 
     // MARK: - Init
 
-    public init(id: String, reason: String, date: String, point: Int, isReward: Bool) {
+    public init(id: String, reason: String, date: String, point: Double, isReward: Bool) {
         self.id = id
         self.reason = reason
         self.date = date

--- a/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleCapabilities.swift
+++ b/UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleCapabilities.swift
@@ -21,15 +21,15 @@ public struct ScheduleCapabilities: Equatable, Sendable {
     /// 출석 정책을 포함한 일정을 만들 수 있는지 여부 (운영진 `true` / 일반 챌린저 `false`)
     public let canCreateAttendanceRequiredSchedule: Bool
 
-    /// 직책별 최대 초대 가능 인원
-    public let maxParticipantCount: Int
+    /// 직책별 최대 초대 가능 인원. 서버 정수를 절대 규칙 #2에 따라 `String`으로 보존한다.
+    public let maxParticipantCount: String
 
     // MARK: - Init
 
     public init(
         canCreateSchedule: Bool,
         canCreateAttendanceRequiredSchedule: Bool,
-        maxParticipantCount: Int
+        maxParticipantCount: String
     ) {
         self.canCreateSchedule = canCreateSchedule
         self.canCreateAttendanceRequiredSchedule = canCreateAttendanceRequiredSchedule

--- a/UMCApp/Features/Home/Presentation/Sources/Components/AttendancePolicyDisplaySection.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/AttendancePolicyDisplaySection.swift
@@ -173,6 +173,7 @@ struct AttendancePolicyDisplaySection: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview {
     let now = Date()
     ScrollView {
@@ -186,3 +187,4 @@ struct AttendancePolicyDisplaySection: View, Equatable {
         .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
     }
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/CalendarGridCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/CalendarGridCard.swift
@@ -137,6 +137,7 @@ struct CalendarGridCard: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     @Previewable @State var selectedDate: Date = .now
     @Previewable @State var month: Date = .now
@@ -148,3 +149,4 @@ struct CalendarGridCard: View, Equatable {
     )
     .padding()
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/CalendarHorizonCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/CalendarHorizonCard.swift
@@ -100,6 +100,7 @@ struct CalendarHorizonCard: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     @Previewable @State var selectedDate: Date = .now
     @Previewable @State var month: Date = .now
@@ -110,3 +111,4 @@ struct CalendarHorizonCard: View, Equatable {
         scheduledDates: [.now, .now.addingTimeInterval(60 * 60 * 24 * 3)]
     )
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/DateCell.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/DateCell.swift
@@ -65,6 +65,7 @@ struct DateCell: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     HStack(spacing: DefaultSpacing.spacing8) {
         DateCell(date: .now, isSelected: true, hasSchedule: true, isToday: true)
@@ -73,3 +74,4 @@ struct DateCell: View {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/DatePill.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/DatePill.swift
@@ -88,6 +88,7 @@ struct DatePill: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     HStack(spacing: DefaultSpacing.spacing12) {
         DatePill(date: .now, isSelected: true, hasSchedule: true, isToday: true) {}
@@ -96,3 +97,4 @@ struct DatePill: View {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/ScheduleHeader.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/Calendar/ScheduleHeader.swift
@@ -154,6 +154,7 @@ fileprivate struct DateSheetPicker: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     @Previewable @State var month: Date = .now
     @Previewable @State var selectedDate: Date = .now
@@ -162,3 +163,4 @@ fileprivate struct DateSheetPicker: View {
     ScheduleHeader(month: $month, selectedDate: $selectedDate, scheduleMode: $scheduleMode)
         .padding()
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/PenaltyCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/PenaltyCard.swift
@@ -1,7 +1,13 @@
 import Charts
 import CoreDesignSystem
+import Foundation
 import HomeDomain
 import SwiftUI
+
+/// 상벌점 표시 문자열. 정수 배점은 `2`, 소수 배점은 `0.5`로 표시한다.
+private func pointText(_ value: Double) -> String {
+    value.formatted(.number.precision(.fractionLength(0...1)))
+}
 
 /// 홈 화면 상벌점 카드
 ///
@@ -22,8 +28,8 @@ struct PenaltyCard: View, Equatable {
     @State private var isHorizontalDrag: Bool?
     /// 팝오버 필터 (nil이면 닫힘)
     @State private var popoverFilter: PointLogFilter?
-    /// chartAngleSelection 선택 값
-    @State private var selectedChartAngle: Int?
+    /// chartAngleSelection 선택 값 (각도 스케일이 `Double`이라 바인딩 타입도 맞춘다)
+    @State private var selectedChartAngle: Double?
 
     fileprivate enum PointLogFilter {
         case reward
@@ -136,7 +142,7 @@ struct PenaltyCard: View, Equatable {
 
                     if !hasData {
                         SectorMark(
-                            angle: .value("없음", 1),
+                            angle: .value("없음", 1.0),
                             innerRadius: .ratio(Constants.innerRadius)
                         )
                         .foregroundStyle(Color.grey200)
@@ -151,7 +157,7 @@ struct PenaltyCard: View, Equatable {
                 }
 
                 VStack(spacing: 2) {
-                    Text("\(generation.rewardPoint + generation.penaltyPoint)")
+                    Text(pointText(generation.rewardPoint + generation.penaltyPoint))
                         .appFont(.title2, weight: .semibold, color: .grey900)
                     Text("총점")
                         .appFont(.caption2, color: .grey500)
@@ -182,7 +188,7 @@ struct PenaltyCard: View, Equatable {
     }
 
     /// 범례 라벨
-    private func legendLabel(color: Color, label: String, value: Int) -> some View {
+    private func legendLabel(color: Color, label: String, value: Double) -> some View {
         HStack(spacing: DefaultSpacing.spacing8) {
             Circle()
                 .fill(color)
@@ -190,7 +196,7 @@ struct PenaltyCard: View, Equatable {
             Text(label)
                 .appFont(.subheadline, color: .grey600)
             Spacer()
-            Text("\(value)")
+            Text(pointText(value))
                 .appFont(.callout, weight: .semibold, color: .grey900)
         }
     }
@@ -280,7 +286,7 @@ fileprivate struct PointLogPopover: View {
 
                     Spacer()
 
-                    Text(log.isReward ? "+\(abs(log.point))" : "-\(abs(log.point))")
+                    Text((log.isReward ? "+" : "-") + pointText(abs(log.point)))
                         .appFont(.subheadline, color: log.isReward ? .indigo500 : .indigo300)
 
                     Text(log.date)
@@ -347,6 +353,7 @@ fileprivate struct GenTabBar: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     PenaltyCard(generations: [
         HomeGeneration(
@@ -379,3 +386,4 @@ fileprivate struct GenTabBar: View {
     ])
     .padding()
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/RecentNoticeCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/RecentNoticeCard.swift
@@ -106,6 +106,7 @@ struct RecentNoticeCard: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     VStack(spacing: DefaultSpacing.spacing12) {
         RecentNoticeCard(notice: NoticeItemModel(
@@ -142,3 +143,4 @@ struct RecentNoticeCard: View {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleCard.swift
@@ -82,6 +82,7 @@ struct ScheduleCard: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     ScheduleCard(
         selectedDate: .constant(.now),
@@ -90,3 +91,4 @@ struct ScheduleCard: View, Equatable {
     )
     .padding()
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleListCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/ScheduleListCard.swift
@@ -77,6 +77,7 @@ struct ScheduleListCard: View, Equatable {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     VStack {
         ScheduleListCard(
@@ -106,3 +107,4 @@ struct ScheduleListCard: View, Equatable {
     }
     .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/Components/SeasonCard.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Components/SeasonCard.swift
@@ -10,7 +10,10 @@ import HomeDomain
 import SwiftUI
 
 /// 홈 화면 시즌 카드 — 소속 기수 목록 또는 누적 활동일을 표시한다.
-struct SeasonCard: View {
+///
+/// 홈 스크롤/상태 갱신마다 재평가되지만 표시 값은 프로필 재조회 때만 바뀌므로,
+/// `Equatable`로 불필요한 body 재계산을 걸러낸다 (호출부에서 `.equatable()` 적용).
+struct SeasonCard: View, Equatable {
 
     // MARK: - Property
 
@@ -88,6 +91,7 @@ struct SeasonCard: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     HStack(spacing: DefaultSpacing.spacing12) {
         SeasonCard(seasonType: .gens(["11", "12"]))
@@ -95,3 +99,4 @@ struct SeasonCard: View {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift
@@ -42,11 +42,19 @@ public final class HomeViewModel {
         Set(scheduleByDates.keys)
     }
 
+    /// 진행 중인 일정 조회/분류 작업의 세대. 월 이동이나 초기화로 요청이 새로 시작되면 증가시켜,
+    /// 뒤늦게 도착한 이전 달 결과가 현재 화면을 덮어쓰지 않게 한다.
+    /// 뷰가 읽지 않는 내부 상태이므로 관찰 대상에서 제외한다.
+    @ObservationIgnored
+    private var scheduleRequestGeneration = 0
+
     private let fetchMyProfileUseCase: FetchHomeProfileUseCaseProtocol
     private let fetchRecentNoticesUseCase: FetchRecentNoticesUseCaseProtocol
     private let fetchMySchedulesUseCase: FetchSchedulesUseCaseProtocol
     private let classifyScheduleUseCase: ClassifyScheduleUseCaseProtocol
     private let challengerGenRepository: ChallengerGenRepositoryProtocol
+    private let fetchMemberProfileUseCase: FetchMemberProfileUseCaseProtocol
+    private let syncProfileStorageUseCase: SyncProfileStorageUseCaseProtocol
 
     // MARK: - Init
 
@@ -56,6 +64,8 @@ public final class HomeViewModel {
         fetchMySchedulesUseCase = container.resolve(FetchSchedulesUseCaseProtocol.self)
         classifyScheduleUseCase = container.resolve(ClassifyScheduleUseCaseProtocol.self)
         challengerGenRepository = container.resolve(ChallengerGenRepositoryProtocol.self)
+        fetchMemberProfileUseCase = container.resolve(FetchMemberProfileUseCaseProtocol.self)
+        syncProfileStorageUseCase = container.resolve(SyncProfileStorageUseCaseProtocol.self)
     }
 
     // MARK: - Function
@@ -84,6 +94,7 @@ public final class HomeViewModel {
             seasonState = .loaded(profile.seasonTypes)
             generationState = .loaded(sortedGenerations)
             syncGenerationMappings(sortedGenerations)
+            await syncProfileStorage()
             await fetchRecentNotices(latestGisuId: sortedGenerations.first?.gisuId)
         } catch is CancellationError {
             seasonState = previousSeasonState
@@ -97,6 +108,19 @@ public final class HomeViewModel {
         } catch {
             setFailed(.unknown(message: error.localizedDescription))
         }
+    }
+
+    /// 최근 공지 섹션의 재시도 진입점.
+    ///
+    /// 최근 공지는 프로필의 최신 기수에 종속되므로, 기수 정보가 아직 없으면(프로필 조회 실패 등)
+    /// 프로필부터 다시 받아야 재조회가 의미를 가진다.
+    public func retryRecentNotices() async {
+        guard case .loaded(let generations) = generationState,
+              let latestGisuId = generations.first?.gisuId else {
+            await fetchProfile()
+            return
+        }
+        await fetchRecentNotices(latestGisuId: latestGisuId)
     }
 
     /// 월별 일정 조회 (KST 기준 월초/월말로 변환해 V2 일정 목록 API를 호출한다).
@@ -113,6 +137,9 @@ public final class HomeViewModel {
         let targetYear = year ?? calendar.component(.year, from: now)
         let targetMonth = month ?? calendar.component(.month, from: now)
 
+        scheduleRequestGeneration += 1
+        let generation = scheduleRequestGeneration
+
         guard
             let startOfMonth = calendar.date(from: DateComponents(year: targetYear, month: targetMonth, day: 1)),
             let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth)
@@ -122,13 +149,16 @@ public final class HomeViewModel {
         }
 
         do {
-            scheduleByDates = try await fetchMySchedulesUseCase.execute(
+            let schedules = try await fetchMySchedulesUseCase.execute(
                 from: startOfMonth.kstStartOfDay,
                 to: endOfMonth.kstEndOfDay,
                 isAttendanceRequired: false
             )
-            await classifySchedules(scheduleByDates.values.flatMap { $0 })
+            guard generation == scheduleRequestGeneration else { return }
+            scheduleByDates = schedules
+            await classifySchedules(schedules.values.flatMap { $0 }, generation: generation)
         } catch {
+            guard generation == scheduleRequestGeneration else { return }
             clearSchedules()
         }
     }
@@ -143,7 +173,31 @@ public final class HomeViewModel {
         scheduleCategories[scheduleId] ?? .general
     }
 
+    /// 주어진 일정들의 아이콘 분류가 모두 끝났는지 여부.
+    ///
+    /// 분류 전에는 전부 `.general`로 그려졌다가 아이콘이 뒤늦게 바뀌는 깜빡임이 생기므로, 뷰는
+    /// 이 값으로 리스트 렌더를 잠깐 보류한다. 화면에 실제로 보이는 일정만 넘겨야 한다 —
+    /// 월 전체를 기준으로 잡으면 첫 렌더가 그만큼 늦어진다.
+    public func areCategoriesReady(for schedules: [ScheduleDetailData]) -> Bool {
+        schedules.allSatisfy { scheduleCategories[$0.scheduleId] != nil }
+    }
+
     // MARK: - Private Function
+
+    /// 정본 프로필을 로컬 저장소(`UserDefaults`/`UserSessionManager`)에 반영한다.
+    ///
+    /// 역할·기수·지부 등 다른 탭이 `AppStorageKey`로 읽는 값들은 로그인 시점에만 기록되므로,
+    /// 세션 도중 서버에서 바뀐 정보(역할 승격 등)는 홈 진입 때 다시 맞춰줘야 한다.
+    /// 홈 프로필 조회가 이미 세션 캐시를 채운 뒤이므로 여기서 추가 왕복은 발생하지 않는다.
+    /// 동기화 실패는 홈 표시에 치명적이지 않으므로 로그만 남긴다.
+    private func syncProfileStorage() async {
+        do {
+            let profile = try await fetchMemberProfileUseCase.execute()
+            syncProfileStorageUseCase.execute(profile: profile)
+        } catch {
+            logger.error("프로필 로컬 저장 동기화 실패: \(error.localizedDescription)")
+        }
+    }
 
     /// 프로필의 기수 목록을 (gen, gisuId) 로컬 매핑에 반영하고 갱신을 브로드캐스트한다.
     /// 공지 탭이 기수 필터를 이 매핑으로 구성하므로, 홈 프로필 조회가 유일한 생산자다.
@@ -165,28 +219,51 @@ public final class HomeViewModel {
     ///
     /// 결과는 로컬 딕셔너리에 누적한 뒤 한 번만 할당한다. 뷰 무효화가 일정 수만큼 쪼개지는 것을
     /// 막고, 현재 일정 집합으로 새로 구성하므로 이전 달 분류 결과가 함께 pruning된다.
-    private func classifySchedules(_ schedules: [ScheduleDetailData]) async {
-        var categories: [String: ScheduleIconCategory] = [:]
+    ///
+    /// 분류는 일정마다 독립적이므로 병렬로 돌린다 — 순차 처리하면 CoreML 추론 지연이 일정 수만큼
+    /// 누적돼 리스트 첫 렌더가 그만큼 밀린다.
+    private func classifySchedules(
+        _ schedules: [ScheduleDetailData],
+        generation: Int
+    ) async {
+        // UseCase 프로토콜에 `Sendable` 표기가 없지만, 구현체의 분류 캐시는 락으로 보호되고
+        // CoreML 추론도 동시 호출이 안전하므로 병렬 태스크로 넘겨도 된다.
+        nonisolated(unsafe) let useCase = classifyScheduleUseCase
 
-        for schedule in schedules {
-            categories[schedule.scheduleId] = await classifyScheduleUseCase.execute(
-                title: schedule.name
-            )
+        var categories: [String: ScheduleIconCategory] = [:]
+        await withTaskGroup(of: (String, ScheduleIconCategory).self) { group in
+            for schedule in schedules {
+                group.addTask {
+                    let category = await useCase.execute(title: schedule.name)
+                    return (schedule.scheduleId, category)
+                }
+            }
+
+            for await (scheduleId, category) in group {
+                categories[scheduleId] = category
+            }
         }
 
+        guard generation == scheduleRequestGeneration else { return }
         scheduleCategories = categories
     }
 
     /// 일정 조회가 불가능하거나 실패했을 때의 degrade 처리. 캘린더는 흐름을 막지 않아야 하므로
     /// 일정과 분류 결과를 함께 비운다 (UseCase 레이어의 분류 캐시는 유지된다).
     private func clearSchedules() {
+        scheduleRequestGeneration += 1
         scheduleByDates = [:]
         scheduleCategories = [:]
     }
 
     /// 최신 기수의 최근 공지 5건을 조회한다. 소속 기수가 없으면 빈 목록으로 처리한다.
+    ///
+    /// 프로필 응답에 기수가 비어 있어도 직전 세션에서 저장된 기수가 남아 있으면 공지를 보여줄 수
+    /// 있으므로, 로컬 저장값을 폴백으로 쓴다.
     private func fetchRecentNotices(latestGisuId: String?) async {
-        guard let gisuId = latestGisuId, !gisuId.isEmpty else {
+        let resolvedGisuId = latestGisuId.flatMap { $0.isEmpty ? nil : $0 }
+            ?? AppStorageKey.gisuIdString()
+        guard let gisuId = resolvedGisuId else {
             recentNoticeState = .loaded([])
             return
         }

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift
@@ -49,6 +49,14 @@ final class ScheduleDetailViewModel {
         return Date() >= schedule.startsAt
     }
 
+    /// 수정 진입을 열어도 되는지 여부.
+    ///
+    /// 권한이 있어도 이미 시작된 일정은 서버가 `SCHEDULE-0028` 로 거부하므로, 편집 화면을 다 채운
+    /// 뒤 저장 단계에서 튕기지 않도록 진입 자체를 막는다.
+    var isEditActionEnabled: Bool {
+        canEditSchedule && !isScheduleStarted
+    }
+
     /// 출석 현황 화면으로 진입할 수 있는지 여부.
     ///
     /// 출석 현황은 운영진 화면이므로 Admin 모드일 때만, 그리고 출석 정책이 붙은 일정에만 연다.

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel+AI.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel+AI.swift
@@ -34,7 +34,14 @@ extension ScheduleRegistrationViewModel {
     func requestAIAutofill() async {
         let rawText = aiRawInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !rawText.isEmpty, !aiAutofillState.isLoading else { return }
-        guard case .available = SystemLanguageModel.default.availability else { return }
+        // 툴바 진입 버튼이 이미 가용성으로 가려져 있어 보통은 여기까지 오지 않는다. 시트를 연 뒤
+        // 설정에서 Apple Intelligence 가 꺼질 수 있어 마지막 방어선으로 남긴다.
+        guard case .available = SystemLanguageModel.default.availability else {
+            aiAutofillState = .failed(
+                .unknown(message: "이 기기에서는 Apple Intelligence를 사용할 수 없습니다.")
+            )
+            return
+        }
 
         aiAutofillState = .loading
 
@@ -45,11 +52,8 @@ extension ScheduleRegistrationViewModel {
             await persistDailyTokenUsage(session: session)
             aiAutofillState = .loaded(true)
         } catch {
-            aiAutofillState = .idle
-            errorHandler?.handle(error, context: ErrorContext(
-                feature: "Home",
-                action: "requestAIAutofill"
-            ))
+            // 시트를 띄운 채 문장을 고쳐 바로 재시도할 수 있도록 전역 Alert 대신 인라인으로 알린다.
+            aiAutofillState = .failed(.unknown(message: error.localizedDescription))
         }
     }
 

--- a/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import CoreDI
+import CoreDomain
 import Foundation
 import HomeDomain
 import SwiftData
@@ -27,6 +28,10 @@ final class ScheduleRegistrationViewModel {
     private let generateScheduleUseCase: GenerateScheduleUseCaseProtocol
     private let updateScheduleUseCase: UpdateScheduleUseCaseProtocol
     private let classifyScheduleUseCase: ClassifyScheduleUseCaseProtocol
+    private let fetchScheduleCapabilitiesUseCase: FetchScheduleCapabilitiesUseCaseProtocol
+
+    /// 현재 로그인한 사용자의 멤버 식별자. 작성자를 참여자에 강제로 포함할 때 쓴다.
+    private let currentMemberId: String?
 
     /// 전역 에러 핸들러. 뷰가 Environment 값을 넘겨준다.
     var errorHandler: ErrorHandler?
@@ -79,6 +84,14 @@ final class ScheduleRegistrationViewModel {
 
     var alertPrompt: AlertPrompt?
 
+    // MARK: - Participant Property
+
+    /// 초대할 참여자 목록. 수정 모드에서는 기존 참여자로 채워진다.
+    private(set) var participants: [ChallengerInfo] = []
+
+    /// 서버가 내려준 일정 생성 권한. `nil` 은 "아직 모름"(미조회 또는 조회 실패)이다.
+    private(set) var capabilities: ScheduleCapabilities?
+
     // MARK: - Attendance Policy Property
 
     var isAttendanceRequired: Bool = false
@@ -118,7 +131,40 @@ final class ScheduleRegistrationViewModel {
     var canSubmit: Bool {
         guard !trimmedTitle.isEmpty, !sanitizedTags.isEmpty else { return false }
         guard attendancePolicyErrorMessage == nil else { return false }
+        guard participantOverflowMessage == nil else { return false }
         return isOnline || hasValidPlace
+    }
+
+    /// 출석 정책 섹션을 노출할지 여부.
+    ///
+    /// 권한을 모르는 동안(미조회·조회 실패)에는 기존처럼 노출한다. 조회 실패로 섹션을 잠그면
+    /// 권한 있는 운영진까지 출석 일정을 못 만들고, 어차피 최종 판정은 서버가 한다.
+    /// 이미 출석 정책이 붙은 일정은 권한과 무관하게 열어 해제 경로를 남긴다.
+    var showsAttendancePolicySection: Bool {
+        guard !isAllDay else { return false }
+        let isPermitted = capabilities?.canCreateAttendanceRequiredSchedule ?? true
+        return isPermitted || initialIsAttendanceRequired
+    }
+
+    /// 초대 가능 인원 상한. 권한을 모르거나 서버가 0 을 주면 상한 없음으로 본다.
+    var maxParticipantCount: Int? {
+        guard let raw = capabilities?.maxParticipantCount,
+              let limit = Int(raw), limit > 0
+        else { return nil }
+        return limit
+    }
+
+    /// 작성자를 포함해 실제로 서버에 나갈 인원 수 (상한 검사·화면 표시 공통 기준).
+    var selectedParticipantCount: Int {
+        submitParticipantMemberIds.count
+    }
+
+    /// 초대 인원이 상한을 넘었을 때의 인라인 안내. `nil` 이면 통과.
+    var participantOverflowMessage: String? {
+        guard let limit = maxParticipantCount, selectedParticipantCount > limit else {
+            return nil
+        }
+        return "최대 \(limit)명까지 초대할 수 있습니다. 현재 \(selectedParticipantCount)명 선택됨."
     }
 
     /// 대면 일정에 필요한 장소 정보(이름 + 실좌표)가 모두 갖춰졌는지.
@@ -184,6 +230,24 @@ final class ScheduleRegistrationViewModel {
         )
     }
 
+    /// 송신용 참여자 식별자 목록 — 작성자 본인을 항상 포함한다.
+    ///
+    /// 작성자가 빠지면 방금 만든 일정에 본인이 참여자로 없어 내 일정 목록에서 사라진다.
+    private var submitParticipantMemberIds: [String] {
+        var memberIds = Set(participants.map(\.memberId).filter { !$0.isEmpty })
+        if let currentMemberId, !currentMemberId.isEmpty {
+            memberIds.insert(currentMemberId)
+        }
+        return memberIds.sorted()
+    }
+
+    /// 수정 모드 PATCH 의 참여자 목록. 변화가 없으면 `nil` 로 필드를 빼 서버 값을 보존한다.
+    private var participantTransitionValue: [String]? {
+        guard let initialEditSnapshot else { return nil }
+        let current = submitParticipantMemberIds
+        return initialEditSnapshot.participantMemberIds == current ? nil : current
+    }
+
     /// 수정 모드 PATCH 의 출석 필수 전환 플래그. 변화가 없으면 `nil` 로 필드를 빼 기존 상태를 둔다.
     private var attendanceRequiredTransitionFlag: Bool? {
         initialIsAttendanceRequired == isAttendanceRequired ? nil : isAttendanceRequired
@@ -197,11 +261,37 @@ final class ScheduleRegistrationViewModel {
 
     // MARK: - Init
 
-    init(container: DIContainer) {
+    /// - Parameters:
+    ///   - container: UseCase 를 resolve 할 DI 컨테이너
+    ///   - currentMemberId: 작성자 강제 포함에 쓰는 멤버 식별자. 기본값은 로그인 세션 값이다.
+    init(container: DIContainer, currentMemberId: String? = AppStorageKey.memberIdString()) {
         generateScheduleUseCase = container.resolve(GenerateScheduleUseCaseProtocol.self)
         updateScheduleUseCase = container.resolve(UpdateScheduleUseCaseProtocol.self)
         classifyScheduleUseCase = container.resolve(ClassifyScheduleUseCaseProtocol.self)
+        fetchScheduleCapabilitiesUseCase = container.resolve(
+            FetchScheduleCapabilitiesUseCaseProtocol.self
+        )
+        self.currentMemberId = currentMemberId
         prefillAttendancePolicyIfNeeded()
+    }
+
+    // MARK: - Capabilities
+
+    /// 서버에서 일정 생성 권한을 받아 온다. 화면 진입 시 한 번 호출한다.
+    ///
+    /// 조회에 실패해도 화면을 막지 않는다. 권한은 "모름"으로 남아 토글 노출·상한 검사가 기존
+    /// 동작을 유지하고, 최종 거부는 서버 응답으로 처리한다.
+    func loadCapabilities() async {
+        guard let loaded = try? await fetchScheduleCapabilitiesUseCase.execute() else { return }
+        capabilities = loaded
+
+        // 권한이 없는데 토글이 켜져 있으면 내린다. 단 진입 시점부터 출석 필수였던 일정은 두는데,
+        // 여기서 내리면 PATCH 가 해제로 나가 서버의 기존 출석 데이터가 지워지기 때문이다.
+        guard !loaded.canCreateAttendanceRequiredSchedule, !initialIsAttendanceRequired else {
+            return
+        }
+        isAttendanceRequired = false
+        validateAttendancePolicy()
     }
 
     // MARK: - Prefill
@@ -225,8 +315,7 @@ final class ScheduleRegistrationViewModel {
         tags = detail.tags.compactMap(Self.scheduleTag(from:))
         isTagManuallyOverridden = !tags.isEmpty
 
-        // ponytail: 참여자 선택은 SelectedChallengerView 가 ActivityPresentation internal 이라
-        // 제외 — 공용 승격 후 결선. 수정 시 participantMemberIds 는 nil 로 보내 서버 값을 보존한다.
+        participants = detail.participants.map(Self.challengerInfo(from:))
 
         if let policy = detail.attendancePolicy {
             isAttendanceRequired = true
@@ -252,6 +341,23 @@ final class ScheduleRegistrationViewModel {
             ?? ScheduleIconCategory.selectableCases.first { $0.korean == normalized }
         guard let matched, !matched.isDeprecated else { return nil }
         return matched
+    }
+
+    /// 일정 상세의 참여자를 참여자 선택 UI 가 쓰는 모델로 옮긴다.
+    ///
+    /// 일정 응답에는 기수·파트가 없다. 두 값은 선택 UI 의 행 식별 키에만 쓰이고 서버로 나가는
+    /// 값(`memberId`)에는 영향이 없어 비운 채로 둔다. 그래서 검색으로 같은 사람을 다시 고르면
+    /// 키가 달라지는데, 중복은 ``updateParticipants(_:)`` 가 `memberId` 기준으로 접는다.
+    private static func challengerInfo(from participant: ScheduleParticipant) -> ChallengerInfo {
+        ChallengerInfo(
+            memberId: participant.memberId,
+            gen: "",
+            name: participant.name,
+            nickname: participant.nickname,
+            schoolName: participant.schoolName,
+            profileImage: participant.profileImageUrl.isEmpty ? nil : participant.profileImageUrl,
+            part: .admin
+        )
     }
 
     // MARK: - Input Function
@@ -288,6 +394,15 @@ final class ScheduleRegistrationViewModel {
 
         tags = sanitized
         isTagManuallyOverridden = !sanitized.isEmpty
+    }
+
+    /// 참여자 선택 결과를 반영한다.
+    ///
+    /// 프리필로 만든 항목은 기수·파트가 비어 있어 검색 결과와 행 식별 키가 다르다. 같은 사람이
+    /// 두 줄로 남지 않도록 `memberId` 기준으로 접는다.
+    func updateParticipants(_ newParticipants: [ChallengerInfo]) {
+        var seenMemberIds: Set<String> = []
+        participants = newParticipants.filter { seenMemberIds.insert($0.memberId).inserted }
     }
 
     /// 장소 선택 결과를 반영한다.
@@ -438,9 +553,7 @@ final class ScheduleRegistrationViewModel {
             startsAt: effectiveStartsAt,
             endsAt: effectiveEndsAt,
             location: submitLocation,
-            // ponytail: 참여자 선택은 SelectedChallengerView 가 ActivityPresentation internal
-            // 이라 제외 — 공용 승격 후 결선.
-            participantMemberIds: [],
+            participantMemberIds: submitParticipantMemberIds,
             tags: sanitizedTags.map(\.rawValue),
             attendancePolicy: submitAttendancePolicy
         )
@@ -484,8 +597,7 @@ final class ScheduleRegistrationViewModel {
             startsAt: effectiveStartsAt,
             endsAt: effectiveEndsAt,
             location: submitLocation,
-            // ponytail: 참여자 선택 UI 를 이식하지 않아 nil(변경 없음)로 서버 값을 보존한다.
-            participantMemberIds: nil,
+            participantMemberIds: participantTransitionValue,
             tags: sanitizedTags.map(\.rawValue),
             attendancePolicy: submitAttendancePolicy,
             isOnline: isOnlineTransitionFlag,
@@ -525,6 +637,7 @@ final class ScheduleRegistrationViewModel {
             endDate: endDate,
             memo: memo,
             tags: sanitizedTags.map(\.rawValue).sorted(),
+            participantMemberIds: submitParticipantMemberIds,
             isAttendanceRequired: isAttendanceRequired,
             checkInStartAt: attendanceCheckInStartAt,
             onTimeEndAt: attendanceOnTimeEndAt,
@@ -545,6 +658,7 @@ final class ScheduleRegistrationViewModel {
         let endDate: Date
         let memo: String
         let tags: [String]
+        let participantMemberIds: [String]
         let isAttendanceRequired: Bool
         let checkInStartAt: Date
         let onTimeEndAt: Date

--- a/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift
@@ -35,6 +35,8 @@ struct HomeView: View {
     @State private var viewModel: HomeViewModel
     @State private var selectedDate: Date = .now
     @State private var currentMonth: Date = .now
+    @State private var isRetryingProfile = false
+    @State private var isRetryingRecentNotice = false
     private let onNoticeSelected: (NoticeDetail) -> Void
     private let onScheduleSelected: (String) -> Void
     private let onAlarmHistoryTapped: () -> Void
@@ -44,9 +46,7 @@ struct HomeView: View {
     // MARK: - Constants
 
     fileprivate enum Constants {
-        static let seasonPlaceholderHeight: CGFloat = 120
-        static let penaltyPlaceholderHeight: CGFloat = 240
-        static let recentNoticePlaceholderHeight: CGFloat = 280
+        static let schedulePlaceholderHeight: CGFloat = 120
     }
 
     // MARK: - Init
@@ -128,7 +128,7 @@ struct HomeView: View {
     private var seasonSection: some View {
         switch viewModel.seasonState {
         case .idle, .loading:
-            loadingPlaceholder(height: Constants.seasonPlaceholderHeight)
+            LoadingView(.home(.seasonLoading))
         case .loaded(let seasonTypes):
             seasonLoaded(seasonTypes)
         case .failed:
@@ -136,8 +136,8 @@ struct HomeView: View {
                 title: "홈 정보를 불러오지 못했어요",
                 systemImage: "exclamationmark.triangle",
                 description: "네트워크 상태를 확인한 뒤 다시 시도해주세요.",
-                isRetrying: false,
-                retryAction: { await viewModel.fetchProfile() }
+                isRetrying: isRetryingProfile,
+                retryAction: { await retryProfile() }
             )
         }
     }
@@ -146,6 +146,7 @@ struct HomeView: View {
         HStack(spacing: DefaultSpacing.spacing12) {
             ForEach(Array(seasonTypes.enumerated()), id: \.offset) { _, seasonType in
                 SeasonCard(seasonType: seasonType)
+                    .equatable()
             }
             Spacer(minLength: 0)
         }
@@ -158,7 +159,7 @@ struct HomeView: View {
     private var generationSection: some View {
         switch viewModel.generationState {
         case .idle, .loading:
-            loadingPlaceholder(height: Constants.penaltyPlaceholderHeight)
+            LoadingView(.home(.penaltyLoading))
         case .loaded(let generations):
             generationLoaded(generations)
         case .failed:
@@ -202,16 +203,29 @@ struct HomeView: View {
 
     // MARK: - Recent Notice Section
 
-    /// 최근 공지 섹션. 프로필 조회에 종속되므로 실패 안내는 `seasonSection`이 대표한다.
-    @ViewBuilder
+    /// 최근 공지 섹션.
+    ///
+    /// 헤더는 상태와 무관하게 항상 보여준다 — 실패 시 섹션이 통째로 사라지면 사용자는
+    /// 공지가 없는 것인지 못 불러온 것인지 구분할 수 없다.
     private var recentNoticeSection: some View {
-        switch viewModel.recentNoticeState {
-        case .idle, .loading:
-            loadingPlaceholder(height: Constants.recentNoticePlaceholderHeight)
-        case .loaded(let notices):
-            recentNoticeLoaded(notices)
-        case .failed:
-            EmptyView()
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
+            Text("최근 공지")
+                .appFont(.title3, weight: .semibold, color: .grey900)
+
+            switch viewModel.recentNoticeState {
+            case .idle, .loading:
+                LoadingView(.home(.recentNoticeLoading))
+            case .loaded(let notices):
+                recentNoticeLoaded(notices)
+            case .failed:
+                RetryContentUnavailableView(
+                    title: "최근 공지를 불러오지 못했어요",
+                    systemImage: "exclamationmark.triangle",
+                    description: "네트워크 상태를 확인한 뒤 다시 시도해주세요.",
+                    isRetrying: isRetryingRecentNotice,
+                    retryAction: { await retryRecentNotices() }
+                )
+            }
         }
     }
 
@@ -228,6 +242,9 @@ struct HomeView: View {
                 .regular,
                 in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
             )
+        } else if !viewModel.areCategoriesReady(for: schedules) {
+            // 분류 전에는 전부 기본 아이콘으로 그려졌다가 뒤늦게 바뀌므로, 보이는 일정만 게이트한다.
+            loadingPlaceholder(height: Constants.schedulePlaceholderHeight)
         } else {
             ForEach(schedules) { schedule in
                 Button {
@@ -246,30 +263,25 @@ struct HomeView: View {
 
     @ViewBuilder
     private func recentNoticeLoaded(_ notices: [NoticeItemModel]) -> some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing12) {
-            Text("최근 공지")
-                .appFont(.title3, weight: .semibold, color: .grey900)
-
-            if notices.isEmpty {
-                ContentUnavailableView(
-                    "최근 공지가 없습니다.",
-                    systemImage: "bell.slash",
-                    description: Text("아직 등록된 공지사항이 없습니다.")
-                )
-                .glassEffect(
-                    .regular,
-                    in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
-                )
-            } else {
-                VStack(spacing: DefaultSpacing.spacing12) {
-                    ForEach(notices) { notice in
-                        Button {
-                            onNoticeSelected(notice.toNoticeDetail())
-                        } label: {
-                            RecentNoticeCard(notice: notice)
-                        }
-                        .buttonStyle(.plain)
+        if notices.isEmpty {
+            ContentUnavailableView(
+                "최근 공지가 없습니다.",
+                systemImage: "bell.slash",
+                description: Text("아직 등록된 공지사항이 없습니다.")
+            )
+            .glassEffect(
+                .regular,
+                in: .rect(corners: .concentric(minimum: DefaultConstant.concentricRadius), isUniform: true)
+            )
+        } else {
+            VStack(spacing: DefaultSpacing.spacing12) {
+                ForEach(notices) { notice in
+                    Button {
+                        onNoticeSelected(notice.toNoticeDetail())
+                    } label: {
+                        RecentNoticeCard(notice: notice)
                     }
+                    .buttonStyle(.plain)
                 }
             }
         }
@@ -295,6 +307,20 @@ struct HomeView: View {
             year: calendar.component(.year, from: month),
             month: calendar.component(.month, from: month)
         )
+    }
+
+    private func retryProfile() async {
+        guard !isRetryingProfile else { return }
+        isRetryingProfile = true
+        defer { isRetryingProfile = false }
+        await viewModel.fetchProfile()
+    }
+
+    private func retryRecentNotices() async {
+        guard !isRetryingRecentNotice else { return }
+        isRetryingRecentNotice = true
+        defer { isRetryingRecentNotice = false }
+        await viewModel.retryRecentNotices()
     }
 
     /// 마지막 요청 이후 4주가 지났으면 앱스토어 리뷰를 요청한다.
@@ -409,6 +435,24 @@ private struct PreviewClassifyScheduleUseCase: ClassifyScheduleUseCaseProtocol {
     }
 }
 
+/// 네트워크 없이 정본 프로필을 제공하는 프리뷰 전용 UseCase (절대규칙 #5)
+private struct PreviewFetchMemberProfileUseCase: FetchMemberProfileUseCaseProtocol {
+    func execute() async throws -> Profile {
+        Profile(
+            memberId: "1",
+            name: "김유엠",
+            nickname: "umc",
+            generations: ["11", "12"],
+            latestGisuId: "10"
+        )
+    }
+}
+
+/// 실제 `UserDefaults`를 건드리지 않기 위한 프리뷰 전용 no-op 동기화 UseCase (절대규칙 #5)
+private struct PreviewSyncProfileStorageUseCase: SyncProfileStorageUseCaseProtocol {
+    func execute(profile: Profile) {}
+}
+
 /// SwiftData 저장소 없이 화면을 그리기 위한 프리뷰 전용 기수 매핑 저장소 (절대규칙 #5)
 private struct PreviewChallengerGenRepository: ChallengerGenRepositoryProtocol {
     func replaceMappings(_ pairs: [(gen: String, gisuId: String)]) throws {}
@@ -423,6 +467,12 @@ private struct PreviewChallengerGenRepository: ChallengerGenRepositoryProtocol {
     container.register(FetchSchedulesUseCaseProtocol.self) { PreviewFetchSchedulesUseCase() }
     container.register(ClassifyScheduleUseCaseProtocol.self) { PreviewClassifyScheduleUseCase() }
     container.register(ChallengerGenRepositoryProtocol.self) { PreviewChallengerGenRepository() }
+    container.register(FetchMemberProfileUseCaseProtocol.self) {
+        PreviewFetchMemberProfileUseCase()
+    }
+    container.register(SyncProfileStorageUseCaseProtocol.self) {
+        PreviewSyncProfileStorageUseCase()
+    }
     return NavigationStack {
         HomeView(container: container)
     }

--- a/UMCApp/Features/Home/Presentation/Sources/Views/Registration/ScheduleRegistrationView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/Registration/ScheduleRegistrationView.swift
@@ -5,14 +5,18 @@
 //  Created by euijjang97 on 1/22/26.
 //
 
+import ActivityDomain
+import ActivityPresentation
 import CoreDesignSystem
 import CoreDI
+import CoreDomain
 import CoreLocation
 import CoreUIComponents
 import FoundationModels
 import HomeDomain
 import SwiftData
 import SwiftUI
+import UIKit
 import UMCFoundation
 
 /// 일정 등록/수정 화면.
@@ -81,6 +85,7 @@ public struct ScheduleRegistrationView: View {
                 viewModel.errorHandler = errorHandler
                 viewModel.modelContext = modelContext
                 viewModel.restoreDailyTokenUsage()
+                await viewModel.loadCapabilities()
             }
     }
 
@@ -91,7 +96,8 @@ public struct ScheduleRegistrationView: View {
             inlineErrorSection
 
             Section {
-                titleField
+                TitleField(title: titleBinding)
+                    .equatable()
             }
 
             placeSection
@@ -106,6 +112,8 @@ public struct ScheduleRegistrationView: View {
             Section {
                 TagSelectionRow(tagList: tagBinding)
             }
+
+            participantSection
 
             Section {
                 MemoEditor(memo: $viewModel.memo)
@@ -131,18 +139,6 @@ public struct ScheduleRegistrationView: View {
                     .appFont(.subheadline, color: Color.red500)
             }
         }
-    }
-
-    private var titleField: some View {
-        TextField(
-            "",
-            text: titleBinding,
-            prompt: Text("일정 제목")
-                .foregroundStyle(Color.grey400)
-        )
-        .appFont(.body, color: Color.grey900)
-        .submitLabel(.return)
-        .tint(.indigo500)
     }
 
     private var allDayToggle: some View {
@@ -178,13 +174,10 @@ public struct ScheduleRegistrationView: View {
         dateTimeRow(title: "종료", date: $viewModel.endDate, field: .end)
     }
 
-    /// 출석 정책 입력 섹션
-    ///
-    /// ponytail: `ScheduleCapabilities` 권한 조회를 이식하지 않아 토글을 항상 노출한다. 권한이
-    /// 없는 사용자는 서버가 생성을 거부한다 — 권한 UseCase 이식 후 사전 차단으로 승격.
+    /// 출석 정책 입력 섹션. 서버 권한이 없으면 섹션 자체를 숨겨 사전 차단한다.
     @ViewBuilder
     private var attendancePolicySection: some View {
-        if !viewModel.isAllDay {
+        if viewModel.showsAttendancePolicySection {
             Section {
                 Toggle(isOn: attendanceToggleBinding) {
                     Text("출석 필수")
@@ -209,8 +202,21 @@ public struct ScheduleRegistrationView: View {
         }
     }
 
-    // ponytail: 참여자 선택은 SelectedChallengerView 가 ActivityPresentation internal 이라 제외
-    // — 공용 승격 후 결선. 최대 초대 인원 표시도 참여자 섹션과 함께 빠졌다.
+    /// 참여자 선택 + 초대 상한 초과 안내 섹션
+    private var participantSection: some View {
+        Section {
+            ParticipantSelectionRow(
+                participants: participantBinding,
+                maxParticipantCount: viewModel.maxParticipantCount,
+                selectedCount: viewModel.selectedParticipantCount
+            )
+
+            if let message = viewModel.participantOverflowMessage {
+                Text(message)
+                    .appFont(.footnote, color: Color.red500)
+            }
+        }
+    }
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
@@ -257,6 +263,13 @@ public struct ScheduleRegistrationView: View {
         Binding(
             get: { viewModel.tags },
             set: { viewModel.updateTagsFromUser($0) }
+        )
+    }
+
+    private var participantBinding: Binding<[ChallengerInfo]> {
+        Binding(
+            get: { viewModel.participants },
+            set: { viewModel.updateParticipants($0) }
         )
     }
 
@@ -370,6 +383,14 @@ public struct ScheduleRegistrationView: View {
 
     /// 같은 슬롯을 다시 누르면 접고, 다른 슬롯을 누르면 그쪽으로 옮긴다.
     private func toggleScheduleSlot(_ slot: ScheduleDateSlot) {
+        // 제목/메모 입력 중 피커를 열면 키보드가 피커를 가리므로 먼저 내린다. Form 스크롤로만
+        // 내려가는 `.scrollDismissesKeyboard` 로는 행 탭이 잡히지 않는다.
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
         withAnimation {
             openScheduleSlot = (openScheduleSlot == slot) ? nil : slot
         }
@@ -392,6 +413,100 @@ public struct ScheduleRegistrationView: View {
 
         let field: Field
         let component: Component
+    }
+}
+
+// MARK: - TitleField
+
+/// 일정 제목 입력 필드
+///
+/// 입력마다 태그 자동 추천이 돌면서 폼 전체가 다시 그려지므로, 제목이 실제로 바뀔 때만
+/// 갱신되도록 `Equatable` 로 감싼다.
+private struct TitleField: View, Equatable {
+
+    // MARK: - Property
+
+    @Binding var title: String
+
+    private enum Constants {
+        static let placeholder = "일정 제목"
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.title == rhs.title
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        TextField(
+            "",
+            text: $title,
+            prompt: Text(Constants.placeholder)
+                .foregroundStyle(Color.grey400)
+        )
+        .appFont(.body, color: Color.grey900)
+        .submitLabel(.return)
+        .tint(.indigo500)
+    }
+}
+
+// MARK: - ParticipantSelectionRow
+
+/// 참여자 선택 시트를 여는 행
+private struct ParticipantSelectionRow: View {
+
+    // MARK: - Property
+
+    @Binding var participants: [ChallengerInfo]
+
+    /// 초대 인원 상한. `nil` 이면 상한을 몰라 인원만 표시한다.
+    let maxParticipantCount: Int?
+
+    /// 작성자를 포함해 실제로 초대되는 인원 수
+    let selectedCount: Int
+
+    @State private var showsParticipantPicker: Bool = false
+
+    private enum Constants {
+        static let title = "참여자"
+        static let chevron = "chevron.right"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Button {
+            showsParticipantPicker.toggle()
+        } label: {
+            HStack {
+                Text(Constants.title)
+                    .appFont(.body, color: Color.grey900)
+
+                Spacer()
+
+                selectedCountLabel
+            }
+        }
+        .sheet(isPresented: $showsParticipantPicker) {
+            SelectedChallengerView(challenger: $participants)
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    private var selectedCountLabel: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Text(countText)
+                .appFont(.callout, color: Color.grey500)
+
+            Image(systemName: Constants.chevron)
+                .foregroundStyle(Color.grey500)
+        }
+    }
+
+    private var countText: String {
+        guard let maxParticipantCount else { return "\(selectedCount)명" }
+        return "\(selectedCount) / \(maxParticipantCount)"
     }
 }
 
@@ -517,6 +632,8 @@ private struct AIAutofillSheet: View {
 
                 autofillButton
 
+                failureMessage
+
                 usageFootnote
 
                 Spacer()
@@ -601,6 +718,19 @@ private struct AIAutofillSheet: View {
         .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
     }
 
+    /// 자동완성 실패 안내
+    ///
+    /// 시트 안에서 그대로 재시도할 수 있도록 전역 Alert 대신 인라인으로 보여 준다. 실패해도
+    /// 입력한 문장이 남아 있어야 사용자가 문장을 고쳐 다시 시도할 수 있다.
+    @ViewBuilder
+    private var failureMessage: some View {
+        if case .failed(let error) = viewModel.aiAutofillState {
+            Text(error.userMessage)
+                .appFont(.footnote, color: Color.red500)
+                .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        }
+    }
+
     @ViewBuilder
     private var usageFootnote: some View {
         if viewModel.aiCumulativeUsedTokens > 0 {
@@ -632,6 +762,22 @@ private struct PreviewClassifyScheduleUseCase: ClassifyScheduleUseCaseProtocol {
     func execute(title: String) async -> ScheduleIconCategory { .study }
 }
 
+private struct PreviewFetchScheduleCapabilitiesUseCase: FetchScheduleCapabilitiesUseCaseProtocol {
+    func execute() async throws -> ScheduleCapabilities {
+        ScheduleCapabilities(
+            canCreateSchedule: true,
+            canCreateAttendanceRequiredSchedule: true,
+            maxParticipantCount: "30"
+        )
+    }
+}
+
+private struct PreviewSearchChallengersUseCase: SearchChallengersUseCaseProtocol {
+    func execute(keyword: String?, cursor: Int?, size: Int) async throws -> ChallengerSearchPage {
+        ChallengerSearchPage(challengers: [], hasNext: false, nextCursor: nil)
+    }
+}
+
 #Preview("ScheduleRegistrationView") {
     let container = DIContainer()
     container.register(GenerateScheduleUseCaseProtocol.self) {
@@ -642,6 +788,13 @@ private struct PreviewClassifyScheduleUseCase: ClassifyScheduleUseCaseProtocol {
     }
     container.register(ClassifyScheduleUseCaseProtocol.self) {
         PreviewClassifyScheduleUseCase()
+    }
+    container.register(FetchScheduleCapabilitiesUseCaseProtocol.self) {
+        PreviewFetchScheduleCapabilitiesUseCase()
+    }
+    // SelectedChallengerView 가 참여자 시트에서 자체 resolve 하므로 프리뷰에도 등록이 필요하다.
+    container.register(SearchChallengersUseCaseProtocol.self) {
+        PreviewSearchChallengersUseCase()
     }
 
     return NavigationStack {

--- a/UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift
+++ b/UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift
@@ -17,6 +17,7 @@ import UMCFoundation
 ///
 /// 장소는 역지오코딩 없이 좌표 그대로 Apple Maps 로 넘긴다. 툴바 액션(수정/삭제)은 각각의
 /// 리소스 권한에 따라 독립적으로 노출하고, 수정은 편집 모드 등록 화면을 시트로 띄운다.
+/// 이미 시작된 일정은 수정 진입을 막고 그 이유를 상단 안내로 알린다.
 ///
 /// 출석 진입은 활동 모드로 갈린다. Admin 모드면 출석 현황 화면으로 이동하는 버튼을, 그 외에는
 /// 내 출석 상태를 read-only 로 보여 준다. 출석 비필수 일정은 두 경우 모두 표시하지 않는다.
@@ -43,8 +44,13 @@ public struct ScheduleDetailView: View {
         static let myAttendanceStatusTitle: String = "내 출석 상태"
         static let editActionTitle: String = "수정하기"
         static let editIcon: String = "pencil"
+        static let editBlockedLabel: String = "일정 수정 불가"
+        static let startedScheduleNotice: String = "이미 시작된 일정은 수정할 수 없습니다"
+        static let lockIcon: String = "lock.fill"
         static let deleteActionTitle: String = "삭제하기"
         static let deleteIcon: String = "trash"
+        static let deletingLabel: String = "일정 삭제 중"
+        static let menuIcon: String = "ellipsis"
         static let failedTitle: String = "일정을 불러오지 못했어요"
         static let failedSystemImage: String = "exclamationmark.triangle"
     }
@@ -109,41 +115,57 @@ public struct ScheduleDetailView: View {
 
     // MARK: - Toolbar
 
+    /// 삭제 중에는 메뉴 자리를 진행 표시로 대체한다.
+    ///
+    /// 레거시는 툴바에 놓인 휴지통 버튼만 `ProgressView` 로 갈아 끼웠지만, 여기서는 액션이
+    /// `ellipsis` 메뉴 하나로 접혀 있어 항목만 바꾸면 메뉴를 열기 전까지 진행 상황이 보이지 않는다.
+    /// 그래서 메뉴 라벨 위치를 통째로 바꿔 닫힌 상태에서도 삭제 중임이 드러나게 하고, 동시에
+    /// 메뉴가 사라지므로 중복 요청도 그대로 막힌다.
+    ///
+    /// 공용 `ToolBarCollection.ToolbarTrailingMenu` 는 항목별 비활성화·접근성 문구를 표현할 수
+    /// 없어 이 화면에서는 메뉴를 직접 구성한다.
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
-        if !toolbarActions.isEmpty {
-            ToolBarCollection.ToolbarTrailingMenu(actions: toolbarActions)
+        if viewModel.isDeleting {
+            ToolbarItem(placement: .topBarTrailing) {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(.red)
+                    .accessibilityLabel(Constants.deletingLabel)
+            }
+        } else if let detail = viewModel.data.value,
+                  viewModel.canEditSchedule || viewModel.canDeleteSchedule {
+            ToolbarItem(placement: .topBarTrailing) {
+                actionMenu(detail)
+            }
         }
     }
 
-    /// 권한별로 구성되는 툴바 액션 목록. 삭제 중에는 비워 중복 요청을 막는다.
-    private var toolbarActions: [ToolBarCollection.ToolbarTrailingMenu.ActionItem] {
-        guard let detail = viewModel.data.value, !viewModel.isDeleting else { return [] }
-
-        var actions: [ToolBarCollection.ToolbarTrailingMenu.ActionItem] = []
-
-        if viewModel.canEditSchedule {
-            actions.append(
-                .init(
-                    title: Constants.editActionTitle,
-                    icon: Constants.editIcon,
-                    action: { editingSchedule = detail }
+    private func actionMenu(_ detail: ScheduleDetailData) -> some View {
+        Menu {
+            if viewModel.canEditSchedule {
+                Button { editingSchedule = detail } label: {
+                    Label(Constants.editActionTitle, systemImage: Constants.editIcon)
+                }
+                .disabled(!viewModel.isEditActionEnabled)
+                .accessibilityLabel(
+                    viewModel.isEditActionEnabled
+                        ? Constants.editActionTitle
+                        : Constants.editBlockedLabel
                 )
-            )
-        }
-
-        if viewModel.canDeleteSchedule {
-            actions.append(
-                .init(
-                    title: Constants.deleteActionTitle,
-                    icon: Constants.deleteIcon,
-                    role: .destructive,
-                    action: viewModel.showDeleteConfirmation
+                .accessibilityHint(
+                    viewModel.isEditActionEnabled ? "" : Constants.startedScheduleNotice
                 )
-            )
-        }
+            }
 
-        return actions
+            if viewModel.canDeleteSchedule {
+                Button(role: .destructive, action: viewModel.showDeleteConfirmation) {
+                    Label(Constants.deleteActionTitle, systemImage: Constants.deleteIcon)
+                }
+            }
+        } label: {
+            Image(systemName: Constants.menuIcon)
+        }
     }
 
     // MARK: - Content
@@ -194,7 +216,17 @@ public struct ScheduleDetailView: View {
 
             SchedulePlaceDateInfo(data: data, onMapLinkTapped: viewModel.openInMaps)
                 .equatable()
+
+            if viewModel.canEditSchedule, viewModel.isScheduleStarted {
+                startedScheduleNotice
+            }
         }
+    }
+
+    /// 잠긴 수정 메뉴의 이유를 설명하는 안내. 수정 권한이 없으면 막힌 진입점 자체가 없어 띄우지 않는다.
+    private var startedScheduleNotice: some View {
+        Label(Constants.startedScheduleNotice, systemImage: Constants.lockIcon)
+            .appFont(.caption1, color: .grey500)
     }
 
     // MARK: - Attendance Section
@@ -392,7 +424,7 @@ private struct PreviewFetchScheduleDetailUseCase: FetchScheduleDetailUseCaseProt
     }
 }
 
-/// 삭제 액션을 노출하기 위한 프리뷰 전용 권한 스텁 (절대규칙 #5)
+/// 수정·삭제 액션을 노출하기 위한 프리뷰 전용 권한 스텁 (절대규칙 #5)
 private struct PreviewAuthorizationUseCase: AuthorizationUseCaseProtocol {
     func getResourcePermission(
         resourceType: AuthorizationResourceType,
@@ -401,7 +433,7 @@ private struct PreviewAuthorizationUseCase: AuthorizationUseCaseProtocol {
         ResourcePermission(
             resourceType: resourceType,
             resourceId: resourceId,
-            grantedPermissions: [.delete]
+            grantedPermissions: [.edit, .delete]
         )
     }
 }

--- a/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
+++ b/UMCApp/Features/Home/Presentation/Tests/HomeViewModelTests.swift
@@ -218,6 +218,10 @@ private func makeViewModel(
     container.register(FetchSchedulesUseCaseProtocol.self) { fetchSchedulesUseCase }
     container.register(ClassifyScheduleUseCaseProtocol.self) { classifyScheduleUseCase }
     container.register(ChallengerGenRepositoryProtocol.self) { StubChallengerGenRepository() }
+    container.register(FetchMemberProfileUseCaseProtocol.self) { StubFetchMemberProfileUseCase() }
+    container.register(SyncProfileStorageUseCaseProtocol.self) {
+        StubSyncProfileStorageUseCase()
+    }
     return HomeViewModel(container: container)
 }
 
@@ -227,6 +231,20 @@ private struct StubChallengerGenRepository: ChallengerGenRepositoryProtocol {
     func replaceMappings(_ pairs: [(gen: String, gisuId: String)]) throws {}
 
     func fetchGenGisuIdPairs() throws -> [(gen: String, gisuId: String)] { [] }
+}
+
+private struct StubFetchMemberProfileUseCase: FetchMemberProfileUseCaseProtocol {
+
+    func execute() async throws -> Profile {
+        Profile(memberId: "1", name: "테스터", nickname: "tester", generations: ["11"])
+    }
+}
+
+/// 실제 `UserDefaults`/`UserSessionManager`를 오염시키지 않도록 no-op으로 둔다
+/// (저장 규칙은 `SyncProfileStorageUseCaseTests`에서 검증).
+private struct StubSyncProfileStorageUseCase: SyncProfileStorageUseCaseProtocol {
+
+    func execute(profile: Profile) {}
 }
 
 private func makeSchedule(scheduleId: String, name: String) -> ScheduleDetailData {
@@ -300,13 +318,18 @@ private final class MockFetchSchedulesUseCase: FetchSchedulesUseCaseProtocol, @u
 }
 
 /// 제목별로 분류 결과를 주입할 수 있는 Mock. 매칭이 없으면 `.general`을 반환한다.
+///
+/// ViewModel이 분류를 병렬로 실행하므로 호출 기록은 락으로 보호한다.
 private final class MockClassifyScheduleUseCase: ClassifyScheduleUseCaseProtocol,
                                                  @unchecked Sendable {
     var resultsByTitle: [String: ScheduleIconCategory] = [:]
-    private(set) var classifiedTitles: [String] = []
+    var classifiedTitles: [String] { lock.withLock { recordedTitles } }
+
+    private let lock = NSLock()
+    private var recordedTitles: [String] = []
 
     func execute(title: String) async -> ScheduleIconCategory {
-        classifiedTitles.append(title)
+        lock.withLock { recordedTitles.append(title) }
         return resultsByTitle[title] ?? .general
     }
 }

--- a/UMCApp/Features/Home/Presentation/Tests/ScheduleDetailViewModelTests.swift
+++ b/UMCApp/Features/Home/Presentation/Tests/ScheduleDetailViewModelTests.swift
@@ -133,6 +133,57 @@ struct ScheduleDetailPermissionTests {
     }
 }
 
+@MainActor
+@Suite("ScheduleDetailViewModel — 시작된 일정 수정 차단과 삭제 진행 표시")
+struct ScheduleDetailEditGuardTests {
+
+    @Test("아직 시작하지 않은 일정은 수정 진입이 열린다")
+    func upcomingScheduleAllowsEdit() async {
+        let viewModel = makeViewModel(permissions: [.edit], startsAtOffset: 3_600)
+        await viewModel.load()
+
+        await viewModel.fetchSchedulePermission()
+
+        #expect(viewModel.isScheduleStarted == false)
+        #expect(viewModel.isEditActionEnabled)
+    }
+
+    @Test("이미 시작된 일정은 수정 권한이 있어도 진입을 막는다")
+    func startedScheduleBlocksEdit() async {
+        let viewModel = makeViewModel(permissions: [.edit], startsAtOffset: -3_600)
+        await viewModel.load()
+
+        await viewModel.fetchSchedulePermission()
+
+        #expect(viewModel.isScheduleStarted)
+        #expect(viewModel.canEditSchedule)
+        #expect(viewModel.isEditActionEnabled == false)
+    }
+
+    @Test("상세를 아직 못 불러왔으면 시작된 일정으로 단정하지 않는다")
+    func unloadedScheduleIsNotStarted() {
+        let viewModel = makeViewModel(permissions: [.edit], startsAtOffset: -3_600)
+
+        #expect(viewModel.isScheduleStarted == false)
+    }
+
+    @Test("삭제하는 동안 진행 중 상태가 노출되고 완료되면 내려간다")
+    func deletionExposesProgressState() async {
+        let probe = DeleteProgressProbe()
+        let viewModel = makeViewModel(permissions: [.delete], deleteProbe: probe)
+        probe.onExecute = { [weak viewModel, weak probe] in
+            probe?.isDeletingObserved = viewModel?.isDeleting ?? false
+        }
+        await viewModel.fetchSchedulePermission()
+
+        await viewModel.deleteSchedule()
+
+        #expect(probe.isDeletingObserved)
+        #expect(viewModel.isDeleting == false)
+        #expect(viewModel.isDeleted)
+    }
+}
+
 // MARK: - Helpers
 
 @MainActor
@@ -141,17 +192,22 @@ private func makeViewModel(
     isAdminMode: Bool = false,
     permissions: Set<AuthorizationPermissionType> = [],
     permissionFails: Bool = false,
-    deleteError: Error? = nil
+    deleteError: Error? = nil,
+    startsAtOffset: TimeInterval = 0,
+    deleteProbe: DeleteProgressProbe? = nil
 ) -> ScheduleDetailViewModel {
     let container = DIContainer()
     container.register(FetchScheduleDetailUseCaseProtocol.self) {
-        StubFetchScheduleDetailUseCase(hasAttendancePolicy: hasAttendancePolicy)
+        StubFetchScheduleDetailUseCase(
+            hasAttendancePolicy: hasAttendancePolicy,
+            startsAtOffset: startsAtOffset
+        )
     }
     container.register(AuthorizationUseCaseProtocol.self) {
         StubAuthorizationUseCase(permissions: permissions, shouldFail: permissionFails)
     }
     container.register(DeleteScheduleUseCaseProtocol.self) {
-        StubDeleteScheduleUseCase(error: deleteError)
+        StubDeleteScheduleUseCase(error: deleteError, probe: deleteProbe)
     }
     container.register(ForceDeleteScheduleUseCaseProtocol.self) {
         StubForceDeleteScheduleUseCase()
@@ -178,9 +234,10 @@ private func makeSession(isAdminMode: Bool) -> UserSessionManager {
 private struct StubFetchScheduleDetailUseCase: FetchScheduleDetailUseCaseProtocol {
 
     let hasAttendancePolicy: Bool
+    let startsAtOffset: TimeInterval
 
     func execute(scheduleId: String) async throws -> ScheduleDetailData {
-        let startsAt = Date.now
+        let startsAt = Date.now.addingTimeInterval(startsAtOffset)
         return ScheduleDetailData(
             scheduleId: scheduleId,
             name: "정기 세미나",
@@ -218,11 +275,23 @@ private struct StubAuthorizationUseCase: AuthorizationUseCaseProtocol {
     }
 }
 
+/// 삭제 UseCase 실행 도중의 `isDeleting` 을 관찰하기 위한 훅.
+///
+/// 삭제는 성공/실패 후 곧바로 플래그를 내리므로, 실행 중 시점을 잡지 않으면 진행 표시를 검증할 수 없다.
+@MainActor
+private final class DeleteProgressProbe {
+    var isDeletingObserved: Bool = false
+    var onExecute: (() -> Void)?
+}
+
 private struct StubDeleteScheduleUseCase: DeleteScheduleUseCaseProtocol {
 
     let error: Error?
+    let probe: DeleteProgressProbe?
 
     func execute(scheduleId: String) async throws {
+        let capturedProbe = probe
+        await MainActor.run { capturedProbe?.onExecute?() }
         if let error { throw error }
     }
 }

--- a/UMCApp/Features/Home/Presentation/Tests/ScheduleRegistrationViewModelTests.swift
+++ b/UMCApp/Features/Home/Presentation/Tests/ScheduleRegistrationViewModelTests.swift
@@ -1,0 +1,321 @@
+//
+//  ScheduleRegistrationViewModelTests.swift
+//  HomePresentationTests
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+import CoreDI
+import CoreDomain
+import Foundation
+import HomeDomain
+import Testing
+import UMCFoundation
+@testable import HomePresentation
+
+@MainActor
+@Suite("ScheduleRegistrationViewModel — 출석 정책 검증")
+struct ScheduleRegistrationAttendancePolicyTests {
+
+    @Test(
+        "세 시각의 순서와 일정 범위를 어기면 각각의 안내가 나온다",
+        arguments: AttendancePolicyCase.all
+    )
+    func validatesAttendancePolicy(policyCase: AttendancePolicyCase) {
+        let viewModel = makeViewModel()
+        viewModel.isAttendanceRequired = true
+        viewModel.attendanceCheckInStartAt = viewModel.startDate
+            .addingTimeInterval(policyCase.checkInOffset)
+        viewModel.attendanceOnTimeEndAt = viewModel.startDate
+            .addingTimeInterval(policyCase.onTimeOffset)
+        viewModel.attendanceLateEndAt = viewModel.startDate
+            .addingTimeInterval(policyCase.lateOffset)
+
+        viewModel.attendanceTimesChanged()
+
+        #expect(viewModel.attendancePolicyErrorMessage == policyCase.expectedMessage)
+    }
+}
+
+@MainActor
+@Suite("ScheduleRegistrationViewModel — 참여자 결선")
+struct ScheduleRegistrationParticipantTests {
+
+    @Test("아무도 고르지 않아도 생성 요청에는 작성자 본인이 들어간다")
+    func creationAlwaysIncludesAuthor() async {
+        let recorder = RequestRecorder()
+        let viewModel = makeViewModel(recorder: recorder)
+        viewModel.title = "정기 세미나"
+
+        await viewModel.submitSchedule()
+
+        #expect(recorder.creation?.participantMemberIds == ["7"])
+    }
+
+    @Test("선택한 참여자에 작성자를 더해 중복 없이 보낸다")
+    func creationMergesAuthorIntoSelection() async {
+        let recorder = RequestRecorder()
+        let viewModel = makeViewModel(recorder: recorder)
+        viewModel.updateParticipants([challenger(memberId: "10"), challenger(memberId: "7")])
+
+        await viewModel.submitSchedule()
+
+        #expect(recorder.creation?.participantMemberIds == ["10", "7"])
+    }
+
+    @Test("초대 인원이 상한을 넘으면 안내가 뜨고 저장이 막힌다")
+    func participantOverflowBlocksSubmit() async {
+        let viewModel = makeViewModel(capabilities: makeCapabilities(maxParticipantCount: "2"))
+        fillRequiredFields(of: viewModel)
+        viewModel.updateParticipants([challenger(memberId: "10"), challenger(memberId: "11")])
+
+        await viewModel.loadCapabilities()
+
+        #expect(viewModel.selectedParticipantCount == 3)
+        #expect(viewModel.participantOverflowMessage != nil)
+        #expect(viewModel.canSubmit == false)
+    }
+
+    @Test("상한 이내면 안내 없이 저장이 열린다")
+    func participantWithinLimitAllowsSubmit() async {
+        let viewModel = makeViewModel(capabilities: makeCapabilities(maxParticipantCount: "3"))
+        fillRequiredFields(of: viewModel)
+        viewModel.updateParticipants([challenger(memberId: "10"), challenger(memberId: "11")])
+
+        await viewModel.loadCapabilities()
+
+        #expect(viewModel.participantOverflowMessage == nil)
+        #expect(viewModel.canSubmit)
+    }
+}
+
+@MainActor
+@Suite("ScheduleRegistrationViewModel — 수정 모드 변경 감지와 서버 거부")
+struct ScheduleRegistrationEditModeTests {
+
+    @Test("참여자만 바뀌어도 변경 감지에 걸린다")
+    func participantChangeMarksEditDirty() {
+        let viewModel = makeViewModel()
+        viewModel.applyPrefill(from: makeDetail(participantMemberIds: ["7", "10"]))
+        #expect(viewModel.hasChangesInEditMode == false)
+
+        viewModel.updateParticipants(viewModel.participants + [challenger(memberId: "11")])
+
+        #expect(viewModel.hasChangesInEditMode)
+    }
+
+    @Test("바뀌지 않은 필드는 PATCH 요청에서 빠진다")
+    func unchangedFieldsAreOmittedFromUpdate() async {
+        let recorder = RequestRecorder()
+        let viewModel = makeViewModel(recorder: recorder)
+        viewModel.applyPrefill(from: makeDetail(participantMemberIds: ["7", "10"]))
+        viewModel.title = "제목만 수정"
+
+        await viewModel.updateSchedule()
+
+        #expect(recorder.update?.name == "제목만 수정")
+        #expect(recorder.update?.participantMemberIds == nil)
+        #expect(recorder.update?.isOnline == nil)
+        #expect(recorder.update?.isAttendanceRequired == nil)
+    }
+
+    @Test("참여자가 바뀌면 PATCH 에 작성자 포함 목록이 실린다")
+    func changedParticipantsAreSentOnUpdate() async {
+        let recorder = RequestRecorder()
+        let viewModel = makeViewModel(recorder: recorder)
+        viewModel.applyPrefill(from: makeDetail(participantMemberIds: ["7"]))
+        viewModel.updateParticipants(viewModel.participants + [challenger(memberId: "10")])
+
+        await viewModel.updateSchedule()
+
+        #expect(recorder.update?.participantMemberIds == ["10", "7"])
+    }
+
+    @Test("서버가 SCHEDULE-0028 로 거부하면 인라인 메시지로 알린다")
+    func startedScheduleRejectionShowsInlineMessage() async {
+        let viewModel = makeViewModel(
+            updateError: RepositoryError.serverError(code: "SCHEDULE-0028", message: "이미 시작됨")
+        )
+        viewModel.applyPrefill(from: makeDetail())
+        viewModel.title = "제목만 수정"
+
+        await viewModel.updateSchedule()
+
+        #expect(viewModel.inlineErrorMessage == "이미 시작된 일정은 수정할 수 없습니다.")
+        #expect(viewModel.submitState.isLoading == false)
+    }
+}
+
+// MARK: - AttendancePolicyCase
+
+/// 출석 정책 검증 입력. 오프셋은 모두 일정 시작 시각 기준이며 일정 종료는 시작 + 3600 이다.
+///
+/// `@Test(arguments:)` 파라미터 타입이라 테스트 메서드와 같은 접근 수준이어야 한다.
+struct AttendancePolicyCase: Sendable {
+
+    let checkInOffset: TimeInterval
+    let onTimeOffset: TimeInterval
+    let lateOffset: TimeInterval
+    let expectedMessage: String?
+
+    static let all: [AttendancePolicyCase] = [
+        AttendancePolicyCase(
+            checkInOffset: 0,
+            onTimeOffset: -60,
+            lateOffset: 600,
+            expectedMessage: "출석 시작은 출석 인정 마감보다 빨라야 합니다."
+        ),
+        AttendancePolicyCase(
+            checkInOffset: -600,
+            onTimeOffset: 0,
+            lateOffset: -300,
+            expectedMessage: "출석 인정 마감은 지각 인정 마감보다 빨라야 합니다."
+        ),
+        AttendancePolicyCase(
+            checkInOffset: 0,
+            onTimeOffset: 60,
+            lateOffset: 120,
+            expectedMessage: "출석 시작은 일정 시작보다 빨라야 합니다."
+        ),
+        AttendancePolicyCase(
+            checkInOffset: -600,
+            onTimeOffset: 0,
+            lateOffset: 3_660,
+            expectedMessage: "지각 인정 마감은 일정 종료 시각을 넘을 수 없습니다."
+        ),
+        AttendancePolicyCase(
+            checkInOffset: -600,
+            onTimeOffset: 0,
+            lateOffset: 600,
+            expectedMessage: nil
+        )
+    ]
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeViewModel(
+    currentMemberId: String? = "7",
+    capabilities: ScheduleCapabilities? = nil,
+    updateError: Error? = nil,
+    recorder: RequestRecorder? = nil
+) -> ScheduleRegistrationViewModel {
+    let container = DIContainer()
+    container.register(GenerateScheduleUseCaseProtocol.self) {
+        StubGenerateScheduleUseCase(recorder: recorder)
+    }
+    container.register(UpdateScheduleUseCaseProtocol.self) {
+        StubUpdateScheduleUseCase(recorder: recorder, error: updateError)
+    }
+    container.register(ClassifyScheduleUseCaseProtocol.self) {
+        StubClassifyScheduleUseCase()
+    }
+    container.register(FetchScheduleCapabilitiesUseCaseProtocol.self) {
+        StubFetchScheduleCapabilitiesUseCase(capabilities: capabilities)
+    }
+    return ScheduleRegistrationViewModel(container: container, currentMemberId: currentMemberId)
+}
+
+/// `canSubmit` 이 참여자 상한 외의 이유로 막히지 않도록 필수 입력을 채운다.
+@MainActor
+private func fillRequiredFields(of viewModel: ScheduleRegistrationViewModel) {
+    viewModel.title = "정기 세미나"
+    viewModel.updateTagsFromUser([.study])
+    viewModel.inPersonModeToggleChanged(to: false)
+}
+
+private func makeCapabilities(maxParticipantCount: String) -> ScheduleCapabilities {
+    ScheduleCapabilities(
+        canCreateSchedule: true,
+        canCreateAttendanceRequiredSchedule: true,
+        maxParticipantCount: maxParticipantCount
+    )
+}
+
+private func challenger(memberId: String) -> ChallengerInfo {
+    ChallengerInfo(
+        memberId: memberId,
+        gen: "11",
+        name: "홍길동",
+        nickname: "gildong",
+        schoolName: "UMC대학교",
+        profileImage: nil,
+        part: .front(type: .ios)
+    )
+}
+
+/// 아직 시작하지 않은 비대면 일정. 수정 모드 가드(SCHEDULE-0028 사전 차단)를 통과한다.
+private func makeDetail(participantMemberIds: [String] = ["7"]) -> ScheduleDetailData {
+    let startsAt = Date.now.addingTimeInterval(3_600)
+    return ScheduleDetailData(
+        scheduleId: "1",
+        name: "정기 세미나",
+        description: "",
+        tags: ["STUDY"],
+        startsAt: startsAt,
+        endsAt: startsAt.addingTimeInterval(3_600),
+        isParticipant: true,
+        participants: participantMemberIds.map {
+            ScheduleParticipant(
+                memberId: $0,
+                name: "홍길동",
+                nickname: "gildong",
+                profileImageUrl: "",
+                schoolId: "1",
+                schoolName: "UMC대학교"
+            )
+        },
+        authorMemberId: "7",
+        isOnline: true
+    )
+}
+
+// MARK: - Stubs
+
+/// 서버로 나간 요청을 붙잡아 두는 기록기.
+@MainActor
+private final class RequestRecorder {
+    var creation: ScheduleCreationRequest?
+    var update: ScheduleUpdateRequest?
+}
+
+private struct StubGenerateScheduleUseCase: GenerateScheduleUseCaseProtocol {
+
+    let recorder: RequestRecorder?
+
+    @discardableResult
+    func execute(request: ScheduleCreationRequest) async throws -> String {
+        let capturedRecorder = recorder
+        await MainActor.run { capturedRecorder?.creation = request }
+        return "1"
+    }
+}
+
+private struct StubUpdateScheduleUseCase: UpdateScheduleUseCaseProtocol {
+
+    let recorder: RequestRecorder?
+    let error: Error?
+
+    func execute(scheduleId: String, request: ScheduleUpdateRequest) async throws {
+        let capturedRecorder = recorder
+        await MainActor.run { capturedRecorder?.update = request }
+        if let error { throw error }
+    }
+}
+
+private struct StubClassifyScheduleUseCase: ClassifyScheduleUseCaseProtocol {
+    func execute(title: String) async -> ScheduleIconCategory { .study }
+}
+
+private struct StubFetchScheduleCapabilitiesUseCase: FetchScheduleCapabilitiesUseCaseProtocol {
+
+    let capabilities: ScheduleCapabilities?
+
+    func execute() async throws -> ScheduleCapabilities {
+        guard let capabilities else {
+            throw RepositoryError.invalidResponse(detail: "권한 stub 미설정")
+        }
+        return capabilities
+    }
+}

--- a/UMCApp/Features/Home/Project.swift
+++ b/UMCApp/Features/Home/Project.swift
@@ -26,6 +26,11 @@ let project = featureProject(
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
         // 홈 루트가 공유 `PathStore` 의 홈 스택 깊이로 루트 복귀를 감지해 월별 일정을 재조회한다.
         .project(target: "CoreRouting", path: .relativeToRoot("Core/Routing")),
+        // 일정 등록의 참여자 선택이 Activity 의 챌린저 검색 UI(SelectedChallengerView)를 그대로
+        // 쓴다. ActivityDomain 은 그 이니셜라이저의 검색 UseCase 타입 해석에 필요하다.
+        // Activity 쪽은 HomeDomain 만 참조하므로 타겟 그래프에 순환이 생기지 않는다.
+        .project(target: "ActivityDomain", path: .relativeToRoot("Features/Activity")),
+        .project(target: "ActivityPresentation", path: .relativeToRoot("Features/Activity")),
         .project(target: "NoticeDomain", path: .relativeToRoot("Features/Notice")),
     ],
     includesDomainTests: true,

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/Attachment/ImageAttachmentCard.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/Attachment/ImageAttachmentCard.swift
@@ -111,6 +111,7 @@ struct ImageAttachmentCard: View, Equatable {
 }
 
 // MARK: - Preview
+#if DEBUG
 #Preview("기본 이미지 카드") {
     @Previewable @State var noticeImageItems: [NoticeImageItem] = []
     @Previewable @State var selectedItems: [PhotosPickerItem] = []
@@ -175,3 +176,4 @@ struct ImageAttachmentCard: View, Equatable {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/Attachment/LinkAttachmentCard.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/Attachment/LinkAttachmentCard.swift
@@ -95,6 +95,7 @@ struct LinkAttachmentCard: View, Equatable {
 }
 
 // MARK: - Preview
+#if DEBUG
 #Preview {
     @Previewable @State var noticeLinkItems: [NoticeLinkItem] = []
     
@@ -111,3 +112,4 @@ struct LinkAttachmentCard: View, Equatable {
     }
     .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/Attachment/VoteAttachmentCard.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/Attachment/VoteAttachmentCard.swift
@@ -113,6 +113,7 @@ struct VoteAttachmentCard: View {
     }
 }
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     @Previewable @State var formData = VoteFormData()
     
@@ -126,3 +127,4 @@ struct VoteAttachmentCard: View {
         )
     }
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/DetailCard/NoticeImageCard.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/DetailCard/NoticeImageCard.swift
@@ -264,6 +264,7 @@ private extension KFImage {
 }
 
 // MARK: - Preview
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     NoticeImageCard(imageURLs: [
         "https://picsum.photos/200/200",
@@ -281,3 +282,4 @@ private extension KFImage {
         "https://httpbin.org/delay/10"
     ])
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/DetailCard/NoticeLinkCard.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/DetailCard/NoticeLinkCard.swift
@@ -292,6 +292,8 @@ public struct LinkTextPresenter: View {
 
 // MARK: - Preview
 // url을 https:// 까지 입력해야 정상작동!
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     NoticeLinkCard(url: "https://www.naver.com")
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/DetailCard/NoticeVoteCard.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/DetailCard/NoticeVoteCard.swift
@@ -524,6 +524,7 @@ public struct VoteResultRow: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview("투표 가능 - 단일선택/익명", traits: .sizeThatFitsLayout) {
     NoticeVoteCard(
         vote: NoticeVote(
@@ -648,3 +649,4 @@ public struct VoteResultRow: View {
     )
     .padding()
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeChip.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeChip.swift
@@ -38,6 +38,7 @@ public struct NoticeChip: View {
 }
 
 // MARK: - Preview
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     HStack {
         NoticeChip(noticeType: .core)
@@ -46,3 +47,4 @@ public struct NoticeChip: View {
         NoticeChip(noticeType: .part)
     }
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeList/NoticeItem.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeList/NoticeItem.swift
@@ -163,6 +163,7 @@ private struct BottomSection: View, Equatable {
     }
 }
 
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     VStack(spacing: 16) {
         NoticeItem(model: NoticeItemModel(
@@ -198,3 +199,4 @@ private struct BottomSection: View, Equatable {
         }
     }
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeReadStatusButton.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeReadStatusButton.swift
@@ -124,6 +124,7 @@ public struct NoticeReadStatusButton: View {
 
 
 // MARK: - Preview
+#if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
     VStack(spacing: 20) {
         NoticeReadStatusButton(confirmedCount: 1100, totalCount: 1250) {
@@ -148,3 +149,4 @@ public struct NoticeReadStatusButton: View {
     }
     .padding()
 }
+#endif

--- a/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeReadStatusItem/NoticeReadStatusItem.swift
+++ b/UMCApp/Features/Notice/Presentation/Sources/Components/NoticeReadStatusItem/NoticeReadStatusItem.swift
@@ -112,6 +112,7 @@ private struct UserInfoSection: View, Equatable {
     }
 }
 
+#if DEBUG
 #Preview {
     VStack {
         NoticeReadStatusItem(
@@ -139,3 +140,4 @@ private struct UserInfoSection: View, Equatable {
         )
     }
 }
+#endif

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/DIContainer+StubSession.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/DIContainer+StubSession.swift
@@ -35,6 +35,9 @@ extension DIContainer {
         register(ScheduleRepositoryProtocol.self) {
             StubScheduleRepository()
         }
+        register(ScheduleCapabilitiesRepositoryProtocol.self) {
+            StubScheduleCapabilitiesRepository()
+        }
         register(NoticeRepositoryProtocol.self) {
             StubNoticeRepository()
         }

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubScheduleCapabilitiesRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubScheduleCapabilitiesRepository.swift
@@ -1,0 +1,25 @@
+//
+//  StubScheduleCapabilitiesRepository.swift
+//  UMCApp
+//
+//  Created by euijjang97 on 8/9/26.
+//
+
+#if DEBUG
+import Foundation
+import HomeDomain
+
+/// 카카오 로그인 서버 미등록 기간 한정 일정 권한 Repository stub (절대규칙 #5).
+///
+/// stub 세션은 운영진 화면까지 둘러보는 용도라 출석 정책 부착까지 열어 둔다.
+struct StubScheduleCapabilitiesRepository: ScheduleCapabilitiesRepositoryProtocol {
+
+    func fetchCapabilities() async throws -> ScheduleCapabilities {
+        ScheduleCapabilities(
+            canCreateSchedule: true,
+            canCreateAttendanceRequiredSchedule: true,
+            maxParticipantCount: "30"
+        )
+    }
+}
+#endif

--- a/docs/claude/home-migration-plan.md
+++ b/docs/claude/home-migration-plan.md
@@ -1,0 +1,443 @@
+# Home 마이그레이션 잔여 검토
+
+> 레거시 `AppProduct/AppProduct/Features/Home/` → Tuist `UMCApp/Features/Home/` 이관의
+> **현재 잔여 범위**를 파일·라인 단위로 확정한 문서입니다.
+> 조사 시점: `develop` (`fa6c7237`, 2026-08-09).
+>
+> - `AppProduct/` 는 v2.2.0 동결 — **열람만 했고 수정하지 않았습니다** (절대 규칙 #9).
+> - 인용은 `path:line` 형식입니다. 확정 근거가 없는 판단은 **추정**으로 표기했습니다.
+
+## ✅ 처리 현황 (2026-08-09 작업 트리 반영)
+
+아래 §1~§3 의 잔여 항목 **17건 전부**를 `develop` 작업 트리에 구현했습니다. 커밋 전 상태입니다.
+
+| 이슈 | 범위 | 상태 |
+|---|---|---|
+| #J | 참여자 선택 결선 (작성자 강제 포함) | ✅ |
+| #K | ScheduleCapabilities 결선 + `maxParticipantCount` `String` 교정 + StubSession 등록 | ✅ |
+| #L | 시작된 일정 편집 사전 차단 + 잠금 배너 + 삭제 진행 표시 | ✅ |
+| #M | 최근 공지 섹션 에러/재시도 복원 + 재시도 스피너 결선 + `LoadingView` | ✅ |
+| #N | 홈 진입 프로필 저장 — `SyncProfileStorageUseCase` **CoreDomain 승격** 후 결선 | ✅ |
+| #O | 분류 게이트 + `TaskGroup` 병렬화, AI 실패 인라인 표시, 키보드 내림, `Equatable` 복원 | ✅ |
+| #P | `ScheduleRegistrationViewModelTests` 신규 (12) + 상세 4 suite | ✅ |
+| #Q | `tuist-file-mapping.md` Home 구간 32행 동기화 | ✅ |
+| #R | Preview `#if DEBUG` 가드 — 저장소 전역 **잔여 0** | ✅ |
+| — | `PointLog.point` 절삭 버그 (`-0.5 → 0`) | ✅ |
+
+**검증**: `tuist generate` 성공(순환 의존 없음) · `make build` **BUILD SUCCEEDED** ·
+테스트 전부 통과 — HomeDomain 19 / HomeData 34 / HomePresentation 36 / UMCAppTests 14 /
+CoreDomain 9 / AuthDomain 51 / AuthPresentation 102 / ActivityDomain 218 / ActivityPresentation 295 /
+CoreUIComponents 29. `git status AppProduct/` 무변경.
+
+### 원안과 달라진 판단 4건
+
+1. **`PointLog.point` 은 `String` 이 아니라 `Double` 유지 + 절삭 제거.**
+   원본 `ProfileChallengerPoint.point` 자체가 `Double`(`decodeDoubleFlexible`) 이라 절대 규칙 #2
+   ("서버 응답 **정수**") 범위 밖입니다. `String` 전환은 숫자 리터럴 생성부 4곳을 깨뜨리기만 하고
+   얻는 게 없습니다. 표시는 `.number.precision(.fractionLength(0...1))`.
+2. **Activity Challenger 컴포넌트는 `SelectedChallengerView` 1개만 `public` 승격.**
+   나머지 3개는 `some View` 뒤에 가려져 Home 에서 직접 참조되지 않습니다 — 공개 API 표면을 늘리지 않았습니다.
+3. **`SyncProfileStorageUseCase` 는 CoreDomain 승격.** Home→AuthDomain 은 의존 방향이 잘못됐고,
+   이 UseCase 는 CoreDomain/UMCFoundation 타입에만 의존해 승격 비용이 0(기존 소비처 import 수정 0건)입니다.
+4. **중복 DTO(`ScheduleLocationDTO`/`ScheduleAttendancePolicyDTO`) 통합은 보류** — §3-7 참조.
+
+### 후속으로 남긴 것
+
+- **중복 DTO 통합**: Home·Activity 사본이 동작상 동일하고 소비처가 각각 1곳뿐이지만, Activity 사본을
+  지우려면 `ActivityData → HomeData` 라는 Feature 간 Data-to-Data 의존을 새로 만들어야 합니다.
+  40줄 중복을 없애려고 레이어 경계를 뚫는 건 손해라 별도 이슈로 분리. 대안은 두 DTO 의 CoreNetwork 승격.
+- **출석 정책 피커 6개 키보드 내림**: `Core/UIComponents/.../AttendancePolicyTimeSection.swift` 의
+  `@State private var openSlot` 이 컴포넌트 내부라 외부에서 토글을 관측할 수 없습니다. 시작/종료 4개만 결선됨.
+- **`LoadingType.Home` 에 일정 로딩 케이스 부재**: 기존 3종은 문구가 고정이라 일정 게이트에는
+  무문구 플레이스홀더를 남겼습니다. 케이스 추가는 CoreUIComponents 변경 건.
+- **`tuist-file-mapping.md` 상단 "목적지별 파일 수" 요약** 미갱신 (766행 전수 재집계 필요).
+
+---
+
+## 0. 요약 — 파일 이관은 끝났고, 남은 건 "결선(wiring)"입니다
+
+초판 계획서의 그룹 A~I는 **전부 머지 완료**입니다.
+
+| 그룹 | 내용 | 머지 커밋 |
+|---|---|---|
+| A | 일정 권한(capabilities) 조회 체인 | `1eb39f89` (#1115) |
+| B | 일정 등록 화면·ViewModel + 라우팅 | `e1a04a19` (#1106) |
+| E·G | 일정 수정·삭제·강제 삭제 파이프라인 | `841d4968` (#1102) |
+| F | Core Authorization 이관 + Notice 스텁 제거 | `dba14433` (#1101) |
+| H | 캘린더 가로(horizon) 모드 + 모드 토글 | `18b07c73` (#1109) |
+| I | ChallengerGenRepository 구현체 + GenerationMappingRecord | `b5441162` (#1099) |
+| — | 일정 상세 수정(연필) 진입점 결선 | `1020a017` (#1114) |
+
+**따라서 "미이식 파일"은 사실상 0입니다.** 남은 문제는 전부 다른 성격입니다:
+
+1. **결선되지 않은 파이프라인** — 타입·Repository·UseCase·DI 등록까지 다 만들어 놓고 소비처가 0인 코드
+2. **화면 안에서 빠진 기능** — 파일은 이관됐지만 섹션/분기가 누락
+3. **규약 위반·테스트 공백** — 이관 과정에서 들어온 부채
+
+잔여 항목은 **P0 기능 결손 5건 / P1 UX·성능 열화 7건 / P2 규약·부채 5건**입니다.
+
+---
+
+## 1. P0 — 기능 결손 (사용자에게 보이는 동작 차이)
+
+### 1-1. ⛔ 참여자 선택이 통째로 없다 — 생성되는 일정에 참여자가 0명
+
+가장 큰 결손이며, 다른 어떤 항목보다 먼저 처리해야 합니다.
+
+| 지점 | 현재 상태 |
+|---|---|
+| 등록 화면 참여자 섹션 | **없음**. 주석만 존재 — `UMCApp/Features/Home/Presentation/Sources/Views/Registration/ScheduleRegistrationView.swift:212-213` |
+| 생성 요청 | `participantMemberIds: []` **하드코딩** — `.../ViewModels/ScheduleRegistrationViewModel.swift:443` |
+| 수정 요청 | `participantMemberIds: nil` (서버 값 보존) — 같은 파일 `:488`. 편집으로 참여자를 바꿀 방법이 없음 |
+| 편집 prefill | 참여자 조회 자체가 없음 — `applyPrefill` 이 건너뜀 (`:228-229`) |
+| 변경 감지 | `EditFormSnapshot` 에 `participantMemberIds` 없음 → 참여자 편집이 폼을 dirty 로 만들지 못함 |
+
+레거시는 `sanitizedParticipantMemberIds()` 에서 **작성자 본인 memberId 를 강제 포함**했습니다
+(`AppProduct/.../ScheduleRegistrationViewModel.swift:614-621`). 지금 UMCApp 이 만드는 일정은
+**작성자조차 참여자에 없습니다.**
+
+**차단 요인 2개 (둘 다 확인됨):**
+
+1. Activity 의 챌린저 컴포넌트 4종이 전부 `internal` —
+   `UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/SearchChallengerView.swift:22`,
+   `SelectedChallengerView.swift:19`, `ChallengerFormView.swift:16`, `ChallengerSearchCard.swift:17`
+   (각 `init` 도 internal).
+2. `UMCApp/Features/Home/Project.swift:18-31` (`presentationExtraDependencies`) 에
+   `ActivityPresentation`·`ActivityDomain` 이 **없음**.
+
+`CoreDomain.ChallengerInfo` 는 이미 `public` 이므로(`UMCApp/Core/Domain/Sources/Member/ChallengerInfo.swift:14`)
+막는 건 뷰 접근 제어자와 모듈 의존 2개뿐입니다.
+
+> **설계 결정 유지**: Core 승격이 아니라 Feature→Feature 의존을 택합니다.
+> 소비 Feature 가 3개가 되면 그때 `CoreUIComponents` 로 올립니다.
+
+### 1-2. ⛔ `ScheduleCapabilities` 파이프라인이 소비처 0 — 만들어만 두고 아무도 안 쓴다
+
+`1eb39f89` 로 DTO·Repository·UseCase·DI 등록(`UMCApp/UMCApp/Sources/DIContainer+Home.swift:55-62`)까지
+전부 들어왔지만, **Presentation 전체에서 `resolve` 하는 곳이 한 군데도 없습니다.**
+`grep -rn "Capabilities" UMCApp/Features/Home/Presentation/` 의 유일한 히트가
+"이식하지 않았다"고 적힌 주석입니다 (`ScheduleRegistrationView.swift:183`).
+
+그 결과 레거시에 있던 두 게이트가 모두 빠졌습니다:
+
+| 레거시 동작 | 근거 | UMCApp 현재 |
+|---|---|---|
+| `canCreateAttendanceRequiredSchedule == false` 면 출석 필수 토글을 강제 `false` 로 내리고 섹션 비노출 | `AppProduct/.../ScheduleRegistrationViewModel.swift:348-364`, `ScheduleRegistrationView.swift:726-730` | **토글 무조건 노출** (`ScheduleRegistrationView.swift:183-187`). 권한 없는 사용자는 서버가 거부할 때까지 모름 |
+| 참여자 수 `maxParticipantCount` 초과 시 인라인 경고 + 등록 차단, `N / max` 표시 | `AppProduct/.../ScheduleRegistrationViewModel.swift:605-611`(문구), `:507-511`(생성), `:686-691`(수정), `View:601-645`(UI) | **없음** (§1-1 참여자 섹션 부재의 종속 항목) |
+
+레거시는 `loadCapabilities()` 를 `.task` 에서 호출했습니다 (`AppProduct/.../ScheduleRegistrationView.swift:86`).
+
+### 1-3. ⛔ 이미 시작된 일정도 편집 화면이 열린다
+
+`ScheduleDetailViewModel.isScheduleStarted` 는 정의돼 있지만
+(`UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleDetailViewModel.swift:47`)
+**저장소 전체에서 이 프로퍼티를 읽는 곳이 없습니다** (`grep -rn "isScheduleStarted" UMCApp/` 결과 1건 = 선언부).
+
+- 레거시는 연필 버튼을 비활성화하고 a11y label/hint 를 바꿨습니다 (`AppProduct/.../ScheduleDetailView.swift:121-127`).
+- 레거시 상세 화면 상단의 **"이미 시작된 일정은 수정할 수 없습니다" 잠금 배너**도 빠졌습니다
+  (`AppProduct/.../ScheduleDetailView.swift:306-312` ↔ 마이그레이션판 `topContent:190-198` 은 이름·장소·날짜만).
+- UMCApp 은 편집 메뉴를 무조건 만듭니다 (`UMCApp/.../Views/ScheduleDetailView.swift:125-133`).
+
+등록 ViewModel 쪽 `SCHEDULE-0028`(이미 시작된 일정) 처리는 살아 있으므로
+(`ScheduleRegistrationViewModel.swift:498-500`), 지금은 **사용자가 편집 화면을 다 채운 뒤 저장에서 거부당하는** 흐름입니다.
+사전 차단으로 승격해야 합니다.
+
+### 1-4. ⛔ 최근 공지 조회 실패가 화면에서 완전히 사라진다
+
+```swift
+case .failed:
+    EmptyView()          // UMCApp/Features/Home/Presentation/Sources/Views/HomeView.swift:213-214
+```
+
+"최근 공지" 섹션 헤더 자체가 `recentNoticeLoaded` 안에 있어(`HomeView.swift:250`)
+실패 시 **헤더까지 통째로 증발**합니다. 에러 표시도 재시도 버튼도 없습니다.
+
+`recentNoticeState` 는 season 이 `.loaded` 인 상태에서 독립적으로 실패할 수 있으므로
+(`.../ViewModels/HomeViewModel.swift:201-209`) 실제로 도달 가능한 분기입니다.
+
+레거시는 `SectionErrorCard` + 재시도를 렌더했고(`AppProduct/.../HomeView.swift:338-349`),
+재시도 핸들러 `retryRecentNoticeSection()` 은 **`roles` 가 비어 있으면 프로필부터 다시 받고** 공지를 재조회했습니다
+(`AppProduct/.../HomeView.swift:377-386`). 이 복구 경로가 통째로 없습니다.
+
+### 1-5. ⛔ 홈 진입 시 프로필 저장(`saveProfileToStorage`)이 미이식 — 세션 중 권한 변경이 반영되지 않음
+
+레거시 `HomeViewModel.saveProfileToStorage()` (`AppProduct/.../HomeViewModel.swift:109-148`) 는
+홈을 열 때마다 `memberId`/`schoolId`/`gisuId`/`challengerId`/`chapterId`/`part`/`organizationType`/
+`organizationId`/`memberRole`/`memberRoles`/`generationOrganizations`/`canAutoLogin` 을 갱신하고,
+`UserSessionManager.updateRole` 호출 + `.memberProfileUpdated` 노티피케이션을 발행했습니다.
+
+UMCApp 에서 이 동작은 **로그인 시점에만** 일어납니다
+(`UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/SyncProfileStorageUseCase.swift:41-68`).
+
+파급:
+
+- 세션 도중 서버에서 역할·기수가 바뀌어도 앱이 모릅니다 (재로그인 전까지).
+- `.memberProfileUpdated` 를 구독하는 **FCM 토큰 재동기화가 홈에서 발화하지 않습니다**
+  (`UMCApp/UMCApp/Sources/AppDelegate.swift:66,149`).
+- 파생 상태 `roles` 가 없어졌습니다 (레거시 `HomeViewModel.swift:28`). `HomeProfileResult` 는
+  `memberId`/`seasonTypes`/`generations` 만 보유 (`UMCApp/.../Data/Sources/Repositories/HomeRepository.swift:53-57`).
+- 공지 조회의 **`gisuId` 폴백 소실**: 레거시는 roles 에 기수가 없으면
+  `UserDefaults[AppStorageKey.gisuId]` 로 폴백했지만(`AppProduct/.../HomeViewModel.swift:234-238`),
+  UMCApp 은 `generations` 가 비면 빈 공지 목록을 반환합니다 (`UMCApp/.../HomeViewModel.swift:189-191`).
+
+> 이 항목은 Home 단독 판단으로 처리하면 안 됩니다. Auth 의 `SyncProfileStorageUseCase` 를 재사용할지,
+> Home 전용 경로를 되살릴지는 **소유권 결정이 선행**돼야 합니다 (§3 #J 참조).
+
+---
+
+## 2. P1 — UX·성능 열화 (동작은 하지만 레거시보다 나쁨)
+
+| # | 항목 | 레거시 | UMCApp 현재 |
+|---|---|---|---|
+| 2-1 | 섹션별 재시도 스피너 | `.loading where isRetryingProfileSection / isRetryingRecentNoticeSection` (`AppProduct/.../HomeView.swift:36-37,141,171,338`) | `isRetrying: false` 하드코딩 (`HomeView.swift:139`) — 재시도해도 아무 피드백 없음 |
+| 2-2 | 일정 아이콘 분류 게이트 | 보이는 일정이 전부 분류될 때까지 리스트를 막고 `TaskGroup` 병렬 분류 + stale 결과 가드 (`AppProduct/.../HomeView.swift:226-228,266-307`) | 게이트 없이 `.general` 폴백 → **아이콘 팝인**. 월 전체를 `for await` **순차** 분류 (`HomeViewModel.swift:142-144,168-178`) |
+| 2-3 | 시맨틱 로딩 뷰 | `LoadingView(.home(.seasonLoading/.penaltyLoading/.recentNoticeLoading))` | 밋밋한 `ProgressView` 박스 (`HomeView.swift:280-287`). `LoadingView` 는 이미 있음 (`UMCApp/Core/UIComponents/Sources/Loading/LoadingView.swift:29`) |
+| 2-4 | AI 자동완성 실패 표시 | 시트 안 `statusArea` 가 `.failed` 인라인 렌더 (`AppProduct/.../ScheduleRegistrationView.swift:863-877`) | `statusArea` 없음. 실패 시 `.idle` 로 되돌리고 전역 알럿에 위임 (`+AI.swift:48-53`) → **시트는 열린 채 이유 없이 멈춤** |
+| 2-5 | AI 미지원 기기 안내 | `"이 기기에서는 Apple Intelligence를 사용할 수 없습니다."` (`AppProduct/.../+AI.swift:28-33`) | 조용히 `return` (`+AI.swift:37`) → **버튼을 눌러도 무반응** |
+| 2-6 | 피커 토글 시 키보드 해제 | `KeyboardDismissOnPickerToggle` 이 10개 피커 + `isAllDay` 에서 `resignFirstResponder` (`AppProduct/.../ScheduleRegistrationView.swift:654-679`) | `.scrollDismissesKeyboard(.immediately)` 뿐. **제목/메모 포커스 상태로 날짜 피커를 열면 키보드가 피커를 가림** |
+| 2-7 | 삭제 진행 중 표시 | 휴지통 → 빨간 `ProgressView` 로 교체 (`AppProduct/.../ScheduleDetailView.swift:131-133`) | 액션 목록을 빈 배열로 반환 (`UMCApp/.../ScheduleDetailView.swift:121`) → **메뉴가 조용히 비어버림** |
+
+**렌더링 성능 회귀 2건** (`Equatable` 소실):
+
+- `SeasonCard` 가 `Equatable` 이 아님 (`UMCApp/.../Components/SeasonCard.swift:13`).
+  레거시는 `.equatable()` 적용 (`AppProduct/.../HomeView.swift:160`) → 프로필 tick 마다 HStack 재렌더.
+- 등록 화면 제목 필드가 `TitleView: View, Equatable` 래퍼를 잃고 raw `TextField` 로 인라인됨
+  (`UMCApp/.../ScheduleRegistrationView.swift:136-146` ↔ 레거시 `:342-364`, `.equatable()` at `:299`).
+  **키 입력마다 폼 전체 행이 diff** 됩니다. `MemoEditor` 는 래퍼를 유지 중(`:452`)이라 대조적입니다.
+
+**의도된 미이식 (조치 불필요, 기록용):**
+
+- 상세 화면 **역지오코딩(도로명 주소)** — 레거시 `fetchRoadAddress` + 주소 행 + 편집 화면 prefill
+  (`AppProduct/.../ScheduleDetailViewModel.swift:56-81`, `View:82-89,163,389-393`).
+  UMCApp 은 좌표를 바로 Maps 로 넘깁니다 (`ScheduleDetailViewModel.swift:106-115`). 의도 명시됨(`View:18`).
+- 편집 화면 표시가 `fullScreenCover` → `sheet` 로 변경 (레거시 `:47-58` ↔ UMCApp `:89-98`).
+- 디버그 권한 오버라이드 `--schedule-force-permission` 미이식 (레거시 VM `:110-117`).
+  이 플래그에 의존하는 UI 테스트가 있다면 훅이 없습니다.
+
+---
+
+## 3. P2 — 규약 위반 · 부채
+
+### 3-1. 절대 규칙 #2 위반 (서버 정수 `String` 통일)
+
+| 위치 | 위반 | 조치 |
+|---|---|---|
+| `UMCApp/Features/Home/Domain/Sources/Models/Schedule/ScheduleCapabilities.swift:25` | `maxParticipantCount: Int` (Domain) | `String` 으로. 비교 시점에만 `Int(...)` |
+| `UMCApp/Features/Home/Data/Sources/DTOs/Response/ScheduleCapabilitiesDTO.swift:26` | `maxParticipantCount: Int` (Response DTO) | 동일. 디코딩은 이미 `decodeIntFlexibleIfPresent`(`:44`)라 타입만 바꾸면 됨 |
+| `UMCApp/Features/Home/Domain/Sources/Models/PointLog.swift:18` | `point: Int` | **버그 동반**: 원본이 `Double`(`UMCApp/Core/Domain/Sources/Member/ProfileChallengerPoint.swift:15`)인데 `Int(point.point)` 로 절삭 (`.../Extensions/ProfileChallengerRecord+HomeMapping.swift:50`) → **`-0.5` 점이 `0` 이 됨** |
+
+`ScheduleCapabilities` 는 **소비처가 0인 지금이 타입을 바꾸기 가장 싼 시점**입니다 (§1-2 결선 전에 처리).
+
+> 참고 — `UMCApp/Features/Home/Data/Sources/GenerationMappingRecord.swift:24,27` 의
+> `gisuId`/`gen` 은 `Int` 이지만 SwiftData 로컬 레코드이고 경계에서 변환됩니다
+> (`ChallengerGenRepository.swift:41-42`). 서버 응답 타입이 아니므로 위반 아님.
+
+### 3-2. 절대 규칙 #3 — **위반 없음**
+
+`UMCApp/Features/Home/Data/Sources/DTOs/Response/` 6개 파일 전부 custom `init(from:)` + `encode(to:)` 보유.
+`ScheduleRepository.swift:236` 의 `decode(Int.self)` 는 `FlexibleIdentifier` 의 single-value 폴백으로 정당(`:217-221` 에 문서화).
+
+### 3-3. 절대 규칙 #5 위반 — Preview 11개가 `#if DEBUG` 미가드
+
+```
+Components/PenaltyCard.swift:350              (HomeGeneration 3 + PointLog 4 — 최대 픽스처)
+Components/RecentNoticeCard.swift:109         Components/ScheduleListCard.swift:80
+Components/AttendancePolicyDisplaySection.swift:176
+Components/SeasonCard.swift:91                Components/ScheduleCard.swift:85
+Components/Calendar/CalendarGridCard.swift:140   CalendarHorizonCard.swift:103
+Components/Calendar/ScheduleHeader.swift:157     DatePill.swift:91   DateCell.swift:68
+```
+
+가드가 제대로 된 대조군: `NoticeAlarmCard.swift:79`, `HomeView.swift:324`,
+`ScheduleDetailView.swift:367`, `ScheduleRegistrationView.swift:620`, `NoticeAlarmView.swift:101`, `TagListView.swift:103`.
+
+> 같은 위반 유형이 Notice·Activity·Core 에도 있습니다. **Home 한정 패스로는 해결되지 않으므로**
+> 전역 스윕은 별도 이슈로 분리합니다.
+
+### 3-4. StubSession 에 `ScheduleCapabilitiesRepositoryProtocol` 미등록
+
+`UMCApp/UMCApp/Sources/Debug/StubSession/DIContainer+StubSession.swift:25-52` 는 9개 Repository 를
+오버라이드하지만 `ScheduleCapabilitiesRepositoryProtocol` 이 빠져 있습니다.
+**스텁 세션인데 이 resolve 만 실제 네트워크를 탑니다.**
+
+지금은 소비처가 0이라(§1-2) 무해하지만, **capabilities 를 결선하는 순간 터집니다.**
+§1-2 와 반드시 같은 PR 에 넣으세요.
+
+### 3-5. 테스트 공백
+
+**테스트 0건:**
+
+| 대상 | 비고 |
+|---|---|
+| `ScheduleRegistrationViewModel` (553줄) + `+AI` (168줄) + `ScheduleDraft` | **Home 최대 미검증 표면**. `*RegistrationViewModelTests` 는 Activity 것만 존재 |
+| `UpdateScheduleUseCase` | `ScheduleUpdatePipelineTests.swift:31` 은 DTO/Repository 계층만 검증 |
+| `GenerateScheduleUseCase` / `FetchScheduleCapabilitiesUseCase` / `ScheduleCapabilitiesRepository` | `ScheduleCapabilitiesDTOTests.swift:16` 은 DTO 만 |
+| `DeleteScheduleUseCase` / `ForceDeleteScheduleUseCase` | `ScheduleDetailViewModelTests` 에서 목으로 간접 커버만 |
+| `FetchSchedulesUseCase` / `FetchScheduleDetailUseCase` | 간접 커버만 |
+
+**커버된 것:** `NoticeHistoryData`, `ClassifyNoticeUseCase`, `ClassifyScheduleUseCase`,
+`FetchHomeProfileUseCase`, `RegisterFCMTokenUseCase`, `ChallengerGenRepository`, `HomeRepository`,
+`ScheduleCapabilitiesDTO`, `ScheduleClassifierRepository`, `ScheduleDetailDTO`,
+`ScheduleRepository`(update/delete 파이프라인), `HomeViewModel`, `ScheduleDetailViewModel`.
+
+### 3-6. `docs/claude/tuist-file-mapping.md` stale 행
+
+범례(`:26-33`)상 **주석 없는 행 = "정상 이식 대상"** 인데, 아래 행들은 이미 다른 모듈로 이관됐거나 dead 입니다.
+
+| 유형 | 행 |
+|---|---|
+| 실제 목적지가 Activity/Core/Notice (행에는 Home 으로 표기) | 403, 404, 405, 406, 412, 422, 427, 435, 450, 475, 478, 480, 488, 489, 490, 492, 498, 513, 517, 518, 519 |
+| Home 내 레이어 오기 (Presentation 표기 → 실제 Domain) | 499 (`NoticeAlarmType`), 505 (`SeasonType`) |
+| dead/superseded 마커 누락 | 443 (`ChallengerRole`→CoreDomain `ProfileRole`), 445 (`RecentNoticeData`→`NoticeItemModel`), 501, 502, 503, 506 (`HomeUseCaseProvider`→`DIContainer+Home`) |
+| 개명 주석 필요 (108/116 행 선례) | 444 (`GenerationData`→`HomeGeneration`), 457 (`ScheduleRegistrationData`→`ScheduleCreationRequest`), 521 (`Registration/ScheduleDetailView`→`Views/ScheduleDetailView.swift`) |
+
+**dead 목록 추가분** (초판 12개에 더해, 레거시 내 참조도 0으로 확인):
+`Presentation/Enum/RecentCategory.swift`, `Presentation/Enum/ScheduleCategory.swift`,
+`Presentation/Enum/ScheduleGenerationType.swift`, `Presentation/Provider/HomeUseCaseProvider.swift`.
+
+### 3-7. 그 밖에 확인된 것
+
+- `ScheduleAttendancePolicyDTO.swift` / `ScheduleLocationDTO.swift` 가
+  `Features/Home/Data/Sources/DTOs/Response/` 와 `Features/Activity/Data/Sources/DTOs/` 에 **중복 존재**.
+  일정 도메인 소유는 Home 으로 확정됐으므로(`fb2cb915`) Activity 쪽 정리 대상 — **추정**(소비처 미확인).
+- 하단 액세서리(`tabViewBottomAccessory`)는 여전히 없습니다. 현재 등록 진입점은
+  `HomeView` 툴바 `+` (`HomeView.swift:99` → `HomeFeatureView.swift:53` → `RootTabView.swift:106`)이며
+  **스스로 임시라고 표기**돼 있습니다(`HomeView.swift:98`). 5개 탭 전체 액세서리 정책이 필요한 App 셸 작업이므로
+  초판 판단(별도 이슈) 유지.
+- `ScheduleRegistrationViewModel` 은 레거시보다 **나은 부분도 있습니다**: `EditFormSnapshot` 에 출석 4필드 추가
+  (`:528-531`, 레거시 `:649-662` 는 누락), `canSubmit` 에 `attendancePolicyErrorMessage == nil` 추가(`:120`).
+  `+AI` 는 토큰 사용량을 기록만 하는 레거시와 달리 복원·표시까지 합니다(`+AI.swift:64-80`, `View:604-611`).
+- 출석 정책 검증 규칙 5종(`checkInStart<onTimeEnd`, `onTimeEnd<lateEnd`, `checkInStart<시작`,
+  `lateEnd<=종료`(=`lateExceedsEnd`), 종일/비출석 시 스킵)은 **전부 이식 완료**
+  (`ScheduleRegistrationViewModel.swift:401-420`).
+
+---
+
+## 4. 이슈 분할안
+
+```
+   ┌───────────────────────────────────────────────┐
+   │ #J 참여자 선택 결선 (P0)  ★ 첫 착수           │
+   │   ├ ActivityPresentation 4종 public 승격      │
+   │   └ Home Project.swift 의존 추가              │
+   └───────────────────┬───────────────────────────┘
+                       ▼
+   ┌───────────────────────────────────────────────┐
+   │ #K capabilities 결선 (P0) — 참여자 상한·출석  │
+   │   + 규칙 #2 교정 + StubSession 등록 (동일 PR) │
+   └───────────────────────────────────────────────┘
+
+   ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────┐
+   │ #L 시작된 일정   │ │ #M 홈 섹션 에러· │ │ #N 프로필 저장   │
+   │    편집 차단     │ │    재시도 복원   │ │    소유권 결정   │
+   └──────────────────┘ └──────────────────┘ └──────────────────┘
+              (셋 다 독립 · P0)
+
+   ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────┐
+   │ #O UX 열화 7건   │ │ #P 등록 VM 테스트│ │ #Q 매핑표 동기화 │
+   └──────────────────┘ └──────────────────┘ └──────────────────┘
+              (P1)              (P2)              (P2)
+```
+
+### ★ #J — `✨ Feature: 홈 일정 등록 참여자 선택 결선` **(첫 착수)**
+
+- **선행**: 없음
+- **범위**
+  - `UMCApp/Features/Activity/Presentation/Sources/Components/Challenger/{SearchChallengerView,SelectedChallengerView,ChallengerFormView,ChallengerSearchCard}.swift` — 타입 + `init` `public` 승격
+  - `UMCApp/Features/Home/Project.swift` — `presentationExtraDependencies` 에 `ActivityPresentation`·`ActivityDomain` 추가
+  - `ScheduleRegistrationViewModel` — `searchChallengersUseCase` 주입, 참여자 상태, `sanitizedParticipantMemberIds()`(본인 강제 포함), 편집 prefill(`fetchPrefillParticipants` 상당), `EditFormSnapshot` 에 `participantMemberIds` 추가
+  - `ScheduleRegistrationView` — 참여자 섹션 + 시트
+  - 생성 `participantMemberIds: []` → 실제 값, 수정 `nil` → 변경 시에만 전송
+- **적용 절대 규칙**: #2(`ChallengerInfo.memberId` 는 이미 `String`), #4 `public`, #7
+- **검수 기준**: 생성된 일정에 **작성자 본인이 항상 포함**. 편집 진입 시 기존 참여자 prefill. 참여자만 바꿔도 저장 버튼 활성화.
+- **순환 의존 확인 필수** — `Features/Activity/Project.swift` 가 Home 을 참조하지 않는지 `tuist generate` 로 검증
+- **크기**: **M**
+- **왜 첫 번째인가**: 유일하게 **잘못된 데이터를 서버에 쓰고 있는** 항목입니다. #K 의 참여자 상한도 여기에 종속됩니다.
+
+### #K — `♻️ Refactor: ScheduleCapabilities 결선 + maxParticipantCount String 교정`
+
+- **선행**: #J
+- **범위**
+  - `ScheduleCapabilities.swift:25` · `ScheduleCapabilitiesDTO.swift:26` — `Int` → `String` (절대 규칙 #2)
+  - `ScheduleRegistrationViewModel` — `loadCapabilities()` 추가, `.task` 호출, 출석 토글 게이트, 참여자 상한 경고 + 등록 차단
+  - `ScheduleRegistrationView:183-187` — stale 주석 제거, 토글 조건부 노출
+  - `DIContainer+StubSession.swift` — `ScheduleCapabilitiesRepositoryProtocol` 등록 **(누락 시 스텁 세션이 실네트워크를 탐)**
+  - `FetchScheduleCapabilitiesUseCase` 테스트 신규
+- **검수 기준**: `maxParticipantCount` 가 `"30"`·`30` 어느 쪽이든 `"30"` 으로 디코딩. 권한 없으면 출석 토글 비노출. 상한 초과 시 인라인 경고 + 등록 차단. 스텁 세션에서 네트워크 미발생.
+- **크기**: **M**
+
+### #L — `🐛 Fix: 이미 시작된 일정 편집 진입 사전 차단`
+
+- **선행**: 없음
+- **범위**: `ScheduleDetailView` 가 `viewModel.isScheduleStarted`(`:47`)를 읽어 편집 메뉴 비활성 + a11y label/hint, 상세 상단 잠금 배너 복원, 삭제 진행 중 `ProgressView` 표시(§2-7)
+- **검수 기준**: 시작된 일정에서 편집 메뉴 비활성 + 사유 표시. 저장 단계 `SCHEDULE-0028` 는 최후 방어선으로 유지.
+- **크기**: **S**
+
+### #M — `🐛 Fix: 홈 섹션 에러 표시·재시도 복원`
+
+- **선행**: 없음
+- **범위**: `HomeView.swift:213-214` 의 `EmptyView` → `SectionErrorCard` + 재시도,
+  `retryRecentNoticeSection()`(roles 비면 프로필 재조회 후 공지) 이식,
+  `isRetrying` 실제 상태 결선(`:139`), `LoadingView(.home(...))` 로 교체(`:280-287`)
+- **검수 기준**: 공지만 실패해도 헤더 유지 + 에러 + 재시도. 재시도 중 스피너 노출.
+- **크기**: **S**
+
+### #N — `♻️ Refactor: 홈 진입 프로필 저장 경로 소유권 확정`
+
+- **선행**: 없음 (단 **설계 결정 선행 필요**)
+- **결정 사항**: Auth 의 `SyncProfileStorageUseCase`(`:41-68`)를 Home 에서 재사용할지, Home 전용 경로를 되살릴지
+- **범위**: 결정에 따라 — 홈 로드 시 프로필 저장 + `UserSessionManager.updateRole` + `.memberProfileUpdated` 발행, 공지 `gisuId` 폴백 복원(`HomeViewModel.swift:189-191`)
+- **검수 기준**: 세션 중 역할·기수 변경이 홈 재진입만으로 반영. FCM 재동기화 발화 확인.
+- **크기**: **M**
+- **비고**: Auth 와 소유권이 겹치므로 Home 단독 판단 금지. `ios-architect` 선행 검토 권장.
+
+### #O — `🐛 Fix: 홈·등록 화면 UX 열화 7건 일괄 복구`
+
+- **선행**: 없음
+- **범위**: §2 표의 2-2(분류 게이트 + `TaskGroup` 병렬화), 2-4·2-5(AI 실패/미지원 안내), 2-6(피커 키보드 해제), `SeasonCard`·제목 필드 `Equatable` 복원
+- **크기**: **M**
+- **비고**: 2-2 는 성능 회귀 성격이라 단독 분리해도 됩니다.
+
+### #P — `✅ Test: 일정 등록 ViewModel + 쓰기 UseCase 테스트`
+
+- **선행**: #J, #K (시그니처 확정 후)
+- **범위**: `ScheduleRegistrationViewModelTests`(검증 규칙 5종 · 편집 변경 감지 · 참여자 상한 · `SCHEDULE-0028`),
+  `UpdateScheduleUseCase` / `GenerateScheduleUseCase` / `DeleteScheduleUseCase` / `ForceDeleteScheduleUseCase` 직접 테스트
+- **크기**: **M**
+
+### #Q — `📝 Docs: tuist-file-mapping.md Home 구간 동기화`
+
+- **선행**: 없음
+- **범위**: §3-6 표의 행 갱신 + dead 목록 4건 추가
+- **크기**: **XS**
+
+### #R — `🔧 Chore: Preview #if DEBUG 가드 전역 스윕`
+
+- **선행**: 없음
+- **범위**: §3-3 의 Home 11건 + Notice·Activity·Core 동일 위반
+- **크기**: **S**
+- **비고**: Home 이슈가 아니라 전역 이슈. 별도 담당 가능.
+
+---
+
+## 5. 리스크
+
+| 지점 | 위험 | 완화 |
+|---|---|---|
+| `Features/Home/Project.swift` 에 `ActivityPresentation` 추가 (#J) | **순환 의존** | `Features/Activity/Project.swift` 가 Home 을 참조하지 않는지 확인 후 `tuist generate` 검증 |
+| Challenger 컴포넌트 `public` 승격 (#J) | 낮음 — 접근 제어자만 변경 | Activity 소비처 회귀 없음 |
+| `ScheduleCapabilities` `Int`→`String` (#K) | 낮음 — **현재 소비처 0** | 지금이 가장 싼 시점. 결선 후에 하면 호출부까지 번짐 |
+| `DIContainer+StubSession` 누락 (#K) | **높음** — 결선 즉시 스텁 세션이 실네트워크 | #K 와 동일 PR 필수 |
+| `PointLog.point` `Int` 절삭 (§3-1) | 중간 — 소수점 벌점이 조용히 0 | `HomeGeneration` 합산 로직 동반 확인 |
+| 프로필 저장 경로 (#N) | **높음** — Auth 와 소유권 중첩 | 설계 결정 선행. 중복 저장 시 `.memberProfileUpdated` 중복 발행 주의 |
+| 분류 게이트 복원 (#O 2-2) | 중간 — 첫 렌더 지연 증가 | 레거시처럼 **보이는 범위만** 게이트. 월 전체 게이트 금지 |
+
+## 6. 조사 방법 · 한계
+
+- 판정 기준은 파일명이 아니라 **역할과 소비자**입니다. `superseded` = UMCApp 의 다른 타입이 같은 역할 수행,
+  `dead` = 레거시 안에서도 참조 0.
+- §1-1·1-2·1-3 의 핵심 주장(참여자 하드코딩, capabilities 소비처 0, `isScheduleStarted` 미사용,
+  Challenger `internal`, Project.swift 의존 부재, StubSession 미등록)은 **직접 grep/read 로 재확인**했습니다.
+- §2 표와 §3-6 의 행 번호는 전문(全文) 대조 결과이며 **개별 재확인은 하지 않았습니다**.
+  착수 전 해당 파일을 다시 열어 확인하세요.
+- `ScheduleAttendancePolicyDTO`/`ScheduleLocationDTO` 중복(§3-7)은 소비처를 확인하지 않은 **추정**입니다.

--- a/docs/claude/tuist-file-mapping.md
+++ b/docs/claude/tuist-file-mapping.md
@@ -400,16 +400,16 @@
 
 | 레거시 파일 | → Tuist 목적지 |
 |---|---|
-| `Data/DTO/AttendanceDetailQuery.swift` | HomeData |
-| `Data/DTO/AttendanceListQuery.swift` | HomeData |
-| `Data/DTO/ChallengerMemeberDTO.swift` | HomeData |
-| `Data/DTO/ChallengerSearchDTO.swift` | HomeData |
+| `Data/DTO/AttendanceDetailQuery.swift` | ActivityData (출석 도메인 소유 — `Data/Sources/DTOs/`) |
+| `Data/DTO/AttendanceListQuery.swift` | ActivityData (출석 도메인 소유 — `Data/Sources/DTOs/`) |
+| `Data/DTO/ChallengerMemeberDTO.swift` | ActivityData (`ChallengerProfileDTO`로 개명 — 포인트 히스토리 필드만 부분 디코딩) |
+| `Data/DTO/ChallengerSearchDTO.swift` | ActivityData (`ChallengerSearchQuery`/`ChallengerSearchCursorDTO`로 분리) |
 | `Data/DTO/GenerateScheduleRequetDTO.swift` | HomeData |
 | `Data/DTO/GisuDetailDTO.swift` | HomeData |
 | `Data/DTO/HomeScheduleDTO.swift` | HomeData |
 | `Data/DTO/MyProfileDTO.swift` | CoreNetwork (Member — MemberProfileResponseDTO로 통합, #961) |
 | `Data/DTO/MySchedulesQuery.swift` | HomeData |
-| `Data/DTO/NoticeListDTO.swift` | HomeData |
+| `Data/DTO/NoticeListDTO.swift` | NoticeData (`NoticeListQuery`로 개명 — 홈 최근 공지도 공지 모듈 쿼리를 재사용) |
 | `Data/DTO/RegisterFCMTokenRequestDTO.swift` | HomeData |
 | `Data/DTO/ScheduleCapabilitiesDTO.swift` | HomeData |
 | `Data/DTO/ScheduleDetailDTO.swift` | HomeData |
@@ -419,12 +419,12 @@
 | `Data/DTO/V2LocationDTO.swift` | HomeData |
 | `Data/GenerationMappingRecord.swift` | HomeData |
 | `Data/Repository/ChallengerGenRepository.swift` | HomeData |
-| `Data/Repository/ChallengerSearchRepository.swift` | HomeData |
+| `Data/Repository/ChallengerSearchRepository.swift` | ActivityData (`MemberRepository`로 통합) |
 | `Data/Repository/HomeRepository.swift` | HomeData |
 | `Data/Repository/MockHomeRepository.swift` | HomeData |
 | `Data/Repository/ScheduleCapabilitiesRepository.swift` | HomeData |
 | `Data/Repository/ScheduleRepository.swift` | HomeData |
-| `Data/Router/ChallengerSearchRouter.swift` | HomeData |
+| `Data/Router/ChallengerSearchRouter.swift` | ActivityData (`StudyRouter`의 챌린저 검색 케이스로 통합) |
 | `Data/Router/HomeRouter.swift` | HomeData |
 | `Data/Router/ScheduleV2Router.swift` | HomeData |
 | `Domain/Impl/Notice/NoticeClassifierRepositoryImpl.swift` | HomeDomain |
@@ -432,7 +432,7 @@
 | `Domain/Impl/Schedule/ScheduleClassifierRepositoryImpl.swift` | HomeDomain |
 | `Domain/Impl/Schedule/ScheduleClassifierUseCaseImpl.swift` | HomeDomain |
 | `Domain/Interface/ChallengerGenRepositoryProtocol.swift` | CoreDomain (Member — 생산자 Home/소비자 Notice 공용, #1083) |
-| `Domain/Interface/ChallengerSearchRepositoryProtocol.swift` | HomeDomain |
+| `Domain/Interface/ChallengerSearchRepositoryProtocol.swift` | ActivityDomain (`MemberRepositoryProtocol`로 통합) |
 | `Domain/Interface/HomeRepositoryProtocol.swift` | HomeDomain |
 | `Domain/Interface/Notice/NoticeClassifierRepository.swift` | HomeDomain |
 | `Domain/Interface/Notice/NoticeClassifierUseCase.swift` | HomeDomain |
@@ -440,21 +440,21 @@
 | `Domain/Interface/Schedule/ScheduleClassifierUseCase.swift` | HomeDomain |
 | `Domain/Interface/ScheduleCapabilitiesRepositoryProtocol.swift` | HomeDomain |
 | `Domain/Interface/ScheduleRepositoryProtocol.swift` | HomeDomain |
-| `Domain/Models/Home/ChallengerRole.swift` | HomeDomain |
-| `Domain/Models/Home/GenerationData.swift` | HomeDomain |
-| `Domain/Models/Home/RecentNoticeData.swift` | HomeDomain |
+| `Domain/Models/Home/ChallengerRole.swift` | **superseded → CoreDomain `ProfileRole`** — 한 파일에 3개 타입이 들어 있어 목적지가 갈린다. `ChallengerRole`은 CoreDomain `ProfileRole`로 대체, `GenerationOrganizationContext`는 NoticeDomain 으로, `HomeProfileResult` 만 HomeDomain 으로 이식됨 |
+| `Domain/Models/Home/GenerationData.swift` | HomeDomain (`HomeGeneration`으로 개명 — `UMCFoundation.Generation`과 이름 충돌 회피) |
+| `Domain/Models/Home/RecentNoticeData.swift` | **superseded → `NoticeDomain.NoticeItemModel`** — 홈 최근 공지도 공지 정본 모델을 그대로 사용한다. 홈 전용 사본을 두지 말 것 |
 | `Domain/Models/Home/ScheduleData.swift` | HomeDomain |
 | `Domain/Models/Home/ScheduleDetailData.swift` | HomeDomain |
 | `Domain/Models/NoticeHistory/NoticeHistoryData.swift` | HomeDomain |
 | `Domain/Models/Schedule/AttendancePolicy.swift` | HomeDomain |
-| `Domain/Models/Schedule/AttendancePolicyError.swift` | HomeDomain |
+| `Domain/Models/Schedule/AttendancePolicyError.swift` | ActivityDomain (`Models/Attendance/`) |
 | `Domain/Models/Schedule/ScheduleCapabilities.swift` | HomeDomain |
 | `Domain/Models/Schedule/ScheduleLocation.swift` | HomeDomain |
 | `Domain/Models/Schedule/ScheduleParticipant.swift` | HomeDomain |
 | `Domain/Models/ScheduleGeneration/CSVImportResult.swift` | HomeDomain |
 | `Domain/Models/ScheduleGeneration/PlaceSearchResult.swift` | HomeDomain |
 | `Domain/Models/ScheduleGeneration/RecentPlace.swift` | HomeDomain |
-| `Domain/Models/ScheduleGeneration/ScheduleRegistrationData.swift` | HomeDomain |
+| `Domain/Models/ScheduleGeneration/ScheduleRegistrationData.swift` | HomeDomain (`ScheduleCreationRequest`로 개명 — 장소·출석 정책은 조회 모델 재사용) |
 | `Domain/UseCases/DeleteScheduleUseCaseProtocol.swift` | HomeDomain |
 | `Domain/UseCases/FetchMyProfileUseCaseProtocol.swift` | HomeDomain (FetchHomeProfileUseCaseProtocol로 개명, CoreDomain 프로필 파이프라인 합성 — #961) |
 | `Domain/UseCases/FetchRecentNoticesUseCaseProtocol.swift` | HomeDomain |
@@ -472,12 +472,12 @@
 | `Domain/UseCases/Implementations/ForceDeleteScheduleUseCase.swift` | HomeDomain |
 | `Domain/UseCases/Implementations/GenerateScheduleUseCase.swift` | HomeDomain |
 | `Domain/UseCases/Implementations/RegisterFCMTokenUseCase.swift` | HomeDomain |
-| `Domain/UseCases/Implementations/SearchChallengersUseCase.swift` | HomeDomain |
+| `Domain/UseCases/Implementations/SearchChallengersUseCase.swift` | ActivityDomain |
 | `Domain/UseCases/Implementations/UpdateScheduleUseCase.swift` | HomeDomain |
 | `Domain/UseCases/RegisterFCMTokenUseCaseProtocol.swift` | HomeDomain |
-| `Domain/UseCases/SearchChallengersUseCaseProtocol.swift` | HomeDomain |
+| `Domain/UseCases/SearchChallengersUseCaseProtocol.swift` | ActivityDomain |
 | `Domain/UseCases/UpdateScheduleUseCaseProtocol.swift` | HomeDomain |
-| `Presentation/Components/Card/ChallengerSearchCard.swift` | HomePresentation |
+| `Presentation/Components/Card/ChallengerSearchCard.swift` | ActivityPresentation (`Components/Challenger/`) |
 | `Presentation/Components/Card/NoticeAlarmCard.swift` | HomePresentation |
 | `Presentation/Components/Card/PenaltyCard.swift` | HomePresentation |
 | `Presentation/Components/Card/RecentNoticeCard.swift` | HomePresentation |
@@ -485,40 +485,40 @@
 | `Presentation/Components/Card/ScheduleListCard.swift` | HomePresentation |
 | `Presentation/Components/Card/SeasonCard.swift` | HomePresentation |
 | `Presentation/Components/Map/SelectedPlaceAnnotation.swift` | HomePresentation |
-| `Presentation/Components/Row/DatePickerRow.swift` | HomePresentation |
-| `Presentation/Components/Row/DateTimeRow.swift` | HomePresentation |
-| `Presentation/Components/Row/TimePickerRow.swift` | HomePresentation |
+| `Presentation/Components/Row/DatePickerRow.swift` | CoreUIComponents (`Sources/Schedule/`) |
+| `Presentation/Components/Row/DateTimeRow.swift` | CoreUIComponents (`Sources/Schedule/`) |
+| `Presentation/Components/Row/TimePickerRow.swift` | CoreUIComponents (`Sources/Schedule/`) |
 | `Presentation/Components/Schedule/AttendancePolicyDisplaySection.swift` | HomePresentation |
-| `Presentation/Components/Schedule/AttendancePolicyTimeSection.swift` | HomePresentation |
+| `Presentation/Components/Schedule/AttendancePolicyTimeSection.swift` | CoreUIComponents (`Sources/Schedule/`) |
 | `Presentation/Components/Schedule/Calendar/CalendarGridCard.swift` | HomePresentation |
 | `Presentation/Components/Schedule/Calendar/CalendarHorizonCard.swift` | HomePresentation |
 | `Presentation/Components/Schedule/Calendar/DateCell.swift` | HomePresentation |
 | `Presentation/Components/Schedule/Calendar/DatePill.swift` | HomePresentation |
 | `Presentation/Components/Schedule/Calendar/ScheduleHeader.swift` | HomePresentation |
-| `Presentation/Components/Schedule/InPersonToggle.swift` | HomePresentation |
-| `Presentation/Enum/NoticeAlarmType.swift` | HomePresentation |
+| `Presentation/Components/Schedule/InPersonToggle.swift` | CoreUIComponents (`Sources/Schedule/`) |
+| `Presentation/Enum/NoticeAlarmType.swift` | HomeDomain (`Models/NoticeHistory/NoticeAlarmType.swift` — Presentation 아님) |
 | `Presentation/Enum/PenalyInfoType.swift` | HomePresentation |
-| `Presentation/Enum/RecentCategory.swift` | HomePresentation |
-| `Presentation/Enum/ScheduleCategory.swift` | HomePresentation |
-| `Presentation/Enum/ScheduleGenerationType.swift` | HomePresentation |
+| `Presentation/Enum/RecentCategory.swift` | **superseded → `NoticeDomain.NoticeCategory`** — 레거시 소비자는 함께 대체된 `NoticeListDTO`·`RecentNoticeData` 뿐 |
+| `Presentation/Enum/ScheduleCategory.swift` | **이식 제외(dead)** — 레거시 참조 0건(`HomeView`의 `isScheduleCategoryLoading` 은 이름만 겹치는 별개 상태) |
+| `Presentation/Enum/ScheduleGenerationType.swift` | **superseded → 각 View 의 `fileprivate enum Constants` + `PlaceSelectView(placeholder:)`** — 폼 placeholder 를 열거형 한 곳에 모으는 설계를 버렸다. 레거시 소비자(`ScheduleRegistrationView`·`PlaceSelectView`)는 UMCApp 에서 각자 상수를 갖는다 |
 | `Presentation/Enum/ScheduleMode.swift` | HomePresentation |
-| `Presentation/Enum/SeasonType.swift` | HomePresentation |
-| `Presentation/Provider/HomeUseCaseProvider.swift` | HomePresentation |
+| `Presentation/Enum/SeasonType.swift` | HomeDomain (`Models/SeasonType.swift` — Presentation 아님) |
+| `Presentation/Provider/HomeUseCaseProvider.swift` | **superseded → `UMCApp/Sources/DIContainer+Home.swift`** — 레거시 유일 소비자는 `Core/DIContainer/DIContainer.swift`. UseCase 조립은 앱 타깃 DIContainer 확장이 담당 |
 | `Presentation/ViewModels/HomeViewModel.swift` | HomePresentation |
 | `Presentation/ViewModels/InlineMapPickerState.swift` | HomePresentation |
 | `Presentation/ViewModels/ScheduleDetailViewModel.swift` | HomePresentation |
 | `Presentation/ViewModels/ScheduleDraft.swift` | HomePresentation |
 | `Presentation/ViewModels/ScheduleRegistrationViewModel+AI.swift` | HomePresentation |
 | `Presentation/ViewModels/ScheduleRegistrationViewModel.swift` | HomePresentation |
-| `Presentation/ViewModels/SearchChallengerViewModel.swift` | HomePresentation |
+| `Presentation/ViewModels/SearchChallengerViewModel.swift` | ActivityPresentation |
 | `Presentation/ViewModels/SearchPlaceViewModel.swift` | HomePresentation |
 | `Presentation/Views/HomeView.swift` | HomePresentation |
 | `Presentation/Views/NoticeAlarmView.swift` | HomePresentation |
-| `Presentation/Views/Registration/Challenger/ChallengerFormView.swift` | HomePresentation |
-| `Presentation/Views/Registration/Challenger/SearchChallengerView.swift` | HomePresentation |
-| `Presentation/Views/Registration/Challenger/SelectedChallengerView.swift` | HomePresentation |
+| `Presentation/Views/Registration/Challenger/ChallengerFormView.swift` | ActivityPresentation (`Components/Challenger/`) |
+| `Presentation/Views/Registration/Challenger/SearchChallengerView.swift` | ActivityPresentation (`Components/Challenger/`) |
+| `Presentation/Views/Registration/Challenger/SelectedChallengerView.swift` | ActivityPresentation (`Components/Challenger/`) |
 | `Presentation/Views/Registration/InlineMapPlacePicker.swift` | HomePresentation |
-| `Presentation/Views/Registration/ScheduleDetailView.swift` | HomePresentation |
+| `Presentation/Views/Registration/ScheduleDetailView.swift` | HomePresentation (`Views/ScheduleDetailView.swift` — Registration 하위 아님) |
 | `Presentation/Views/Registration/ScheduleRegistrationView.swift` | HomePresentation |
 | `Presentation/Views/Registration/SearchPlaceResultRow.swift` | HomePresentation |
 | `Presentation/Views/Registration/SearchPlaceView.swift` | HomePresentation |


### PR DESCRIPTION
## ✨ PR 유형

Feature + Fix + Refactor — Home 마이그레이션의 **잔여 결선(wiring)** 일괄 처리

레거시 `AppProduct/Features/Home/` → `UMCApp/Features/Home/` 이관을 재감사한 결과 **미이식 파일은 0**이었고, 남은 문제는 전부 성격이 달랐습니다.

1. **결선되지 않은 파이프라인** — DTO·Repository·UseCase·DI 등록까지 다 만들어두고 소비처가 0인 코드
2. **화면 안에서 빠진 기능** — 파일은 이관됐지만 섹션/분기가 누락
3. **규약 위반·테스트 공백**

P0 5건 / P1 7건 / P2 5건을 전부 처리했습니다. 상세 감사 내역은 `docs/claude/home-migration-plan.md` 참고.

## 📷 스크린샷 or 영상(UI 변경 시)

> ⚠️ UI 변경이 포함되어 있습니다. 아래 화면 캡처 첨부가 필요합니다.
> - 일정 등록 — 참여자 선택 섹션 / 상한 초과 경고
> - 일정 상세 — 시작된 일정의 편집 비활성화 + 잠금 배너
> - 홈 — 최근 공지 조회 실패 시 에러·재시도 표시

## 🛠️ 작업내용

### P0 — 기능 결손

- **참여자 선택 결선** — 일정 생성이 `participantMemberIds` 를 빈 배열로 하드코딩해 **작성자 본인조차 참여자로 들어가지 않던** 문제 수정. 생성 시 작성자 `memberId` 강제 포함, 편집 진입 시 기존 참여자 프리필, `EditFormSnapshot` 에 참여자 추가(참여자만 바꿔도 저장 활성화). 수정은 변경됐을 때만 전송해 PATCH 3-state 유지
  - 차단 요인이던 `SelectedChallengerView` `public` 승격 + `Home/Project.swift` 에 `ActivityDomain`·`ActivityPresentation` 추가
- **`ScheduleCapabilities` 결선** — 소비처가 0이던 파이프라인을 `.task` 에 연결. 권한 없으면 출석 필수 토글 비노출, 참여자 상한 초과 시 인라인 경고 + 등록 차단, `N / max` 표시. `maxParticipantCount` 를 `Int` → `String` 으로 교정(절대 규칙 #2)
  - `DIContainer+StubSession` 에 `ScheduleCapabilitiesRepositoryProtocol` 등록 — 누락 시 스텁 세션이 실네트워크를 탐
- **시작된 일정 편집 사전 차단** — 선언만 되고 아무도 읽지 않던 `isScheduleStarted` 를 툴바에 결선. 잠금 안내 배너 복원, 삭제 진행 중 `ProgressView` 표시
- **최근 공지 섹션 에러 복원** — 조회 실패 시 `EmptyView()` 를 반환해 **섹션 헤더까지 사라지던** 문제 수정. 헤더를 상태 밖으로 빼고 `RetryContentUnavailableView` + 실제 재시도 스피너 결선
- **홈 진입 프로필 저장** — `SyncProfileStorageUseCase` 를 `AuthDomain` → `CoreDomain` 으로 승격 후 홈에 결선. 세션 중 역할·기수 변경과 FCM 토큰 재동기화가 홈에서도 반영됨

### P1 — UX·성능

- 일정 아이콘 분류 게이트 복원(선택 날짜 범위만) + 월 전체 순차 `for await` → `TaskGroup` 병렬화, stale 가드를 `fetchSchedules` 응답 반영까지 확장
- AI 자동완성 실패를 전역 알럿 대신 시트 내 인라인 상태로 복구, 미지원 기기 안내 추가
- 피커 토글 시 키보드 내림, 제목 필드 및 `SeasonCard` `Equatable` 복원
- `LoadingView(.home(...))` 시맨틱 로딩 뷰 적용

### P2 — 규약·부채

- **상벌점 소수점 절삭 버그** — `Int(point.point)` 로 `-0.5` 가 `0` 이 되던 문제 수정
- Preview `#if DEBUG` 가드 전역 스윕 (Home 11 · Notice 11 · CoreUIComponents 5 · Activity 2, **잔여 0**)
- `ScheduleRegistrationViewModelTests` 신규 12건 + 상세 4 suite
- `tuist-file-mapping.md` Home 구간 32행 동기화

## 📋 추후 진행 상황

- **중복 DTO 통합**(`ScheduleLocationDTO`/`ScheduleAttendancePolicyDTO`) — Home·Activity 사본이 동작상 동일하고 소비처가 각 1곳뿐이나, Activity 사본 제거에는 `ActivityData → HomeData` 라는 Feature 간 Data-to-Data 의존이 필요합니다. 40줄 중복 제거 대가로 레이어 경계를 뚫는 건 손해라 별도 이슈로 분리 (대안: 두 DTO 의 CoreNetwork 승격)
- **출석 정책 피커 6개 키보드 내림** — `AttendancePolicyTimeSection` 의 `openSlot` 이 컴포넌트 내부 `@State` 라 외부에서 관측 불가. 현재는 시작/종료 4개만 결선
- **`LoadingType.Home` 일정 로딩 케이스 추가** — 기존 3종은 문구 고정이라 일정 게이트에는 무문구 플레이스홀더 사용
- `tuist-file-mapping.md` 상단 "목적지별 파일 수" 요약 재집계(766행 전수 필요)

## 📌 리뷰 포인트

- `UMCApp/Features/Home/Presentation/Sources/ViewModels/ScheduleRegistrationViewModel.swift` — 작성자 강제 포함 로직과 수정 시 미변경 필드를 `nil` 로 유지하는 PATCH 3-state 처리
- `UMCApp/Features/Home/Presentation/Sources/Views/Registration/ScheduleRegistrationView.swift` — 참여자 섹션, capabilities 기반 출석 토글 게이팅
- `UMCApp/Core/Domain/Sources/Member/SyncProfileStorageUseCase.swift` — **AuthDomain → CoreDomain 승격**. `Home → AuthDomain` 은 의존 방향이 잘못됐고 이 UseCase 는 CoreDomain/UMCFoundation 타입에만 의존해 승격 비용이 0(기존 Auth 소비처 import 수정 0건)이라는 판단. 이 방향이 맞는지 확인 부탁드립니다
- `UMCApp/Features/Home/Presentation/Sources/ViewModels/HomeViewModel.swift` — `TaskGroup` 병렬 분류와 세대(generation) 기반 stale 가드. 가드를 분류뿐 아니라 `fetchSchedules` 응답 반영까지 확장하지 않으면 늦게 도착한 이전 달 응답이 최신 분류와 어긋나 게이트가 영구 로딩으로 굳습니다
- `UMCApp/Features/Home/Domain/Sources/Models/PointLog.swift` — `String` 이 아니라 `Double` 을 택한 이유(원본이 `Double`, 절대 규칙 #2 는 "서버 응답 **정수**" 대상)를 프로퍼티 주석에 남겼습니다
- `UMCApp/Features/Home/Presentation/Sources/Views/ScheduleDetailView.swift` — 항목별 `disabled` 와 a11y label/hint 표현을 위해 공용 `ToolbarTrailingMenu` 대신 화면 전용 `Menu` 로 구성

### 검증

- `tuist generate` 성공 — `ActivityPresentation` 추가에 따른 **순환 의존 없음**
- `make build` **BUILD SUCCEEDED**
- 테스트 전건 통과 — HomeDomain 19 / HomeData 34 / HomePresentation 36 / UMCAppTests 14 / CoreDomain 9 / AuthDomain 51 / AuthPresentation 102 / ActivityDomain 218 / ActivityPresentation 295 / CoreUIComponents 29
- `AppProduct/` 무변경 (절대 규칙 #9)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)