### PR TITLE
📄 [Docs] 장소 검색 체인·PenalyInfoType 이식 제외 사유 명시

### DIFF
--- a/docs/claude/tuist-file-mapping.md
+++ b/docs/claude/tuist-file-mapping.md
@@ -452,8 +452,8 @@
 | `Domain/Models/Schedule/ScheduleLocation.swift` | HomeDomain |
 | `Domain/Models/Schedule/ScheduleParticipant.swift` | HomeDomain |
 | `Domain/Models/ScheduleGeneration/CSVImportResult.swift` | HomeDomain |
-| `Domain/Models/ScheduleGeneration/PlaceSearchResult.swift` | HomeDomain |
-| `Domain/Models/ScheduleGeneration/RecentPlace.swift` | HomeDomain |
+| `Domain/Models/ScheduleGeneration/PlaceSearchResult.swift` | **이식 제외(dead)** — 텍스트 장소 검색 체인. 아래 ⓟ 주석 참조 |
+| `Domain/Models/ScheduleGeneration/RecentPlace.swift` | **이식 제외(dead)** — 텍스트 장소 검색 체인. 아래 ⓟ 주석 참조 |
 | `Domain/Models/ScheduleGeneration/ScheduleRegistrationData.swift` | HomeDomain (`ScheduleCreationRequest`로 개명 — 장소·출석 정책은 조회 모델 재사용) |
 | `Domain/UseCases/DeleteScheduleUseCaseProtocol.swift` | HomeDomain |
 | `Domain/UseCases/FetchMyProfileUseCaseProtocol.swift` | HomeDomain (FetchHomeProfileUseCaseProtocol로 개명, CoreDomain 프로필 파이프라인 합성 — #961) |
@@ -484,7 +484,7 @@
 | `Presentation/Components/Card/ScheduleCard.swift` | HomePresentation |
 | `Presentation/Components/Card/ScheduleListCard.swift` | HomePresentation |
 | `Presentation/Components/Card/SeasonCard.swift` | HomePresentation |
-| `Presentation/Components/Map/SelectedPlaceAnnotation.swift` | HomePresentation |
+| `Presentation/Components/Map/SelectedPlaceAnnotation.swift` | **이식 제외(dead)** — 텍스트 장소 검색 체인. 아래 ⓟ 주석 참조 |
 | `Presentation/Components/Row/DatePickerRow.swift` | CoreUIComponents (`Sources/Schedule/`) |
 | `Presentation/Components/Row/DateTimeRow.swift` | CoreUIComponents (`Sources/Schedule/`) |
 | `Presentation/Components/Row/TimePickerRow.swift` | CoreUIComponents (`Sources/Schedule/`) |
@@ -497,7 +497,7 @@
 | `Presentation/Components/Schedule/Calendar/ScheduleHeader.swift` | HomePresentation |
 | `Presentation/Components/Schedule/InPersonToggle.swift` | CoreUIComponents (`Sources/Schedule/`) |
 | `Presentation/Enum/NoticeAlarmType.swift` | HomeDomain (`Models/NoticeHistory/NoticeAlarmType.swift` — Presentation 아님) |
-| `Presentation/Enum/PenalyInfoType.swift` | HomePresentation |
+| `Presentation/Enum/PenalyInfoType.swift` | **타입별로 갈림** — ① `PointLogItem` → **superseded → `HomeDomain.PointLog`** (`id` 를 `UUID()` → 서버 발급 `String` 으로, `point` 를 `Int` → `Double` 로 확장해 서버의 `-0.5` 소수 배점 보존). 소비처 `PenaltyCard` 는 `fileprivate enum PointLogFilter` 까지 레거시 그대로 이식됨 ② `PenaltyInfoItem` → **이식 제외(dead)** — `GenerationData.penaltyLogs`(레거시 주석 "하위호환")에 담기기만 하고 읽는 곳 0건 ③ `InfoType` → **이식 제외(dead)** — 레거시 참조 0건 |
 | `Presentation/Enum/RecentCategory.swift` | **superseded → `NoticeDomain.NoticeCategory`** — 레거시 소비자는 함께 대체된 `NoticeListDTO`·`RecentNoticeData` 뿐 |
 | `Presentation/Enum/ScheduleCategory.swift` | **이식 제외(dead)** — 레거시 참조 0건(`HomeView`의 `isScheduleCategoryLoading` 은 이름만 겹치는 별개 상태) |
 | `Presentation/Enum/ScheduleGenerationType.swift` | **superseded → 각 View 의 `fileprivate enum Constants` + `PlaceSelectView(placeholder:)`** — 폼 placeholder 를 열거형 한 곳에 모으는 설계를 버렸다. 레거시 소비자(`ScheduleRegistrationView`·`PlaceSelectView`)는 UMCApp 에서 각자 상수를 갖는다 |
@@ -505,24 +505,39 @@
 | `Presentation/Enum/SeasonType.swift` | HomeDomain (`Models/SeasonType.swift` — Presentation 아님) |
 | `Presentation/Provider/HomeUseCaseProvider.swift` | **superseded → `UMCApp/Sources/DIContainer+Home.swift`** — 레거시 유일 소비자는 `Core/DIContainer/DIContainer.swift`. UseCase 조립은 앱 타깃 DIContainer 확장이 담당 |
 | `Presentation/ViewModels/HomeViewModel.swift` | HomePresentation |
-| `Presentation/ViewModels/InlineMapPickerState.swift` | HomePresentation |
+| `Presentation/ViewModels/InlineMapPickerState.swift` | **이식 제외(dead)** — 텍스트 장소 검색 체인. 아래 ⓟ 주석 참조 |
 | `Presentation/ViewModels/ScheduleDetailViewModel.swift` | HomePresentation |
 | `Presentation/ViewModels/ScheduleDraft.swift` | HomePresentation |
 | `Presentation/ViewModels/ScheduleRegistrationViewModel+AI.swift` | HomePresentation |
 | `Presentation/ViewModels/ScheduleRegistrationViewModel.swift` | HomePresentation |
 | `Presentation/ViewModels/SearchChallengerViewModel.swift` | ActivityPresentation |
-| `Presentation/ViewModels/SearchPlaceViewModel.swift` | HomePresentation |
+| `Presentation/ViewModels/SearchPlaceViewModel.swift` | **이식 제외(dead)** — 텍스트 장소 검색 체인. 아래 ⓟ 주석 참조 |
 | `Presentation/Views/HomeView.swift` | HomePresentation |
 | `Presentation/Views/NoticeAlarmView.swift` | HomePresentation |
 | `Presentation/Views/Registration/Challenger/ChallengerFormView.swift` | ActivityPresentation (`Components/Challenger/`) |
 | `Presentation/Views/Registration/Challenger/SearchChallengerView.swift` | ActivityPresentation (`Components/Challenger/`) |
 | `Presentation/Views/Registration/Challenger/SelectedChallengerView.swift` | ActivityPresentation (`Components/Challenger/`) |
-| `Presentation/Views/Registration/InlineMapPlacePicker.swift` | HomePresentation |
+| `Presentation/Views/Registration/InlineMapPlacePicker.swift` | **이식 제외(dead)** — 텍스트 장소 검색 체인. 아래 ⓟ 주석 참조 |
 | `Presentation/Views/Registration/ScheduleDetailView.swift` | HomePresentation (`Views/ScheduleDetailView.swift` — Registration 하위 아님) |
 | `Presentation/Views/Registration/ScheduleRegistrationView.swift` | HomePresentation |
-| `Presentation/Views/Registration/SearchPlaceResultRow.swift` | HomePresentation |
-| `Presentation/Views/Registration/SearchPlaceView.swift` | HomePresentation |
+| `Presentation/Views/Registration/SearchPlaceResultRow.swift` | **이식 제외(dead)** — 텍스트 장소 검색 체인. 아래 ⓟ 주석 참조 |
+| `Presentation/Views/Registration/SearchPlaceView.swift` | **이식 제외(dead)** — 텍스트 장소 검색 체인. 아래 ⓟ 주석 참조 |
 | `Presentation/Views/Registration/TagListView.swift` | HomePresentation |
+
+> **ⓟ 텍스트 장소 검색 체인 (8파일) — 이식 제외(dead)**
+>
+> `SearchPlaceView` · `SearchPlaceViewModel` · `SearchPlaceResultRow` · `InlineMapPlacePicker` ·
+> `InlineMapPickerState` · `SelectedPlaceAnnotation` · `PlaceSearchResult` · `RecentPlace`
+>
+> 레거시가 지도 피커로 전환하면서 연결이 끊긴 잔해다. **8파일 모두 AppProduct 내 참조 0건**이고,
+> 레거시 `ScheduleRegistrationView.swift:135` 는 이미 `PlaceSelectView(place:)` 를 쓴다 —
+> 이 컴포넌트가 `CoreUIComponents/Sources/PlaceSelectView/` 로 이식된 현재 구현이므로
+> **"레거시에서 쓰던 방식"은 이미 UMCApp 에 그대로 있다.** 이식하면 레거시에서도 한 번도 돌지 않은
+> 코드를 되살리는 셈이라 대상에서 제외한다.
+>
+> 다만 그 결과로 **지도 피커에 텍스트 검색이 없다** (POI 길게누르기 + 리버스 지오코딩만 가능).
+> 이는 이관 누락이 아니라 신규 기능이며 #1122 에서 다룬다. `AppStorageKey.recentSearchPlaces`
+> 키가 UMCApp 에 정의만 되고 미사용으로 남아 있는 것도 같은 이유다.
 
 ### Features/Maintenance
 


### PR DESCRIPTION
## ✨ PR 유형

Docs — `docs/claude/tuist-file-mapping.md` 의 잘못된 "미이식" 표기를 정정합니다. 코드 변경 없음.

Tuist 마이그레이션 잔여 작업을 점검하던 중, 실제로는 **이식할 필요가 없는 파일 9개가 미이식 항목으로 집계**되는 것을 발견했습니다. 표에 목적지 모듈만 적혀 있고 제외 사유가 없어 매번 같은 오탐이 반복되던 자리입니다.

## 📷 스크린샷 or 영상(UI 변경 시)

<!-- 문서 변경만 있어 해당 없음 -->

## 🛠️ 작업내용

**텍스트 장소 검색 체인 8파일 → `이식 제외(dead)`**

`SearchPlaceView` · `SearchPlaceViewModel` · `SearchPlaceResultRow` · `InlineMapPlacePicker` · `InlineMapPickerState` · `SelectedPlaceAnnotation` · `PlaceSearchResult` · `RecentPlace`

- **8파일 모두 AppProduct 내 참조 0건.** 레거시가 지도 피커로 전환하면서 연결이 끊긴 잔해입니다
- 레거시 `ScheduleRegistrationView.swift:135` 는 이미 `PlaceSelectView(place:)` 를 사용 — 이 컴포넌트는 `CoreUIComponents/Sources/PlaceSelectView/` 로 이식 완료 상태이므로, **"레거시에서 쓰던 방식"이 이미 UMCApp 에 그대로 있습니다**
- 반복 설명을 피하려고 Home 표 끝에 각주(ⓟ) 하나로 근거를 모았습니다

**`PenalyInfoType.swift` → 타입별로 분리 표기**

한 파일에 타입 3개가 들어 있어 일괄 판정이 불가능했습니다:

| 타입 | 레거시 참조 | 처리 |
|---|---|---|
| `PointLogItem` | 3곳 | superseded → `HomeDomain.PointLog` |
| `PenaltyInfoItem` | `GenerationData.penaltyLogs` 에 담기기만 하고 읽는 곳 0건 (레거시 주석에 "하위호환" 명시) | 이식 제외(dead) |
| `InfoType` | 0곳 | 이식 제외(dead) |

`PointLog` 는 이식 과정에서 `id` 를 `UUID()` → 서버 발급 `String` 으로, `point` 를 `Int` → `Double` 로 확장해 서버의 `-0.5` 소수 배점을 보존합니다. 소비처 `PenaltyCard` 는 `fileprivate enum PointLogFilter` 까지 레거시와 동일하게 이식돼 있습니다.

## 📋 추후 진행 상황

- 위 정리의 부수 효과로 **지도 피커에 텍스트 검색이 없다**는 점이 드러났습니다. POI 길게누르기 + 리버스 지오코딩만 가능한 상태입니다. 이관 누락이 아니라 신규 기능이라 #1122 로 분리했습니다 (우선순위 Low — Community 이관 뒤 순번)
- `AppStorageKey.recentSearchPlaces` 가 정의만 되고 미사용으로 남아 있는 것도 같은 맥락이며, #1122 에서 함께 다룹니다
- 잔여 마이그레이션의 실질 항목은 **Community 73파일(#591)** 입니다

## 📌 리뷰 포인트

- `docs/claude/tuist-file-mapping.md` — Home 표 끝 각주(ⓟ)의 판단이 맞는지. **"레거시에 파일이 있으니 옮겨야 한다"가 아니라 "레거시에서도 안 쓰이니 옮기지 않는다"** 는 결론이라, 이 기준에 동의하는지 확인 부탁드립니다
- 같은 표의 기존 `ScheduleCategory.swift`(이식 제외) · `RecentCategory.swift`(superseded) 표기법을 따랐습니다

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)