### PR TITLE
✨[Feat] MyPage 탭 실연결 — 섹션 조립·내 활동 목록·진입 라우팅

### DIFF
--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Row/MyActivePostRow.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Row/MyActivePostRow.swift
@@ -1,0 +1,75 @@
+//
+//  MyActivePostRow.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreDesignSystem
+import CoreDomain
+import SwiftUI
+import UMCFoundation
+
+/// 내 활동(작성/댓글/스크랩) 목록의 게시글 한 줄.
+///
+/// 커뮤니티 상세 화면이 아직 이식되지 않아 탭 동작 없이 요약만 보여준다.
+struct MyActivePostRow: View {
+
+    // MARK: - Property
+
+    private let item: CommunityItemModel
+
+    private enum Constants {
+        static let contentLineLimit: Int = 2
+    }
+
+    // MARK: - Init
+
+    init(item: CommunityItemModel) {
+        self.item = item
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            header
+            Text(item.title)
+                .appFont(.subheadline, weight: .semibold, color: .grey900)
+            Text(item.content)
+                .appFont(.footnote, color: .grey600)
+                .lineLimit(Constants.contentLineLimit)
+                .multilineTextAlignment(.leading)
+            counts
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - View Component
+
+    private var header: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Text(item.category.text)
+                .appFont(.caption1, weight: .semibold, color: .indigo500)
+            Text(item.displayUserName)
+                .appFont(.caption1, color: .grey500)
+            Spacer()
+            Text(item.createdAt.timeAgoText)
+                .appFont(.caption1, color: .grey500)
+        }
+    }
+
+    private var counts: some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            countLabel(systemImage: "heart", count: item.likeCount)
+            countLabel(systemImage: "bubble.right", count: item.commentCount)
+            countLabel(systemImage: "bookmark", count: item.scrapCount)
+        }
+    }
+
+    private func countLabel(systemImage: String, count: Int) -> some View {
+        Label("\(count)", systemImage: systemImage)
+            .labelStyle(.titleAndIcon)
+            .appFont(.caption2, color: .grey500)
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/AuthSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/AuthSection.swift
@@ -5,31 +5,48 @@
 //  Created by 김동민 on 7/4/26.
 //
 
+import CoreUIComponents
 import Foundation
 import SwiftUI
 import UMCFoundation
-import CoreDI
-import CoreUIComponents
 
 /// 마이페이지의 인증 관련 섹션 (로그아웃, 회원탈퇴)
 ///
 /// 사용자 인증 관련 작업을 처리하는 섹션으로, AlertPrompt를 통해 확인 다이얼로그를 표시합니다.
+/// 실제 세션 종료·탈퇴 수행은 상위(``MyPageView``)가 주입한 액션이 담당합니다.
 public struct AuthSection: View {
+
     // MARK: - Property
-    
+
     private let sectionType: MyPageSectionType
     @Binding private var alertPrompt: AlertPrompt?
-    @Environment(\.di) private var di
-//    @Environment(\.appFlow) private var appFlow
-    @Environment(ErrorHandler.self) private var errorHandler
+    private let onLogout: () -> Void
+    private let onDeleteAccount: () -> Void
 
-    // TODO(#816): PathStore 네비게이션 배선 — DIContainer에서 PathStore를 resolve해 사용
-//    private var pathStore: PathStore {
-//        di.resolve(PathStore.self)
-//    }
-    
+    /// 노출할 인증 항목.
+    ///
+    /// 비밀번호 변경 화면은 아직 이식 전이라 행을 숨긴다. 화면이 들어오면 필터를 걷어내고
+    /// ``AuthType/changePassword`` 분기에 진입점을 연결한다.
+    private var visibleAuthTypes: [AuthType] {
+        AuthType.allCases.filter { $0 != .changePassword }
+    }
+
+    // MARK: - Init
+
+    public init(
+        sectionType: MyPageSectionType = .auth,
+        alertPrompt: Binding<AlertPrompt?>,
+        onLogout: @escaping () -> Void,
+        onDeleteAccount: @escaping () -> Void
+    ) {
+        self.sectionType = sectionType
+        self._alertPrompt = alertPrompt
+        self.onLogout = onLogout
+        self.onDeleteAccount = onDeleteAccount
+    }
+
     // MARK: - Body
-    
+
     public var body: some View {
         Section(content: {
             sectionContent
@@ -37,39 +54,44 @@ public struct AuthSection: View {
             SectionHeaderView(title: sectionType.rawValue)
         })
     }
-    
+
     // MARK: - Function
+
     private var sectionContent: some View {
-        ForEach(AuthType.allCases, id: \.rawValue) { auth in
+        ForEach(visibleAuthTypes, id: \.rawValue) { auth in
             content(auth)
         }
     }
-    
+
     private func content(_ auth: AuthType) -> some View {
         Button(action: {
             typeAction(auth)
         }, label: {
             // 회원 탈퇴는 빨간색으로 표시
-            MyPageSectionRow(systemIcon: auth.icon, title: auth.rawValue, rightText: "", iconBackgroundColor: auth.color, titleColor: auth == .accountDelete ? .red : .black)
+            MyPageSectionRow(
+                systemIcon: auth.icon,
+                title: auth.rawValue,
+                rightText: "",
+                iconBackgroundColor: auth.color,
+                titleColor: auth == .accountDelete ? .red : .black
+            )
         })
+        .buttonStyle(.borderless)
     }
-    
+
     /// 인증 타입에 따른 액션을 처리하고 AlertPrompt를 표시
     ///
     /// - Parameter auth: 처리할 인증 타입 (비밀번호 변경, 로그아웃 또는 회원탈퇴)
     private func typeAction(_ auth: AuthType) {
         switch auth {
         case .changePassword:
-            // TODO(#816): 비밀번호 변경 View로 이동 배선
-            print("비밀번호 변경 View로 이동")
+            break
         case .logout:
             alertPrompt = .init(
                 title: "로그아웃",
                 message: "정말 로그아웃 하시겠습니까?",
                 positiveBtnTitle: "로그아웃",
-                positiveBtnAction: {
-                    // TODO(#816): 로그아웃 UseCase 배선
-                },
+                positiveBtnAction: onLogout,
                 negativeBtnTitle: "취소",
                 isPositiveBtnDestructive: true
             )
@@ -78,22 +100,10 @@ public struct AuthSection: View {
                 title: "계정 삭제",
                 message: "계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다. 정말 삭제하시겠습니까?",
                 positiveBtnTitle: "삭제",
-                positiveBtnAction: {
-                    Task {
-                        // TODO(#816): deleteMemberUseCase 배선 후 활성화
-//                        await deleteAccount()
-                    }
-                },
+                positiveBtnAction: onDeleteAccount,
                 negativeBtnTitle: "취소",
                 isPositiveBtnDestructive: true
             )
         }
-    }
-
-    /// 회원 탈퇴를 수행합니다.
-    ///
-    /// - TODO(#816): `deleteMemberUseCase` 호출 및 성공/실패 처리 배선
-    @MainActor
-    private func deleteAccount() async {
     }
 }

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/InfoSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/InfoSection.swift
@@ -1,0 +1,106 @@
+//
+//  InfoSection.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreUIComponents
+import SwiftUI
+
+/// 앱 버전·리뷰·공유·기술 블로그 등 앱 정보 섹션.
+public struct InfoSection: View {
+
+    // MARK: - Property
+
+    private let sectionType: MyPageSectionType
+    @Environment(\.openURL) private var openURL
+
+    private enum Constants {
+        static let appName = "UMC"
+        static let shareDescription = "UMC 동아리 운영을 한 곳에서 관리할 수 있는 앱이에요."
+        static let appStoreURL = "https://apps.apple.com/us/app/umc/id6759412446"
+        static let reviewURL = "https://apps.apple.com/app/id6759412446?action=write-review"
+        static let techBlogURL = "https://tech.university.neordinary.com/"
+        static let unknownVersion = "Unknown"
+    }
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+            ?? Constants.unknownVersion
+    }
+
+    private var shareContent: String {
+        """
+        \(Constants.appName)
+        \(Constants.shareDescription)
+        \(Constants.appStoreURL)
+        """
+    }
+
+    // MARK: - Init
+
+    public init(sectionType: MyPageSectionType = .info) {
+        self.sectionType = sectionType
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Section(content: {
+            MyPageSectionRow(
+                systemIcon: "info.circle",
+                title: "버전",
+                rightText: appVersion,
+                iconBackgroundColor: .cyan
+            )
+
+            linkRow(systemIcon: "star.fill", title: "앱 평가 및 리뷰", color: .pink) {
+                open(Constants.reviewURL)
+            }
+
+            ShareLink(item: shareContent, preview: SharePreview(Constants.appName)) {
+                MyPageSectionRow(
+                    systemIcon: "square.and.arrow.up",
+                    title: "앱 공유하기",
+                    rightImage: "arrow.up.right",
+                    iconBackgroundColor: .yellow
+                )
+            }
+
+            linkRow(
+                systemIcon: "newspaper.fill",
+                title: "UMC Product Tech Blog",
+                color: .indigo
+            ) {
+                open(Constants.techBlogURL)
+            }
+        }, header: {
+            SectionHeaderView(title: sectionType.rawValue)
+        })
+    }
+
+    // MARK: - Function
+
+    private func linkRow(
+        systemIcon: String,
+        title: String,
+        color: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action, label: {
+            MyPageSectionRow(
+                systemIcon: systemIcon,
+                title: title,
+                rightImage: "arrow.up.right",
+                iconBackgroundColor: color
+            )
+        })
+        .buttonStyle(.borderless)
+    }
+
+    private func open(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        openURL(url)
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/LawSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/LawSection.swift
@@ -1,0 +1,83 @@
+//
+//  LawSection.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreDI
+import CoreUIComponents
+import MyPageDomain
+import SwiftUI
+import UMCFoundation
+
+/// 개인정보처리 방침 / 이용약관 링크 섹션.
+///
+/// 약관 링크는 서버(`fetchTermsUseCase`)가 내려주므로 탭 시점에 조회해 외부 브라우저로 엽니다.
+public struct LawSection: View {
+
+    // MARK: - Property
+
+    private let sectionType: MyPageSectionType
+    @Environment(\.di) private var di
+    @Environment(\.openURL) private var openURL
+    @Environment(ErrorHandler.self) private var errorHandler
+
+    // MARK: - Init
+
+    public init(sectionType: MyPageSectionType = .laws) {
+        self.sectionType = sectionType
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Section(content: {
+            sectionContent
+        }, header: {
+            SectionHeaderView(title: sectionType.rawValue)
+        })
+    }
+
+    // MARK: - Function
+
+    private var sectionContent: some View {
+        ForEach(LawsType.allCases, id: \.rawValue) { law in
+            content(law)
+        }
+    }
+
+    private func content(_ law: LawsType) -> some View {
+        Button(action: {
+            Task { await openTerms(law) }
+        }, label: {
+            MyPageSectionRow(
+                systemIcon: law.icon,
+                title: law.rawValue,
+                rightImage: "arrow.up.right",
+                iconBackgroundColor: law.color
+            )
+        })
+        .buttonStyle(.borderless)
+    }
+
+    @MainActor
+    private func openTerms(_ law: LawsType) async {
+        do {
+            let provider = di.resolve(MyPageUseCaseProviding.self)
+            let terms = try await provider.fetchTermsUseCase.execute(termsType: law.apiType)
+
+            guard let url = URL(string: terms.link) else {
+                throw AppError.validation(
+                    .invalidFormat(field: "termsLink", expected: "https://...")
+                )
+            }
+            openURL(url)
+        } catch {
+            errorHandler.handle(
+                error,
+                context: ErrorContext(feature: "MyPage", action: "openTerms(\(law.apiType))")
+            )
+        }
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/MyActiveLogSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/MyActiveLogSection.swift
@@ -1,0 +1,60 @@
+//
+//  MyActiveLogSection.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreUIComponents
+import SwiftUI
+
+/// 내가 쓴 글 / 댓글 단 글 / 스크랩으로 이동하는 활동 내역 섹션.
+public struct MyActiveLogSection: View {
+
+    // MARK: - Property
+
+    private let sectionType: MyPageSectionType
+    private let onSelect: (MyActiveLogsType) -> Void
+
+    // MARK: - Init
+
+    public init(
+        sectionType: MyPageSectionType = .myActiveLogs,
+        onSelect: @escaping (MyActiveLogsType) -> Void
+    ) {
+        self.sectionType = sectionType
+        self.onSelect = onSelect
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Section(content: {
+            sectionContent
+        }, header: {
+            SectionHeaderView(title: sectionType.rawValue)
+        })
+    }
+
+    // MARK: - Function
+
+    private var sectionContent: some View {
+        ForEach(MyActiveLogsType.allCases) { log in
+            content(log)
+        }
+    }
+
+    private func content(_ log: MyActiveLogsType) -> some View {
+        Button(action: {
+            onSelect(log)
+        }, label: {
+            MyPageSectionRow(
+                systemIcon: log.icon,
+                title: log.rawValue,
+                rightImage: "chevron.right",
+                iconBackgroundColor: log.backgroundColor
+            )
+        })
+        .buttonStyle(.borderless)
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/ProfileLinkSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/ProfileLinkSection.swift
@@ -1,0 +1,95 @@
+//
+//  ProfileLinkSection.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreUIComponents
+import MyPageDomain
+import SwiftUI
+import UMCFoundation
+
+/// 사용자가 등록한 외부 링크(GitHub / LinkedIn / Blog)를 열어 주는 섹션.
+///
+/// 등록된 링크가 없으면 이동 대신 프로필에서 링크를 추가하도록 안내합니다.
+public struct ProfileLinkSection: View {
+
+    // MARK: - Property
+
+    private let sectionType: MyPageSectionType
+    private let profileLink: [ProfileLink]
+    @Binding private var alertPrompt: AlertPrompt?
+    @Environment(\.openURL) private var openURL
+
+    // MARK: - Init
+
+    public init(
+        sectionType: MyPageSectionType = .profileLink,
+        profileLink: [ProfileLink],
+        alertPrompt: Binding<AlertPrompt?>
+    ) {
+        self.sectionType = sectionType
+        self.profileLink = profileLink
+        self._alertPrompt = alertPrompt
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Section(content: {
+            sectionContent
+        }, header: {
+            SectionHeaderView(title: sectionType.rawValue)
+        })
+    }
+
+    // MARK: - Function
+
+    private var sectionContent: some View {
+        ForEach(SocialLinkType.allCases, id: \.rawValue) { linkType in
+            content(linkType)
+        }
+    }
+
+    private func content(_ linkType: SocialLinkType) -> some View {
+        Button(action: {
+            open(linkType)
+        }, label: {
+            MyPageSectionRow(
+                systemIcon: linkType.icon,
+                title: linkType.title,
+                rightImage: "arrow.up.right",
+                iconBackgroundColor: linkType.color
+            )
+        })
+        .buttonStyle(.borderless)
+    }
+
+    private func open(_ linkType: SocialLinkType) {
+        let rawURL = profileLink.first(where: { $0.type == linkType })?.url ?? ""
+
+        guard let url = Self.normalizedURL(rawURL) else {
+            alertPrompt = AlertPrompt(
+                title: "\(linkType.title) 열 수 없어요",
+                message: "아직 등록된 링크가 없습니다. 프로필에서 링크를 추가해 주세요.",
+                positiveBtnTitle: "확인"
+            )
+            return
+        }
+
+        openURL(url)
+    }
+
+    /// 스킴이 없는 입력(`github.com/foo`)도 열리도록 `https://` 를 보완합니다.
+    private static func normalizedURL(_ rawURL: String) -> URL? {
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let directURL = URL(string: trimmed), directURL.scheme != nil {
+            return directURL
+        }
+
+        return URL(string: "https://\(trimmed)")
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/SettingSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/SettingSection.swift
@@ -16,7 +16,13 @@ public struct SettingSection: View {
     // MARK: - Property
     
     private let sectionType: MyPageSectionType
-    
+
+    // MARK: - Init
+
+    public init(sectionType: MyPageSectionType = .settings) {
+        self.sectionType = sectionType
+    }
+
     // MARK: - Body
     
     public var body: some View {

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/SocialConnectSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/SocialConnectSection.swift
@@ -1,0 +1,76 @@
+//
+//  SocialConnectSection.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+/// 아직 연동하지 않은 소셜 계정을 추가 연동하도록 유도하는 섹션.
+///
+/// 연동 해제는 프로필 화면의 ``ConnectionSocial`` 이 담당하므로 여기서는 추가만 다룹니다.
+public struct SocialConnectSection: View {
+
+    // MARK: - Property
+
+    private let sectionType: MyPageSectionType
+    private let connectedSocials: [SocialType]
+    private let connectingSocial: SocialType?
+    private let onConnect: (SocialType) -> Void
+
+    private var connectableSocials: [SocialType] {
+        SocialType.appConnectableCases.filter { !connectedSocials.contains($0) }
+    }
+
+    // MARK: - Init
+
+    public init(
+        sectionType: MyPageSectionType = .socialConnect,
+        connectedSocials: [SocialType],
+        connectingSocial: SocialType?,
+        onConnect: @escaping (SocialType) -> Void
+    ) {
+        self.sectionType = sectionType
+        self.connectedSocials = connectedSocials
+        self.connectingSocial = connectingSocial
+        self.onConnect = onConnect
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        if !connectableSocials.isEmpty {
+            Section(content: {
+                sectionContent
+            }, header: {
+                SectionHeaderView(title: sectionType.rawValue)
+            })
+        }
+    }
+
+    // MARK: - Function
+
+    private var sectionContent: some View {
+        ForEach(connectableSocials, id: \.rawValue) { social in
+            content(social)
+        }
+    }
+
+    private func content(_ social: SocialType) -> some View {
+        Button(action: {
+            onConnect(social)
+        }, label: {
+            MyPageSectionRow(
+                systemIcon: "link",
+                title: social.displayName,
+                rightText: connectingSocial == social ? "연동 중" : "연동하기",
+                iconBackgroundColor: social.color
+            )
+        })
+        .buttonStyle(.borderless)
+        .disabled(connectingSocial != nil)
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/ProfileCardSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/ProfileCardSection.swift
@@ -7,29 +7,23 @@
 
 import SwiftUI
 import MyPageDomain
-import CoreDI
 import CoreDesignSystem
 import CoreUIComponents
 
 /// MyPage 상단에 표시되는 사용자 프로필 카드 컴포넌트
 ///
-/// 프로필 이미지, 이름 / 닉네임, 학교 / 기수 / 파트 정보를 보여주며, 탭하면 상세 프로필 페이지로 이동합니다.
+/// 프로필 이미지, 이름 / 닉네임, 학교 / 기수 / 파트 정보를 보여줍니다.
+///
+/// - Note: 프로필 상세(``MyPageProfileView``)는 아직 본문이 비어 있어 이동 진입점을 열지 않는다.
+///   상세 화면이 이식되면 이 카드를 탭 가능한 진입점으로 되돌린다.
 struct ProfileCardSection: View {
     // MARK: - property
-    
+
     let profileData: ProfileData
-    @Environment(\.di) var di
-    
+
     private enum Constants {
-        static let chevronSize: CGFloat = 9
         static let profileImageSize: CGSize = .init(width: 64, height: 64)
-        static let chevron: String = "chevron.right"
     }
-    
-    // TODO(#816): PathStore 네비게이션 배선 — DIContainer에서 PathStore를 resolve해 사용
-//    private var pathStore: PathStore {
-//        di.resolve(PathStore.self)
-//    }
 
     // MARK: - Function
 
@@ -38,18 +32,13 @@ struct ProfileCardSection: View {
     }
 
     var body: some View {
-        Button(action: {
-            // TODO(#816): pathStore로 myPage(.myInfo(profileData: self.profileData)) 이동 배선
-        }, label: {
-            HStack(spacing: DefaultSpacing.spacing12, content: {
-                profileImage
-                profileInfo
-                Spacer()
-                SectionRightImage(rightImage: Constants.chevron)
-            })
+        HStack(spacing: DefaultSpacing.spacing12, content: {
+            profileImage
+            profileInfo
+            Spacer()
         })
     }
-    
+
     
     /// 프로필 이미지 뷰(무지개 태두리 효과 포함)
     private var profileImage: some View {

--- a/UMCApp/Features/MyPage/Presentation/Sources/Enum/LawsType.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Enum/LawsType.swift
@@ -1,0 +1,49 @@
+//
+//  LawsType.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import Foundation
+import SwiftUI
+
+/// MyPage에서 표시되는 법률 문서 타입
+///
+/// 개인정보처리 방침, 이용약관을 구분하고 약관 조회 API의 `termsType` 값과 표시용 아이콘·색상을 제공합니다.
+public enum LawsType: String, CaseIterable {
+    /// 개인정보처리 방침
+    case policy = "개인정보처리 방침"
+    /// 이용약관
+    case terms = "이용약관"
+
+    /// 약관 조회 API에서 사용하는 termsType 값
+    public var apiType: String {
+        switch self {
+        case .policy:
+            return "PRIVACY"
+        case .terms:
+            return "SERVICE"
+        }
+    }
+
+    /// 각 법률 문서 타입에 맞는 SF Symbol 아이콘 이름
+    public var icon: String {
+        switch self {
+        case .policy:
+            return "hand.raised.fill"
+        case .terms:
+            return "doc.text.fill"
+        }
+    }
+
+    /// 각 법률 문서 타입에 맞는 테마 색상
+    public var color: Color {
+        switch self {
+        case .policy:
+            return .purple
+        case .terms:
+            return .indigo
+        }
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Enum/MyActiveLogsType.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Enum/MyActiveLogsType.swift
@@ -11,14 +11,16 @@ import SwiftUI
 /// 사용자의 활동 내역 타입을 정의하는 열거형
 ///
 /// 커뮤니티 내에서 사용자가 수행한 활동(글 작성, 댓글, 스크랩)을 분류하고 각각의 아이콘 및 배경 색상을 제공합니다.
-public enum MyActiveLogsType: String, CaseIterable {
+public enum MyActiveLogsType: String, CaseIterable, Identifiable {
     /// 사용자가 직접 작성한 게시글
     case myWritePost = "내가 쓴 글"
     /// 사용자가 댓글을 남긴 게시글
     case myWriteComment = "댓글 단 글"
     /// 사용자가 스크랩한 게시글
     case myScrapPost = "스크랩"
-    
+
+    public var id: String { rawValue }
+
     /// 각 활동 타입에 맞는 SF Symbol 아이콘 이름
     public var icon: String {
         switch self {

--- a/UMCApp/Features/MyPage/Presentation/Sources/Extensions/SocialLinkType+UI.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Extensions/SocialLinkType+UI.swift
@@ -1,0 +1,51 @@
+//
+//  SocialLinkType+UI.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import MyPageDomain
+import SwiftUI
+
+/// `SocialLinkType`의 표시용 프로퍼티.
+///
+/// 도메인 열거형은 서버 문자열만 알고, 아이콘·라벨은 Presentation에서 붙인다.
+public extension SocialLinkType {
+
+    /// 링크 종류를 나타내는 SF Symbol 이름
+    var icon: String {
+        switch self {
+        case .github:
+            return "chevron.left.forwardslash.chevron.right"
+        case .linkedin:
+            return "person.crop.rectangle"
+        case .blog:
+            return "text.book.closed"
+        }
+    }
+
+    /// 행에 노출할 서비스 이름
+    var title: String {
+        switch self {
+        case .github:
+            return "GitHub"
+        case .linkedin:
+            return "LinkedIn"
+        case .blog:
+            return "Blog"
+        }
+    }
+
+    /// 아이콘 배경에 사용하는 테마 색상
+    var color: Color {
+        switch self {
+        case .github:
+            return .black
+        case .linkedin:
+            return .blue
+        case .blog:
+            return .brown
+        }
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageDestination.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageDestination.swift
@@ -1,0 +1,20 @@
+//
+//  MyPageDestination.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+/// MyPage 탭 안에서 push 되는 화면 목적지.
+///
+/// 목적지를 App 의 공용 enum 이 아니라 이 모듈이 소유한다 — ``ActivityDestination`` 과 같은 이유로,
+/// 공용 enum 은 연관값 때문에 Core → Feature 역방향 의존을 만든다. `CoreRouting.PathStore` 가
+/// 타입 소거 경로를 쓰므로 Feature 가 자기 목적지를 들고도 같은 탭 스택에 실린다.
+/// 등록까지 탭 루트(``MyPageView``)가 맡으므로 목적지도 화면도 `public` 으로 열 필요가 없다.
+enum MyPageDestination: Hashable {
+
+    /// 내 활동 게시글 목록 (내가 쓴 글 / 댓글 단 글 / 스크랩).
+    ///
+    /// - Parameter logType: 진입 시 처음 보여줄 활동 종류. 화면 안에서 세 종류를 전환할 수 있다.
+    case myActivePosts(logType: MyActiveLogsType)
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageRoutingView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageRoutingView.swift
@@ -1,0 +1,37 @@
+//
+//  MyPageRoutingView.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreDI
+import SwiftUI
+
+/// ``MyPageDestination``을 실제 화면으로 바꾸는 라우팅 뷰.
+///
+/// MyPage 탭 루트가 `.navigationDestination(for: MyPageDestination.self)`에서 사용한다.
+/// 라우팅을 App이 아니라 이 모듈이 맡는 덕분에 목적지 화면을 `public`으로 열지 않아도 된다.
+struct MyPageRoutingView: View {
+
+    // MARK: - Property
+
+    private let destination: MyPageDestination
+    private let container: DIContainer
+
+    // MARK: - Init
+
+    init(destination: MyPageDestination, container: DIContainer) {
+        self.destination = destination
+        self.container = container
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        switch destination {
+        case .myActivePosts(let logType):
+            MyActivePostsView(container: container, logType: logType)
+        }
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageViewModel.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageViewModel.swift
@@ -7,6 +7,7 @@
 
 import AuthDomain
 import CoreDI
+import CoreDomain
 import CoreNetwork
 import Foundation
 import MyPageDomain
@@ -121,7 +122,43 @@ public final class MyPageViewModel {
         }
     }
 
+    /// 로그아웃을 수행합니다.
+    ///
+    /// 화면 전환(`AppFlow`)은 절대규칙 #1에 따라 View가 담당하므로, 여기서는 세션 정리까지만
+    /// 책임지고 실패는 그대로 던져 호출자가 `ErrorHandler`로 넘기게 한다.
+    @MainActor
+    public func logout() async throws {
+        UserDefaults.standard.set(false, forKey: AppStorageKey.canAutoLogin)
+        try await tearDownSession()
+    }
+
+    /// 회원 탈퇴 후 세션을 정리합니다.
+    @MainActor
+    public func deleteAccount() async throws {
+        try await myPageProvider.deleteMemberUseCase.execute()
+        UserDefaults.standard.set(false, forKey: AppStorageKey.canAutoLogin)
+        try await tearDownSession()
+    }
+
     // MARK: - Private Function
+
+    /// 토큰·세션 역할·프로필 캐시·DI 캐시를 차례로 비웁니다.
+    ///
+    /// `resetCache()`보다 먼저 참조를 확보하는 이유는 `AppRootView.handleAuthSessionExpired`와
+    /// 같다 — 캐시를 비운 뒤 resolve하면 새 인스턴스가 만들어져 정리 대상이 어긋난다.
+    @MainActor
+    private func tearDownSession() async throws {
+        let networkClient = container.resolve(NetworkClient.self)
+        let memberProfileRepository = container.resolveIfRegistered(
+            MemberProfileRepositoryProtocol.self
+        )
+        let userSessionManager = container.resolve(UserSessionManager.self)
+
+        try await networkClient.logout()
+        userSessionManager.reset()
+        await memberProfileRepository?.invalidateCache()
+        container.resetCache()
+    }
 
     /// `/member-oauth/me`를 조회해 연동 소셜 목록을 동기화합니다.
     ///

--- a/UMCApp/Features/MyPage/Presentation/Sources/Views/MyActivePostsView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Views/MyActivePostsView.swift
@@ -1,0 +1,153 @@
+//
+//  MyActivePostsView.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreDesignSystem
+import CoreDI
+import CoreDomain
+import CoreUIComponents
+import MyPageDomain
+import SwiftUI
+import UMCFoundation
+
+/// 내 활동(내가 쓴 글 / 댓글 단 글 / 스크랩) 목록 화면.
+///
+/// 세 목록은 조회 UseCase만 다르고 화면 구성이 같아, 타이틀 메뉴로 종류를 바꾼다.
+/// ``MyActivePostsViewModel``은 종류를 `let`으로 고정하므로 전환 시 목록 뷰를 새로 만든다.
+///
+/// - Important: 자체 `NavigationStack`을 만들지 않는다. 탭별 스택은 상위 탭 셸이 소유한다.
+struct MyActivePostsView: View {
+
+    // MARK: - Property
+
+    @State private var logType: MyActiveLogsType
+
+    private let container: DIContainer
+
+    // MARK: - Init
+
+    init(container: DIContainer, logType: MyActiveLogsType) {
+        self.container = container
+        self._logType = State(initialValue: logType)
+    }
+
+    // MARK: - Computed Property
+
+    private var naviTitle: NavigationTitle.MyPage {
+        switch logType {
+        case .myWritePost:
+            return .writtenPosts
+        case .myWriteComment:
+            return .commentedPosts
+        case .myScrapPost:
+            return .scrappedPosts
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        MyActivePostListView(
+            viewModel: MyActivePostsViewModel(
+                logType: logType,
+                useCaseProvider: container.resolve(MyPageUseCaseProviding.self)
+            )
+        )
+        .id(logType)
+        .navigation(naviTitle: naviTitle, displayMode: .inline)
+        .umcDefaultBackground()
+        .toolbar {
+            ToolBarCollection.ToolBarCenterMenu(
+                items: MyActiveLogsType.allCases,
+                selection: $logType,
+                itemLabel: \.rawValue,
+                itemIcon: \.icon
+            )
+        }
+    }
+}
+
+// MARK: - List
+
+/// 한 가지 활동 종류의 목록. 종류가 바뀌면 `.id`로 통째 교체돼 새 ViewModel과 함께 다시 만들어진다.
+private struct MyActivePostListView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: MyActivePostsViewModel
+
+    // MARK: - Init
+
+    init(viewModel: MyActivePostsViewModel) {
+        self._viewModel = State(initialValue: viewModel)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        content
+            .task {
+                await viewModel.fetchInitialIfNeeded()
+            }
+    }
+
+    // MARK: - View Component
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.postState {
+        case .idle, .loading:
+            Progress()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .loaded(let items):
+            if items.isEmpty {
+                emptyView
+            } else {
+                list(items)
+            }
+
+        case .failed(let error):
+            RetryContentUnavailableView(
+                title: "목록을 불러오지 못했어요",
+                systemImage: "exclamationmark.triangle",
+                description: error.errorDescription ?? "잠시 후 다시 시도해 주세요.",
+                isRetrying: viewModel.postState.isLoading,
+                retryAction: { await viewModel.refresh() }
+            )
+        }
+    }
+
+    private var emptyView: some View {
+        ContentUnavailableView(
+            viewModel.logType.rawValue,
+            systemImage: viewModel.logType.icon,
+            description: Text("아직 \(viewModel.logType.rawValue)이 없어요.")
+        )
+    }
+
+    private func list(_ items: [CommunityItemModel]) -> some View {
+        List {
+            ForEach(items) { item in
+                MyActivePostRow(item: item)
+                    .task {
+                        await viewModel.loadMoreIfNeeded(currentItem: item)
+                    }
+            }
+
+            if viewModel.isLoadingMore {
+                Progress(size: .small)
+                    .frame(maxWidth: .infinity)
+                    .listRowSeparator(.hidden)
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .refreshable {
+            await viewModel.refresh()
+        }
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageFeatureView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageFeatureView.swift
@@ -5,14 +5,26 @@
 //  Created by euijjang97 on 3/6/26.
 //
 
-import BadgeDomain
+import CoreDI
 import SwiftUI
 
+/// MyPage 탭의 공개 진입점.
+///
+/// 탭 셸이 이 타입만 알면 되도록 DI 컨테이너·에러 핸들러 확보를 여기서 끝내고,
+/// 실제 화면 조립은 모듈 내부의 ``MyPageView``가 맡는다.
 public struct MyPageFeatureView: View {
+
+    // MARK: - Property
+
+    @Environment(\.di) private var di
+
+    // MARK: - Init
+
     public init() {}
 
+    // MARK: - Body
+
     public var body: some View {
-        // TODO(#816): ProfileCardSection·AuthSection·SettingSection 등 이관된 섹션 조립
-        Text("MyPage Feature")
+        MyPageView(container: di)
     }
 }

--- a/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageView.swift
@@ -1,0 +1,161 @@
+//
+//  MyPageView.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreDI
+import CoreRouting
+import CoreUIComponents
+import MyPageDomain
+import SwiftUI
+import UMCFoundation
+
+/// MyPage 탭 루트 화면.
+///
+/// 프로필 카드와 ``MyPageSectionType`` 순서의 섹션들을 조립한다. 프로필이 있어야 의미가 있는
+/// 섹션(외부 링크·소셜 연동)은 조회가 끝난 뒤에만 노출한다.
+///
+/// - Important: 자체 `NavigationStack`을 만들지 않는다. 탭별 스택은 상위 탭 셸이 소유한다.
+struct MyPageView: View {
+
+    // MARK: - Property
+
+    @State private var viewModel: MyPageViewModel
+
+    /// 연동 요청 중인 소셜. 외부 로그인 시트가 떠 있는 동안 중복 탭을 막는 화면 상태다.
+    @State private var connectingSocial: SocialType?
+
+    @Environment(PathStore.self) private var pathStore
+    @Environment(ErrorHandler.self) private var errorHandler
+    @Environment(\.appFlow) private var appFlow
+
+    private let container: DIContainer
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - container: 섹션·목적지 화면이 UseCase를 resolve할 DI 컨테이너
+    ///   - viewModel: 프리뷰/테스트용 주입 지점 (기본값: container로 생성)
+    init(container: DIContainer, viewModel: MyPageViewModel? = nil) {
+        self.container = container
+        _viewModel = State(initialValue: viewModel ?? MyPageViewModel(container: container))
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Form {
+            profileContent
+
+            if let profile = viewModel.profileData.value {
+                ProfileLinkSection(
+                    profileLink: profile.profileLink,
+                    alertPrompt: $viewModel.alertPrompt
+                )
+            }
+
+            MyActiveLogSection(onSelect: { logType in
+                pathStore.push(
+                    MyPageDestination.myActivePosts(logType: logType),
+                    on: .mypage
+                )
+            })
+
+            SettingSection()
+            LawSection()
+            InfoSection()
+
+            if let profile = viewModel.profileData.value {
+                SocialConnectSection(
+                    connectedSocials: profile.socialConnected,
+                    connectingSocial: connectingSocial,
+                    onConnect: connect
+                )
+            }
+
+            AuthSection(
+                alertPrompt: $viewModel.alertPrompt,
+                onLogout: { endSession("logout", perform: viewModel.logout) },
+                onDeleteAccount: { endSession("deleteAccount", perform: viewModel.deleteAccount) }
+            )
+        }
+        .navigation(naviTitle: NavigationTitle.MyPage.root, displayMode: .inline)
+        .umcDefaultBackground()
+        .alertPrompt(item: $viewModel.alertPrompt)
+        .navigationDestination(for: MyPageDestination.self) { destination in
+            MyPageRoutingView(destination: destination, container: container)
+        }
+        .task {
+            await viewModel.fetchProfile()
+        }
+    }
+
+    // MARK: - View Component
+
+    @ViewBuilder
+    private var profileContent: some View {
+        switch viewModel.profileData {
+        case .idle, .loading:
+            Progress()
+                .frame(maxWidth: .infinity)
+
+        case .loaded(let profile):
+            ProfileCardSection(profileData: profile)
+
+        case .failed(let error):
+            RetryContentUnavailableView(
+                title: "프로필을 불러오지 못했어요",
+                systemImage: "person.crop.circle.badge.exclamationmark",
+                description: error.errorDescription ?? "잠시 후 다시 시도해 주세요.",
+                isRetrying: viewModel.profileData.isLoading,
+                retryAction: { await viewModel.fetchProfile(forceRefresh: true) }
+            )
+        }
+    }
+
+    // MARK: - Function
+
+    /// 소셜 연동을 요청하고 결과를 프로필 상태에 반영한다.
+    private func connect(_ social: SocialType) {
+        guard connectingSocial == nil else { return }
+        connectingSocial = social
+
+        Task {
+            defer { connectingSocial = nil }
+
+            do {
+                try await viewModel.connectSocial(social)
+            } catch {
+                errorHandler.handle(
+                    error,
+                    context: ErrorContext(
+                        feature: "MyPage",
+                        action: "connectSocial(\(social.rawValue))"
+                    )
+                )
+            }
+        }
+    }
+
+    /// 세션을 끝내는 액션(로그아웃·탈퇴)을 수행하고 로그인 화면으로 되돌린다.
+    ///
+    /// ViewModel은 절대규칙 #1에 따라 `AppFlow`를 들고 있지 않으므로 전환은 여기서 한다.
+    private func endSession(
+        _ actionName: String,
+        perform: @MainActor @escaping () async throws -> Void
+    ) {
+        Task {
+            do {
+                try await perform()
+                appFlow.logout()
+            } catch {
+                errorHandler.handle(
+                    error,
+                    context: ErrorContext(feature: "MyPage", action: actionName)
+                )
+            }
+        }
+    }
+}

--- a/UMCApp/Features/MyPage/Project.swift
+++ b/UMCApp/Features/MyPage/Project.swift
@@ -12,6 +12,10 @@ let project = featureProject(
     presentationExtraDependencies: [
         .project(target: "CoreDI", path: .relativeToRoot("Core/DI")),
         .project(target: "CorePhoto", path: .relativeToRoot("Core/Photo")),
+        // 탭 루트가 자기 목적지(MyPageDestination)를 탭 스택에 push 한다.
+        .project(target: "CoreRouting", path: .relativeToRoot("Core/Routing")),
+        // 로그아웃/탈퇴가 UserSessionManager·MemberProfileRepository 캐시를 직접 정리한다.
+        .project(target: "CoreDomain", path: .relativeToRoot("Core/Domain")),
         // 소셜 연동 추가/해제(#1029)가 AuthDomain의 MemberOAuth UseCase와
         // CoreNetwork의 소셜 로그인 매니저를 사용한다.
         .project(target: "CoreNetwork", path: .relativeToRoot("Core/Network")),

--- a/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
+++ b/UMCApp/UMCApp/Sources/RootTab/RootTabView.swift
@@ -125,7 +125,6 @@ struct RootTabView: View {
             // TODO: CommunityPresentation의 실제 CommunityView 연결 (Community 탭 실연결 후속 이슈)
             CommunityFeatureView()
         case .mypage:
-            // TODO: MyPagePresentation의 실제 MyPageView 연결 (MyPage 탭 실연결 후속 이슈)
             MyPageFeatureView()
         }
     }


### PR DESCRIPTION
## ✨ PR 유형

Feature — MyPage 탭이 `Text("MyPage Feature")` 스텁 상태였습니다. Presentation 컴포넌트·ViewModel·UseCase·DI 는 이미 이식돼 있었지만 **조립과 결선이 비어 있어** 탭에 들어가도 아무것도 없었습니다. 이걸 실제 동작하는 화면으로 결선했습니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- MyPage 탭 전체 + 내 활동 목록(3종 전환) — 영상 첨부 필요 -->

## 🛠️ 작업내용

**탭 루트 조립**
- `MyPageView` 신설 — `Form` 안에 프로필 카드 + `MyPageSectionType` 순서대로 섹션 조립
- `MyPageFeatureView` 스텁 제거, `\.di` 로 `MyPageView` 조립 (`ActivityFeatureView` 패턴)
- `RootTabView` 의 `.mypage` TODO 해소

**`MyPageSectionType` 7개 케이스를 모두 채움**
- 신규: `ProfileLinkSection`, `MyActiveLogSection`, `LawSection`, `InfoSection`, `SocialConnectSection`
- 기존 `AuthSection`·`SettingSection` 은 **`public init` 이 없어 모듈 밖에서 생성조차 불가**했던 상태 → init 개방

**내 활동 목록**
- `MyActivePostsView` 신설 — `MyActivePostsViewModel`(기존 이식분)에 붙는 화면, `ToolBarCenterMenu` 로 3종(내가 쓴 글/댓글 단 글/스크랩) 전환
- `MyActivePostRow` — `CommunityItemModel` 요약 행

**라우팅**
- `MyPageDestination` + `MyPageRoutingView` — 앱 소유 `NavigationDestination` 대신 **피처 소유 목적지**(`ActivityDestination` 선례)
- `MyPageViewModel` 에 `logout()` / `deleteAccount()` / `tearDownSession()` 추가

**기타**
- `LawsType`, `SocialLinkType+UI` 추가 (에셋 미이관이라 SF Symbol 사용)
- `MyActiveLogsType` `Identifiable` 채택, `Features/MyPage/Project.swift` 에 `CoreRouting`·`CoreDomain` 의존 추가

## 📋 추후 진행 상황

**이 PR 이후에도 MyPage 는 완료가 아닙니다.** 결선 과정에서 드러난 도달 불가 지점:

1. **`MyPageProfileView.body` 가 `Text("")` 스텁** → 프로필 카드를 일부러 탭 불가로 막았습니다. 프로필 이미지·닉네임·활동이력·외부링크 **수정 기능 전체가 도달 불가**입니다. `MyPageProfileViewModel` 은 이식돼 있으니 View 본문만 남았습니다. → **별도 이슈 필요**
2. **게시글 행 탭 불가** — 커뮤니티 상세 목적지가 없습니다(Community 모듈 = 스텁). Community 탭 결선 이후 가능.
3. **`AuthType.changePassword` 행은 필터로 숨김** — 화면이 `feat/change-password` 브랜치(#1119)에 있습니다. 그 PR 머지 후 `AuthSection` 의 필터 한 줄만 걷으면 됩니다. WHY 주석 남겨 뒀습니다.
4. `MyActiveLogsType` 에 `Sendable` 채택 필요 — 지금은 경고지만 Swift 6 모드에서 에러가 됩니다. 범위 밖이라 손대지 않았습니다.
5. 세션 정리 시퀀스가 3곳(`AppRootView`, `FailedVerificationUMCViewModel`, `MyPageViewModel`) 중복 → UseCase 추출 후보.
6. `#584` 팔로우, 레거시 문의/FAQ 는 대응 enum·API 가 없어 미이관 (임의 생성하지 않음).

## 📌 리뷰 포인트

- `UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageView.swift` — 섹션 조립 순서와 `.navigationDestination` 등록 위치
- `UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageDestination.swift` — **피처 소유 목적지로 간 판단**이 현재 방향과 맞는지 (앱 소유 `NavigationDestination` 은 Home/Notice 과도기 목적지만 담고 있음)
- `UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageViewModel.swift` — **로그아웃/탈퇴 세션 정리 순서**. `AppFlowViewModel.logout()` 이 상태 전환만 하고 토큰/세션을 지우지 않아서, `FailedVerificationUMCViewModel` 과 같은 순서(토큰 삭제 → 세션 리셋 → 프로필 캐시 무효화 → DI 캐시 리셋, `resetCache()` 전에 참조 확보)를 따랐습니다. 이 중복이 지금 단계에서 허용 가능한지 봐주세요.
- `UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageSection/AuthSection.swift` — `public init` 신설 + `changePassword` 필터
- `UMCApp/Features/MyPage/Presentation/Sources/Views/MyActivePostsView.swift` — 3종 전환 시 목록 교체(`.id(logType)`) 방식

**레거시와 갈라진 판단:**
- 레거시의 `FollowsSection`·`HelpSection`·`LinkSection`(팀 소개)은 `MyPageSectionType` 에 대응 케이스가 없어 **복원하지 않았습니다.** 재설계된 enum 을 정본으로 삼았습니다.
- 소셜은 **루트 = 연동 추가 / 프로필 = 연동 해제**로 나눴습니다. 해제 로직은 `MyPageProfileViewModel` 에만 있어 그대로 두고, 루트에 `SocialConnectSection` 을 새로 만들어 그동안 호출자가 없던 `MyPageViewModel.connectSocial` 을 결선했습니다.

## ⚠️ 머지 순서 참고

`AuthSection.swift` 를 #1119 도 함께 수정합니다. **이 PR 을 먼저 머지하고 #1119 를 rebase 하는 편이 안전합니다.**

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)