### PR TITLE
♻️[Refactor] MemberOAuth 이관 및 MyPage 소셜 연동 결선 (#1029)

### DIFF
--- a/UMCApp/Core/Network/Sources/Auth/SocialLoginManagerProtocols.swift
+++ b/UMCApp/Core/Network/Sources/Auth/SocialLoginManagerProtocols.swift
@@ -11,6 +11,12 @@
 public protocol KakaoLoginManaging {
     /// 카카오 로그인을 수행하고 액세스 토큰과 이메일을 반환한다.
     func login() async throws -> (accessToken: String, email: String)
+
+    /// 액세스 토큰만 발급받는다.
+    ///
+    /// 연동 해제 검증(`DELETE /api/v1/member-oauth/{id}`)에는 이메일이 필요 없고, 이메일을
+    /// 공유하지 않는 카카오 계정에서는 `login()`이 실패하므로 토큰만 받는 경로를 따로 둔다.
+    func fetchAccessToken() async throws -> String
 }
 
 extension KakaoLoginManager: KakaoLoginManaging {}
@@ -39,6 +45,9 @@ extension AppleLoginManager: AppleLoginManaging {}
 public protocol GoogleLoginManaging {
     /// 구글 로그인을 수행하고 서버 전송용 OAuth accessToken과 계정 이메일을 반환한다.
     func login() async throws -> (accessToken: String, email: String?)
+
+    /// 서버 전송용 OAuth accessToken만 발급받는다. (연동 추가/해제 검증용)
+    func fetchAccessToken() async throws -> String
 }
 
 extension GoogleLoginManager: GoogleLoginManaging {}

--- a/UMCApp/Features/Auth/Data/Sources/DTOs/Request/AddMemberOAuthRequestDTO.swift
+++ b/UMCApp/Features/Auth/Data/Sources/DTOs/Request/AddMemberOAuthRequestDTO.swift
@@ -1,0 +1,18 @@
+//
+//  AddMemberOAuthRequestDTO.swift
+//  AuthData
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// 로그인 OAuth 수단 추가 연동 요청 DTO
+///
+/// `POST /api/v1/member-oauth`
+public struct AddMemberOAuthRequestDTO: Encodable {
+    /// 소셜 로그인 시 발급받은 OAuth 검증 토큰
+    public let oAuthVerificationToken: String
+
+    public init(oAuthVerificationToken: String) {
+        self.oAuthVerificationToken = oAuthVerificationToken
+    }
+}

--- a/UMCApp/Features/Auth/Data/Sources/DTOs/Request/DeleteMemberOAuthRequestDTO.swift
+++ b/UMCApp/Features/Auth/Data/Sources/DTOs/Request/DeleteMemberOAuthRequestDTO.swift
@@ -1,0 +1,21 @@
+//
+//  DeleteMemberOAuthRequestDTO.swift
+//  AuthData
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// 로그인 OAuth 수단 연동 해제 요청 DTO
+///
+/// `DELETE /api/v1/member-oauth/{memberOAuthId}`
+public struct DeleteMemberOAuthRequestDTO: Encodable {
+    /// Google 연동 해제 검증용 액세스 토큰
+    public let googleAccessToken: String?
+    /// Kakao 연동 해제 검증용 액세스 토큰
+    public let kakaoAccessToken: String?
+
+    public init(googleAccessToken: String?, kakaoAccessToken: String?) {
+        self.googleAccessToken = googleAccessToken
+        self.kakaoAccessToken = kakaoAccessToken
+    }
+}

--- a/UMCApp/Features/Auth/Data/Sources/DTOs/Response/MemberOAuthDTO.swift
+++ b/UMCApp/Features/Auth/Data/Sources/DTOs/Response/MemberOAuthDTO.swift
@@ -1,0 +1,57 @@
+//
+//  MemberOAuthDTO.swift
+//  AuthData
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import AuthDomain
+import UMCFoundation
+
+/// 회원 OAuth 연동 정보 API 응답 DTO
+///
+/// `GET /api/v1/member-oauth/me`, `POST /api/v1/member-oauth` 응답 요소.
+public struct MemberOAuthDTO: Codable, Sendable, Equatable {
+
+    // MARK: - Property
+
+    /// OAuth 연동 ID (서버 응답 String 기준)
+    public let memberOAuthId: String
+    /// 회원 ID (서버 응답 String 기준)
+    public let memberId: String
+    /// OAuth 제공자 raw 문자열 (KAKAO, APPLE, GOOGLE)
+    public let provider: String
+
+    private enum CodingKeys: String, CodingKey {
+        case memberOAuthId
+        case memberId
+        case provider
+    }
+
+    // MARK: - Init
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // 연동 해제 경로(/member-oauth/{id})에 그대로 실리는 필수 식별자라 누락되면 throw한다.
+        memberOAuthId = try container.decodeFlexibleString(forKey: .memberOAuthId)
+        memberId = container.decodeFlexibleStringOrEmpty(forKey: .memberId)
+        provider = try container.decodeIfPresent(String.self, forKey: .provider) ?? ""
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(memberOAuthId, forKey: .memberOAuthId)
+        try container.encode(memberId, forKey: .memberId)
+        try container.encode(provider, forKey: .provider)
+    }
+
+    // MARK: - Mapping
+
+    public func toDomain() -> MemberOAuth {
+        MemberOAuth(
+            memberOAuthId: memberOAuthId,
+            memberId: memberId,
+            provider: OAuthProvider(raw: provider)
+        )
+    }
+}

--- a/UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift
+++ b/UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift
@@ -138,7 +138,60 @@ public struct AuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         }
     }
 
+    public func fetchMyOAuth() async throws -> [MemberOAuth] {
+        try await requestMemberOAuthList(AuthRouter.fetchMyOAuth)
+    }
+
+    public func addMemberOAuth(oAuthVerificationToken: String) async throws -> [MemberOAuth] {
+        try await requestMemberOAuthList(
+            AuthRouter.addMemberOAuth(
+                body: AddMemberOAuthRequestDTO(oAuthVerificationToken: oAuthVerificationToken)
+            )
+        )
+    }
+
+    public func deleteMemberOAuth(
+        memberOAuthId: String,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws {
+        let response = try await adapter.request(
+            AuthRouter.deleteMemberOAuth(
+                memberOAuthId: memberOAuthId,
+                body: DeleteMemberOAuthRequestDTO(
+                    googleAccessToken: googleAccessToken,
+                    kakaoAccessToken: kakaoAccessToken
+                )
+            )
+        )
+
+        do {
+            let apiResponse = try JSONDecoder().decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let decodingError as DecodingError {
+            throw RepositoryError.decodingError(detail: "\(decodingError)")
+        }
+    }
+
     // MARK: - Private Function
+
+    /// OAuth 연동 목록을 반환하는 엔드포인트(조회/추가) 공통 디코딩 경로.
+    private func requestMemberOAuthList(_ target: AuthRouter) async throws -> [MemberOAuth] {
+        let response = try await adapter.request(target)
+
+        do {
+            let apiResponse = try JSONDecoder().decode(
+                APIResponse<[MemberOAuthDTO]>.self,
+                from: response.data
+            )
+            return try apiResponse.unwrap().map { $0.toDomain() }
+        } catch let decodingError as DecodingError {
+            throw RepositoryError.decodingError(detail: "\(decodingError)")
+        }
+    }
 
     /// OAuth 로그인 응답을 디코딩하고, 기존 회원이면 토큰을 저장한 뒤 결과를 반환한다.
     private func performOAuthLogin(_ target: AuthRouter) async throws -> OAuthLoginResult {

--- a/UMCApp/Features/Auth/Data/Sources/Router/AuthRouter.swift
+++ b/UMCApp/Features/Auth/Data/Sources/Router/AuthRouter.swift
@@ -50,6 +50,12 @@ public enum AuthRouter: BaseTargetType {
     case registerExistingChallenger(body: RegisterExistingChallengerRequestDTO)
     /// 비밀번호 재설정
     case resetPassword(body: ResetPasswordRequestDTO)
+    /// 내 OAuth 연동 정보 조회
+    case fetchMyOAuth
+    /// 로그인 OAuth 수단 추가 연동
+    case addMemberOAuth(body: AddMemberOAuthRequestDTO)
+    /// 로그인 OAuth 수단 연동 해제
+    case deleteMemberOAuth(memberOAuthId: String, body: DeleteMemberOAuthRequestDTO)
 
     // MARK: - Path
 
@@ -85,6 +91,12 @@ public enum AuthRouter: BaseTargetType {
             return "/api/v1/challenger-record/member"
         case .resetPassword:
             return "/api/v1/auth/password/reset"
+        case .fetchMyOAuth:
+            return "/api/v1/member-oauth/me"
+        case .addMemberOAuth:
+            return "/api/v1/member-oauth"
+        case .deleteMemberOAuth(let memberOAuthId, _):
+            return "/api/v1/member-oauth/\(memberOAuthId)"
         }
     }
 
@@ -92,14 +104,17 @@ public enum AuthRouter: BaseTargetType {
 
     public var method: Moya.Method {
         switch self {
-        case .checkEmailAvailability, .fetchSchools, .fetchTerms:
+        case .checkEmailAvailability, .fetchSchools, .fetchTerms, .fetchMyOAuth:
             return .get
         case .loginKakao, .loginApple, .loginGoogle, .loginByEmail,
              .sendEmailVerification, .resendEmailVerification, .verifyEmailCode,
-             .register, .registerByEmail, .registerCredential, .registerExistingChallenger:
+             .register, .registerByEmail, .registerCredential, .registerExistingChallenger,
+             .addMemberOAuth:
             return .post
         case .resetPassword:
             return .patch
+        case .deleteMemberOAuth:
+            return .delete
         }
     }
 
@@ -139,6 +154,12 @@ public enum AuthRouter: BaseTargetType {
         case .registerExistingChallenger(let body):
             return .requestJSONEncodable(body)
         case .resetPassword(let body):
+            return .requestJSONEncodable(body)
+        case .fetchMyOAuth:
+            return .requestPlain
+        case .addMemberOAuth(let body):
+            return .requestJSONEncodable(body)
+        case .deleteMemberOAuth(_, let body):
             return .requestJSONEncodable(body)
         }
     }

--- a/UMCApp/Features/Auth/Domain/Sources/Interfaces/AuthRepositoryProtocol.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/Interfaces/AuthRepositoryProtocol.swift
@@ -50,4 +50,24 @@ public protocol AuthRepositoryProtocol {
     ///   - password: 평문 비밀번호 (TLS 구간 서버 해싱 위임)
     /// - Returns: 로그인 결과 (회원 ID). 토큰 저장은 Repository가 처리한다.
     func loginByEmail(email: String, password: String) async throws -> LoginByIdPwResult
+
+    /// 내 OAuth 연동 목록을 조회한다.
+    /// - Returns: 연동된 OAuth 목록
+    func fetchMyOAuth() async throws -> [MemberOAuth]
+
+    /// OAuth 수단을 추가 연동한다.
+    /// - Parameter oAuthVerificationToken: 소셜 로그인으로 발급받은 검증 토큰
+    /// - Returns: 연동 완료 후 전체 OAuth 목록
+    func addMemberOAuth(oAuthVerificationToken: String) async throws -> [MemberOAuth]
+
+    /// OAuth 수단 연동을 해제한다.
+    /// - Parameters:
+    ///   - memberOAuthId: 해제할 OAuth 연동 ID
+    ///   - googleAccessToken: Google 해제 검증용 액세스 토큰
+    ///   - kakaoAccessToken: Kakao 해제 검증용 액세스 토큰
+    func deleteMemberOAuth(
+        memberOAuthId: String,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws
 }

--- a/UMCApp/Features/Auth/Domain/Sources/Models/MemberOAuth.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/Models/MemberOAuth.swift
@@ -1,0 +1,29 @@
+//
+//  MemberOAuth.swift
+//  AuthDomain
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// 회원 OAuth 연동 정보.
+public struct MemberOAuth: Equatable, Sendable {
+
+    // MARK: - Property
+
+    /// OAuth 연동 ID (서버 응답 String 기준)
+    public let memberOAuthId: String
+
+    /// 회원 ID (서버 응답 String 기준)
+    public let memberId: String
+
+    /// OAuth 제공자 (APPLE, KAKAO, GOOGLE)
+    public let provider: OAuthProvider
+
+    // MARK: - Init
+
+    public init(memberOAuthId: String, memberId: String, provider: OAuthProvider) {
+        self.memberOAuthId = memberOAuthId
+        self.memberId = memberId
+        self.provider = provider
+    }
+}

--- a/UMCApp/Features/Auth/Domain/Sources/Models/OAuthProvider.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/Models/OAuthProvider.swift
@@ -1,0 +1,65 @@
+//
+//  OAuthProvider.swift
+//  AuthDomain
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import UMCFoundation
+
+/// 서버가 내려주는 OAuth provider 타입.
+///
+/// 스웨거 enum 기준(APPLE, KAKAO, GOOGLE)으로 모델링하며, 지원하지 않는 값은 `.unknown`으로
+/// 흡수해 화면에서 무시한다(서버가 provider를 추가해도 디코딩이 실패하지 않도록).
+public enum OAuthProvider: Equatable, Sendable {
+    /// Apple 로그인
+    case apple
+    /// Kakao 로그인
+    case kakao
+    /// Google 로그인
+    case google
+    /// 서버에서 내려온 알 수 없는 provider (하위 호환용)
+    case unknown(String)
+
+    /// 서버 raw 문자열("APPLE", "KAKAO", "GOOGLE")을 case로 변환한다.
+    public init(raw: String) {
+        switch raw.uppercased() {
+        case "APPLE":
+            self = .apple
+        case "KAKAO":
+            self = .kakao
+        case "GOOGLE":
+            self = .google
+        default:
+            self = .unknown(raw)
+        }
+    }
+
+    /// 서버 전송/저장용 raw 문자열.
+    public var raw: String {
+        switch self {
+        case .apple:
+            return "APPLE"
+        case .kakao:
+            return "KAKAO"
+        case .google:
+            return "GOOGLE"
+        case .unknown(let raw):
+            return raw
+        }
+    }
+
+    /// 앱 내부에서 사용하는 `SocialType`으로 변환한다. (`.unknown`은 nil)
+    public var socialType: SocialType? {
+        switch self {
+        case .apple:
+            return .apple
+        case .kakao:
+            return .kakao
+        case .google:
+            return .google
+        case .unknown:
+            return nil
+        }
+    }
+}

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/AddMemberOAuthUseCaseProtocol.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/AddMemberOAuthUseCaseProtocol.swift
@@ -1,0 +1,7 @@
+/// 로그인 OAuth 수단 추가 연동 UseCase 인터페이스
+public protocol AddMemberOAuthUseCaseProtocol {
+    /// OAuth 검증 토큰으로 연동을 추가한다.
+    /// - Parameter oAuthVerificationToken: 소셜 로그인 시 발급받은 검증 토큰
+    /// - Returns: 연동 완료 후 전체 OAuth 목록
+    func execute(oAuthVerificationToken: String) async throws -> [MemberOAuth]
+}

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/DeleteMemberOAuthUseCaseProtocol.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/DeleteMemberOAuthUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+/// 로그인 OAuth 수단 연동 해제 UseCase 인터페이스
+public protocol DeleteMemberOAuthUseCaseProtocol {
+    /// OAuth 연동을 해제한다.
+    /// - Parameters:
+    ///   - memberOAuthId: 해제할 OAuth 연동 ID
+    ///   - googleAccessToken: Google 연동 해제 검증용 액세스 토큰
+    ///   - kakaoAccessToken: Kakao 연동 해제 검증용 액세스 토큰
+    func execute(
+        memberOAuthId: String,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws
+}

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/FetchMyOAuthUseCaseProtocol.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/FetchMyOAuthUseCaseProtocol.swift
@@ -1,0 +1,6 @@
+/// 내 OAuth 연동 정보 조회 UseCase 인터페이스
+public protocol FetchMyOAuthUseCaseProtocol {
+    /// 내 OAuth 연동 정보를 조회한다.
+    /// - Returns: 연동된 OAuth 목록
+    func execute() async throws -> [MemberOAuth]
+}

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/AddMemberOAuthUseCase.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/AddMemberOAuthUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  AddMemberOAuthUseCase.swift
+//  AuthDomain
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// OAuth 수단 추가 연동 UseCase 구현체
+public final class AddMemberOAuthUseCase: AddMemberOAuthUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: AuthRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(oAuthVerificationToken: String) async throws -> [MemberOAuth] {
+        try await repository.addMemberOAuth(oAuthVerificationToken: oAuthVerificationToken)
+    }
+}

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/DeleteMemberOAuthUseCase.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/DeleteMemberOAuthUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  DeleteMemberOAuthUseCase.swift
+//  AuthDomain
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// OAuth 수단 연동 해제 UseCase 구현체
+public final class DeleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: AuthRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(
+        memberOAuthId: String,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws {
+        try await repository.deleteMemberOAuth(
+            memberOAuthId: memberOAuthId,
+            googleAccessToken: googleAccessToken,
+            kakaoAccessToken: kakaoAccessToken
+        )
+    }
+}

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/FetchMyOAuthUseCase.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/FetchMyOAuthUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  FetchMyOAuthUseCase.swift
+//  AuthDomain
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// 내 OAuth 연동 정보 조회 UseCase 구현체
+public final class FetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: AuthRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute() async throws -> [MemberOAuth] {
+        try await repository.fetchMyOAuth()
+    }
+}

--- a/UMCApp/Features/Auth/Domain/Tests/Support/MockAuthRepository.swift
+++ b/UMCApp/Features/Auth/Domain/Tests/Support/MockAuthRepository.swift
@@ -119,4 +119,48 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         loginByEmailReceivedPassword = password
         return try loginByEmailResult.get()
     }
+
+    // MARK: - fetchMyOAuth
+
+    var fetchMyOAuthResult: Result<[MemberOAuth], Error> = .failure(MockError.notStubbed)
+    private(set) var fetchMyOAuthCallCount = 0
+
+    func fetchMyOAuth() async throws -> [MemberOAuth] {
+        fetchMyOAuthCallCount += 1
+        return try fetchMyOAuthResult.get()
+    }
+
+    // MARK: - addMemberOAuth
+
+    var addMemberOAuthResult: Result<[MemberOAuth], Error> = .failure(MockError.notStubbed)
+    private(set) var addMemberOAuthCallCount = 0
+    private(set) var addMemberOAuthReceivedToken: String?
+
+    func addMemberOAuth(oAuthVerificationToken: String) async throws -> [MemberOAuth] {
+        addMemberOAuthCallCount += 1
+        addMemberOAuthReceivedToken = oAuthVerificationToken
+        return try addMemberOAuthResult.get()
+    }
+
+    // MARK: - deleteMemberOAuth
+
+    var deleteMemberOAuthError: Error?
+    private(set) var deleteMemberOAuthCallCount = 0
+    private(set) var deleteMemberOAuthReceivedId: String?
+    private(set) var deleteMemberOAuthReceivedGoogleAccessToken: String?
+    private(set) var deleteMemberOAuthReceivedKakaoAccessToken: String?
+
+    func deleteMemberOAuth(
+        memberOAuthId: String,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws {
+        deleteMemberOAuthCallCount += 1
+        deleteMemberOAuthReceivedId = memberOAuthId
+        deleteMemberOAuthReceivedGoogleAccessToken = googleAccessToken
+        deleteMemberOAuthReceivedKakaoAccessToken = kakaoAccessToken
+        if let deleteMemberOAuthError {
+            throw deleteMemberOAuthError
+        }
+    }
 }

--- a/UMCApp/Features/Auth/Domain/Tests/UseCases/MemberOAuthUseCaseTests.swift
+++ b/UMCApp/Features/Auth/Domain/Tests/UseCases/MemberOAuthUseCaseTests.swift
@@ -1,0 +1,103 @@
+//
+//  MemberOAuthUseCaseTests.swift
+//  AuthDomainTests
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import Testing
+@testable import AuthDomain
+
+@Suite("MemberOAuth UseCase — Repository 위임 검증")
+struct MemberOAuthUseCaseTests {
+
+    // MARK: - FetchMyOAuthUseCase
+
+    @Test("execute()는 repository.fetchMyOAuth() 결과를 그대로 반환한다")
+    func fetchMyOAuthDelegatesToRepository() async throws {
+        let repository = MockAuthRepository()
+        repository.fetchMyOAuthResult = .success([
+            MemberOAuth(memberOAuthId: "1", memberId: "10", provider: .kakao)
+        ])
+        let useCase = FetchMyOAuthUseCase(repository: repository)
+
+        let result = try await useCase.execute()
+
+        #expect(repository.fetchMyOAuthCallCount == 1)
+        #expect(result == [MemberOAuth(memberOAuthId: "1", memberId: "10", provider: .kakao)])
+    }
+
+    @Test("repository.fetchMyOAuth()가 에러를 던지면 그대로 전파한다")
+    func fetchMyOAuthPropagatesError() async {
+        let repository = MockAuthRepository()
+        repository.fetchMyOAuthResult = .failure(AuthTestError.boom)
+        let useCase = FetchMyOAuthUseCase(repository: repository)
+
+        await #expect(throws: AuthTestError.boom) {
+            _ = try await useCase.execute()
+        }
+    }
+
+    // MARK: - AddMemberOAuthUseCase
+
+    @Test("execute(oAuthVerificationToken:)는 토큰을 그대로 전달하고 갱신된 목록을 반환한다")
+    func addMemberOAuthDelegatesToRepository() async throws {
+        let repository = MockAuthRepository()
+        repository.addMemberOAuthResult = .success([
+            MemberOAuth(memberOAuthId: "1", memberId: "10", provider: .kakao),
+            MemberOAuth(memberOAuthId: "2", memberId: "10", provider: .google)
+        ])
+        let useCase = AddMemberOAuthUseCase(repository: repository)
+
+        let result = try await useCase.execute(oAuthVerificationToken: "verify-token")
+
+        #expect(repository.addMemberOAuthCallCount == 1)
+        #expect(repository.addMemberOAuthReceivedToken == "verify-token")
+        #expect(result.map(\.provider) == [.kakao, .google])
+    }
+
+    @Test("repository.addMemberOAuth()가 에러를 던지면 그대로 전파한다")
+    func addMemberOAuthPropagatesError() async {
+        let repository = MockAuthRepository()
+        repository.addMemberOAuthResult = .failure(AuthTestError.boom)
+        let useCase = AddMemberOAuthUseCase(repository: repository)
+
+        await #expect(throws: AuthTestError.boom) {
+            _ = try await useCase.execute(oAuthVerificationToken: "verify-token")
+        }
+    }
+
+    // MARK: - DeleteMemberOAuthUseCase
+
+    @Test("execute()는 연동 ID와 소셜별 검증 토큰을 그대로 전달한다")
+    func deleteMemberOAuthDelegatesToRepository() async throws {
+        let repository = MockAuthRepository()
+        let useCase = DeleteMemberOAuthUseCase(repository: repository)
+
+        try await useCase.execute(
+            memberOAuthId: "7",
+            googleAccessToken: nil,
+            kakaoAccessToken: "kakao-token"
+        )
+
+        #expect(repository.deleteMemberOAuthCallCount == 1)
+        #expect(repository.deleteMemberOAuthReceivedId == "7")
+        #expect(repository.deleteMemberOAuthReceivedGoogleAccessToken == nil)
+        #expect(repository.deleteMemberOAuthReceivedKakaoAccessToken == "kakao-token")
+    }
+
+    @Test("repository.deleteMemberOAuth()가 에러를 던지면 그대로 전파한다")
+    func deleteMemberOAuthPropagatesError() async {
+        let repository = MockAuthRepository()
+        repository.deleteMemberOAuthError = AuthTestError.boom
+        let useCase = DeleteMemberOAuthUseCase(repository: repository)
+
+        await #expect(throws: AuthTestError.boom) {
+            try await useCase.execute(
+                memberOAuthId: "7",
+                googleAccessToken: nil,
+                kakaoAccessToken: nil
+            )
+        }
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Tests/LoginViewModelTests.swift
+++ b/UMCApp/Features/Auth/Presentation/Tests/LoginViewModelTests.swift
@@ -388,6 +388,12 @@ private final class MockKakaoLoginManager: KakaoLoginManaging, @unchecked Sendab
         if let error { throw error }
         return (accessToken, email)
     }
+
+    func fetchAccessToken() async throws -> String {
+        callCount += 1
+        if let error { throw error }
+        return accessToken
+    }
 }
 
 /// 로딩 중 중복 호출 방지를 검증하기 위해 인위적인 지연을 주는 Kakao 매니저.
@@ -412,6 +418,10 @@ private final class SlowKakaoLoginManager: KakaoLoginManaging, @unchecked Sendab
         try await Task.sleep(nanoseconds: delayNanoseconds)
         return ("kakao-token", "kakao@umc.dev")
     }
+
+    func fetchAccessToken() async throws -> String {
+        try await login().accessToken
+    }
 }
 
 private final class MockGoogleLoginManager: GoogleLoginManaging, @unchecked Sendable {
@@ -424,6 +434,12 @@ private final class MockGoogleLoginManager: GoogleLoginManaging, @unchecked Send
         callCount += 1
         if let error { throw error }
         return (accessToken, email)
+    }
+
+    func fetchAccessToken() async throws -> String {
+        callCount += 1
+        if let error { throw error }
+        return accessToken
     }
 }
 

--- a/UMCApp/Features/MyPage/Domain/Sources/Models/ProfileData.swift
+++ b/UMCApp/Features/MyPage/Domain/Sources/Models/ProfileData.swift
@@ -53,15 +53,15 @@ public struct ProfileData: Identifiable, Equatable, Hashable {
 
 /// 연동된 소셜 계정의 서버 식별자와 타입을 나타내는 모델입니다.
 public struct SocialConnection: Identifiable, Equatable, Hashable {
-    /// OAuth 연동 ID
-    public let memberOAuthId: Int
+    /// OAuth 연동 ID (서버 응답 String 기준)
+    public let memberOAuthId: String
 
     /// 연동된 소셜 타입
     public let socialType: SocialType
 
-    public var id: Int { memberOAuthId }
+    public var id: String { memberOAuthId }
 
-    public init(memberOAuthId: Int, socialType: SocialType) {
+    public init(memberOAuthId: String, socialType: SocialType) {
         self.memberOAuthId = memberOAuthId
         self.socialType = socialType
     }

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/ConnectionSocial.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/ConnectionSocial.swift
@@ -1,0 +1,80 @@
+//
+//  ConnectionSocial.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import SwiftUI
+import CoreDesignSystem
+import CoreUIComponents
+import MyPageDomain
+import UMCFoundation
+
+/// 연동된 소셜 계정을 태그로 노출하고 탭하면 연동 해제를 요청하는 섹션입니다.
+public struct ConnectionSocial: View {
+    // MARK: - Property
+
+    private let sectionType: MyPageSectionType
+    private let socialConnections: [SocialConnection]
+    private let disconnectingSocialType: SocialType?
+    private let onDisconnect: (SocialConnection) -> Void
+
+    // MARK: - Body
+
+    public var body: some View {
+        if !socialConnections.isEmpty {
+            Section(content: {
+                socialTags
+            }, header: {
+                SectionHeaderView(title: sectionType.rawValue)
+            })
+        }
+    }
+
+    // MARK: - Function
+
+    public init(
+        sectionType: MyPageSectionType = .socialConnect,
+        socialConnections: [SocialConnection],
+        disconnectingSocialType: SocialType?,
+        onDisconnect: @escaping (SocialConnection) -> Void
+    ) {
+        self.sectionType = sectionType
+        self.socialConnections = socialConnections
+        self.disconnectingSocialType = disconnectingSocialType
+        self.onDisconnect = onDisconnect
+    }
+
+    private var socialTags: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            ForEach(socialConnections) { connection in
+                socialTag(connection)
+            }
+        }
+    }
+
+    private func socialTag(_ connection: SocialConnection) -> some View {
+        let social = connection.socialType
+
+        return Button(action: {
+            onDisconnect(connection)
+        }, label: {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                Text(social.displayName)
+                Image(
+                    systemName: disconnectingSocialType == social
+                        ? "hourglass"
+                        : "minus.circle.fill"
+                )
+                .font(.caption)
+            }
+            .appFont(.caption1, weight: .semibold, color: social.fontColor)
+            .padding(.vertical, DefaultSpacing.spacing4)
+            .padding(.horizontal, DefaultSpacing.spacing8)
+            .glassEffect(.clear.tint(social.color), in: .capsule)
+        })
+        .buttonStyle(.plain)
+        .disabled(disconnectingSocialType != nil)
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Extensions/SocialConnection+MemberOAuth.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Extensions/SocialConnection+MemberOAuth.swift
@@ -1,0 +1,22 @@
+//
+//  SocialConnection+MemberOAuth.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import AuthDomain
+import MyPageDomain
+
+extension SocialConnection {
+    /// 서버 OAuth 연동 정보를 화면 표시용 모델로 변환합니다.
+    ///
+    /// 앱이 모르는 provider(`OAuthProvider.unknown`)는 화면에서 무시하도록 `nil`을 반환합니다.
+    init?(memberOAuth: MemberOAuth) {
+        guard let socialType = memberOAuth.provider.socialType else {
+            return nil
+        }
+
+        self.init(memberOAuthId: memberOAuth.memberOAuthId, socialType: socialType)
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageProfileViewModel.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageProfileViewModel.swift
@@ -8,6 +8,8 @@
 import UMCFoundation
 import SwiftUI
 import PhotosUI
+import AuthDomain
+import CoreNetwork
 import CorePhoto
 import MyPageDomain
 
@@ -21,11 +23,11 @@ public final class MyPageProfileViewModel: SinglePhotoPickerManageable {
     /// 프로필 정보
     public var profileData: ProfileData
     private let useCaseProvider: MyPageUseCaseProviding
-    // FIXME: - Auth 모듈 수정 후 고치기
-//    private let authUseCaseProvider: AuthUseCaseProviding
-//    private let kakaoLoginManager = KakaoLoginManager()
-//    private let googleLoginManager = GoogleLoginManager()
-    
+    private let fetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol
+    private let deleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol
+    private let kakaoLoginManager: KakaoLoginManaging
+    private let googleLoginManager: GoogleLoginManaging
+
     /// PhotosPicker에서 선택된 아이템(PHPickerResult)
     public var selectedPhotoItem: PhotosPickerItem?
     
@@ -84,14 +86,17 @@ public final class MyPageProfileViewModel: SinglePhotoPickerManageable {
     public init(
         profileData: ProfileData,
         useCaseProvider: MyPageUseCaseProviding,
-        /*
-        // FIXME: - Auth 모듈 수정 후 고치기
-        authUseCaseProvider: AuthUseCaseProviding
-         */
+        fetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol,
+        deleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol,
+        kakaoLoginManager: KakaoLoginManaging = KakaoLoginManager(),
+        googleLoginManager: GoogleLoginManaging = GoogleLoginManager()
     ) {
         self.profileData = profileData
         self.useCaseProvider = useCaseProvider
-//        self.authUseCaseProvider = authUseCaseProvider
+        self.fetchMyOAuthUseCase = fetchMyOAuthUseCase
+        self.deleteMemberOAuthUseCase = deleteMemberOAuthUseCase
+        self.kakaoLoginManager = kakaoLoginManager
+        self.googleLoginManager = googleLoginManager
         self.initialProfileLinkState = Self.makeProfileLinkState(from: profileData.profileLink)
     }
     
@@ -169,21 +174,29 @@ public final class MyPageProfileViewModel: SinglePhotoPickerManageable {
     }
     
     /// 특정 소셜 연동을 해제하고 최신 연동 목록으로 갱신합니다.
-    // FIXME: - Auth 모듈 수정 후 고치기
-    /*
     @MainActor
     public func disconnectSocial(_ connection: SocialConnection) async throws {
         guard disconnectingSocialType == nil else {
             return
         }
-        
+
         disconnectingSocialType = connection.socialType
         defer { disconnectingSocialType = nil }
-        
-//        let verification = try await
+
+        let verification = try await makeDeleteVerification(for: connection.socialType)
+
+        try await deleteMemberOAuthUseCase.execute(
+            memberOAuthId: connection.memberOAuthId,
+            googleAccessToken: verification.googleAccessToken,
+            kakaoAccessToken: verification.kakaoAccessToken
+        )
+
+        let oauths = try await fetchMyOAuthUseCase.execute()
+        let updatedConnections = oauths.compactMap(SocialConnection.init(memberOAuth:))
+        profileData.socialConnections = updatedConnections
+        SocialType.saveConnected(updatedConnections.map(\.socialType))
     }
-     */
-    
+
     /// 프로필 링크 배열을 `[SocialLinkType: String]` 스냅샷으로 변환합니다.
     ///
     /// 변경 감지(diff) 비교에 사용되며, URL 공백을 제거하고
@@ -215,23 +228,20 @@ public final class MyPageProfileViewModel: SinglePhotoPickerManageable {
         }
     }
     
-    /// 소셜 로그인들의 연동 해제한 것을 확인합니다.
-    // MARK: - Todo -> Auth완성되면 진행필요
-    /*
+    /// 연동 해제 요청에 필요한 소셜별 검증 토큰을 발급받습니다.
+    ///
+    /// Apple은 서버가 별도 검증 토큰을 요구하지 않아 두 토큰 모두 `nil`입니다.
+    @MainActor
     private func makeDeleteVerification(
         for socialType: SocialType
     ) async throws -> (googleAccessToken: String?, kakaoAccessToken: String?) {
         switch socialType {
         case .kakao:
+            return (nil, try await kakaoLoginManager.fetchAccessToken())
         case .apple:
+            return (nil, nil)
         case .google:
+            return (try await googleLoginManager.fetchAccessToken(), nil)
         }
     }
-    */
-    
-    // MARK: - Todo -> Auth완성되면 구현 필요
-    /*
-    private static func makeSocialConnection() -> SocialConnection? {
-    }
-     */
 }

--- a/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageViewModel.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageViewModel.swift
@@ -5,19 +5,17 @@
 //  Created by One on 5/24/26.
 //
 
-import Foundation
-import UMCFoundation
+import AuthDomain
 import CoreDI
+import CoreNetwork
+import Foundation
 import MyPageDomain
+import UMCFoundation
 
 /// MyPage 화면의 상태 및 비즈니스 로직을 관리하는 ViewModel.
 ///
 /// `@Observable`을 사용하여 SwiftUI View와 양방향 데이터 바인딩을 수행합니다.
 /// 사용자 프로필 데이터와 Alert 상태를 관리합니다.
-///
-/// - Note: 본 PR은 `fetchProfile`만 이식한 최소 set입니다. `connectSocial` 및
-///   `/member-oauth/me` 기반 소셜 연동 동기화는 후속 이슈(Auth UseCase /
-///   KakaoLoginManager / AppleLoginManager 이식 후)에서 복원됩니다.
 @Observable
 public final class MyPageViewModel {
 
@@ -31,19 +29,35 @@ public final class MyPageViewModel {
 
     private let container: DIContainer
     private let myPageProvider: MyPageUseCaseProviding
+    private let fetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol
+    private let addMemberOAuthUseCase: AddMemberOAuthUseCaseProtocol
+    private let loginUseCase: LoginUseCaseProtocol
+    private let kakaoLoginManager: KakaoLoginManaging
+    private let appleLoginManager: AppleLoginManaging
+    private let googleLoginManager: GoogleLoginManaging
 
     // MARK: - Init
 
-    public init(container: DIContainer) {
+    public init(
+        container: DIContainer,
+        kakaoLoginManager: KakaoLoginManaging = KakaoLoginManager(),
+        appleLoginManager: AppleLoginManaging = AppleLoginManager(),
+        googleLoginManager: GoogleLoginManaging = GoogleLoginManager()
+    ) {
         self.container = container
         self.myPageProvider = container.resolve(MyPageUseCaseProviding.self)
+        self.fetchMyOAuthUseCase = container.resolve(FetchMyOAuthUseCaseProtocol.self)
+        self.addMemberOAuthUseCase = container.resolve(AddMemberOAuthUseCaseProtocol.self)
+        self.loginUseCase = container.resolve(LoginUseCaseProtocol.self)
+        self.kakaoLoginManager = kakaoLoginManager
+        self.appleLoginManager = appleLoginManager
+        self.googleLoginManager = googleLoginManager
     }
 
     #if DEBUG
     /// 프리뷰 전용 — 미리 로드된 프로필 상태로 시작합니다.
-    public init(container: DIContainer, previewProfileData: ProfileData) {
-        self.container = container
-        self.myPageProvider = container.resolve(MyPageUseCaseProviding.self)
+    public convenience init(container: DIContainer, previewProfileData: ProfileData) {
+        self.init(container: container)
         self.profileData = .loaded(previewProfileData)
     }
     #endif
@@ -57,11 +71,7 @@ public final class MyPageViewModel {
     /// - `AppError` → `.failed(error)`
     /// - 그 외 → `.failed(.unknown(message:))`
     ///
-    /// - Important: 본 PR은 `/member-oauth/me` 동기화를 호출하지 않으므로
-    ///   `socialConnections`는 항상 빈 배열로 세팅됩니다. 소셜 연동 표시는
-    ///   Auth UseCase 이식 후속 PR에서 복원합니다.
     /// - Parameter forceRefresh: `true`이면 세션 프로필 캐시를 우회해 서버 최신으로 갱신한다.
-    ///   (#816 화면 조립 시 당겨서 새로고침 경로로 연결 예정)
     @MainActor
     public func fetchProfile(forceRefresh: Bool = false) async {
         if profileData.isLoading { return }
@@ -73,8 +83,8 @@ public final class MyPageViewModel {
             var profile = try await myPageProvider.fetchMyPageProfileUseCase.execute(
                 forceRefresh: forceRefresh
             )
-            // TODO: Auth UseCase 이식 후속 PR에서 syncConnectedSocials() 호출로 교체
-            profile.socialConnections = []
+            // 소셜 연동 노출 기준은 `/member-oauth/me` 응답만 사용한다.
+            profile.socialConnections = await syncConnectedSocials() ?? []
             profileData = .loaded(profile)
         } catch is CancellationError {
             profileData = previousState
@@ -85,6 +95,108 @@ public final class MyPageViewModel {
             profileData = previousState
         } catch {
             profileData = .failed(.unknown(message: error.localizedDescription))
+        }
+    }
+
+    /// 소셜 계정 연동을 수행합니다.
+    ///
+    /// 소셜 로그인으로 OAuth 검증 토큰을 얻은 뒤 연동 추가 API를 호출하고,
+    /// 응답으로 받은 전체 연동 목록을 프로필 상태에 반영합니다.
+    ///
+    /// - Parameter social: 연동할 소셜 타입
+    /// - Throws: 소셜 로그인 실패 또는 서버 연동 에러
+    @MainActor
+    public func connectSocial(_ social: SocialType) async throws {
+        let verificationToken = try await fetchOAuthVerificationToken(social: social)
+        let linked = try await addMemberOAuthUseCase.execute(
+            oAuthVerificationToken: verificationToken
+        )
+
+        let connected = linked.compactMap(SocialConnection.init(memberOAuth:))
+        SocialType.saveConnected(connected.map(\.socialType))
+
+        if case .loaded(var profile) = profileData {
+            profile.socialConnections = connected
+            profileData = .loaded(profile)
+        }
+    }
+
+    // MARK: - Private Function
+
+    /// `/member-oauth/me`를 조회해 연동 소셜 목록을 동기화합니다.
+    ///
+    /// 조회 실패는 프로필 조회 전체를 실패시키지 않고 `nil`을 반환합니다.
+    @MainActor
+    private func syncConnectedSocials() async -> [SocialConnection]? {
+        do {
+            let oauths = try await fetchMyOAuthUseCase.execute()
+            let connections = oauths.compactMap(SocialConnection.init(memberOAuth:))
+            SocialType.saveConnected(connections.map(\.socialType))
+            return connections
+        } catch {
+            return nil
+        }
+    }
+
+    /// 소셜 타입별 OAuth 로그인을 수행하여 검증 토큰을 반환합니다.
+    @MainActor
+    private func fetchOAuthVerificationToken(social: SocialType) async throws -> String {
+        let result: OAuthLoginResult
+
+        switch social {
+        case .kakao:
+            let (accessToken, email) = try await kakaoLoginManager.login()
+            result = try await loginUseCase.executeKakao(accessToken: accessToken, email: email)
+        case .apple:
+            let authorizationCode = try await fetchAppleAuthorizationCode()
+            result = try await loginUseCase.executeApple(
+                authorizationCode: authorizationCode,
+                email: nil,
+                fullName: nil
+            )
+        case .google:
+            let accessToken = try await googleLoginManager.fetchAccessToken()
+            result = try await loginUseCase.executeGoogle(accessToken: accessToken)
+        }
+
+        return try extractVerificationToken(from: result, providerName: social.rawValue)
+    }
+
+    /// `AppleLoginManager`의 콜백을 async/await로 브릿징하여 authorization code를 반환합니다.
+    @MainActor
+    private func fetchAppleAuthorizationCode() async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            appleLoginManager.onAuthorizationCompleted = { code, _, _ in
+                continuation.resume(returning: code)
+            }
+            appleLoginManager.onAuthorizationFailed = { error in
+                continuation.resume(throwing: error)
+            }
+            appleLoginManager.signWithApple()
+        }
+    }
+
+    /// `OAuthLoginResult`에서 연동용 검증 토큰을 추출합니다.
+    ///
+    /// - Note: 검증 토큰은 신규 회원(`newMember`) 응답에만 존재합니다. 기존 회원은 이미 다른
+    ///   계정에 연결된 소셜이므로 연동 불가로 에러를 던집니다.
+    private func extractVerificationToken(
+        from result: OAuthLoginResult,
+        providerName: String
+    ) throws -> String {
+        switch result {
+        case .newMember(let token) where !token.isEmpty:
+            return token
+        case .newMember:
+            throw AuthError.socialLoginFailed(
+                provider: providerName,
+                reason: "OAuth 검증 토큰이 비어있습니다."
+            )
+        case .existingMember:
+            throw AuthError.socialLoginFailed(
+                provider: providerName,
+                reason: "이미 연동된 계정이거나 연동 가능한 검증 토큰이 없습니다."
+            )
         }
     }
 }

--- a/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageProfileView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageProfileView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import PhotosUI
 import UMCFoundation
+import AuthDomain
 import CoreDI
 import MyPageDomain
 
@@ -26,15 +27,12 @@ public struct MyPageProfileView: View {
     @State private var alertPrompt: AlertPrompt?
     
     public init(container: DIContainer, profileData: ProfileData) {
-        let provider = container.resolve(MyPageUseCaseProviding.self)
-        // MARK: - Todo -> Auth 완성되면 진행 필요
-//        let authProvider = container.resolve(AuthUseCaseProviding.self)
         self._viewModel = .init(
             initialValue: .init(
                 profileData: profileData,
-                useCaseProvider: provider,
-                // MARK: - Todo -> Auth 완성되면 진행 필요
-//                authUseCaseProvider: authProvider
+                useCaseProvider: container.resolve(MyPageUseCaseProviding.self),
+                fetchMyOAuthUseCase: container.resolve(FetchMyOAuthUseCaseProtocol.self),
+                deleteMemberOAuthUseCase: container.resolve(DeleteMemberOAuthUseCaseProtocol.self)
             )
         )
     }

--- a/UMCApp/Features/MyPage/Presentation/Tests/MyPageProfileViewModelTests.swift
+++ b/UMCApp/Features/MyPage/Presentation/Tests/MyPageProfileViewModelTests.swift
@@ -8,7 +8,9 @@
 import Testing
 import Foundation
 import UMCFoundation
+import AuthDomain
 import CoreDomain
+import CoreNetwork
 import MyPageDomain
 @testable import MyPagePresentation
 
@@ -61,7 +63,7 @@ struct MyPageProfileViewModelTests {
     func submitImageUpdateCallsImageUseCase() async throws {
         let original = makeStubProfileData(
             challengeId: 1,
-            socialConnections: [SocialConnection(memberOAuthId: 10, socialType: .kakao)]
+            socialConnections: [SocialConnection(memberOAuthId: "10", socialType: .kakao)]
         )
         // 서버 응답의 socialConnections가 비어 있어도 VM이 로컬 값을 복원해야 함
         let serverProfile = makeStubProfileData(challengeId: 42, socialConnections: [])
@@ -193,7 +195,7 @@ struct MyPageProfileViewModelTests {
     func addActivityLogSuccess() async throws {
         let original = makeStubProfileData(
             challengeId: 1,
-            socialConnections: [SocialConnection(memberOAuthId: 5, socialType: .apple)]
+            socialConnections: [SocialConnection(memberOAuthId: "5", socialType: .apple)]
         )
         let refreshed = makeStubProfileData(challengeId: 55, socialConnections: [])
         let mock = MockMyPageRepository()
@@ -227,6 +229,81 @@ struct MyPageProfileViewModelTests {
         #expect(viewModel.didRecentlyAddActivityLog == false)
         #expect(viewModel.isAddingActivityLog == false)
     }
+
+    // MARK: - disconnectSocial
+
+    @Test("카카오 연동 해제 — kakaoAccessToken 전달 + 재조회 결과로 목록 갱신 + 진행 플래그 복구")
+    func disconnectKakaoPassesKakaoTokenAndRefreshesConnections() async throws {
+        let kakao = SocialConnection(memberOAuthId: "10", socialType: .kakao)
+        let deleteUseCase = SpyDeleteMemberOAuthUseCase()
+        let viewModel = makeViewModel(
+            profile: makeStubProfileData(
+                socialConnections: [kakao, SocialConnection(memberOAuthId: "11", socialType: .apple)]
+            ),
+            fetchMyOAuthUseCase: StubFetchMyOAuthUseCase(result: .success([
+                MemberOAuth(memberOAuthId: "11", memberId: "1", provider: .apple)
+            ])),
+            deleteMemberOAuthUseCase: deleteUseCase
+        )
+
+        try await viewModel.disconnectSocial(kakao)
+
+        #expect(deleteUseCase.callCount == 1)
+        #expect(deleteUseCase.receivedMemberOAuthId == "10")
+        #expect(deleteUseCase.receivedKakaoAccessToken == "kakao-token")
+        #expect(deleteUseCase.receivedGoogleAccessToken == nil)
+        #expect(viewModel.profileData.socialConnections.map(\.socialType) == [.apple])
+        #expect(viewModel.disconnectingSocialType == nil)
+    }
+
+    @Test("구글 연동 해제 — googleAccessToken만 전달")
+    func disconnectGooglePassesGoogleToken() async throws {
+        let google = SocialConnection(memberOAuthId: "20", socialType: .google)
+        let deleteUseCase = SpyDeleteMemberOAuthUseCase()
+        let viewModel = makeViewModel(
+            profile: makeStubProfileData(socialConnections: [google]),
+            deleteMemberOAuthUseCase: deleteUseCase
+        )
+
+        try await viewModel.disconnectSocial(google)
+
+        #expect(deleteUseCase.receivedGoogleAccessToken == "google-token")
+        #expect(deleteUseCase.receivedKakaoAccessToken == nil)
+        #expect(viewModel.profileData.socialConnections.isEmpty)
+    }
+
+    @Test("애플 연동 해제 — 검증 토큰 없이 요청")
+    func disconnectApplePassesNoVerificationToken() async throws {
+        let apple = SocialConnection(memberOAuthId: "30", socialType: .apple)
+        let deleteUseCase = SpyDeleteMemberOAuthUseCase()
+        let viewModel = makeViewModel(
+            profile: makeStubProfileData(socialConnections: [apple]),
+            deleteMemberOAuthUseCase: deleteUseCase
+        )
+
+        try await viewModel.disconnectSocial(apple)
+
+        #expect(deleteUseCase.receivedGoogleAccessToken == nil)
+        #expect(deleteUseCase.receivedKakaoAccessToken == nil)
+    }
+
+    @Test("연동 해제 실패 — 에러 전파 + 기존 목록 유지 + 진행 플래그 복구")
+    func disconnectFailureKeepsExistingConnections() async {
+        let kakao = SocialConnection(memberOAuthId: "10", socialType: .kakao)
+        let deleteUseCase = SpyDeleteMemberOAuthUseCase()
+        deleteUseCase.error = MyPageTestError.boom
+        let viewModel = makeViewModel(
+            profile: makeStubProfileData(socialConnections: [kakao]),
+            deleteMemberOAuthUseCase: deleteUseCase
+        )
+
+        await #expect(throws: MyPageTestError.boom) {
+            try await viewModel.disconnectSocial(kakao)
+        }
+
+        #expect(viewModel.profileData.socialConnections == [kakao])
+        #expect(viewModel.disconnectingSocialType == nil)
+    }
 }
 
 // MARK: - Helpers
@@ -234,10 +311,71 @@ struct MyPageProfileViewModelTests {
 @MainActor
 private func makeViewModel(
     profile: ProfileData,
-    repository: MockMyPageRepository = MockMyPageRepository()
+    repository: MockMyPageRepository = MockMyPageRepository(),
+    fetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol = StubFetchMyOAuthUseCase(result: .success([])),
+    deleteMemberOAuthUseCase: SpyDeleteMemberOAuthUseCase = SpyDeleteMemberOAuthUseCase()
 ) -> MyPageProfileViewModel {
+    // GoogleLoginManaging은 MainActor 격리라 파라미터 기본값으로 만들 수 없어 본문에서 생성한다.
     MyPageProfileViewModel(
         profileData: profile,
-        useCaseProvider: makeUseCaseProvider(repository)
+        useCaseProvider: makeUseCaseProvider(repository),
+        fetchMyOAuthUseCase: fetchMyOAuthUseCase,
+        deleteMemberOAuthUseCase: deleteMemberOAuthUseCase,
+        kakaoLoginManager: StubKakaoLoginManager(),
+        googleLoginManager: StubGoogleLoginManager()
     )
+}
+
+// MARK: - Stubs (소셜 연동)
+
+private struct StubFetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol {
+    let result: Result<[MemberOAuth], Error>
+
+    func execute() async throws -> [MemberOAuth] {
+        try result.get()
+    }
+}
+
+private final class SpyDeleteMemberOAuthUseCase: DeleteMemberOAuthUseCaseProtocol, @unchecked Sendable {
+    var error: Error?
+    private(set) var callCount = 0
+    private(set) var receivedMemberOAuthId: String?
+    private(set) var receivedGoogleAccessToken: String?
+    private(set) var receivedKakaoAccessToken: String?
+
+    func execute(
+        memberOAuthId: String,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws {
+        callCount += 1
+        receivedMemberOAuthId = memberOAuthId
+        receivedGoogleAccessToken = googleAccessToken
+        receivedKakaoAccessToken = kakaoAccessToken
+        if let error { throw error }
+    }
+}
+
+private final class StubKakaoLoginManager: KakaoLoginManaging, @unchecked Sendable {
+    var accessToken = "kakao-token"
+
+    func login() async throws -> (accessToken: String, email: String) {
+        (accessToken, "kakao@umc.dev")
+    }
+
+    func fetchAccessToken() async throws -> String {
+        accessToken
+    }
+}
+
+private final class StubGoogleLoginManager: GoogleLoginManaging, @unchecked Sendable {
+    var accessToken = "google-token"
+
+    func login() async throws -> (accessToken: String, email: String?) {
+        (accessToken, nil)
+    }
+
+    func fetchAccessToken() async throws -> String {
+        accessToken
+    }
 }

--- a/UMCApp/Features/MyPage/Presentation/Tests/MyPageViewModelTests.swift
+++ b/UMCApp/Features/MyPage/Presentation/Tests/MyPageViewModelTests.swift
@@ -8,6 +8,7 @@
 import Testing
 import Foundation
 import UMCFoundation
+import AuthDomain
 import CoreDI
 import UMCFoundation
 import CoreDomain
@@ -24,13 +25,19 @@ struct MyPageViewModelTests {
         #expect(viewModel.profileData == .idle)
     }
 
-    @Test("fetchProfile 성공 시 .loaded(profile) — socialConnections는 빈 배열로 강제 (#802 Auth 디커플링)")
-    func fetchProfileSuccessSetsLoadedWithEmptySocialConnections() async {
+    @Test("fetchProfile 성공 시 .loaded(profile) — socialConnections는 member-oauth 응답으로 채워진다 (#1029)")
+    func fetchProfileSuccessSyncsSocialConnections() async {
         let original = makeProfileData(
             challengeId: 7,
-            socialConnections: [SocialConnection(memberOAuthId: 1, socialType: .kakao)]
+            socialConnections: [SocialConnection(memberOAuthId: "999", socialType: .google)]
         )
-        let viewModel = makeViewModel(repository: StubRepository(result: .success(original)))
+        let viewModel = makeViewModel(
+            repository: StubRepository(result: .success(original)),
+            oauthResult: .success([
+                MemberOAuth(memberOAuthId: "1", memberId: "1", provider: .kakao),
+                MemberOAuth(memberOAuthId: "2", memberId: "1", provider: .unknown("NAVER"))
+            ])
+        )
 
         await viewModel.fetchProfile()
 
@@ -39,7 +46,24 @@ struct MyPageViewModelTests {
             return
         }
         #expect(loaded.challengeId == 7)
-        #expect(loaded.socialConnections.isEmpty, "본 PR은 Auth 디커플링 — socialConnections는 항상 빈 배열")
+        #expect(loaded.socialConnections.map(\.socialType) == [.kakao], "모르는 provider는 제외한다")
+        #expect(loaded.socialConnections.first?.memberOAuthId == "1")
+    }
+
+    @Test("member-oauth 조회 실패는 프로필 조회를 실패시키지 않고 연동 목록만 비운다")
+    func oauthFailureKeepsProfileLoaded() async {
+        let viewModel = makeViewModel(
+            repository: StubRepository(result: .success(makeProfileData(
+                challengeId: 3,
+                socialConnections: [SocialConnection(memberOAuthId: "1", socialType: .kakao)]
+            ))),
+            oauthResult: .failure(GenericTestError.boom)
+        )
+
+        await viewModel.fetchProfile()
+
+        #expect(viewModel.profileData.value?.challengeId == 3)
+        #expect(viewModel.profileData.value?.socialConnections.isEmpty == true)
     }
 
     @Test("AppError 발생 시 .failed로 전이")
@@ -151,6 +175,7 @@ private enum GenericTestError: Error { case boom }
 @MainActor
 private func makeViewModel(
     repository: MyPageRepositoryProtocol,
+    oauthResult: Result<[MemberOAuth], Error> = .success([]),
     previewProfileData: ProfileData? = nil
 ) -> MyPageViewModel {
     let container = DIContainer()
@@ -158,6 +183,13 @@ private func makeViewModel(
     container.register(MyPageUseCaseProviding.self) {
         MyPageUseCaseProvider(repository: container.resolve(MyPageRepositoryProtocol.self))
     }
+    container.register(FetchMyOAuthUseCaseProtocol.self) {
+        StubFetchMyOAuthUseCase(result: oauthResult)
+    }
+    container.register(AddMemberOAuthUseCaseProtocol.self) {
+        StubAddMemberOAuthUseCase(result: oauthResult)
+    }
+    container.register(LoginUseCaseProtocol.self) { StubLoginUseCase() }
     #if DEBUG
     if let preview = previewProfileData {
         return MyPageViewModel(container: container, previewProfileData: preview)
@@ -186,6 +218,42 @@ private func makeProfileData(
         activityLogs: [],
         profileLink: []
     )
+}
+
+// MARK: - Stub UseCases (소셜 연동)
+
+private struct StubFetchMyOAuthUseCase: FetchMyOAuthUseCaseProtocol {
+    let result: Result<[MemberOAuth], Error>
+
+    func execute() async throws -> [MemberOAuth] {
+        try result.get()
+    }
+}
+
+private struct StubAddMemberOAuthUseCase: AddMemberOAuthUseCaseProtocol {
+    let result: Result<[MemberOAuth], Error>
+
+    func execute(oAuthVerificationToken: String) async throws -> [MemberOAuth] {
+        try result.get()
+    }
+}
+
+private struct StubLoginUseCase: LoginUseCaseProtocol {
+    func executeKakao(accessToken: String, email: String) async throws -> OAuthLoginResult {
+        .newMember(verificationToken: "stub-token")
+    }
+
+    func executeApple(
+        authorizationCode: String,
+        email: String?,
+        fullName: String?
+    ) async throws -> OAuthLoginResult {
+        .newMember(verificationToken: "stub-token")
+    }
+
+    func executeGoogle(accessToken: String) async throws -> OAuthLoginResult {
+        .newMember(verificationToken: "stub-token")
+    }
 }
 
 // MARK: - Stub Repositories

--- a/UMCApp/Features/MyPage/Project.swift
+++ b/UMCApp/Features/MyPage/Project.swift
@@ -12,6 +12,10 @@ let project = featureProject(
     presentationExtraDependencies: [
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         .project(target: "CorePhoto", path: .relativeToRoot("Core/Photo")),
+        // 소셜 연동 추가/해제(#1029)가 AuthDomain의 MemberOAuth UseCase와
+        // CoreNetwork의 소셜 로그인 매니저를 사용한다.
+        .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
+        .project(target: "AuthDomain", path: .relativeToRoot("Features/Auth")),
         .project(target: "BadgeDomain", path: .relativeToRoot("Features/Badge")),
     ],
     includesDomainTests: true,
@@ -29,6 +33,9 @@ let project = featureProject(
     presentationTestDependencies: [
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
+        .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
         .project(target: "UMCFoundation", path: .relativeToRoot("Core/Foundation")),
+        // 소셜 연동(#1029) ViewModel 테스트가 AuthDomain UseCase 목을 직접 구성한다.
+        .project(target: "AuthDomain", path: .relativeToRoot("Features/Auth")),
     ]
 )

--- a/UMCApp/UMCApp/Sources/DIContainer+Auth.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Auth.swift
@@ -49,6 +49,18 @@ extension DIContainer {
             LoginByEmailUseCase(repository: self.resolve(AuthRepositoryProtocol.self))
         }
 
+        // MARK: - 소셜 연동(MemberOAuth) UseCase (#1029)
+
+        register(FetchMyOAuthUseCaseProtocol.self) {
+            FetchMyOAuthUseCase(repository: self.resolve(AuthRepositoryProtocol.self))
+        }
+        register(AddMemberOAuthUseCaseProtocol.self) {
+            AddMemberOAuthUseCase(repository: self.resolve(AuthRepositoryProtocol.self))
+        }
+        register(DeleteMemberOAuthUseCaseProtocol.self) {
+            DeleteMemberOAuthUseCase(repository: self.resolve(AuthRepositoryProtocol.self))
+        }
+
         // MARK: - 회원가입(SignUp) 관련 UseCase (#944)
 
         register(FetchSignUpDataUseCaseProtocol.self) {

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubAuthRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubAuthRepository.swift
@@ -43,5 +43,19 @@ struct StubAuthRepository: AuthRepositoryProtocol {
     func loginByEmail(email: String, password: String) async throws -> LoginByIdPwResult {
         LoginByIdPwResult(memberId: StubSessionFixtures.profile.memberId)
     }
+
+    func fetchMyOAuth() async throws -> [MemberOAuth] {
+        []
+    }
+
+    func addMemberOAuth(oAuthVerificationToken: String) async throws -> [MemberOAuth] {
+        []
+    }
+
+    func deleteMemberOAuth(
+        memberOAuthId: String,
+        googleAccessToken: String?,
+        kakaoAccessToken: String?
+    ) async throws {}
 }
 #endif


### PR DESCRIPTION
## ✨ PR 유형

리팩터링 (레거시 → Tuist 이관) · closes #1029

## 📷 스크린샷 or 영상(UI 변경 시)

없음 — `MyPageProfileView.body`가 아직 `#816` 플레이스홀더라 `ConnectionSocial`이 화면에 노출되지 않습니다. 자세한 내용은 아래 리뷰 포인트 3번 참고.

## 🛠️ 작업내용

`#802` Auth 디커플링 때 미뤄뒀던 소셜 연동(OAuth) 레이어를 레거시에서 `UMCApp/Features/Auth`로 이관하고, 그동안 막혀 있던 MyPage 쪽 결선을 되살렸습니다.

**AuthDomain**
- `MemberOAuth` · `OAuthProvider` 모델 이관
- `FetchMyOAuth` / `AddMemberOAuth` / `DeleteMemberOAuth` UseCase 3종 + 프로토콜
- `AuthRepositoryProtocol`에 조회/추가/해제 메서드 추가 (레거시 `getMyOAuth` → 현행 `fetch*` 네이밍)

**AuthData**
- `MemberOAuthDTO` (custom `init(from:)`/`encode(to:)`), `AddMemberOAuthRequestDTO`, `DeleteMemberOAuthRequestDTO`
- `AuthRouter`에 `GET /member-oauth/me`, `POST /member-oauth`, `DELETE /member-oauth/{id}` 추가 (인라인 딕셔너리 없이 Body DTO 사용)
- 레거시 `AuthRepositoryProvider` / `AuthUseCaseProvider`는 이관하지 않고 `DIContainer+Auth`가 조립

**MyPage 결선**
- `MyPageViewModel`: `profile.socialConnections = []` 강제 제거 → 서버 값이 실제로 흐름. `syncConnectedSocials` / `connectSocial` / `fetchOAuthVerificationToken` / `fetchAppleAuthorizationCode` / `extractVerificationToken` 복원
- `MyPageProfileViewModel`: `disconnectSocial` / `makeDeleteVerification` 복원
- 레거시에서 두 ViewModel에 중복돼 있던 `makeSocialConnection`을 `SocialConnection.init?(memberOAuth:)` 하나로 통합
- `ConnectionSocial` 섹션은 레거시 구조를 그대로 옮기지 않고 현행 `MyPageSectionType` + `SectionHeaderView` 패턴에 맞춰 재작성

**식별자 String 통일 (절대 규칙 #2)**
- `SocialConnection.memberOAuthId` · `MemberOAuth.memberOAuthId`를 `Int` → `String`으로 변경
- 디코딩은 신규 헬퍼 없이 기존 `UMCFoundation.decodeFlexibleString(forKey:)` 재사용 — 서버가 `123`으로 내려도 `"123"`으로 흡수

**버그 수정 (이관 중 발견)**
- Apple 로그인 실패 콜백이 continuation을 재개하지 않아 사용자가 취소하면 영구 대기하던 문제 → `resume(throwing:)`으로 보강
- 이메일 미동의 카카오 계정은 `login()`이 `emailNotFound`를 던져 연동 해제가 불가능했던 문제 → `KakaoLoginManaging`/`GoogleLoginManaging`에 `fetchAccessToken()` 추가 (구현체엔 이미 존재)

**테스트**
- `MemberOAuth` UseCase 단위 테스트 6건 신규
- `disconnectSocial` 경로 테스트 4건 (카카오/구글/애플 토큰 분기, 실패 시 목록 보존)
- 기존 "socialConnections는 항상 빈 배열 (#802 Auth 디커플링)" 단정 테스트는 전제가 폐기되어 실제 동작 검증으로 교체

## 📋 추후 진행 상황

- `#816` 플레이스홀더 해제 후 `ConnectionSocial` 실제 노출 및 연동/해제 동작 QA
- 로그인 후 비밀번호 변경(`ChangePassword`) 이관 — 이번 PR 범위 밖, 별도 진행 예정
- 남은 Tuist 미이관: Community 피처 전량(#591), MyPage 일부 섹션, Activity 운영진 잔여

## 📌 리뷰 포인트

1. **`decodeFlexibleString` throw 버전 선택** — `OrEmpty`/`OrNil` 대신 throw 버전을 썼습니다. 이 id가 `DELETE /member-oauth/{id}` 경로에 그대로 실려서, 빈 문자열 폴백이면 `/member-oauth/`로 잘못된 요청이 나가고 `ForEach`의 `id`도 충돌하기 때문입니다. 대신 `memberOAuthId` 누락 응답은 목록 전체 디코딩 실패가 됩니다(이전 `?? 0` 무음 폴백과 다름). 호출부 `syncConnectedSocials()`가 실패를 삼켜 연동 목록만 비우고 프로필은 `.loaded`를 유지하도록 테스트로 고정해 뒀습니다. 이 트레이드오프가 맞는지 봐주세요.
2. **`MyPagePresentation → AuthDomain` 의존 추가** — `AuthPresentation → MyPageDomain`이 이미 있어 프로젝트 레벨에서 MyPage↔Auth 상호 참조가 됩니다. 타깃 그래프는 비순환이라 `tuist generate`·빌드 모두 정상이지만, 향후 `AuthDomain`이 `MyPageDomain`을 참조하면 순환이 됩니다.
3. **`ConnectionSocial` 미노출 상태로 머지** — `MyPageProfileView.body`가 `#816` 플레이스홀더라 UI에 붙지 않습니다. `AuthSection`·`SettingSection`도 동일 상태여서 기존 관례를 따랐습니다. 따라서 이번 변경은 **테스트로만 검증된 상태**이고 실기기 동작 확인은 `#816` 이후에 가능합니다.
4. **연동 해제 시 Apple은 검증 토큰 없이 요청** (레거시 동작 유지). 서버가 Apple 검증을 요구하도록 바뀌면 `makeDeleteVerification`만 수정하면 됩니다.

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

### 테스트 결과 (iPhone 17 Pro / iOS 26.5)

| 스킴 | 결과 |
|---|---|
| AuthDomain | 57 tests / 15 suites — passed |
| AuthData | 82 tests / 30 suites — passed |
| AuthPresentation | 102 tests / 16 suites — passed |
| MyPageDomain | 24 tests / 10 suites — passed |
| MyPageData | 62 tests / 18 suites — passed |
| MyPagePresentation | 37 tests / 3 suites — passed |
| UMCApp | 14 tests / 2 suites — passed |
