### PR TITLE
♻️[Refactor] 운영진 스터디 관리 화면 파일 분할 (#1060)

### DIFF
--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/OperatorStudyGroupSection.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/OperatorStudyGroupSection.swift
@@ -1,0 +1,180 @@
+//
+//  OperatorStudyGroupSection.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/10/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+import UMCFoundation
+
+// MARK: - OperatorStudyGroupSection
+
+/// 운영진 스터디 관리의 그룹 관리 섹션
+///
+/// 제출 현황 섹션과 상태를 공유하지 않고 ViewModel 하나만 함께 보기 때문에, 목록·빈 상태·권한
+/// 안내·에러까지 그룹 관리에만 필요한 표현을 이 파일로 모았습니다.
+struct OperatorStudyGroupSection: View {
+
+    // MARK: - Property
+
+    let viewModel: OperatorStudyManagementViewModel
+
+    /// 스터디 그룹 생성 권한 보유 여부 — 빈 상태·에러를 권한 안내로 바꿔 그릴지 판단한다.
+    let canCreateStudyGroup: Bool
+
+    /// 일정 등록 화면 이동 요청 (권한 확인을 통과한 그룹만 전달)
+    let onRegisterSchedule: (StudyGroupInfo) -> Void
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let loadingMessage: String = "스터디 그룹 관리 불러오는 중..."
+        static let emptyTitle: String = "등록된 스터디 그룹이 없어요"
+        static let emptyDescription: String =
+            "스터디 그룹 생성 기능을 준비하고 있어요.\n곧 이곳에서 스터디원과 멘토를 배정할 수 있어요."
+        static let errorTitle: String = "불러오지 못했어요"
+    }
+
+    // MARK: - Body
+
+    @ViewBuilder
+    var body: some View {
+        switch viewModel.studyGroupDetailsState {
+        case .idle, .loading:
+            StudyManagementLoadingView(message: Constants.loadingMessage)
+
+        case .loaded:
+            if viewModel.studyGroupDetails.isEmpty {
+                emptyView
+            } else {
+                listView(groups: viewModel.studyGroupDetails)
+            }
+
+        case .failed(let error):
+            errorView(error: error) {
+                await viewModel.fetchGroupManagementData()
+            }
+        }
+    }
+
+    // MARK: - Group List View
+
+    @ViewBuilder
+    private var emptyView: some View {
+        if canCreateStudyGroup {
+            ContentUnavailableView {
+                Label(Constants.emptyTitle, systemImage: "person.3")
+            } description: {
+                Text(Constants.emptyDescription)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        } else {
+            StudyGroupPermissionGuideView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        }
+    }
+
+    private func listView(groups: [StudyGroupInfo]) -> some View {
+        ScrollView {
+            // Apple iOS 26 가이드: 같은 화면에 Liquid Glass가 여러 개 있을 때
+            // GlassEffectContainer 로 묶어 카드 사이 morphing/blending + 렌더링 성능 ↑
+            GlassEffectContainer(spacing: DefaultSpacing.spacing16) {
+                LazyVStack(spacing: DefaultSpacing.spacing16) {
+                    ForEach(groups) { group in
+                        StudyGroupCard(
+                            detail: group,
+                            onEdit: {
+                                viewModel.showEditSheet(for: group)
+                            },
+                            onDelete: {
+                                Task { await viewModel.deleteGroup(group) }
+                            },
+                            onAddMember: {
+                                viewModel.showAddMemberSheet(for: group)
+                            },
+                            onAddMentor: {
+                                viewModel.showAddMentorSheet(for: group)
+                            },
+                            onSchedule: {
+                                guard viewModel.canRegisterSchedule(for: group) else {
+                                    viewModel.presentScheduleRegistrationDenied()
+                                    return
+                                }
+                                onRegisterSchedule(group)
+                            },
+                            onRemoveMember: { member in
+                                Task {
+                                    await viewModel.removeMember(member, from: group)
+                                }
+                            },
+                            onRemoveMentor: { mentor in
+                                Task {
+                                    await viewModel.removeMentor(mentor, from: group)
+                                }
+                            }
+                        )
+                        .equatable()
+                        .task {
+                            await viewModel.loadMoreGroupManagementDataIfNeeded(
+                                currentGroupID: group.id
+                            )
+                        }
+                    }
+
+                    if viewModel.isLoadingMoreStudyGroupDetails {
+                        StudyManagementLoadMoreIndicator()
+                    }
+                }
+            }
+            .safeAreaPadding(
+                .horizontal,
+                DefaultConstant.defaultSafeBtnPadding
+            )
+        }
+        .contentMargins(
+            .bottom,
+            DefaultConstant.defaultContentBottomMargins,
+            for: .scrollContent
+        )
+    }
+
+    // MARK: - Error View
+
+    /// 로딩 실패 처리.
+    ///
+    /// 레거시는 `AppError.isPermissionDenied`(403)로 권한 안내 분기를 판단했으나 이식된
+    /// `AppError` 에는 해당 프로퍼티가 없다. 권한 안내의 의도(생성 권한 없는 사용자에게 역할
+    /// 가이드 노출)를 세션 권한(`canCreateStudyGroup`)으로 대신 판단한다.
+    @ViewBuilder
+    private func errorView(
+        error: AppError,
+        retryAction: @escaping () async -> Void
+    ) -> some View {
+        if !canCreateStudyGroup {
+            StudyGroupPermissionGuideView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+        } else {
+            RetryContentUnavailableView(
+                title: Constants.errorTitle,
+                systemImage: "exclamationmark.triangle",
+                description: error.userMessage,
+                isRetrying: false,
+                topPadding: DefaultSpacing.spacing32
+            ) {
+                await retryAction()
+            }
+            .safeAreaPadding(
+                .horizontal,
+                DefaultConstant.defaultSafeHorizon
+            )
+        }
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/OperatorStudySubmissionSection.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/OperatorStudySubmissionSection.swift
@@ -1,0 +1,196 @@
+//
+//  OperatorStudySubmissionSection.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/10/26.
+//
+
+import ActivityDomain
+import CoreDesignSystem
+import CoreUIComponents
+import SwiftUI
+
+// MARK: - OperatorStudySubmissionSection
+
+/// 운영진 스터디 관리의 제출 현황 섹션
+///
+/// 그룹·주차 필터와 제출 현황 목록은 그룹 관리와 상태를 공유하지 않아, 워크북 상세 결선 같은
+/// 후속 작업이 그룹 관리 코드와 섞이지 않도록 이 파일로 떼어냈습니다.
+struct OperatorStudySubmissionSection: View {
+
+    // MARK: - Property
+
+    let viewModel: OperatorStudyManagementViewModel
+
+    /// 워크북 상세 진입 요청 — 상세 화면이 미이식이라 안내 알럿은 상위(셸)가 띄운다.
+    let onSelectWorkbook: () -> Void
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let allGroupsFilterTitle: String = "전체 그룹"
+        static let loadingMessage: String = "제출 현황 불러오는 중..."
+        static let idleTitle: String = "제출 현황을 불러올 준비가 됐어요"
+        static let idleDescription: String = "아래 버튼을 눌러 불러올 수 있어요."
+        static let emptyTitle: String = "제출 현황이 없어요"
+        static let emptyDescription: String =
+            "선택한 조건에 해당하는 스터디원이 없어요.\n그룹이나 주차 필터를 바꿔보세요."
+        static let errorTitle: String = "불러오지 못했어요"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            filterBar
+
+            switch viewModel.submissionsState {
+            // `.idle` 을 스피너로 그리지 않는다. 조회가 취소되면 이 상태로 되돌아오는데,
+            // 그때 in-flight 가 없으므로 스피너는 영원히 돌기만 한다. 재시도 수단을 준다.
+            case .idle:
+                retryView(
+                    title: Constants.idleTitle,
+                    systemImage: "doc.text.magnifyingglass",
+                    description: Constants.idleDescription
+                )
+
+            case .loading:
+                StudyManagementLoadingView(message: Constants.loadingMessage)
+
+            case .loaded(let rows):
+                if rows.isEmpty {
+                    emptyView
+                } else {
+                    listView(rows: rows)
+                }
+
+            case .failed(let error):
+                retryView(
+                    title: Constants.errorTitle,
+                    systemImage: "exclamationmark.triangle",
+                    description: error.userMessage
+                )
+            }
+        }
+        .task {
+            await viewModel.fetchSubmissions()
+        }
+    }
+
+    // MARK: - Filter Bar
+
+    /// 그룹·주차 필터 — 서버가 두 필터를 모두 선택 파라미터로 받는다.
+    private var filterBar: some View {
+        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
+            // ChipButton 의 buttonSize/buttonStyle 은 `AnyChipButton` 전용이라 둘을 이어 붙일 수
+            // 없다(첫 모디파이어가 `some View` 를 돌려줌). 두 값 모두 Environment 로 전달한다.
+            ScrollView(.horizontal) {
+                HStack(spacing: DefaultSpacing.spacing8) {
+                    ChipButton(
+                        Constants.allGroupsFilterTitle,
+                        isSelected: viewModel.selectedSubmissionGroupId == nil
+                    ) {
+                        Task { await viewModel.selectSubmissionGroup(nil) }
+                    }
+
+                    ForEach(viewModel.studyGroupNames) { group in
+                        ChipButton(
+                            group.name,
+                            isSelected: viewModel.selectedSubmissionGroupId == group.groupId
+                        ) {
+                            Task { await viewModel.selectSubmissionGroup(group.groupId) }
+                        }
+                    }
+                }
+                .environment(\.chipButtonSize, .small)
+                .environment(\.chipButtonStyle, .filter)
+                .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+            }
+            .scrollIndicators(.hidden)
+
+            if !viewModel.availableSubmissionWeekNos.isEmpty {
+                ScrollView(.horizontal) {
+                    HStack(spacing: DefaultSpacing.spacing8) {
+                        ForEach(viewModel.availableSubmissionWeekNos, id: \.self) { weekNo in
+                            ChipButton(
+                                "\(weekNo)주차",
+                                isSelected: viewModel.selectedSubmissionWeekNos
+                                    .contains(weekNo)
+                            ) {
+                                Task { await viewModel.toggleSubmissionWeek(weekNo) }
+                            }
+                        }
+                    }
+                    .environment(\.chipButtonSize, .small)
+                    .environment(\.chipButtonStyle, .fame)
+                    .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+    }
+
+    // MARK: - Submission List View
+
+    private var emptyView: some View {
+        ContentUnavailableView {
+            Label(Constants.emptyTitle, systemImage: "doc.text.magnifyingglass")
+        } description: {
+            Text(Constants.emptyDescription)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+
+    private func listView(rows: [StudyMemberSubmission]) -> some View {
+        ScrollView {
+            // 카드마다 Liquid Glass 를 쓰므로 Container 로 묶어 렌더링 비용을 줄인다.
+            GlassEffectContainer(spacing: DefaultSpacing.spacing16) {
+                LazyVStack(spacing: DefaultSpacing.spacing16) {
+                    ForEach(rows) { submission in
+                        StudyManagementCard(submission: submission) { _ in
+                            // TODO: 워크북 상세(WORKBOOK-102) 진입 결선 - [26.08.03] 이재원
+                            //  — 상세 화면이 미이식이라 진입은 보류하고 안내만 표시한다.
+                            onSelectWorkbook()
+                        }
+                        .task {
+                            await viewModel.loadMoreSubmissionsIfNeeded(
+                                currentMemberID: submission.studyGroupMemberId
+                            )
+                        }
+                    }
+
+                    if viewModel.isLoadingMoreSubmissions {
+                        StudyManagementLoadMoreIndicator()
+                    }
+                }
+            }
+            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeBtnPadding)
+        }
+        .contentMargins(
+            .bottom,
+            DefaultConstant.defaultContentBottomMargins,
+            for: .scrollContent
+        )
+    }
+
+    // MARK: - Retry View
+
+    private func retryView(
+        title: String,
+        systemImage: String,
+        description: String
+    ) -> some View {
+        RetryContentUnavailableView(
+            title: title,
+            systemImage: systemImage,
+            description: description,
+            isRetrying: false,
+            topPadding: DefaultSpacing.spacing32
+        ) {
+            await viewModel.retrySubmissions()
+        }
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+}

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupPermissionGuideView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupPermissionGuideView.swift
@@ -1,0 +1,113 @@
+//
+//  StudyGroupPermissionGuideView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/10/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+
+// MARK: - StudyGroupPermissionGuideView
+
+/// 스터디 그룹 생성 권한이 없는 사용자에게 보여주는 역할 안내
+///
+/// 그룹 관리 섹션의 빈 상태와 에러 상태 두 곳에서 같은 화면을 쓰기 때문에 별도 컴포넌트로
+/// 분리했습니다. 바깥 여백은 호출부가 상황에 맞게 붙입니다.
+struct StudyGroupPermissionGuideView: View {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let title: String = "스터디 그룹 관리"
+        static let description: String = "등록된 스터디 그룹이 없습니다\n스터디 그룹 생성에는 별도 권한이 필요해요"
+        static let guideTitle: String = "스터디 관리가 가능한 역할"
+        static let iconWidth: CGFloat = 32
+        static let roleTextSpacing: CGFloat = 2
+    }
+
+    // MARK: - Role
+
+    /// 스터디 관리 권한을 가진 역할과 그 설명
+    private enum ManageableRole: String, CaseIterable, Identifiable {
+        case chapterLeader = "지부장"
+        case president = "회장 / 부회장"
+        case operatorStaff = "운영진"
+
+        var id: String { rawValue }
+
+        var icon: String {
+            switch self {
+            case .chapterLeader: "building.columns.fill"
+            case .president: "star.fill"
+            case .operatorStaff: "person.badge.key.fill"
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .chapterLeader: "지부 내 전체 학교의 스터디를 관리할 수 있어요"
+            case .president: "소속 학교의 스터디 그룹을 생성·관리할 수 있어요"
+            case .operatorStaff: "담당 파트의 스터디를 조회할 수 있어요"
+            }
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: DefaultSpacing.spacing32) {
+                ContentUnavailableView {
+                    Label(Constants.title, systemImage: "person.3")
+                } description: {
+                    Text(Constants.description)
+                        .multilineTextAlignment(.center)
+                }
+
+                VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
+                    Text(Constants.guideTitle)
+                        .appFont(.callout, weight: .semibold)
+
+                    ForEach(ManageableRole.allCases) { role in
+                        roleRow(role)
+                    }
+                }
+                .padding(DefaultSpacing.spacing16)
+                .background(
+                    .regularMaterial,
+                    in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius)
+                )
+            }
+            .padding(.top, DefaultSpacing.spacing32)
+        }
+    }
+
+    // MARK: - Function
+
+    private func roleRow(_ role: ManageableRole) -> some View {
+        HStack(spacing: DefaultSpacing.spacing12) {
+            Image(systemName: role.icon)
+                .font(.app(.title3))
+                .foregroundStyle(Color.grey600)
+                .frame(width: Constants.iconWidth, alignment: .center)
+
+            VStack(alignment: .leading, spacing: Constants.roleTextSpacing) {
+                Text(role.rawValue)
+                    .appFont(.subheadline)
+                Text(role.description)
+                    .appFont(.footnote)
+                    .foregroundStyle(Color.grey500)
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("스터디 그룹 권한 안내") {
+    StudyGroupPermissionGuideView()
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyManagementLoadingView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyManagementLoadingView.swift
@@ -1,0 +1,67 @@
+//
+//  StudyManagementLoadingView.swift
+//  ActivityPresentation
+//
+//  Created by jaewon Lee on 8/10/26.
+//
+
+import CoreDesignSystem
+import SwiftUI
+
+// MARK: - StudyManagementLoadingView
+
+/// 운영진 스터디 관리의 전체 영역 로딩 표시
+///
+/// 그룹 관리·제출 현황 두 섹션이 첫 로딩에서 같은 모양을 쓰기 때문에, 섹션 파일이 갈린 뒤에도
+/// 각자 스피너를 다시 선언하지 않도록 공용 컴포넌트로 뺐습니다.
+struct StudyManagementLoadingView: View {
+
+    // MARK: - Property
+
+    /// 로딩 중임을 설명하는 안내 문구
+    let message: String
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: DefaultSpacing.spacing12) {
+            ProgressView()
+                .controlSize(.large)
+                .tint(Color.grey500)
+
+            Text(message)
+                .appFont(.subheadline, color: .grey500)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
+    }
+}
+
+// MARK: - StudyManagementLoadMoreIndicator
+
+/// 리스트 하단의 다음 페이지 로딩 표시
+///
+/// 그룹 관리·제출 현황 모두 무한 스크롤을 쓰고 하단 스피너 모양이 같아 함께 묶었습니다.
+struct StudyManagementLoadMoreIndicator: View {
+
+    // MARK: - Body
+
+    var body: some View {
+        ProgressView()
+            .tint(Color.grey500)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, DefaultSpacing.spacing8)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("스터디 관리 로딩") {
+    VStack(spacing: DefaultSpacing.spacing24) {
+        StudyManagementLoadingView(message: "스터디 그룹 관리 불러오는 중...")
+
+        StudyManagementLoadMoreIndicator()
+    }
+}
+#endif

--- a/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyManagementView.swift
+++ b/UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyManagementView.swift
@@ -16,6 +16,9 @@ import UMCFoundation
 ///
 /// 운영진이 스터디와 활동을 관리하는 화면입니다.
 /// ViewModel 과 세션은 상위(라우터/루트 화면)에서 주입받습니다.
+///
+/// 본문은 성격이 다른 두 섹션(``OperatorStudyGroupSection`` / ``OperatorStudySubmissionSection``)이
+/// 맡고, 이 화면은 섹션 전환과 두 섹션에 걸친 툴바·시트·알럿만 관리합니다.
 struct OperatorStudyManagementView: View {
 
     // MARK: - Property
@@ -71,22 +74,10 @@ struct OperatorStudyManagementView: View {
     // MARK: - Constants
 
     private enum Constants {
-        static let permissionTitle: String = "스터디 그룹 관리"
-        static let permissionDescription: String = "등록된 스터디 그룹이 없습니다\n스터디 그룹 생성에는 별도 권한이 필요해요"
-        static let permissionGuideTitle: String = "스터디 관리가 가능한 역할"
-        static let roleChapterLeader: String = "지부장"
-        static let rolePresident: String = "회장 / 부회장"
-        static let roleOperator: String = "운영진"
-        static let roleChapterLeaderDescription: String = "지부 내 전체 학교의 스터디를 관리할 수 있어요"
-        static let rolePresidentDescription: String = "소속 학교의 스터디 그룹을 생성·관리할 수 있어요"
-        static let roleOperatorDescription: String = "담당 파트의 스터디를 조회할 수 있어요"
         static let sectionPickerTitle: String = "스터디 관리 섹션"
-        static let allGroupsFilterTitle: String = "전체 그룹"
-        static let submissionLoadingMessage: String = "제출 현황 불러오는 중..."
-        static let submissionIdleTitle: String = "제출 현황을 불러올 준비가 됐어요"
-        static let submissionIdleDescription: String = "아래 버튼을 눌러 불러올 수 있어요."
-        static let submissionEmptyDescription: String =
-            "선택한 조건에 해당하는 스터디원이 없어요.\n그룹이나 주차 필터를 바꿔보세요."
+        static let workbookUnavailableTitle: String = "준비 중"
+        static let workbookUnavailableMessage: String = "워크북 상세 화면은 커리큘럼 상세 이식 후 연결됩니다."
+        static let confirmTitle: String = "확인"
     }
 
     // MARK: - Body
@@ -97,9 +88,15 @@ struct OperatorStudyManagementView: View {
 
             switch selectedSection {
             case .groups:
-                groupManagementContentView
+                OperatorStudyGroupSection(
+                    viewModel: viewModel,
+                    canCreateStudyGroup: canCreateStudyGroup,
+                    onRegisterSchedule: onRegisterSchedule
+                )
             case .submissions:
-                submissionContentView
+                OperatorStudySubmissionSection(viewModel: viewModel) {
+                    showWorkbookDetailUnavailable = true
+                }
             }
         }
             .task {
@@ -145,10 +142,13 @@ struct OperatorStudyManagementView: View {
                 )
             }
             .alertPrompt(item: $viewModel.alertPrompt)
-            .alert("준비 중", isPresented: $showWorkbookDetailUnavailable) {
-                Button("확인", role: .cancel) {}
+            .alert(
+                Constants.workbookUnavailableTitle,
+                isPresented: $showWorkbookDetailUnavailable
+            ) {
+                Button(Constants.confirmTitle, role: .cancel) {}
             } message: {
-                Text("워크북 상세 화면은 커리큘럼 상세 이식 후 연결됩니다.")
+                Text(Constants.workbookUnavailableMessage)
             }
     }
 
@@ -170,380 +170,6 @@ struct OperatorStudyManagementView: View {
     /// 스터디 그룹 생성 권한 확인 (보유 역할 중 회장/부회장 포함 여부)
     private var canCreateStudyGroup: Bool {
         userSession.hasAnyRole(where: { $0.canCreateStudyGroup })
-    }
-
-    // MARK: - Group Management View
-
-    @ViewBuilder
-    private var groupManagementContentView: some View {
-        switch viewModel.studyGroupDetailsState {
-        case .idle, .loading:
-            loadingView(message: "스터디 그룹 관리 불러오는 중...")
-
-        case .loaded:
-            if viewModel.studyGroupDetails.isEmpty {
-                groupManagementEmptyView
-            } else {
-                groupManagementListView(groups: viewModel.studyGroupDetails)
-            }
-
-        case .failed(let error):
-            errorView(error: error) {
-                await viewModel.fetchGroupManagementData()
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var groupManagementEmptyView: some View {
-        if canCreateStudyGroup {
-            ContentUnavailableView {
-                Label("등록된 스터디 그룹이 없어요", systemImage: "person.3")
-            } description: {
-                Text("스터디 그룹 생성 기능을 준비하고 있어요.\n곧 이곳에서 스터디원과 멘토를 배정할 수 있어요.")
-                    .multilineTextAlignment(.center)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-        } else {
-            permissionDeniedView
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-        }
-    }
-
-    private func groupManagementListView(groups: [StudyGroupInfo]) -> some View {
-        ScrollView {
-            // Apple iOS 26 가이드: 같은 화면에 Liquid Glass가 여러 개 있을 때
-            // GlassEffectContainer 로 묶어 카드 사이 morphing/blending + 렌더링 성능 ↑
-            GlassEffectContainer(spacing: DefaultSpacing.spacing16) {
-                LazyVStack(spacing: DefaultSpacing.spacing16) {
-                    ForEach(groups) { group in
-                        StudyGroupCard(
-                            detail: group,
-                            onEdit: {
-                                viewModel.showEditSheet(for: group)
-                            },
-                            onDelete: {
-                                Task { await viewModel.deleteGroup(group) }
-                            },
-                            onAddMember: {
-                                viewModel.showAddMemberSheet(for: group)
-                            },
-                            onAddMentor: {
-                                viewModel.showAddMentorSheet(for: group)
-                            },
-                            onSchedule: {
-                                guard viewModel.canRegisterSchedule(for: group) else {
-                                    viewModel.presentScheduleRegistrationDenied()
-                                    return
-                                }
-                                onRegisterSchedule(group)
-                            },
-                            onRemoveMember: { member in
-                                Task {
-                                    await viewModel.removeMember(member, from: group)
-                                }
-                            },
-                            onRemoveMentor: { mentor in
-                                Task {
-                                    await viewModel.removeMentor(mentor, from: group)
-                                }
-                            }
-                        )
-                        .equatable()
-                        .task {
-                            await viewModel.loadMoreGroupManagementDataIfNeeded(
-                                currentGroupID: group.id
-                            )
-                        }
-                    }
-
-                    if viewModel.isLoadingMoreStudyGroupDetails {
-                        ProgressView()
-                            .tint(Color.grey500)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, DefaultSpacing.spacing8)
-                    }
-                }
-            }
-            .safeAreaPadding(
-                .horizontal,
-                DefaultConstant.defaultSafeBtnPadding
-            )
-        }
-        .contentMargins(
-            .bottom,
-            DefaultConstant.defaultContentBottomMargins,
-            for: .scrollContent
-        )
-    }
-
-    // MARK: - Submission View
-
-    /// 제출 현황 섹션 — 필터 + 상태별 본문
-    private var submissionContentView: some View {
-        VStack(spacing: DefaultSpacing.spacing12) {
-            submissionFilterBar
-
-            switch viewModel.submissionsState {
-            // `.idle` 을 스피너로 그리지 않는다. 조회가 취소되면 이 상태로 되돌아오는데,
-            // 그때 in-flight 가 없으므로 스피너는 영원히 돌기만 한다. 재시도 수단을 준다.
-            case .idle:
-                submissionRetryView(
-                    title: Constants.submissionIdleTitle,
-                    systemImage: "doc.text.magnifyingglass",
-                    description: Constants.submissionIdleDescription
-                )
-
-            case .loading:
-                loadingView(message: Constants.submissionLoadingMessage)
-
-            case .loaded(let rows):
-                if rows.isEmpty {
-                    submissionEmptyView
-                } else {
-                    submissionListView(rows: rows)
-                }
-
-            case .failed(let error):
-                submissionRetryView(
-                    title: "불러오지 못했어요",
-                    systemImage: "exclamationmark.triangle",
-                    description: error.userMessage
-                )
-            }
-        }
-        .task {
-            await viewModel.fetchSubmissions()
-        }
-    }
-
-    private func submissionRetryView(
-        title: String,
-        systemImage: String,
-        description: String
-    ) -> some View {
-        RetryContentUnavailableView(
-            title: title,
-            systemImage: systemImage,
-            description: description,
-            isRetrying: false,
-            topPadding: DefaultSpacing.spacing32
-        ) {
-            await viewModel.retrySubmissions()
-        }
-        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-    }
-
-    /// 그룹·주차 필터 — 서버가 두 필터를 모두 선택 파라미터로 받는다.
-    private var submissionFilterBar: some View {
-        VStack(alignment: .leading, spacing: DefaultSpacing.spacing8) {
-            // ChipButton 의 buttonSize/buttonStyle 은 `AnyChipButton` 전용이라 둘을 이어 붙일 수
-            // 없다(첫 모디파이어가 `some View` 를 돌려줌). 두 값 모두 Environment 로 전달한다.
-            ScrollView(.horizontal) {
-                HStack(spacing: DefaultSpacing.spacing8) {
-                    ChipButton(
-                        Constants.allGroupsFilterTitle,
-                        isSelected: viewModel.selectedSubmissionGroupId == nil
-                    ) {
-                        Task { await viewModel.selectSubmissionGroup(nil) }
-                    }
-
-                    ForEach(viewModel.studyGroupNames) { group in
-                        ChipButton(
-                            group.name,
-                            isSelected: viewModel.selectedSubmissionGroupId == group.groupId
-                        ) {
-                            Task { await viewModel.selectSubmissionGroup(group.groupId) }
-                        }
-                    }
-                }
-                .environment(\.chipButtonSize, .small)
-                .environment(\.chipButtonStyle, .filter)
-                .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
-            }
-            .scrollIndicators(.hidden)
-
-            if !viewModel.availableSubmissionWeekNos.isEmpty {
-                ScrollView(.horizontal) {
-                    HStack(spacing: DefaultSpacing.spacing8) {
-                        ForEach(viewModel.availableSubmissionWeekNos, id: \.self) { weekNo in
-                            ChipButton(
-                                "\(weekNo)주차",
-                                isSelected: viewModel.selectedSubmissionWeekNos
-                                    .contains(weekNo)
-                            ) {
-                                Task { await viewModel.toggleSubmissionWeek(weekNo) }
-                            }
-                        }
-                    }
-                    .environment(\.chipButtonSize, .small)
-                    .environment(\.chipButtonStyle, .fame)
-                    .padding(.horizontal, DefaultConstant.defaultSafeHorizon)
-                }
-                .scrollIndicators(.hidden)
-            }
-        }
-    }
-
-    private var submissionEmptyView: some View {
-        ContentUnavailableView {
-            Label("제출 현황이 없어요", systemImage: "doc.text.magnifyingglass")
-        } description: {
-            Text(Constants.submissionEmptyDescription)
-                .multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-    }
-
-    private func submissionListView(rows: [StudyMemberSubmission]) -> some View {
-        ScrollView {
-            // 카드마다 Liquid Glass 를 쓰므로 Container 로 묶어 렌더링 비용을 줄인다.
-            GlassEffectContainer(spacing: DefaultSpacing.spacing16) {
-                LazyVStack(spacing: DefaultSpacing.spacing16) {
-                    ForEach(rows) { submission in
-                        StudyManagementCard(submission: submission) { _ in
-                            // TODO: 워크북 상세(WORKBOOK-102) 진입 결선 - [26.08.03] 이재원
-                            //  — 상세 화면이 미이식이라 진입은 보류하고 안내만 표시한다.
-                            showWorkbookDetailUnavailable = true
-                        }
-                        .task {
-                            await viewModel.loadMoreSubmissionsIfNeeded(
-                                currentMemberID: submission.studyGroupMemberId
-                            )
-                        }
-                    }
-
-                    if viewModel.isLoadingMoreSubmissions {
-                        ProgressView()
-                            .tint(Color.grey500)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, DefaultSpacing.spacing8)
-                    }
-                }
-            }
-            .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeBtnPadding)
-        }
-        .contentMargins(
-            .bottom,
-            DefaultConstant.defaultContentBottomMargins,
-            for: .scrollContent
-        )
-    }
-
-    // MARK: - Loading View
-
-    private func loadingView(message: String) -> some View {
-        VStack(spacing: DefaultSpacing.spacing12) {
-            ProgressView()
-                .controlSize(.large)
-                .tint(Color.grey500)
-
-            Text(message)
-                .appFont(.subheadline, color: .grey500)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-    }
-
-    // MARK: - Permission Denied View
-
-    private var permissionDeniedView: some View {
-        ScrollView {
-            VStack(spacing: DefaultSpacing.spacing32) {
-                ContentUnavailableView {
-                    Label(Constants.permissionTitle, systemImage: "person.3")
-                } description: {
-                    Text(Constants.permissionDescription)
-                        .multilineTextAlignment(.center)
-                }
-
-                VStack(alignment: .leading, spacing: DefaultSpacing.spacing16) {
-                    Text(Constants.permissionGuideTitle)
-                        .appFont(.callout, weight: .semibold)
-
-                    permissionRoleRow(
-                        icon: "building.columns.fill",
-                        role: Constants.roleChapterLeader,
-                        description: Constants.roleChapterLeaderDescription
-                    )
-
-                    permissionRoleRow(
-                        icon: "star.fill",
-                        role: Constants.rolePresident,
-                        description: Constants.rolePresidentDescription
-                    )
-
-                    permissionRoleRow(
-                        icon: "person.badge.key.fill",
-                        role: Constants.roleOperator,
-                        description: Constants.roleOperatorDescription
-                    )
-                }
-                .padding(DefaultSpacing.spacing16)
-                .background(
-                    .regularMaterial,
-                    in: .rect(cornerRadius: DefaultConstant.defaultCornerRadius)
-                )
-            }
-            .padding(.top, DefaultSpacing.spacing32)
-        }
-    }
-
-    private func permissionRoleRow(
-        icon: String,
-        role: String,
-        description: String
-    ) -> some View {
-        HStack(spacing: DefaultSpacing.spacing12) {
-            Image(systemName: icon)
-                .font(.app(.title3))
-                .foregroundStyle(Color.grey600)
-                .frame(width: 32, alignment: .center)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(role)
-                    .appFont(.subheadline)
-                Text(description)
-                    .appFont(.footnote)
-                    .foregroundStyle(Color.grey500)
-            }
-        }
-    }
-
-    // MARK: - Error View
-
-    /// 로딩 실패 처리.
-    ///
-    /// 레거시는 `AppError.isPermissionDenied`(403)로 권한 안내 분기를 판단했으나 이식된
-    /// `AppError` 에는 해당 프로퍼티가 없다. 권한 안내의 의도(생성 권한 없는 사용자에게 역할
-    /// 가이드 노출)를 세션 권한(`canCreateStudyGroup`)으로 대신 판단한다.
-    @ViewBuilder
-    private func errorView(
-        error: AppError,
-        retryAction: @escaping () async -> Void
-    ) -> some View {
-        if !canCreateStudyGroup {
-            permissionDeniedView
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .safeAreaPadding(.horizontal, DefaultConstant.defaultSafeHorizon)
-        } else {
-            RetryContentUnavailableView(
-                title: "불러오지 못했어요",
-                systemImage: "exclamationmark.triangle",
-                description: error.userMessage,
-                isRetrying: false,
-                topPadding: DefaultSpacing.spacing32
-            ) {
-                await retryAction()
-            }
-            .safeAreaPadding(
-                .horizontal,
-                DefaultConstant.defaultSafeHorizon
-            )
-        }
     }
 }
 


### PR DESCRIPTION
## ✨ PR 유형

Refactor — 620줄까지 커진 `OperatorStudyManagementView` 를 섹션 단위로 분할했습니다. 동작·레이아웃 변경 없음.

## 📷 스크린샷 or 영상(UI 변경 시)

UI 변경 없음 — 기존 프리뷰 6종이 그대로 유지되며 렌더 결과가 동일합니다.

## 🛠️ 작업내용

- `OperatorStudyManagementView` 620 → **246줄**. 섹션 전환(Picker) · 툴바 · 시트 3종 · 알럿 · 프리뷰만 남긴 셸로 축소
- `OperatorStudyGroupSection` (180줄) 신설 — 그룹 관리 섹션의 목록/빈 상태/권한 안내/에러 분기
- `OperatorStudySubmissionSection` (196줄) 신설 — 제출 현황의 그룹·주차 필터 + 상태별 본문
- `StudyManagementLoadingView` (67줄) 신설 — 두 섹션이 공유하던 전체 로딩 스피너와 하단 더보기 인디케이터
- `StudyGroupPermissionGuideView` (113줄) 신설 — 빈 상태·에러 두 곳에서 쓰던 역할 안내를 공용 컴포넌트로 분리
- 하드코딩 문자열을 각 파일의 `Constants` 로 정리 (문구 값은 기존과 동일)
- 역할 3종(지부장 / 회장·부회장 / 운영진)을 `ManageableRole` enum + `ForEach` 로 정리 — 순서·아이콘·문구·레이아웃 모두 기존과 동일

## 📋 추후 진행 상황

- 워크북 상세(`WORKBOOK-102`) 진입은 상세 화면 이식 후 결선 예정 (현재는 안내 알럿 유지)

## 📌 리뷰 포인트

- `UMCApp/Features/Activity/Presentation/Sources/Views/Operator/OperatorStudyManagementView.swift` — 셸에 남은 책임(섹션 전환·툴바·시트·알럿)이 적절한지
- `UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/OperatorStudyGroupSection.swift` — `canCreateStudyGroup` 을 프로퍼티로 주입해 세션 의존을 셸에 남긴 구조
- `UMCApp/Features/Activity/Presentation/Sources/Components/Operator/Study/StudyGroupPermissionGuideView.swift` — `ManageableRole` 변환이 기존 3개 행과 동일하게 렌더되는지
- ViewModel · Domain · Data · 테스트 코드는 **한 줄도 건드리지 않았습니다** (`git diff --name-only` 로 확인 가능)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

Closes #1060