### PR TITLE
✨[Feat] MyPageProfileView 이식 및 프로필 상세 진입점 결선

### DIFF
--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Row/ActiveLogRow.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Row/ActiveLogRow.swift
@@ -1,0 +1,83 @@
+//
+//  ActiveLogRow.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreDesignSystem
+import CoreUIComponents
+import MyPageDomain
+import SwiftUI
+import UMCFoundation
+
+/// 활동 이력 한 건(기수 · 파트 · 역할)을 한 줄로 보여주는 행.
+struct ActiveLogRow: View, Equatable {
+
+    // MARK: - Property
+
+    private let row: ActivityLog
+
+    private enum Constants {
+        static let badgePadding = EdgeInsets(top: 5, leading: 8, bottom: 5, trailing: 8)
+    }
+
+    // MARK: - Init
+
+    init(row: ActivityLog) {
+        self.row = row
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            generationTag
+            part
+            Spacer()
+            roles
+        }
+    }
+
+    // MARK: - View Component
+
+    private var generationTag: some View {
+        Text("\(row.generation)기")
+            .appFont(.footnote, color: .black)
+            .padding(Constants.badgePadding)
+            .background {
+                RoundedRectangle(cornerRadius: DefaultConstant.defaultCornerRadius)
+                    .fill(.clear)
+                    .stroke(Color.grey300, style: .init())
+            }
+    }
+
+    /// Admin은 파트 개념이 없어 이름을 비운다.
+    @ViewBuilder
+    private var part: some View {
+        if row.part != .admin {
+            Text(row.part.name)
+                .appFont(.subheadline, color: .black)
+        }
+    }
+
+    /// 같은 기수에 운영진 역할이 여러 개일 수 있어 모두 나열한다. 챌린저는 배지를 달지 않는다.
+    @ViewBuilder
+    private var roles: some View {
+        let displayRoles = row.roles.filter { $0 != .challenger }
+
+        if !displayRoles.isEmpty {
+            HStack(spacing: DefaultSpacing.spacing4) {
+                ForEach(displayRoles, id: \.self) { role in
+                    Text(role.displayName)
+                        .appFont(.footnote, weight: .medium, color: role.textColor)
+                        .padding(Constants.badgePadding)
+                        .glassEffect(
+                            .clear.tint(role.backgroundColor),
+                            in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius)
+                        )
+                }
+            }
+        }
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Row/ReadOnlyTextField.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Row/ReadOnlyTextField.swift
@@ -1,0 +1,37 @@
+//
+//  ReadOnlyTextField.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreUIComponents
+import SwiftUI
+
+/// 수정 불가능한 사용자 정보(이름, 학교 등)를 한 섹션으로 보여주는 읽기 전용 필드.
+struct ReadOnlyTextField: View, Equatable {
+
+    // MARK: - Property
+
+    private let placeholder: String
+    private let header: String
+
+    // MARK: - Init
+
+    init(placeholder: String, header: String) {
+        self.placeholder = placeholder
+        self.header = header
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Section(content: {
+            // 값을 prompt로만 넘겨 편집 불가 상태에서도 회색 본문처럼 읽히게 한다.
+            TextField("", text: .constant(""), prompt: Text(placeholder))
+                .disabled(true)
+        }, header: {
+            SectionHeaderView(title: header)
+        })
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/ActiveLogs.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/ActiveLogs.swift
@@ -1,0 +1,100 @@
+//
+//  ActiveLogs.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreDesignSystem
+import CoreUIComponents
+import MyPageDomain
+import SwiftUI
+
+/// 기수별 활동 이력 목록과 운영진 코드로 기록을 추가하는 진입점을 담은 섹션.
+struct ActiveLogs: View {
+
+    // MARK: - Property
+
+    private let rows: [ActivityLog]
+    private let header: String
+    private let onAddTap: (() -> Void)?
+    private let isAdding: Bool
+    private let didRecentlyAdd: Bool
+
+    private enum Constants {
+        static let addTitle = "기록 추가"
+        static let addedTitle = "추가되었습니다"
+        static let addIcon = "plus.circle"
+        static let addedIcon = "checkmark.circle.fill"
+        static let feedbackAnimationDuration: Double = 0.25
+    }
+
+    // MARK: - Init
+
+    init(
+        rows: [ActivityLog],
+        header: String,
+        onAddTap: (() -> Void)? = nil,
+        isAdding: Bool = false,
+        didRecentlyAdd: Bool = false
+    ) {
+        self.rows = rows
+        self.header = header
+        self.onAddTap = onAddTap
+        self.isAdding = isAdding
+        self.didRecentlyAdd = didRecentlyAdd
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Section(content: {
+            VStack(spacing: DefaultSpacing.spacing16) {
+                ForEach(rows) { row in
+                    // Container-Presenter 분리로 목록 전체 재계산을 막는다.
+                    ActiveLogRow(row: row)
+                        .equatable()
+                }
+            }
+        }, header: {
+            HStack {
+                SectionHeaderView(title: header)
+                Spacer()
+                addButton
+            }
+        })
+    }
+
+    // MARK: - View Component
+
+    @ViewBuilder
+    private var addButton: some View {
+        if let onAddTap {
+            Button(action: onAddTap) {
+                if isAdding {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    addLabel
+                }
+            }
+            .buttonStyle(.plain)
+            .disabled(isAdding)
+        }
+    }
+
+    private var addLabel: some View {
+        Label(
+            didRecentlyAdd ? Constants.addedTitle : Constants.addTitle,
+            systemImage: didRecentlyAdd ? Constants.addedIcon : Constants.addIcon
+        )
+        .labelStyle(.titleAndIcon)
+        .labelIconToTitleSpacing(DefaultSpacing.spacing8)
+        .appFont(.footnote, color: didRecentlyAdd ? .green : .indigo500)
+        .contentTransition(.symbolEffect(.replace))
+        .animation(
+            .easeInOut(duration: Constants.feedbackAnimationDuration),
+            value: didRecentlyAdd
+        )
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/NameAndNickname.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/NameAndNickname.swift
@@ -1,0 +1,38 @@
+//
+//  NameAndNickname.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import SwiftUI
+
+/// 실명과 닉네임을 각각 읽기 전용 섹션으로 보여준다.
+struct NameAndNickname: View, Equatable {
+
+    // MARK: - Property
+
+    private let name: String
+    private let nickname: String
+
+    private enum Constants {
+        static let nameHeader = "이름"
+        static let nicknameHeader = "닉네임"
+    }
+
+    // MARK: - Init
+
+    init(name: String, nickname: String) {
+        self.name = name
+        self.nickname = nickname
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            ReadOnlyTextField(placeholder: name, header: Constants.nameHeader)
+            ReadOnlyTextField(placeholder: nickname, header: Constants.nicknameHeader)
+        }
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/ProfileLinkEditSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/ProfileLinkEditSection.swift
@@ -1,0 +1,82 @@
+//
+//  ProfileLinkEditSection.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import CoreDesignSystem
+import CoreUIComponents
+import MyPageDomain
+import SwiftUI
+
+/// 외부 프로필 링크(GitHub / LinkedIn / Blog)를 TextField로 직접 편집하는 섹션.
+///
+/// 링크를 열기만 하는 ``ProfileLinkSection``과 달리 프로필 수정 화면 전용이다.
+struct ProfileLinkEditSection: View, Equatable {
+
+    // MARK: - Property
+
+    @Binding private var profileLink: [ProfileLink]
+    private let header: String
+
+    private enum Constants {
+        static let iconSize: CGFloat = 24
+    }
+
+    // MARK: - Init
+
+    init(profileLink: Binding<[ProfileLink]>, header: String) {
+        self._profileLink = profileLink
+        self.header = header
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.header == rhs.header && lhs.profileLink == rhs.profileLink
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Section(content: {
+            ForEach(SocialLinkType.allCases, id: \.rawValue) { type in
+                linkField(type)
+            }
+        }, header: {
+            SectionHeaderView(title: header)
+        })
+    }
+
+    // MARK: - Function
+
+    private func linkField(_ type: SocialLinkType) -> some View {
+        HStack(spacing: DefaultSpacing.spacing8) {
+            Image(systemName: type.icon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: Constants.iconSize, height: Constants.iconSize)
+                .foregroundStyle(type.color)
+
+            TextField("", text: binding(for: type), prompt: Text(type.placeholder))
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+        }
+    }
+
+    /// 서버가 모든 링크 타입을 항상 내려주지는 않으므로, 없는 타입은 입력 시점에 추가한다.
+    private func binding(for type: SocialLinkType) -> Binding<String> {
+        Binding(
+            get: { profileLink.first(where: { $0.type == type })?.url ?? "" },
+            set: { newValue in
+                if let index = profileLink.firstIndex(where: { $0.type == type }) {
+                    profileLink[index].url = newValue
+                } else {
+                    profileLink.append(ProfileLink(type: type, url: newValue))
+                }
+            }
+        )
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/SchoolSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/SchoolSection.swift
@@ -1,0 +1,30 @@
+//
+//  SchoolSection.swift
+//  MyPagePresentation
+//
+//  Created by euijjang97 on 8/10/26.
+//
+
+import SwiftUI
+
+/// 소속 대학교를 읽기 전용 섹션으로 보여준다.
+struct SchoolSection: View, Equatable {
+
+    // MARK: - Property
+
+    private let univ: String
+    private let header: String
+
+    // MARK: - Init
+
+    init(univ: String, header: String) {
+        self.univ = univ
+        self.header = header
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ReadOnlyTextField(placeholder: univ, header: header)
+    }
+}

--- a/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/ProfileCardSection.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Components/Section/ProfileCardSection.swift
@@ -12,14 +12,12 @@ import CoreUIComponents
 
 /// MyPage 상단에 표시되는 사용자 프로필 카드 컴포넌트
 ///
-/// 프로필 이미지, 이름 / 닉네임, 학교 / 기수 / 파트 정보를 보여줍니다.
-///
-/// - Note: 프로필 상세(``MyPageProfileView``)는 아직 본문이 비어 있어 이동 진입점을 열지 않는다.
-///   상세 화면이 이식되면 이 카드를 탭 가능한 진입점으로 되돌린다.
+/// 프로필 이미지, 이름 / 닉네임, 학교 / 기수 / 파트 정보를 보여주며 프로필 상세로 이동합니다.
 struct ProfileCardSection: View {
     // MARK: - property
 
     let profileData: ProfileData
+    private let onTap: () -> Void
 
     private enum Constants {
         static let profileImageSize: CGSize = .init(width: 64, height: 64)
@@ -27,19 +25,27 @@ struct ProfileCardSection: View {
 
     // MARK: - Function
 
-    init(profileData: ProfileData) {
+    /// - Parameter onTap: 프로필 상세로의 이동. 섹션은 `PathStore`를 알지 않고 탭 루트가 push한다.
+    init(profileData: ProfileData, onTap: @escaping () -> Void) {
         self.profileData = profileData
+        self.onTap = onTap
     }
 
     var body: some View {
-        HStack(spacing: DefaultSpacing.spacing12, content: {
-            profileImage
-            profileInfo
-            Spacer()
+        Button(action: onTap, label: {
+            HStack(spacing: DefaultSpacing.spacing12, content: {
+                profileImage
+                profileInfo
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .appFont(.footnote, color: .grey500)
+            })
+            .contentShape(.rect)
         })
+        .buttonStyle(.plain)
     }
 
-    
+
     /// 프로필 이미지 뷰(무지개 태두리 효과 포함)
     private var profileImage: some View {
         RemoteImage(urlString: profileData.challengerInfo.profileImage ?? "", size: Constants.profileImageSize)

--- a/UMCApp/Features/MyPage/Presentation/Sources/Extensions/SocialLinkType+UI.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Extensions/SocialLinkType+UI.swift
@@ -37,6 +37,18 @@ public extension SocialLinkType {
         }
     }
 
+    /// 링크 입력 필드에 노출할 예시 URL
+    var placeholder: String {
+        switch self {
+        case .github:
+            return "https://github.com/"
+        case .linkedin:
+            return "https://linkedin.com/in/yourprofile"
+        case .blog:
+            return "https://yourblog.com"
+        }
+    }
+
     /// 아이콘 배경에 사용하는 테마 색상
     var color: Color {
         switch self {

--- a/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageDestination.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageDestination.swift
@@ -5,6 +5,8 @@
 //  Created by euijjang97 on 8/10/26.
 //
 
+import MyPageDomain
+
 /// MyPage 탭 안에서 push 되는 화면 목적지.
 ///
 /// 목적지를 App 의 공용 enum 이 아니라 이 모듈이 소유한다 — ``ActivityDestination`` 과 같은 이유로,
@@ -12,6 +14,13 @@
 /// 타입 소거 경로를 쓰므로 Feature 가 자기 목적지를 들고도 같은 탭 스택에 실린다.
 /// 등록까지 탭 루트(``MyPageView``)가 맡으므로 목적지도 화면도 `public` 으로 열 필요가 없다.
 enum MyPageDestination: Hashable {
+
+    /// 프로필 상세/편집.
+    ///
+    /// - Parameter profileData: 탭 루트가 이미 조회해 둔 프로필 스냅샷. 상세 화면은 이 값을
+    ///   편집 시작점으로 삼으므로 목적지가 직접 싣는다 — 재조회하면 카드에 보이던 값과
+    ///   어긋난 상태로 편집이 시작될 수 있다.
+    case profile(profileData: ProfileData)
 
     /// 내 활동 게시글 목록 (내가 쓴 글 / 댓글 단 글 / 스크랩).
     ///

--- a/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageRoutingView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageRoutingView.swift
@@ -34,6 +34,9 @@ struct MyPageRoutingView: View {
 
     var body: some View {
         switch destination {
+        case .profile(let profileData):
+            MyPageProfileView(container: container, profileData: profileData)
+
         case .myActivePosts(let logType):
             MyActivePostsView(container: container, logType: logType)
 

--- a/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageProfileViewModel.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageProfileViewModel.swift
@@ -167,7 +167,11 @@ public final class MyPageProfileViewModel: SinglePhotoPickerManageable {
         
         let currentSocialConnections = profileData.socialConnections
         try await useCaseProvider.addChallengerRecordUseCase.execute(code: code)
-        profileData = try await useCaseProvider.fetchMyPageProfileUseCase.execute()
+        // 기록 추가는 세션 프로필 캐시를 무효화하지 않으므로, 캐시 경로로 읽으면 방금 추가한
+        // 이력이 빠진 스냅샷이 돌아온다.
+        profileData = try await useCaseProvider.fetchMyPageProfileUseCase.execute(
+            forceRefresh: true
+        )
         profileData.socialConnections = currentSocialConnections
         initialProfileLinkState = Self.makeProfileLinkState(from: profileData.profileLink)
         showRecentActivityLogAddedState()

--- a/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageProfileView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageProfileView.swift
@@ -5,19 +5,22 @@
 //  Created by 김동민 on 7/8/26.
 //
 
-import SwiftUI
-import PhotosUI
-import UMCFoundation
 import AuthDomain
 import CoreDI
+import CoreDomain
+import CoreUIComponents
 import MyPageDomain
+import PhotosUI
+import SwiftUI
+import UMCFoundation
 
 /// 마이페이지 정보 Write & Read 화면입니다.
 ///
 /// 사용자의 프로필 이미지, 닉네임, 학교, 활동 로그, 소셜 링크 등을 확인하고 수정할 수 있습니다.
 public struct MyPageProfileView: View {
-    
+
     // MARK: - Property
+
     @State private var viewModel: MyPageProfileViewModel
     @Environment(\.di) private var di
     @Environment(ErrorHandler.self) private var errorHandler
@@ -25,7 +28,20 @@ public struct MyPageProfileView: View {
     @State private var showAddActivityLogAlert: Bool = false
     @State private var challengerCode: String = ""
     @State private var alertPrompt: AlertPrompt?
-    
+
+    private enum Constants {
+        static let schoolHeader = "학교"
+        static let activityLogHeader = "활동 이력"
+        static let profileLinkHeader = "외부 프로필 링크"
+
+        static let codeAlertTitle = "챌린저 코드 입력"
+        static let codeAlertMessage = "운영진에게 발급받은 6자리 코드를 입력해주세요."
+        static let codeFieldPlaceholder = "6자리 코드"
+        static let codeLength = 6
+    }
+
+    // MARK: - Init
+
     public init(container: DIContainer, profileData: ProfileData) {
         self._viewModel = .init(
             initialValue: .init(
@@ -36,17 +52,267 @@ public struct MyPageProfileView: View {
             )
         )
     }
-    
+
+    // MARK: - Body
+
     public var body: some View {
-        Text("")
+        Form {
+            sectionContent($viewModel.profileData)
+        }
+        .navigation(naviTitle: NavigationTitle.MyPage.profile, displayMode: .inline)
+        .umcDefaultBackground()
+        .toolbar {
+            ToolBarCollection.ConfirmBtn(
+                action: submitProfileUpdate,
+                disable: !viewModel.canSubmit,
+                isLoading: viewModel.isUpdatingProfileImage,
+                dismissOnTap: false
+            )
+        }
+        .onChange(of: viewModel.selectedPhotoItem) { _, _ in
+            Task { await viewModel.loadSelectedImage() }
+        }
+        .alert(
+            Constants.codeAlertTitle,
+            isPresented: $showAddActivityLogAlert,
+            actions: challengerCodeAlertActions,
+            message: challengerCodeAlertMessage
+        )
+        .alertPrompt(item: $alertPrompt)
     }
-    
+
+    // MARK: - View Component
+
     /// 섹션 구현부
     /// - Parameter profile: 프로필 데이터 바인딩
     @ViewBuilder
-    private func sectionConnectionImpl(_ profile: Binding<ProfileData>) -> some View {
-        // 프로필 이미지 수정
-        ProfileImagePicker(selectedPhotoItem: $viewModel.selectedPhotoItem, selectedImage: viewModel.selectedImage, profileImage: viewModel.profileData.challengerInfo.profileImage)
-        
+    private func sectionContent(_ profile: Binding<ProfileData>) -> some View {
+        ProfileImagePicker(
+            selectedPhotoItem: $viewModel.selectedPhotoItem,
+            selectedImage: viewModel.selectedImage,
+            profileImage: profile.wrappedValue.challengerInfo.profileImage
+        )
+
+        ConnectionSocial(
+            socialConnections: profile.wrappedValue.socialConnections,
+            disconnectingSocialType: viewModel.disconnectingSocialType,
+            onDisconnect: presentDisconnectPrompt
+        )
+
+        NameAndNickname(
+            name: profile.wrappedValue.challengerInfo.name,
+            nickname: profile.wrappedValue.challengerInfo.nickname
+        )
+
+        SchoolSection(
+            univ: profile.wrappedValue.challengerInfo.schoolName,
+            header: Constants.schoolHeader
+        )
+
+        ActiveLogs(
+            rows: profile.wrappedValue.activityLogs,
+            header: Constants.activityLogHeader,
+            onAddTap: { showAddActivityLogAlert = true },
+            isAdding: viewModel.isAddingActivityLog,
+            didRecentlyAdd: viewModel.didRecentlyAddActivityLog
+        )
+
+        ProfileLinkEditSection(
+            profileLink: profile.profileLink,
+            header: Constants.profileLinkHeader
+        )
+    }
+
+    @ViewBuilder
+    private func challengerCodeAlertActions() -> some View {
+        TextField(Constants.codeFieldPlaceholder, text: $challengerCode)
+            .keyboardType(.asciiCapable)
+
+        Button("닫기", role: .cancel) {
+            challengerCode = ""
+        }
+
+        Button("전송", action: submitChallengerCode)
+    }
+
+    private func challengerCodeAlertMessage() -> some View {
+        Text(Constants.codeAlertMessage)
+    }
+
+    // MARK: - Function
+
+    /// 프로필 수정(이미지·링크)을 서버에 제출하고 완료 시 화면을 닫습니다.
+    private func submitProfileUpdate() {
+        Task {
+            do {
+                try await viewModel.submitProfileUpdate()
+                dismiss()
+            } catch {
+                errorHandler.handle(
+                    error,
+                    context: ErrorContext(feature: "MyPage", action: "submitProfileUpdate")
+                )
+            }
+        }
+    }
+
+    /// 활동 이력 추가 코드를 서버에 전송하고, 성공 시 프로필과 로컬 세션 저장소를 갱신합니다.
+    private func submitChallengerCode() {
+        let trimmedCode = challengerCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isValidChallengerCode(trimmedCode) else {
+            errorHandler.handle(
+                AppError.validation(
+                    .invalidFormat(
+                        field: "challengerCode",
+                        expected: "\(Constants.codeLength)자리 영숫자 코드"
+                    )
+                ),
+                context: ErrorContext(feature: "MyPage", action: "submitChallengerCode")
+            )
+            return
+        }
+
+        Task {
+            defer { challengerCode = "" }
+
+            do {
+                try await viewModel.addActivityLog(code: trimmedCode)
+                await syncProfileStorage()
+            } catch let error as RepositoryError {
+                presentCodeFailurePrompt(code: error.code, message: error.userMessage)
+            } catch {
+                errorHandler.handle(
+                    error,
+                    context: ErrorContext(feature: "MyPage", action: "addActivityLog")
+                )
+            }
+        }
+    }
+
+    private func isValidChallengerCode(_ code: String) -> Bool {
+        code.count == Constants.codeLength
+            && code.unicodeScalars.allSatisfy(CharacterSet.alphanumerics.contains)
+    }
+
+    /// 활동 이력이 추가되면 역할·기수가 바뀌므로 `AppStorageKey` 기반 로컬 세션 값도 맞춘다.
+    ///
+    /// 동기화 실패는 이력 추가 자체를 되돌리지 않으므로 화면 흐름을 끊지 않는다.
+    private func syncProfileStorage() async {
+        let fetchProfile = di.resolve(FetchMemberProfileUseCaseProtocol.self)
+
+        guard let profile = try? await fetchProfile.execute() else { return }
+
+        di.resolve(SyncProfileStorageUseCaseProtocol.self).execute(profile: profile)
+    }
+
+    private func presentCodeFailurePrompt(code: String?, message: String) {
+        let resolvedMessage: String
+
+        switch code {
+        case "CHALLENGER-0002":
+            resolvedMessage = "이미 등록된 사용자입니다."
+        case "CHALLENGER-0012":
+            resolvedMessage = "이미 사용된 챌린저 기록 추가용 코드입니다."
+        case "CHALLENGER-0013":
+            resolvedMessage = "코드에 등록된 사용자 이름이 요청자와 일치하지 않습니다."
+        case "CHALLENGER-0014":
+            resolvedMessage = "코드에 등록된 학교가 요청자 소속과 일치하지 않습니다."
+        case "CHALLENGER-0016":
+            resolvedMessage = "챌린저 기록 코드를 먼저 입력해주세요."
+        default:
+            resolvedMessage = Self.sanitizedErrorMessage(from: message)
+        }
+
+        alertPrompt = AlertPrompt(
+            title: "인증 실패",
+            message: resolvedMessage,
+            positiveBtnTitle: "확인"
+        )
+    }
+
+    private func presentDisconnectPrompt(_ connection: SocialConnection) {
+        alertPrompt = AlertPrompt(
+            title: "연동 해제",
+            message: "\(connection.socialType.displayName) 계정 연동을 해제할까요?",
+            positiveBtnTitle: "해제",
+            positiveBtnAction: { disconnectSocial(connection) },
+            negativeBtnTitle: "취소",
+            isPositiveBtnDestructive: true
+        )
+    }
+
+    private func disconnectSocial(_ connection: SocialConnection) {
+        Task {
+            do {
+                try await viewModel.disconnectSocial(connection)
+            } catch let error as RepositoryError {
+                presentDisconnectFailurePrompt(code: error.code, message: error.userMessage)
+            } catch let error as NetworkError {
+                // 연동 해제 거부는 서버가 본문 code로만 구분해 주므로 응답을 직접 열어본다.
+                guard let serverError = Self.parseServerError(error) else {
+                    errorHandler.handle(
+                        error,
+                        context: ErrorContext(feature: "MyPage", action: "disconnectSocial")
+                    )
+                    return
+                }
+
+                presentDisconnectFailurePrompt(
+                    code: serverError.code,
+                    message: serverError.message
+                )
+            } catch {
+                errorHandler.handle(
+                    error,
+                    context: ErrorContext(feature: "MyPage", action: "disconnectSocial")
+                )
+            }
+        }
+    }
+
+    private func presentDisconnectFailurePrompt(code: String?, message: String) {
+        let resolvedMessage: String
+
+        switch code {
+        case "AUTHENTICATION-0016":
+            resolvedMessage = "연동된 계정이 하나뿐이면 연동을 해제할 수 없습니다. 회원 탈퇴를 이용해주세요."
+        default:
+            resolvedMessage = Self.sanitizedErrorMessage(from: message)
+        }
+
+        alertPrompt = AlertPrompt(
+            title: "연동 해제 불가",
+            message: resolvedMessage,
+            positiveBtnTitle: "확인"
+        )
+    }
+
+    private static func parseServerError(
+        _ error: NetworkError
+    ) -> (code: String?, message: String)? {
+        guard case .requestFailed(_, let data) = error,
+              let data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        return (
+            code: json["code"] as? String,
+            message: (json["message"] as? String) ?? error.userMessage
+        )
+    }
+
+    /// 사용자에게 노출할 문구에서 `CHALLENGER-0012:` 같은 서버 코드 접두사를 걷어낸다.
+    private static func sanitizedErrorMessage(from message: String) -> String {
+        let trimmed = message
+            .replacingOccurrences(
+                of: #"^[A-Z]+-\d{4}\s*[:\-]?\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return trimmed.isEmpty ? "인증에 실패했습니다. 다시 시도해주세요." : trimmed
     }
 }

--- a/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageView.swift
+++ b/UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageView.swift
@@ -93,6 +93,12 @@ struct MyPageView: View {
         .task {
             await viewModel.fetchProfile()
         }
+        // 프로필 상세에서 이미지·링크를 수정하고 돌아오면 카드가 옛 스냅샷으로 남는다.
+        // 수정 API가 세션 캐시를 갱신해 두므로 여기서는 추가 왕복 없이 최신 값을 다시 읽는다.
+        .onChange(of: pathStore.depth(of: .mypage)) { previousDepth, currentDepth in
+            guard currentDepth < previousDepth else { return }
+            Task { await viewModel.fetchProfile() }
+        }
     }
 
     // MARK: - View Component
@@ -105,7 +111,15 @@ struct MyPageView: View {
                 .frame(maxWidth: .infinity)
 
         case .loaded(let profile):
-            ProfileCardSection(profileData: profile)
+            ProfileCardSection(
+                profileData: profile,
+                onTap: {
+                    pathStore.push(
+                        MyPageDestination.profile(profileData: profile),
+                        on: .mypage
+                    )
+                }
+            )
 
         case .failed(let error):
             RetryContentUnavailableView(

--- a/UMCApp/Features/MyPage/Presentation/Tests/MyPageProfileViewModelTests.swift
+++ b/UMCApp/Features/MyPage/Presentation/Tests/MyPageProfileViewModelTests.swift
@@ -207,6 +207,8 @@ struct MyPageProfileViewModelTests {
         #expect(mock.addChallengerRecordCallCount == 1)
         #expect(mock.addChallengerRecordReceivedCode == "UMC-CODE")
         #expect(mock.fetchMyProfileCallCount == 1)
+        // 기록 추가는 세션 캐시를 무효화하지 않으므로 캐시를 우회해야 방금 추가한 이력이 보인다.
+        #expect(mock.fetchMyProfileReceivedForceRefresh == true)
         #expect(viewModel.profileData.challengeId == 55)
         #expect(viewModel.profileData.socialConnections == original.socialConnections)
         #expect(viewModel.didRecentlyAddActivityLog == true)


### PR DESCRIPTION
## ✨ PR 유형

Feature — 레거시 `AppProduct` 의 마이페이지 프로필 상세/편집 화면을 `UMCApp`(Tuist) 으로 이식했습니다.

`MyPageProfileView` 의 `body` 가 `Text("")` 라 화면이 죽어 있었고, `ProfileCardSection` 도 그 이유로 진입점을 막아둔 상태였습니다. 화면을 완성하고 진입점까지 열었습니다. #1120(탭 실연결) · #1119(비밀번호 변경 결선)에 이어지는 MyPage 마이그레이션 마무리 건입니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 프로필 카드 탭 → 상세 진입 → 이미지·링크 수정 → 저장 후 카드 갱신 흐름 영상 첨부 필요 -->
<!-- 활동 이력 추가(챌린저 코드 alert) 흐름 스크린샷 첨부 필요 -->

## 🛠️ 작업내용

**화면 본문**
- `MyPageProfileView.body` 구현 — 프로필 이미지 / 소셜 연동 / 이름·닉네임 / 학교 / 활동 이력 / 외부 링크 섹션 조립
- 챌린저 코드로 활동 이력 추가하는 alert 결선, 서버 에러 코드별(`CHALLENGER-0002/0012/0013/0014/0016`, `AUTHENTICATION-0016`) 실패 문구 보존
- 소셜 연동 해제를 `AlertPrompt` 로 확인받도록 결선

**컴포넌트 이식 (레거시 → MyPagePresentation)**
- `ActiveLogs` / `NameAndNickname` / `SchoolSection` — `MyPageProfileSection/` 으로 이식
- `ReadOnlyTextField` — 위 두 섹션이 쓰는 읽기 전용 필드
- `ActiveLogRow` — `ActiveLogs` 가 의존하는데 UMCApp 에 없어 함께 이식
- `ProfileLinkEditSection` — 레거시 `MyPageProfileSection/ProfileLinkSection.swift` 의 이식본 (네이밍은 리뷰 포인트 참고)
- `SocialLinkType+UI` 에 입력 placeholder 추가

**진입점 결선**
- `MyPageDestination.profile(profileData:)` 추가, `MyPageRoutingView` 분기 연결
- `ProfileCardSection` 의 "본문이 비어 있어 진입점을 열지 않는다" Note 제거 후 콜백 기반 진입점으로 전환 — 섹션은 `PathStore` 를 모르고 실제 push 는 탭 루트(`MyPageView`)가 수행 (#1119 의 `changePassword`, `MyActiveLogSection` 과 동일 패턴)
- 상세에서 pop 시 카드 스냅샷 갱신

**레거시 → 현행 규약 반영**
- `@StateObject`/`@ObservedObject` → `@State private var viewModel` (절대 규칙 #1)
- 하드코딩 색상·폰트·여백 → `DefaultSpacing.*` / `.appFont` / `DefaultConstant.defaultCornerRadius` / 컬러 토큰
- 레거시 `syncProfileToStorage`(80줄, `AuthUseCaseProvider` + `KeychainTokenStore` + `HomeUseCaseProviding` 의존) → CoreDomain 의 `FetchMemberProfileUseCaseProtocol` + `SyncProfileStorageUseCaseProtocol` 조합 3줄. 신규 의존성 없음
- `await MainActor.run` → MainActor 상속 `Task` + `defer`
- 오타·모호한 식별자 정리: `nickaname` → `nickname`, `genTag` → `generationTag`, `role` → `roles`, `Constants.padding` → `badgePadding` (절대 규칙 #7)

**버그 수정**
- `MyPageProfileViewModel.addActivityLog` 의 프로필 재조회를 `execute()` → `execute(forceRefresh: true)` 로 변경. `addChallengerRecord` 가 세션 프로필 캐시를 무효화하지 않아, 캐시 경로로 읽으면 방금 추가한 이력이 빠진 스냅샷이 돌아왔습니다 (화면상 "추가되었습니다" 만 뜨고 목록은 그대로)
- 회귀 방지 단언 추가 — 기존 테스트가 `forceRefresh` 수신값을 기록만 하고 단언하지 않아 되돌아가도 감지되지 않는 상태였습니다

## 📋 추후 진행 상황

- `#Preview` 미이식. 레거시 프리뷰 컨테이너가 `AuthUseCaseProvider` / `KeychainTokenStore` / `AuthRepositoryProvider.mock()` 에 의존하는데 UMCApp 대응물이 없어, 프리뷰만을 위해 새로 만들지 않았습니다.
- Tuist 마이그레이션 잔여 중 **Community 피처(73파일, 0%)** 가 최대 항목으로 남습니다. 탭이 아직 `Text("Community Feature")` 스텁이고 DI 등록도 없습니다.

## 📌 리뷰 포인트

- `UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageProfileView.swift` — 섹션 조립 순서와 `submitProfileUpdate` 의 에러 처리 분기(`ErrorHandler` 위임)가 `architecture.md` 기준에 맞는지
- `UMCApp/Features/MyPage/Presentation/Sources/ViewModels/MyPageProfileViewModel.swift` — **`forceRefresh: true` 변경.** 이식 작업 중 발견한 실제 버그 수정이라 화면 이식과 한 커밋에 들어갔습니다. 분리가 필요하면 말씀해 주세요.
- `UMCApp/Features/MyPage/Presentation/Sources/Components/Section/MyPageProfileSection/ProfileLinkEditSection.swift` — **네이밍 판단이 필요합니다.** UMCApp 의 기존 `ProfileLinkSection` 은 레거시 `MypageSection/LinkSection.swift`(읽기 전용 URL 오프너)의 이식본이라 이름이 이미 점유돼 있었습니다. 레거시 편집용 섹션은 대응물이 없었고, 이게 없으면 `canSubmit` 이 `hasPendingLinkUpdate` 에 걸려 `updateMyPageProfileLinksUseCase` 가 UI 에서 도달 불가입니다.
- `UMCApp/Features/MyPage/Presentation/Sources/Navigation/MyPageDestination.swift` — `ProfileData` 를 목적지에 직접 실었습니다(`ProfileData` 가 이미 `Hashable`). 상세에서 재조회하면 카드에 보이던 값과 다른 스냅샷으로 편집이 시작될 수 있어서인데, 이 트레이드오프가 맞는지 봐주세요.
- `UMCApp/Features/MyPage/Presentation/Sources/Views/MyPageView.swift` — pop 감지(`.onChange(of: pathStore.depth(of: .mypage))`) 로 카드를 갱신합니다. 수정 API 가 세션 캐시를 갱신해 두므로 추가 왕복은 없습니다.

**판단이 필요한 항목:**
1. **`ChallengerGenRepositoryProtocol.replaceMappings` 동기화를 의도적으로 이식하지 않았습니다.** `HomeViewModel` 이 "홈 프로필 조회가 유일한 생산자" 를 명시하고 있어, 프로필 화면을 두 번째 생산자로 만드는 것은 그 불변조건 위반이라고 판단했습니다. 레거시와 동작 차이가 생기는 지점이라 확인 부탁드립니다.
2. `ConnectionSocial` 헤더 문구는 UMCApp 기존 "소셜계정 연동" 을 유지했습니다 (레거시는 "연동된 계정"). 문구 통일이 필요하면 지정해 주세요.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
