### PR TITLE
✨[Feat] 비밀번호 변경(ChangePassword) 체인 이식 및 마이페이지 진입점 결선

### DIFF
--- a/UMCApp/Core/UIComponents/Sources/Utilities/NavigationTitle.swift
+++ b/UMCApp/Core/UIComponents/Sources/Utilities/NavigationTitle.swift
@@ -28,6 +28,7 @@ public enum NavigationTitle {
     public enum Auth: String, NavigationTitleRepresentable {
         case signUp = "회원가입"
         case resetPassword = "비밀번호 재설정"
+        case changePassword = "비밀번호 변경"
     }
 
     /// 공지사항 화면용 타이틀

--- a/UMCApp/Features/Auth/Data/Sources/DTOs/Request/ChangePasswordRequestDTO.swift
+++ b/UMCApp/Features/Auth/Data/Sources/DTOs/Request/ChangePasswordRequestDTO.swift
@@ -1,0 +1,21 @@
+//
+//  ChangePasswordRequestDTO.swift
+//  AuthData
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// 로그인 상태에서 비밀번호를 변경하는 요청 DTO
+///
+/// `PATCH /api/v1/auth/password`
+public struct ChangePasswordRequestDTO: Encodable {
+    /// 현재 비밀번호(평문)
+    public let currentPassword: String
+    /// 새로 설정할 평문 비밀번호
+    public let newPassword: String
+
+    public init(currentPassword: String, newPassword: String) {
+        self.currentPassword = currentPassword
+        self.newPassword = newPassword
+    }
+}

--- a/UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift
+++ b/UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift
@@ -512,6 +512,36 @@ extension AuthRepository: AuthRegistrationRepositoryProtocol {
             throw RepositoryError.decodingError(detail: "\(decodingError)")
         }
     }
+
+    // MARK: - Change Password
+
+    public func changePassword(currentPassword: String, newPassword: String) async throws {
+        let response: Response
+        do {
+            response = try await adapter.request(
+                AuthRouter.changePassword(
+                    body: ChangePasswordRequestDTO(
+                        currentPassword: currentPassword,
+                        newPassword: newPassword
+                    )
+                )
+            )
+        } catch let networkError as NetworkError {
+            // 현재 비밀번호 불일치가 비-2xx로 오므로, 화면이 인라인 메시지로 쓸 수 있게
+            // `loginByEmail`과 동일하게 서버 코드/메시지를 살려 정규화한다.
+            throw Self.parseServerError(from: networkError) ?? networkError
+        }
+
+        do {
+            let apiResponse = try JSONDecoder().decode(
+                APIResponse<EmptyResult>.self,
+                from: response.data
+            )
+            try apiResponse.validateSuccess()
+        } catch let decodingError as DecodingError {
+            throw RepositoryError.decodingError(detail: "\(decodingError)")
+        }
+    }
 }
 
 // MARK: - Helpers (Email Verification Error Mapping)

--- a/UMCApp/Features/Auth/Data/Sources/Router/AuthRouter.swift
+++ b/UMCApp/Features/Auth/Data/Sources/Router/AuthRouter.swift
@@ -50,6 +50,8 @@ public enum AuthRouter: BaseTargetType {
     case registerExistingChallenger(body: RegisterExistingChallengerRequestDTO)
     /// 비밀번호 재설정
     case resetPassword(body: ResetPasswordRequestDTO)
+    /// 로그인 상태에서의 비밀번호 변경
+    case changePassword(body: ChangePasswordRequestDTO)
     /// 내 OAuth 연동 정보 조회
     case fetchMyOAuth
     /// 로그인 OAuth 수단 추가 연동
@@ -91,6 +93,8 @@ public enum AuthRouter: BaseTargetType {
             return "/api/v1/challenger-record/member"
         case .resetPassword:
             return "/api/v1/auth/password/reset"
+        case .changePassword:
+            return "/api/v1/auth/password"
         case .fetchMyOAuth:
             return "/api/v1/member-oauth/me"
         case .addMemberOAuth:
@@ -111,7 +115,7 @@ public enum AuthRouter: BaseTargetType {
              .register, .registerByEmail, .registerCredential, .registerExistingChallenger,
              .addMemberOAuth:
             return .post
-        case .resetPassword:
+        case .resetPassword, .changePassword:
             return .patch
         case .deleteMemberOAuth:
             return .delete
@@ -154,6 +158,8 @@ public enum AuthRouter: BaseTargetType {
         case .registerExistingChallenger(let body):
             return .requestJSONEncodable(body)
         case .resetPassword(let body):
+            return .requestJSONEncodable(body)
+        case .changePassword(let body):
             return .requestJSONEncodable(body)
         case .fetchMyOAuth:
             return .requestPlain

--- a/UMCApp/Features/Auth/Domain/Sources/Interfaces/AuthRepositoryProtocol.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/Interfaces/AuthRepositoryProtocol.swift
@@ -60,6 +60,15 @@ public protocol AuthRepositoryProtocol {
     /// - Returns: 연동 완료 후 전체 OAuth 목록
     func addMemberOAuth(oAuthVerificationToken: String) async throws -> [MemberOAuth]
 
+    /// 로그인 상태에서 비밀번호를 변경한다.
+    ///
+    /// 이메일 인증 토큰으로 재설정하는 `AuthRegistrationRepositoryProtocol.resetPassword`와 달리
+    /// 현재 세션의 액세스 토큰으로 본인을 식별하므로 세션 계약인 이쪽에 둔다.
+    /// - Parameters:
+    ///   - currentPassword: 현재 비밀번호(평문)
+    ///   - newPassword: 새로 설정할 평문 비밀번호
+    func changePassword(currentPassword: String, newPassword: String) async throws
+
     /// OAuth 수단 연동을 해제한다.
     /// - Parameters:
     ///   - memberOAuthId: 해제할 OAuth 연동 ID

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/ChangePasswordUseCaseProtocol.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/ChangePasswordUseCaseProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  ChangePasswordUseCaseProtocol.swift
+//  AuthDomain
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// 비밀번호 변경 UseCase 인터페이스
+public protocol ChangePasswordUseCaseProtocol {
+    /// 현재 비밀번호를 확인한 뒤 새 비밀번호로 변경한다.
+    /// - Parameters:
+    ///   - currentPassword: 현재 비밀번호(평문)
+    ///   - newPassword: 새로 설정할 평문 비밀번호
+    func execute(currentPassword: String, newPassword: String) async throws
+}

--- a/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/ChangePasswordUseCase.swift
+++ b/UMCApp/Features/Auth/Domain/Sources/UseCases/Implementations/ChangePasswordUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  ChangePasswordUseCase.swift
+//  AuthDomain
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// 비밀번호 변경 UseCase 구현체
+public final class ChangePasswordUseCase: ChangePasswordUseCaseProtocol {
+
+    // MARK: - Property
+
+    private let repository: AuthRepositoryProtocol
+
+    // MARK: - Init
+
+    public init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+
+    public func execute(currentPassword: String, newPassword: String) async throws {
+        try await repository.changePassword(
+            currentPassword: currentPassword,
+            newPassword: newPassword
+        )
+    }
+}

--- a/UMCApp/Features/Auth/Domain/Tests/Support/MockAuthRepository.swift
+++ b/UMCApp/Features/Auth/Domain/Tests/Support/MockAuthRepository.swift
@@ -142,6 +142,22 @@ final class MockAuthRepository: AuthRepositoryProtocol, @unchecked Sendable {
         return try addMemberOAuthResult.get()
     }
 
+    // MARK: - changePassword
+
+    var changePasswordError: Error?
+    private(set) var changePasswordCallCount = 0
+    private(set) var changePasswordReceivedCurrentPassword: String?
+    private(set) var changePasswordReceivedNewPassword: String?
+
+    func changePassword(currentPassword: String, newPassword: String) async throws {
+        changePasswordCallCount += 1
+        changePasswordReceivedCurrentPassword = currentPassword
+        changePasswordReceivedNewPassword = newPassword
+        if let changePasswordError {
+            throw changePasswordError
+        }
+    }
+
     // MARK: - deleteMemberOAuth
 
     var deleteMemberOAuthError: Error?

--- a/UMCApp/Features/Auth/Domain/Tests/UseCases/ChangePasswordUseCaseTests.swift
+++ b/UMCApp/Features/Auth/Domain/Tests/UseCases/ChangePasswordUseCaseTests.swift
@@ -1,0 +1,42 @@
+//
+//  ChangePasswordUseCaseTests.swift
+//  AuthDomainTests
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import Testing
+@testable import AuthDomain
+
+@Suite("ChangePasswordUseCase — Repository 위임 검증")
+struct ChangePasswordUseCaseTests {
+
+    @Test("execute() 호출 시 repository.changePassword()에 파라미터를 그대로 전달한다")
+    func executeDelegatesToRepository() async throws {
+        let repository = MockAuthRepository()
+        let useCase = ChangePasswordUseCase(repository: repository)
+
+        try await useCase.execute(
+            currentPassword: "currentPassword123",
+            newPassword: "newPassword123"
+        )
+
+        #expect(repository.changePasswordCallCount == 1)
+        #expect(repository.changePasswordReceivedCurrentPassword == "currentPassword123")
+        #expect(repository.changePasswordReceivedNewPassword == "newPassword123")
+    }
+
+    @Test("현재 비밀번호가 틀려 repository가 에러를 던지면 그대로 전파한다")
+    func executePropagatesError() async {
+        let repository = MockAuthRepository()
+        repository.changePasswordError = AuthTestError.boom
+        let useCase = ChangePasswordUseCase(repository: repository)
+
+        await #expect(throws: AuthTestError.boom) {
+            try await useCase.execute(
+                currentPassword: "wrongPassword",
+                newPassword: "newPassword123"
+            )
+        }
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/ViewModels/ChangePasswordViewModel.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/ViewModels/ChangePasswordViewModel.swift
@@ -1,0 +1,116 @@
+//
+//  ChangePasswordViewModel.swift
+//  AuthPresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import AuthDomain
+import CoreDI
+import Foundation
+import UMCFoundation
+
+/// 비밀번호 변경 화면의 상태 및 액션을 관리하는 ViewModel.
+///
+/// 절대규칙 #1에 따라 `@Observable`을 사용한다. 현재 비밀번호 불일치는 화면 안에서 다시
+/// 입력해 해결할 수 있는 상태라 `EmailLoginViewModel`과 동일하게 인라인 메시지로 표시하고,
+/// 그 밖의 실패(네트워크·세션 등)만 흐름 중단형으로 보고 `ErrorHandler`에 넘긴다.
+@Observable
+final class ChangePasswordViewModel {
+
+    // MARK: - Constant
+
+    private enum Constants {
+        static let minimumPasswordLength: Int = 8
+        static let changeFailedMessage: String = "비밀번호를 변경하지 못했습니다. 현재 비밀번호를 확인해 주세요."
+        static let action: String = "changePassword"
+    }
+
+    // MARK: - Property
+
+    private let changePasswordUseCase: ChangePasswordUseCaseProtocol
+    private let errorHandler: ErrorHandler
+
+    /// 현재 비밀번호 입력값
+    var currentPassword: String = ""
+
+    /// 새 비밀번호 입력값
+    var newPassword: String = ""
+
+    /// 비밀번호 변경 진행 상태
+    private(set) var changePasswordState: Loadable<Bool> = .idle
+
+    /// 변경 실패 인라인 메시지
+    private(set) var changePasswordErrorMessage: String?
+
+    // MARK: - Init
+
+    init(container: DIContainer, errorHandler: ErrorHandler) {
+        self.changePasswordUseCase = container.resolve(ChangePasswordUseCaseProtocol.self)
+        self.errorHandler = errorHandler
+    }
+
+    // MARK: - Computed Property
+
+    /// 새 비밀번호 최소 길이(8자) 충족 여부
+    var isNewPasswordValid: Bool {
+        newPassword.count >= Constants.minimumPasswordLength
+    }
+
+    /// 변경 제출 가능 여부 — 현재 비밀번호와 같은 값으로는 변경할 수 없다.
+    var canSubmit: Bool {
+        !currentPassword.isEmpty && isNewPasswordValid && newPassword != currentPassword
+    }
+
+    // MARK: - Function
+
+    /// 비밀번호 변경 실행
+    @MainActor
+    func changePassword() async {
+        guard !changePasswordState.isLoading, canSubmit else { return }
+
+        changePasswordState = .loading
+        changePasswordErrorMessage = nil
+
+        do {
+            try await changePasswordUseCase.execute(
+                currentPassword: currentPassword,
+                newPassword: newPassword
+            )
+            changePasswordState = .loaded(true)
+        } catch let error as RepositoryError {
+            handleChangeFailure(error)
+        } catch let error as AppError {
+            guard case .repository(let repositoryError) = error else {
+                handleUnexpectedFailure(error)
+                return
+            }
+            handleChangeFailure(repositoryError)
+        } catch {
+            handleUnexpectedFailure(error)
+        }
+    }
+
+    // MARK: - Private Function
+
+    /// 서버가 거절한 변경 요청을 인라인 메시지로 변환한다.
+    @MainActor
+    private func handleChangeFailure(_ error: RepositoryError) {
+        if case .serverError(_, let message) = error, let message, !message.isEmpty {
+            changePasswordErrorMessage = message
+        } else {
+            changePasswordErrorMessage = Constants.changeFailedMessage
+        }
+        changePasswordState = .failed(.repository(error))
+    }
+
+    @MainActor
+    private func handleUnexpectedFailure(_ error: Error) {
+        changePasswordState = .idle
+        errorHandler.handle(error, context: ErrorContext(
+            feature: "Auth",
+            action: Constants.action,
+            retryAction: { [weak self] in await self?.changePassword() }
+        ))
+    }
+}

--- a/UMCApp/Features/Auth/Presentation/Sources/Views/ChangePasswordView.swift
+++ b/UMCApp/Features/Auth/Presentation/Sources/Views/ChangePasswordView.swift
@@ -1,0 +1,184 @@
+//
+//  ChangePasswordView.swift
+//  AuthPresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreDesignSystem
+import CoreDI
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 비밀번호 변경 화면 — 로그인한 회원이 현재 비밀번호를 확인받고 새 비밀번호로 교체한다.
+///
+/// - Note: 마이페이지에서 push되는 화면이므로 자체 `NavigationStack`을 두지 않는다
+///   (`ResetPasswordView`와 동일).
+public struct ChangePasswordView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: ChangePasswordViewModel
+    @State private var alertPrompt: AlertPrompt?
+    @FocusState private var focusedField: ChangePasswordFocusField?
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Constant
+
+    fileprivate enum Constants {
+        static let currentPasswordTitle: String = "현재 비밀번호"
+        static let currentPasswordPlaceholder: String = "현재 비밀번호를 입력해 주세요"
+        static let newPasswordTitle: String = "새 비밀번호"
+        static let newPasswordPlaceholder: String = "8자 이상 입력"
+        static let newPasswordGuide: String = "8자 이상 입력해 주세요."
+        static let submitTitle: String = "변경하기"
+        static let completedTitle: String = "비밀번호 변경 완료"
+        static let completedMessage: String = "변경된 비밀번호로 다시 로그인해 주세요."
+        static let confirmTitle: String = "확인"
+        static let messageLeadingPadding: CGFloat = 10
+    }
+
+    // MARK: - Init
+
+    public init(container: DIContainer, errorHandler: ErrorHandler) {
+        _viewModel = State(initialValue: ChangePasswordViewModel(
+            container: container,
+            errorHandler: errorHandler
+        ))
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DefaultSpacing.spacing24) {
+                currentPasswordField
+                newPasswordField
+                changeErrorMessageView
+            }
+            .safeAreaPadding(.vertical, DefaultConstant.defaultContentTopMargins)
+            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .navigation(naviTitle: NavigationTitle.Auth.changePassword, displayMode: .inline)
+        .safeAreaInset(edge: .bottom) {
+            submitButton
+        }
+        .onChange(of: viewModel.changePasswordState) { _, newState in
+            handleChangePasswordStateChange(newState)
+        }
+        .alertPrompt(item: $alertPrompt)
+    }
+
+    // MARK: - Subviews
+
+    private var currentPasswordField: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            TitleLabel(title: Constants.currentPasswordTitle, isRequired: true)
+
+            SecureField(
+                "",
+                text: $viewModel.currentPassword,
+                prompt: Text(Constants.currentPasswordPlaceholder).font(.app(.callout))
+            )
+            .foregroundStyle(Color.grey900)
+            .padding(DefaultConstant.defaultTextFieldPadding)
+            .glassEffect(.regular, in: .capsule)
+            .textContentType(.password)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .submitLabel(.next)
+            .focused($focusedField, equals: .currentPassword)
+            .onSubmit { focusedField = .newPassword }
+            .accessibilityLabel(Text(Constants.currentPasswordTitle))
+        }
+    }
+
+    private var newPasswordField: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            TitleLabel(title: Constants.newPasswordTitle, isRequired: true)
+
+            SecureField(
+                "",
+                text: $viewModel.newPassword,
+                prompt: Text(Constants.newPasswordPlaceholder).font(.app(.callout))
+            )
+            .foregroundStyle(Color.grey900)
+            .padding(DefaultConstant.defaultTextFieldPadding)
+            .glassEffect(.regular, in: .capsule)
+            .textContentType(.newPassword)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .submitLabel(.done)
+            .focused($focusedField, equals: .newPassword)
+            .onSubmit { submit() }
+            .accessibilityLabel(Text(Constants.newPasswordTitle))
+
+            if !viewModel.newPassword.isEmpty, !viewModel.isNewPasswordValid {
+                guideMessage(Constants.newPasswordGuide)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var changeErrorMessageView: some View {
+        if let changePasswordErrorMessage = viewModel.changePasswordErrorMessage {
+            guideMessage(changePasswordErrorMessage)
+        }
+    }
+
+    private func guideMessage(_ message: String) -> some View {
+        Text(message)
+            .appFont(.footnote, color: .red500)
+            .padding(.leading, Constants.messageLeadingPadding)
+    }
+
+    private var submitButton: some View {
+        Button {
+            submit()
+        } label: {
+            Group {
+                if viewModel.changePasswordState.isLoading {
+                    ProgressView()
+                        .tint(.white)
+                } else {
+                    Text(Constants.submitTitle)
+                        .appFont(.subheadline, weight: .semibold, color: .white)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, DefaultConstant.defaultBtnPadding)
+        }
+        .buttonStyle(.glassProminent)
+        .tint(.indigo500)
+        .disabled(!viewModel.canSubmit || viewModel.changePasswordState.isLoading)
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    // MARK: - Function
+
+    private func submit() {
+        focusedField = nil
+        Task { await viewModel.changePassword() }
+    }
+
+    private func handleChangePasswordStateChange(_ newState: Loadable<Bool>) {
+        guard case .loaded = newState else { return }
+
+        alertPrompt = AlertPrompt(
+            title: Constants.completedTitle,
+            message: Constants.completedMessage,
+            positiveBtnTitle: Constants.confirmTitle,
+            positiveBtnAction: { dismiss() }
+        )
+    }
+}
+
+// MARK: - Focus Field
+
+/// 비밀번호 변경 화면의 키보드 포커스 대상 필드.
+fileprivate enum ChangePasswordFocusField: Hashable {
+    case currentPassword
+    case newPassword
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/AuthSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/AuthSection.swift
@@ -10,37 +10,32 @@ import Foundation
 import SwiftUI
 import UMCFoundation
 
-/// 마이페이지의 인증 관련 섹션 (로그아웃, 회원탈퇴)
+/// 마이페이지의 인증 관련 섹션 (비밀번호 변경, 로그아웃, 회원탈퇴)
 ///
 /// 사용자 인증 관련 작업을 처리하는 섹션으로, AlertPrompt를 통해 확인 다이얼로그를 표시합니다.
-/// 실제 세션 종료·탈퇴 수행은 상위(``MyPageView``)가 주입한 액션이 담당합니다.
+/// 실제 화면 이동·세션 종료·탈퇴 수행은 상위(``MyPageView``)가 주입한 액션이 담당합니다.
 public struct AuthSection: View {
 
     // MARK: - Property
 
     private let sectionType: MyPageSectionType
     @Binding private var alertPrompt: AlertPrompt?
+    private let onChangePassword: () -> Void
     private let onLogout: () -> Void
     private let onDeleteAccount: () -> Void
-
-    /// 노출할 인증 항목.
-    ///
-    /// 비밀번호 변경 화면은 아직 이식 전이라 행을 숨긴다. 화면이 들어오면 필터를 걷어내고
-    /// ``AuthType/changePassword`` 분기에 진입점을 연결한다.
-    private var visibleAuthTypes: [AuthType] {
-        AuthType.allCases.filter { $0 != .changePassword }
-    }
 
     // MARK: - Init
 
     public init(
         sectionType: MyPageSectionType = .auth,
         alertPrompt: Binding<AlertPrompt?>,
+        onChangePassword: @escaping () -> Void,
         onLogout: @escaping () -> Void,
         onDeleteAccount: @escaping () -> Void
     ) {
         self.sectionType = sectionType
         self._alertPrompt = alertPrompt
+        self.onChangePassword = onChangePassword
         self.onLogout = onLogout
         self.onDeleteAccount = onDeleteAccount
     }
@@ -58,7 +53,7 @@ public struct AuthSection: View {
     // MARK: - Function
 
     private var sectionContent: some View {
-        ForEach(visibleAuthTypes, id: \.rawValue) { auth in
+        ForEach(AuthType.allCases, id: \.rawValue) { auth in
             content(auth)
         }
     }
@@ -79,13 +74,13 @@ public struct AuthSection: View {
         .buttonStyle(.borderless)
     }
 
-    /// 인증 타입에 따른 액션을 처리하고 AlertPrompt를 표시
+    /// 인증 타입에 따른 액션을 처리하고, 파괴적 작업은 AlertPrompt로 확인받는다.
     ///
     /// - Parameter auth: 처리할 인증 타입 (비밀번호 변경, 로그아웃 또는 회원탈퇴)
     private func typeAction(_ auth: AuthType) {
         switch auth {
         case .changePassword:
-            break
+            onChangePassword()
         case .logout:
             alertPrompt = .init(
                 title: "로그아웃",

--- a/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageDestination.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageDestination.swift
@@ -17,4 +17,7 @@ enum MyPageDestination: Hashable {
     ///
     /// - Parameter logType: 진입 시 처음 보여줄 활동 종류. 화면 안에서 세 종류를 전환할 수 있다.
     case myActivePosts(logType: MyActiveLogsType)
+
+    /// 비밀번호 변경. 화면은 `AuthPresentation` 이 소유한다.
+    case changePassword
 }

--- a/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageRoutingView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageRoutingView.swift
@@ -5,8 +5,10 @@
 //  Created by euijjang97 on 8/10/26.
 //
 
+import AuthPresentation
 import CoreDI
 import SwiftUI
+import UMCFoundation
 
 /// ``MyPageDestination``을 실제 화면으로 바꾸는 라우팅 뷰.
 ///
@@ -18,6 +20,8 @@ struct MyPageRoutingView: View {
 
     private let destination: MyPageDestination
     private let container: DIContainer
+
+    @Environment(ErrorHandler.self) private var errorHandler
 
     // MARK: - Init
 
@@ -32,6 +36,9 @@ struct MyPageRoutingView: View {
         switch destination {
         case .myActivePosts(let logType):
             MyActivePostsView(container: container, logType: logType)
+
+        case .changePassword:
+            ChangePasswordView(container: container, errorHandler: errorHandler)
         }
     }
 }

--- a/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageView.swift
@@ -77,6 +77,9 @@ struct MyPageView: View {
 
             AuthSection(
                 alertPrompt: $viewModel.alertPrompt,
+                onChangePassword: {
+                    pathStore.push(MyPageDestination.changePassword, on: .mypage)
+                },
                 onLogout: { endSession("logout", perform: viewModel.logout) },
                 onDeleteAccount: { endSession("deleteAccount", perform: viewModel.deleteAccount) }
             )

--- a/UMCApp/Features/MyPage/Project.swift
+++ b/UMCApp/Features/MyPage/Project.swift
@@ -20,6 +20,8 @@ let project = featureProject(
         // CoreNetwork의 소셜 로그인 매니저를 사용한다.
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),
         .project(target: "AuthDomain", path: .relativeToRoot("Features/Auth")),
+        // 회원관리 섹션의 비밀번호 변경 행이 AuthPresentation의 ChangePasswordView로 push 한다.
+        .project(target: "AuthPresentation", path: .relativeToRoot("Features/Auth")),
         .project(target: "BadgeDomain", path: .relativeToRoot("Features/Badge")),
     ],
     includesDomainTests: true,

--- a/UMCApp/UMCApp/Sources/DIContainer+Auth.swift
+++ b/UMCApp/UMCApp/Sources/DIContainer+Auth.swift
@@ -116,5 +116,11 @@ extension DIContainer {
                 repository: self.resolve(AuthRegistrationRepositoryProtocol.self)
             )
         }
+
+        // MARK: - 비밀번호 변경(ChangePassword) 관련 UseCase
+
+        register(ChangePasswordUseCaseProtocol.self) {
+            ChangePasswordUseCase(repository: self.resolve(AuthRepositoryProtocol.self))
+        }
     }
 }

--- a/UMCApp/UMCApp/Sources/Debug/StubSession/StubAuthRepository.swift
+++ b/UMCApp/UMCApp/Sources/Debug/StubSession/StubAuthRepository.swift
@@ -52,6 +52,8 @@ struct StubAuthRepository: AuthRepositoryProtocol {
         []
     }
 
+    func changePassword(currentPassword: String, newPassword: String) async throws {}
+
     func deleteMemberOAuth(
         memberOAuthId: String,
         googleAccessToken: String?,


### PR DESCRIPTION
## ✨ PR 유형

Feature — 레거시 `AppProduct` 에만 있던 비밀번호 변경 기능을 `UMCApp`(Tuist) 으로 이식하고, 마이페이지 회원관리 섹션에 진입점까지 결선했습니다. Tuist 마이그레이션 잔여 작업 중 Auth 피처에 남아 있던 유일한 항목입니다.

> #1120(MyPage 탭 실연결) 머지 후 `develop` 위로 rebase 했고, 진입점 결선 커밋을 추가했습니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- ChangePasswordView 신규 화면 + 마이페이지 회원관리 섹션 진입 — 스크린샷 첨부 필요 -->

## 🛠️ 작업내용

**Data**
- `ChangePasswordRequestDTO` 추가
- `AuthRouter` 에 `.changePassword` 케이스 추가 (`PATCH /api/v1/auth/password`, `requestJSONEncodable`)
- `AuthRepository.changePassword` 구현 — `NetworkError` → `parseServerError` 정규화 (`loginByEmail` 과 동일 처리)

**Domain**
- `AuthRepositoryProtocol` 에 시그니처 추가 (세션 토큰으로 본인 식별하므로 비인증용 `AuthRegistrationRepositoryProtocol` 이 아닌 쪽에 배치, 근거는 doc comment 로 명시)
- `ChangePasswordUseCaseProtocol` + `ChangePasswordUseCase` 추가
- `ChangePasswordUseCaseTests` 추가 (Repository 위임·에러 전파)

**Presentation**
- `ChangePasswordViewModel` (@Observable) — 서버가 거절한 요청만 인라인 메시지, 네트워크·세션 오류는 `ErrorHandler` + `retryAction`
- `ChangePasswordView` — `TitleLabel` + `SecureField` + glass capsule 조립, 완료 `AlertPrompt` 후 `dismiss`

**진입점 결선 (MyPage)**
- `AuthSection` — #1120 이 걸어둔 `changePassword` 숨김 필터 제거, `AuthType.allCases` 전체 노출
- `AuthSection` 에 `onChangePassword` 콜백 추가 — 섹션은 `PathStore` 를 모르고, 실제 push 는 탭 루트(`MyPageView`)가 수행 (기존 `MyActiveLogSection` 과 동일 패턴)
- `MyPageDestination.changePassword` + `MyPageRoutingView` 분기 → `ChangePasswordView(container:errorHandler:)`
- `MyPage/Project.swift` 에 `AuthPresentation` 의존성 추가

**DI / 기타**
- `DIContainer+Auth` UseCase 등록, `StubAuthRepository`(`#if DEBUG`)·`MockAuthRepository` 프로토콜 대응
- `NavigationTitle.Auth.changePassword` 추가

## 📋 추후 진행 상황

- 현재 비밀번호 불일치의 서버 에러 코드가 확인되면 `EmailLoginViewModel` 처럼 코드 → 고정 문구 매핑으로 교체하는 편이 낫습니다. 지금은 서버 `message` 패스스루입니다.
- `AuthRouterTests` 에 `.changePassword` path/method 케이스 추가 여부는 리뷰 의견을 받고 싶습니다.
- `AuthType.color` 가 `.changePassword` 와 `.logout` 모두 `.primary` 라, 행이 보이기 시작하면서 두 아이콘 배경이 같은 색으로 나란히 노출됩니다. 디자인 판단 영역이라 이 PR 에서 건드리지 않았습니다.

## 📌 리뷰 포인트

- `UMCApp/Features/Auth/Presentation/Sources/ViewModels/ChangePasswordViewModel.swift` — **에러 분기 기준이 레거시와 다릅니다.** 레거시는 모든 실패를 인라인 처리했는데, `architecture.md` 의 "흐름 중단 → ErrorHandler / 화면 내 상태 → Loadable" 기준에 맞춰 나눴습니다. 이 분기가 적절한지 봐주세요.
- `UMCApp/Features/Auth/Data/Sources/Repositories/AuthRepository.swift` — `parseServerError` 정규화 위치
- `UMCApp/Features/Auth/Domain/Sources/Interfaces/AuthRepositoryProtocol.swift` — `resetPassword` 와 다른 프로토콜에 배치한 근거
- `UMCApp/Features/Auth/Presentation/Sources/Views/ChangePasswordView.swift` — 레거시 `UnderlineTextField` 를 되살리지 않고 `EmailLoginView` 비밀번호 필드와 동일하게 조립했습니다.
- `UMCApp/Features/MyPage/Project.swift` — `MyPagePresentation → AuthPresentation` 의존성 추가. `AuthPresentation` 이 참조하는 MyPage 타깃은 `MyPageDomain` 뿐이고 `MyPagePresentation` 을 참조하는 모듈은 없어 순환은 없습니다(`tuist generate` 로도 확인).
- `UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageRoutingView.swift` — `ErrorHandler` 를 `@Environment` 로 읽는 방식이 `ActivityRoutingView` 선례와 동일한지 확인 부탁드립니다.

**판단이 필요한 항목 2가지:**
1. **새 비밀번호 확인 필드** — 현재는 레거시대로 2필드(현재 + 새). `ResetPasswordView` 는 `SignUpPasswordSection` 으로 확인 필드가 있어 불일치합니다. UX 결정이 필요해 임의로 맞추지 않았습니다.
2. **변경 성공 후 세션 정책** — 완료 Alert 후 `dismiss()` 만 합니다. 서버가 비밀번호 변경 시 기존 세션을 무효화한다면 강제 로그아웃 결선이 필요합니다. 안내 문구는 "변경된 비밀번호로 다시 로그인해 주세요." 로 적어 뒀습니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
